### PR TITLE
Store weight of FastestCalc as seconds

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/Path.java
+++ b/core/src/main/java/com/graphhopper/routing/Path.java
@@ -171,7 +171,7 @@ public class Path {
 
     /**
      * This method calculates not only the weight but also the distance in
-     * kilometer for the specified edge.
+     * meter for the specified edge.
      */
     protected void calcDistance(EdgeIterator iter) {
         distance += iter.distance();

--- a/core/src/main/java/com/graphhopper/routing/util/FastestCalc.java
+++ b/core/src/main/java/com/graphhopper/routing/util/FastestCalc.java
@@ -35,16 +35,16 @@ public class FastestCalc implements WeightCalculation {
 
     @Override
     public double getMinWeight(double distance) {
-        return distance / maxSpeed;
+        return (distance * 3.6 )/ maxSpeed;
     }
 
     @Override
     public double getWeight(double distance, int flags) {
-        return distance / encoder.getSpeed(flags);
+        return (distance * 3.6)/ encoder.getSpeed(flags);
     }
 
     @Override public double revertWeight(double weight, int flags) {
-        return weight * encoder.getSpeed(flags);
+        return (weight / 3.6) * encoder.getSpeed(flags) ;
     }
 
     @Override public String toString() {


### PR DESCRIPTION
It would be more convenient if the weight of a fastest route calculation would be returned as seconds.
