### PR TITLE
Preparing support of turn restrictions (1): Extended GraphStorage 

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/QueryGraph.java
+++ b/core/src/main/java/com/graphhopper/routing/QueryGraph.java
@@ -24,12 +24,14 @@ import com.graphhopper.storage.index.QueryResult;
 import com.graphhopper.util.*;
 import com.graphhopper.util.shapes.BBox;
 import com.graphhopper.util.shapes.GHPoint;
+
 import gnu.trove.list.array.TIntArrayList;
 import gnu.trove.map.TIntObjectMap;
 import gnu.trove.map.hash.TIntObjectHashMap;
 import gnu.trove.procedure.TIntProcedure;
 import gnu.trove.procedure.TObjectProcedure;
 import gnu.trove.set.hash.TIntHashSet;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -69,8 +71,9 @@ public class QueryGraph implements Graph
     }
 
     /**
-     * For all specified query results calculate snapped point and set closest node and edge to a
-     * virtual one if necessary. Additionally the wayIndex can change if an edge is swapped.
+     * For all specified query results calculate snapped point and set closest
+     * node and edge to a virtual one if necessary. Additionally the wayIndex
+     * can change if an edge is swapped.
      */
     public void lookup( List<QueryResult> resList )
     {
@@ -282,6 +285,12 @@ public class QueryGraph implements Graph
     }
 
     @Override
+    public int getAdditionalNodeField( int nodeId )
+    {
+        return mainGraph.getAdditionalNodeField(nodeId);
+    }
+
+    @Override
     public BBox getBounds()
     {
         return mainGraph.getBounds();
@@ -449,6 +458,12 @@ public class QueryGraph implements Graph
     }
 
     @Override
+    public void setAdditionalNodeField( int nodeId, int additionalValue )
+    {
+        exc();
+    }
+
+    @Override
     public EdgeIteratorState edge( int a, int b )
     {
         throw exc();
@@ -587,6 +602,18 @@ public class QueryGraph implements Graph
         {
             return edges.toString();
         }
+
+        @Override
+        public int getAdditionalField()
+        {
+            return edges.get(current).getAdditionalField();
+        }
+
+        @Override
+        public EdgeIteratorState setAdditionalField( int value )
+        {
+            return edges.get(current).setAdditionalField(value);
+        }
     }
 
     /**
@@ -713,6 +740,12 @@ public class QueryGraph implements Graph
         }
 
         @Override
+        public int getAdditionalField()
+        {
+            throw new UnsupportedOperationException("Not supported.");
+        }
+
+        @Override
         public int getSkippedEdge1()
         {
             throw new UnsupportedOperationException("Not supported.");
@@ -738,6 +771,12 @@ public class QueryGraph implements Graph
 
         @Override
         public EdgeIteratorState detach()
+        {
+            throw new UnsupportedOperationException("Not supported.");
+        }
+
+        @Override
+        public EdgeIteratorState setAdditionalField( int value )
         {
             throw new UnsupportedOperationException("Not supported.");
         }

--- a/core/src/main/java/com/graphhopper/storage/ExtendedStorage.java
+++ b/core/src/main/java/com/graphhopper/storage/ExtendedStorage.java
@@ -1,0 +1,155 @@
+package com.graphhopper.storage;
+
+/**
+ * You need custom storages, like turn cost tables, or osmid tables for your
+ * graph? Implement this interface now and put it in any graph storage you want.
+ * It's that easy!
+ */
+public interface ExtendedStorage
+{
+
+    /**
+     * @return true, if and only if, if an additional field at the graphs node
+     *         storage is required
+     */
+    boolean isRequireNodeField();
+
+    /**
+     * @return true, if and only if, if an additional field at the graphs edge
+     *         storage is required
+     */
+    boolean isRequireEdgeField();
+    
+    /**
+     * @return the default field value which will be set for default when creating nodes 
+     */
+    int getDefaultNodeFieldValue();
+    
+    /**
+     * @return the default field value which will be set for default when creating edges 
+     */
+    int getDefaultEdgeFieldValue();
+
+    /**
+     * initializes the extended storage by giving the graph storage
+     */
+    void init( GraphStorage graph );
+
+    /**
+     * creates all additional data storages
+     */
+    void create( long initSize );
+
+    /**
+     * loads from existing data storages
+     */
+    boolean loadExisting();
+
+    /**
+     * sets the segment size in all additional data storages
+     */
+    void setSegmentSize( int bytes );
+
+    /**
+     * flushes all additional data storages
+     */
+    void flush();
+
+    /**
+     * closes all additional data storages
+     */
+    void close();
+
+    /**
+     * returns the sum of all additional data storages capacity
+     */
+    long getCapacity();
+
+    /**
+     * creates a copy of this extended storage
+     */
+    ExtendedStorage copyTo( ExtendedStorage extStorage );
+
+    /**
+     * default implementation defines no additional fields or any logic. there's like nothing
+     * , like the default behavior.
+     */
+    public class NoExtendedStorage implements ExtendedStorage
+    {
+
+        @Override
+        public boolean isRequireNodeField()
+        {
+            return false;
+        }
+
+        @Override
+        public boolean isRequireEdgeField()
+        {
+            return false;
+        }
+
+        @Override
+        public int getDefaultNodeFieldValue()
+        {
+            return 0;
+        }
+
+        @Override
+        public int getDefaultEdgeFieldValue()
+        {
+            return 0;
+        }
+        
+        @Override
+        public void init( GraphStorage grap )
+        {
+            // noop
+        }
+
+        @Override
+        public void create( long initSize )
+        {
+            // noop
+        }
+
+        @Override
+        public boolean loadExisting()
+        {
+            // noop
+            return true;
+        }
+
+        @Override
+        public void setSegmentSize( int bytes )
+        {
+            // noop
+        }
+
+        @Override
+        public void flush()
+        {
+            // noop
+        }
+
+        @Override
+        public void close()
+        {
+            // noop
+        }
+
+        @Override
+        public long getCapacity()
+        {
+            return 0;
+        }
+
+        @Override
+        public ExtendedStorage copyTo( ExtendedStorage extStorage )
+        {
+            // noop
+            return extStorage;
+        }
+
+    }
+}

