### PR TITLE
update web/ReadMe; modify link to API and usage of graphhopper.sh

### DIFF
--- a/web/Readme.md
+++ b/web/Readme.md
@@ -1,5 +1,5 @@
 This application uses jQuery and Leaflet to display the calculated route from GraphHopper.
-Execute `./graphhopper.sh web europe_germany_berlin` in the parent folder. Then go to [http://localhost:8989/](http://localhost:8989/). 
-Get the raw json query [here](http://localhost:8989/api?from=52.439688,13.276863&to=52.532932,13.479424)
+Execute `./graphhopper.sh web europe_germany_berlin.osm` in the parent folder. Then go to [http://localhost:8989/](http://localhost:8989/).
+Get the raw json query [here](http://localhost:8989/api/route?from=52.439688,13.276863&to=52.532932,13.479424)
 
 [![GraphHopper Maps image](http://karussell.files.wordpress.com/2013/07/maps-preview1.png)](http://graphhopper.com/maps/?point=new%20york&point=los%20angeles)


### PR DESCRIPTION
Two update for web/Readme.md
- graphhopper.sh requires *.osm to download osm file
- api is actually under api/route, not /api