--- a/core/src/main/java/com/graphhopper/storage/Graph.java
+++ b/core/src/main/java/com/graphhopper/storage/Graph.java
@@ -53,6 +53,18 @@ public interface Graph
     double getLongitude( int nodeId );
 
     /**
+     * @return the additional value at the specified node index
+     * @throws AssertionError if, and only if, the extendedStorage does not require an additional node field 
+     */
+	int getAdditionalNodeField(int nodeId);
+
+	/**
+	 * Sets the additional value at the specified node index
+	 * @throws AssertionError if, and only if, the extendedStorage does not require an additional node field
+	 */
+	void setAdditionalNodeField(int nodeId, int additionalValue);
+
+    /**
      * Returns the implicit bounds of this graph calculated from the lat,lon input of setNode
      */
     BBox getBounds();

--- a/core/src/main/java/com/graphhopper/storage/TurnCostStorage.java
+++ b/core/src/main/java/com/graphhopper/storage/TurnCostStorage.java
@@ -1,0 +1,302 @@
+package com.graphhopper.storage;
+
+import com.graphhopper.util.EdgeIterator;
+import com.graphhopper.util.TurnCostIterator;
+
+/**
+ * Holds turn cost tables for each node. The additional field of a node will be used
+ * to point towards the first entry within a node cost table to identify turn restrictions, 
+ * or later, turn costs.
+ * 
+ * @author karl.huebner
+ */
+public class TurnCostStorage implements ExtendedStorage
+{
+
+    /* pointer for no cost entry */
+    protected final int NO_COST_ENTRY = -1;
+
+    /*
+     * items in turn cost tables: edge from, edge to, costs, pointer to next
+     * cost entry of same node
+     */
+    protected final int TC_FROM, TC_TO, TC_COSTS, TC_NEXT;
+
+    protected DataAccess turnCosts;
+    protected int turnCostsEntryIndex = -4;
+    protected int turnCostsEntryBytes;
+    protected int turnCostsCount;
+
+    private GraphStorage graph;
+
+    public TurnCostStorage()
+    {
+        TC_FROM = nextTurnCostsEntryIndex();
+        TC_TO = nextTurnCostsEntryIndex();
+        TC_COSTS = nextTurnCostsEntryIndex();
+        TC_NEXT = nextTurnCostsEntryIndex();
+        turnCostsEntryBytes = turnCostsEntryIndex + 4;
+        turnCostsCount = 0;
+    }
+
+    @Override
+    public void init( GraphStorage graph )
+    {
+
+        if (turnCostsCount > 0)
+        {
+            throw new AssertionError("The turn cost storage must be initialized only once.");
+        }
+
+        this.graph = graph;
+
+        Directory dir = this.graph.getDirectory();
+
+        this.turnCosts = dir.find("turnCosts");
+    }
+
+    protected final int nextTurnCostsEntryIndex()
+    {
+        turnCostsEntryIndex += 4;
+        return turnCostsEntryIndex;
+    }
+
+    @Override
+    public void setSegmentSize( int bytes )
+    {
+        turnCosts.setSegmentSize(bytes);
+    }
+
+    @Override
+    public void create( long initBytes )
+    {
+        turnCosts.create((long) initBytes * turnCostsEntryBytes);
+    }
+
+    @Override
+    public void flush()
+    {
+        turnCosts.setHeader(0, turnCostsEntryBytes);
+        turnCosts.setHeader(1 * 4, turnCostsCount);
+        turnCosts.flush();
+    }
+
+    @Override
+    public void close()
+    {
+        turnCosts.close();
+    }
+
+    @Override
+    public long getCapacity()
+    {
+        return turnCosts.getCapacity();
+    }
+
+    public int entries()
+    {
+        return turnCostsCount;
+    }
+
+    @Override
+    public boolean loadExisting()
+    {
+        if (!turnCosts.loadExisting())
+            throw new IllegalStateException("cannot load node costs. corrupt file or directory? " + graph.getDirectory());
+
+        turnCostsEntryBytes = turnCosts.getHeader(0);
+        turnCostsCount = turnCosts.getHeader(4);
+        return true;
+    }
+
+    private int getCostTableAdress( int index )
+    {
+        if (index >= graph.getNodes() || index < 0)
+        {
+            return NO_COST_ENTRY;
+        }
+        return graph.getAdditionalNodeField(index);
+    }
+
+    public void setTurnCosts( int nodeIndex, int from, int to, int flags )
+    {
+        // append
+        int newEntryIndex = turnCostsCount;
+        turnCostsCount++;
+        ensureTurnCostsIndex(newEntryIndex);
+
+        // determine if we already have an cost entry for this node
+        int previousEntryIndex = getCostTableAdress(nodeIndex);
+        if (previousEntryIndex == NO_COST_ENTRY)
+        {
+            // set cost-pointer to this new cost entry
+            graph.setAdditionalNodeField(nodeIndex, newEntryIndex);
+        } else
+        {
+            int i = 0;
+            int tmp = previousEntryIndex;
+            while ((tmp = turnCosts.getInt((long) tmp * turnCostsEntryBytes + TC_NEXT)) != NO_COST_ENTRY)
+            {
+                previousEntryIndex = tmp;
+                // search for the last added cost entry
+                if (i++ > 1000)
+                {
+                    throw new IllegalStateException("Something unexpected happened. A node probably will not have 1000+ relations.");
+                }
+            }
+            // set next-pointer to this new cost entry
+            turnCosts.setInt((long) previousEntryIndex * turnCostsEntryBytes + TC_NEXT, newEntryIndex);
+        }
+        // add entry
+        long costsBase = (long) newEntryIndex * turnCostsEntryBytes;
+        turnCosts.setInt(costsBase + TC_FROM, from);
+        turnCosts.setInt(costsBase + TC_TO, to);
+        turnCosts.setInt(costsBase + TC_COSTS, flags);
+        // next-pointer is NO_COST_ENTRY
+        turnCosts.setInt(costsBase + TC_NEXT, NO_COST_ENTRY);
+    }
+
+    public int getTurnCosts( int node, int edgeFrom, int edgeTo )
+    {
+        if (edgeFrom != EdgeIterator.NO_EDGE && edgeTo != EdgeIterator.NO_EDGE)
+        {
+            TurnCostIterator tc = createTurnCostIterable(node, edgeFrom, edgeTo);
+            if (tc.next())
+            {
+                return tc.costs();
+            }
+        }
+        return 0;
+    }
+
+    public TurnCostIterator createTurnCostIterable( int node, int edgeFrom, int edgeTo )
+    {
+        return new TurnCostIteratable(node, edgeFrom, edgeTo);
+    }
+
+    void ensureTurnCostsIndex( int nodeIndex )
+    {
+        long deltaCap = ((long) nodeIndex + 4) * turnCostsEntryBytes - turnCosts.getCapacity();
+        if (deltaCap <= 0)
+        {
+            return;
+        }
+        turnCosts.incCapacity(deltaCap);
+    }
+
+    @Override
+    public boolean isRequireNodeField()
+    {
+        //we require the additional field in the graph to point to the first entry in the node table
+        return true;
+    }
+
+    @Override
+    public boolean isRequireEdgeField()
+    {
+        return false;
+    }
+
+    @Override
+    public int getDefaultNodeFieldValue()
+    {
+        return NO_COST_ENTRY;
+    }
+
+    @Override
+    public int getDefaultEdgeFieldValue()
+    {
+        throw new UnsupportedOperationException("Not supported by this storage");
+    }
+
+    @Override
+    public ExtendedStorage copyTo( ExtendedStorage clonedStorage )
+    {
+
+        if (!(clonedStorage instanceof TurnCostStorage))
+        {
+            throw new IllegalStateException("the extended storage to clone must be the same");
+        }
+
+        TurnCostStorage clonedTC = (TurnCostStorage) clonedStorage;
+
+        turnCosts.copyTo(clonedTC.turnCosts);
+        clonedTC.turnCostsCount = turnCostsCount;
+        clonedTC.graph = graph; //TODO might be faulty
+
+        return clonedStorage;
+    }
+
+    public class TurnCostIteratable implements TurnCostIterator
+    {
+
+        int nodeVia;
+        int edgeFrom;
+        int edgeTo;
+        int iteratorEdgeFrom;
+        int iteratorEdgeTo;
+        int turnCostIndex;
+        long turnCostPtr;
+
+        public TurnCostIteratable( int node, int edgeFrom, int edgeTo )
+        {
+            this.nodeVia = node;
+            this.iteratorEdgeFrom = edgeFrom;
+            this.iteratorEdgeTo = edgeTo;
+            this.edgeFrom = EdgeIterator.NO_EDGE;
+            this.edgeTo = EdgeIterator.NO_EDGE;
+            this.turnCostIndex = getCostTableAdress(nodeVia);
+            this.turnCostPtr = -1L;
+        }
+
+        @Override
+        public boolean next()
+        {
+            int i = 0;
+            boolean found = false;
+            for (; i < 1000; i++)
+            {
+                if (turnCostIndex == NO_COST_ENTRY)
+                    break;
+                turnCostPtr = (long) turnCostIndex * turnCostsEntryBytes;
+                edgeFrom = turnCosts.getInt(turnCostPtr + TC_FROM);
+                edgeTo = turnCosts.getInt(turnCostPtr + TC_TO);
+
+                int nextTurnCostIndex = turnCosts.getInt(turnCostPtr + TC_NEXT);
+                if (nextTurnCostIndex == turnCostIndex)
+                {
+                    throw new IllegalStateException("something went wrong: next entry would be the same");
+                }
+                turnCostIndex = nextTurnCostIndex;
+
+                if (edgeFrom != EdgeIterator.NO_EDGE && edgeTo != EdgeIterator.NO_EDGE && //
+                        (iteratorEdgeFrom == TurnCostIterator.ANY_EDGE || edgeFrom == iteratorEdgeFrom) && //
+                        (iteratorEdgeTo == TurnCostIterator.ANY_EDGE || edgeTo == iteratorEdgeTo))
+                {
+                    found = true;
+                    break;
+                }
+            }
+            // so many turn restrictions on one node? here is something wrong
+            if (i > 1000)
+                throw new IllegalStateException("something went wrong: no end of turn cost-list found");
+            return found;
+        }
+
+        public int edgeFrom()
+        {
+            return edgeFrom;
+        }
+
+        public int edgeTo()
+        {
+            return edgeTo;
+        }
+
+        public int costs()
+        {
+            return turnCosts.getInt(turnCostPtr + TC_COSTS);
+        }
+    }
+
+}

--- a/core/src/main/java/com/graphhopper/storage/index/LocationIndexTreeSC.java
+++ b/core/src/main/java/com/graphhopper/storage/index/LocationIndexTreeSC.java
@@ -164,6 +164,18 @@ public class LocationIndexTreeSC extends LocationIndexTree
             {
                 return tmpIter.setName(name);
             }
+
+			@Override
+			public int getAdditionalField()
+			{
+				return tmpIter.getAdditionalField();
+			}
+
+			@Override
+			public EdgeIteratorState setAdditionalField(int value) 
+			{
+				return tmpIter.setAdditionalField(value);
+			}
         };
     }
 

--- a/core/src/main/java/com/graphhopper/util/EdgeIteratorState.java
+++ b/core/src/main/java/com/graphhopper/util/EdgeIteratorState.java
@@ -77,6 +77,16 @@ public interface EdgeIteratorState
     long getFlags();
 
     EdgeIteratorState setFlags( long flags );
+    
+    /**
+     * @return the additional field value for this edge
+     */
+    int getAdditionalField();
+
+    /**
+     * Updates the additional field value for this edge
+     */
+    EdgeIteratorState setAdditionalField( int value );
 
     String getName();
 

--- a/core/src/main/java/com/graphhopper/util/GHUtility.java
+++ b/core/src/main/java/com/graphhopper/util/GHUtility.java
@@ -419,6 +419,16 @@ public class GHUtility
         {
             throw new UnsupportedOperationException("Not supported. Edge is empty.");
         }
+
+		@Override
+		public int getAdditionalField() {
+			throw new UnsupportedOperationException("Not supported. Edge is empty.");
+		}
+
+		@Override
+		public EdgeIteratorState setAdditionalField(int value) {
+			throw new UnsupportedOperationException("Not supported. Edge is empty.");
+		}
     };
 
     /**

--- a/core/src/main/java/com/graphhopper/util/TurnCostIterator.java
+++ b/core/src/main/java/com/graphhopper/util/TurnCostIterator.java
@@ -1,0 +1,19 @@
+package com.graphhopper.util;
+
+/**
+ * @author Karl Hübner
+ */
+public interface TurnCostIterator
+{
+
+    public static int ANY_EDGE = -2;
+
+    public boolean next();
+
+    public int edgeFrom();
+
+    public int edgeTo();
+
+    public int costs();
+
+}

--- a/core/src/test/java/com/graphhopper/storage/AbstractGraphStorageTester.java
+++ b/core/src/test/java/com/graphhopper/storage/AbstractGraphStorageTester.java
@@ -23,7 +23,6 @@ import static com.graphhopper.util.GHUtility.*;
 import com.graphhopper.util.shapes.BBox;
 import java.io.Closeable;
 import java.io.File;
-import java.io.IOException;
 import java.util.Arrays;
 import static org.junit.Assert.*;
 import org.junit.After;
@@ -61,6 +60,11 @@ public abstract class AbstractGraphStorageTester
     }
 
     abstract GraphStorage createGraph( String location, int size );
+    
+    protected GraphStorage newRAMGraph()
+    {
+        return new GraphHopperStorage(new RAMDirectory(), encodingManager);
+    }
 
     @Before
     public void setUp()
@@ -258,7 +262,7 @@ public abstract class AbstractGraphStorageTester
     {
         graph = createGraph();
         initExampleGraph(graph);
-        GraphHopperStorage gs = new GraphHopperStorage(new RAMDirectory(), encodingManager);
+        GraphStorage gs = newRAMGraph();
         gs.setSegmentSize(8000);
         gs.create(10);
         try

--- a/core/src/test/java/com/graphhopper/storage/GraphHopperStorageWithTurnCostsTest.java
+++ b/core/src/test/java/com/graphhopper/storage/GraphHopperStorageWithTurnCostsTest.java
@@ -1,0 +1,96 @@
+/*
+ *  Licensed to GraphHopper and Peter Karich under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for 
+ *  additional information regarding copyright ownership.
+ * 
+ *  GraphHopper licenses this file to you under the Apache License, 
+ *  Version 2.0 (the "License"); you may not use this file except in 
+ *  compliance with the License. You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.storage;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import com.graphhopper.util.EdgeIteratorState;
+import com.graphhopper.util.Helper;
+
+
+/**
+ *
+ * @author Karl Hübner
+ */
+public class GraphHopperStorageWithTurnCostsTest extends GraphHopperStorageTest
+{
+    private TurnCostStorage turnCostStorage;
+
+    @Override
+    protected GraphStorage newGraph(Directory dir) {
+        turnCostStorage = new TurnCostStorage();
+    	return new GraphHopperStorage(dir, encodingManager, turnCostStorage);
+    }
+    
+    @Override
+    protected GraphStorage newRAMGraph()
+    {
+        return newGraph(new RAMDirectory());
+    }
+    
+    @Test
+    public void testSave_and_fileFormat_withTurnCostEntries() throws IOException
+    {
+        GraphStorage graph = createGraphStorage(new RAMDirectory(defaultGraph, true));
+        graph.setNode(0, 10, 10);
+        graph.setNode(1, 11, 20);
+        graph.setNode(2, 12, 12);
+
+        EdgeIteratorState iter2 = graph.edge(0, 1, 100, true); 
+        iter2.setWayGeometry(Helper.createPointList(1.5, 1, 2, 3));
+        EdgeIteratorState iter1 = graph.edge(0, 2, 200, true);
+        iter1.setWayGeometry(Helper.createPointList(3.5, 4.5, 5, 6));
+        graph.edge(9, 10, 200, true);
+        graph.edge(9, 11, 200, true);
+        graph.edge(1, 2, 120, false);
+
+        turnCostStorage.setTurnCosts(0, iter1.getEdge(), iter2.getEdge(), 1337);
+        turnCostStorage.setTurnCosts(0, iter2.getEdge(), iter1.getEdge(), 666);
+        turnCostStorage.setTurnCosts(1, iter1.getEdge(), iter2.getEdge(), 815);
+        
+        iter1.setName("named street1");
+        iter2.setName("named street2");
+
+        checkGraph(graph);
+        graph.flush();
+        graph.close();
+
+        graph = newGraph(new MMapDirectory(defaultGraph));
+        assertTrue(graph.loadExisting());
+
+        assertEquals(12, graph.getNodes());
+        checkGraph(graph);
+
+        assertEquals("named street1", graph.getEdgeProps(iter1.getEdge(), iter1.getAdjNode()).getName());
+        assertEquals("named street2", graph.getEdgeProps(iter2.getEdge(), iter2.getAdjNode()).getName());
+        
+        assertEquals(1337, turnCostStorage.getTurnCosts(0, iter1.getEdge(), iter2.getEdge()));
+        assertEquals(666, turnCostStorage.getTurnCosts(0, iter2.getEdge(), iter1.getEdge()));
+        assertEquals(815, turnCostStorage.getTurnCosts(1, iter1.getEdge(), iter2.getEdge()));
+        assertEquals(0, turnCostStorage.getTurnCosts(3, iter1.getEdge(), iter2.getEdge()));
+        
+        graph.edge(3, 4, 123, true).setWayGeometry(Helper.createPointList(4.4, 5.5, 6.6, 7.7));
+        checkGraph(graph);
+        graph.close();
+    }
+}


### PR DESCRIPTION
The last attempt to implement turn restriction support "failed" due to one huge commit no one could work with. However, I would love to see this feature in the master very soon, therefore I decided to use the knowledge I gained  and try to redesign the whole thing step by step. So here is the first step: storing turn restrictions.

Turn restrictions need to be stored within the graph. To do so and to keep an eye on further extensions like turn costs, a turn cost table needs be stored next to nodes and edges. However, we need to store pointers from nodes to those table somehow which requires additional fields on the nodes. In my first attempt, I created a new complete Graph which extended the current GraphHopperStorage, which was not a good decision. However, I designed the storage problem of turn cost tables from scratch and therefore I want to introduce a component called ExtendedStorage:

An implementation of such ExtendedStorage will be put into GraphHopperStorage on initialization time and offers the possibility to store additional stuff next to nodes and edges without touching GraphHopperStorage. GraphHopperStorage now has an additional integer field for each node and edge. Both fields are optional and the implementation of ExtendedStorage decides, whether those fields will be created or not and those fields should be used. 

For example, TurnCostStorage (extends ExtendedStorage) requires the additional field for nodes and stores a pointer towards the first entry of a turn cost table, which is managed by TurnCostStorage.

Relates to #55 and #2
