### PR TITLE
Preparing support of turn restrictions (2): Encode turn costs depending on vehicle type

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/AbstractTurnCostEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/AbstractTurnCostEncoder.java
@@ -1,0 +1,68 @@
+package com.graphhopper.routing.util;
+
+/**
+ * Very simple turn cost encoder, which stores the turn restriction in the first bit,
+ * and the turn costs (in seconds) in x additional bits (0..2^x-1)
+ * 
+ * @author karl.huebner
+ */
+public abstract class AbstractTurnCostEncoder implements TurnCostEncoder
+{
+    private final int maxCostsBits;
+    private final int costsMask;
+
+    protected int restrictionBit;
+    protected int costShift;
+
+    public AbstractTurnCostEncoder( int maxCostsBits )
+    {
+        this.maxCostsBits = maxCostsBits;
+
+        int mask = 0;
+        for (int i = 0; i < this.maxCostsBits; i++)
+        {
+            mask |= (1 << i);
+        }
+        this.costsMask = mask;
+
+        defineBits(0, 0);
+    }
+
+    @Override
+    public int defineBits( int index, int shift )
+    {
+        restrictionBit = 1 << shift;
+        costShift = shift + 1;
+        return shift + maxCostsBits + 1;
+    }
+
+    @Override
+    public boolean isRestricted( int flag )
+    {
+        return (flag & restrictionBit) != 0;
+    }
+
+    @Override
+    public int getCosts( int flag )
+    {
+        int result = (flag >> costShift) & costsMask;
+        if (result >= Math.pow(2, maxCostsBits) || result < 0)
+        {
+            throw new IllegalStateException("Wrong encoding of turn costs");
+        }
+        return result;
+    }
+
+    @Override
+    public int flags( boolean restricted, int costs )
+    {
+        costs = Math.min(costs, (int) (Math.pow(2, maxCostsBits) - 1));
+        int encode = costs << costShift;
+        if (restricted)
+        {
+            encode |= restrictionBit;
+        }
+        return encode;
+    }
+
+}

--- a/core/src/main/java/com/graphhopper/routing/util/DefaultTurnCostEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/DefaultTurnCostEncoder.java
@@ -1,0 +1,42 @@
+package com.graphhopper.routing.util;
+
+/**
+ * Default implementation of {@link AbstractTurnCostEncoder} which 
+ * does not encode any costs yet, but only restrictions in one bit.
+ * Therefore, each turn cost encoder requires only 1 bit storage size
+ * at the moment.
+ * 
+ * @author karl.huebner
+ */
+public class DefaultTurnCostEncoder extends AbstractTurnCostEncoder
+{
+    /**
+     * no costs, but only restrictions will be encoded
+     */
+    public DefaultTurnCostEncoder()
+    {
+        this(0); //we don't need costs yet
+    }
+
+    /**
+     * Next to restrictions, turn costs will be encoded as well
+     * 
+     * @param maxCosts the maximum costs to be encoded by this encoder, everything above this costs will be encoded as maxCosts
+     */
+    public DefaultTurnCostEncoder( int maxCosts )
+    {
+        super(determineRequiredBits(maxCosts)); //determine the number of bits required to store maxCosts
+    }
+
+    private static int determineRequiredBits( int number )
+    {
+        int bits = 0;
+        while (number > 0)
+        {
+            number = number >> 1;
+            bits++;
+        }
+        return bits;
+    }
+
+}

--- a/core/src/main/java/com/graphhopper/routing/util/EncodingManager.java
+++ b/core/src/main/java/com/graphhopper/routing/util/EncodingManager.java
@@ -17,12 +17,15 @@
  */
 package com.graphhopper.routing.util;
 
-import com.graphhopper.reader.OSMNode;
-import com.graphhopper.reader.OSMWay;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.graphhopper.reader.OSMNode;
+import com.graphhopper.reader.OSMWay;
+import com.graphhopper.routing.util.TurnCostEncoder.NoTurnCostsEncoder;
 
 /**
  * Manager class to register encoder, assign their flag values and check objects with all encoders
@@ -36,18 +39,30 @@ public class EncodingManager
     public static final String CAR = "car";
     public static final String BIKE = "bike";
     public static final String FOOT = "foot";
-    private static final HashMap<String, String> defaultEncoders = new HashMap<String, String>();
+    private static final Map<String, String> defaultEdgeFlagEncoders = new HashMap<String, String>();
+    private static final Map<String, String> defaultTurnFlagEncoders = new HashMap<String, String>();
 
     static
     {
-        defaultEncoders.put(CAR, CarFlagEncoder.class.getName());
-        defaultEncoders.put(BIKE, BikeFlagEncoder.class.getName());
-        defaultEncoders.put(FOOT, FootFlagEncoder.class.getName());
+        defaultEdgeFlagEncoders.put(CAR, CarFlagEncoder.class.getName());
+        defaultEdgeFlagEncoders.put(BIKE, BikeFlagEncoder.class.getName());
+        defaultEdgeFlagEncoders.put(FOOT, FootFlagEncoder.class.getName());
+
+        defaultTurnFlagEncoders.put(CAR, DefaultTurnCostEncoder.class.getName());
+        defaultTurnFlagEncoders.put(BIKE, DefaultTurnCostEncoder.class.getName());
+        defaultTurnFlagEncoders.put(FOOT, NoTurnCostsEncoder.class.getName());
     }
+
     public static final int MAX_BITS = 32;
-    private ArrayList<AbstractFlagEncoder> encoders = new ArrayList<AbstractFlagEncoder>();
-    private int encoderCount = 0;
-    private int nextBit = 0;
+
+    //edge encoders
+    private List<AbstractFlagEncoder> encoders = new ArrayList<AbstractFlagEncoder>();
+    private int edgeEncoderCount = 0;
+    private int edgeEncoderNextBit = 0;
+
+    private List<TurnCostEncoder> turnCostEncoders = new ArrayList<TurnCostEncoder>();
+    private int turnEncoderCount = 0;
+    private int turnEncoderNextBit = 0;
 
     public EncodingManager()
     {
@@ -60,11 +75,52 @@ public class EncodingManager
      * <p/>
      * @param encoderList comma delimited list of encoders. The order does not matter.
      */
-    @SuppressWarnings("unchecked")
     public EncodingManager( String encoderList )
+    {
+        this(encoderList, "");
+    }
+
+    /**
+     * Instantiate manager with the given list of encoders. The manager knows the default encoders:
+     * CAR, FOOT and BIKE Custom encoders can be added by giving a full class name e.g.
+     * "CAR:com.graphhopper.myproject.MyCarEncoder"
+     * <p/>
+     * @param encoderList comma delimited list of encoders. The order does not matter.
+     * @param turnCostEncoderList comma delimited list of turn cost encoders. The order does not matter.
+     */
+    public EncodingManager( String encoderList, String turnCostEncoderList )
+    {
+
+        for (AbstractFlagEncoder flagEncoder : test(defaultEdgeFlagEncoders, encoderList, AbstractFlagEncoder.class))
+        {
+            registerEdgeFlagEncoder(flagEncoder);
+        }
+
+        for (TurnCostEncoder turnCostEncoder : test(defaultTurnFlagEncoders, turnCostEncoderList, TurnCostEncoder.class))
+        {
+            registerTurnCostFlagEncoder(turnCostEncoder);
+        }
+
+        /*
+         // comment this in to detect involuntary changes of the encoding
+         if( instance != null )
+         {
+         System.out.println( "WARNING: Overwriting Encoding Manager " + instance.toString() + " with new instance " + toString());
+         StackTraceElement[] trace = Thread.currentThread().getStackTrace();
+         for( int i = 2; i < trace.length; i++ ) {
+         System.out.println( trace[i] );
+         }
+         }
+         */
+        // instance = this;
+    }
+
+    private <T> List<T> test( Map<String, String> defaultEncoders, String encoderList, Class<T> encoderClass )
     {
         String[] entries = encoderList.split(",");
         Arrays.sort(entries);
+
+        List<T> resultEncoders = new ArrayList<T>();
 
         for (String entry : entries)
         {
@@ -86,40 +142,43 @@ public class EncodingManager
 
             try
             {
-                Class cls = Class.forName(className);
-                register((AbstractFlagEncoder) cls.getDeclaredConstructor().newInstance());
+                @SuppressWarnings("unchecked")
+                Class<T> cls = (Class<T>) Class.forName(className);
+                resultEncoders.add((T) cls.getDeclaredConstructor().newInstance());
             } catch (Exception e)
             {
                 throw new IllegalArgumentException("Cannot instantiate class " + className, e);
             }
         }
-
-        /*
-         // comment this in to detect involuntary changes of the encoding
-         if( instance != null )
-         {
-         System.out.println( "WARNING: Overwriting Encoding Manager " + instance.toString() + " with new instance " + toString());
-         StackTraceElement[] trace = Thread.currentThread().getStackTrace();
-         for( int i = 2; i < trace.length; i++ ) {
-         System.out.println( trace[i] );
-         }
-         }
-         */
-        // instance = this;
+        return resultEncoders;
     }
 
-    public void register( AbstractFlagEncoder encoder )
+    public void registerEdgeFlagEncoder( AbstractFlagEncoder encoder )
     {
         encoders.add(encoder);
 
-        int usedBits = encoder.defineBits(encoderCount, nextBit);
+        int usedBits = encoder.defineBits(edgeEncoderCount, edgeEncoderNextBit);
         if (usedBits >= MAX_BITS)
         {
             throw new IllegalArgumentException("Encoders are requesting more than 32 bits of flags");
         }
 
-        nextBit = usedBits;
-        encoderCount = encoders.size();
+        edgeEncoderNextBit = usedBits;
+        edgeEncoderCount = encoders.size();
+    }
+
+    public void registerTurnCostFlagEncoder( TurnCostEncoder encoder )
+    {
+        turnCostEncoders.add(encoder);
+
+        int usedBits = encoder.defineBits(turnEncoderCount, turnEncoderNextBit);
+        if (usedBits >= MAX_BITS)
+        {
+            throw new IllegalArgumentException("Encoders are requesting more than 32 bits of flags");
+        }
+
+        turnEncoderNextBit = usedBits;
+        turnEncoderCount = turnCostEncoders.size();
     }
 
     /**
@@ -135,9 +194,14 @@ public class EncodingManager
         return getEncoder(name, true);
     }
 
+    public TurnCostEncoder getTurnCostEncoder( String name )
+    {
+        return getTurnCostEncoder(name, true);
+    }
+
     private AbstractFlagEncoder getEncoder( String name, boolean throwExc )
     {
-        for (int i = 0; i < encoderCount; i++)
+        for (int i = 0; i < edgeEncoderCount; i++)
         {
             if (name.equalsIgnoreCase(encoders.get(i).toString()))
                 return encoders.get(i);
@@ -147,13 +211,25 @@ public class EncodingManager
         return null;
     }
 
+    private TurnCostEncoder getTurnCostEncoder( String name, boolean throwExc )
+    {
+        for (int i = 0; i < turnEncoderCount; i++)
+        {
+            if (name.equalsIgnoreCase(turnCostEncoders.get(i).toString()))
+                return turnCostEncoders.get(i);
+        }
+        if (throwExc)
+            throw new IllegalArgumentException("Turn Cost Encoder for " + name + " not found.");
+        return null;
+    }
+
     /**
      * Determine whether an osm way is a routable way for one of its encoders.
      */
     public int accept( OSMWay way )
     {
         int includeWay = 0;
-        for (int i = 0; i < encoderCount; i++)
+        for (int i = 0; i < edgeEncoderCount; i++)
         {
             includeWay |= encoders.get(i).isAllowed(way);
         }
@@ -170,7 +246,7 @@ public class EncodingManager
     public long handleWayTags( int includeWay, OSMWay way )
     {
         long flags = 0;
-        for (int i = 0; i < encoderCount; i++)
+        for (int i = 0; i < edgeEncoderCount; i++)
         {
             flags |= encoders.get(i).handleWayTags(includeWay, way);
         }
@@ -180,14 +256,14 @@ public class EncodingManager
 
     public int getVehicleCount()
     {
-        return encoderCount;
+        return edgeEncoderCount;
     }
 
     @Override
     public String toString()
     {
         StringBuilder str = new StringBuilder();
-        for (int i = 0; i < encoderCount; i++)
+        for (int i = 0; i < edgeEncoderCount; i++)
         {
             if (str.length() > 0)
             {
@@ -202,7 +278,7 @@ public class EncodingManager
     public String encoderList()
     {
         StringBuilder str = new StringBuilder();
-        for (int i = 0; i < encoderCount; i++)
+        for (int i = 0; i < edgeEncoderCount; i++)
         {
             if (str.length() > 0)
             {
@@ -237,7 +313,7 @@ public class EncodingManager
     public int flagsDefault( boolean forward, boolean backward )
     {
         int flags = 0;
-        for (int i = 0; i < encoderCount; i++)
+        for (int i = 0; i < edgeEncoderCount; i++)
         {
             flags |= encoders.get(i).flagsDefault(forward, backward);
         }
@@ -249,7 +325,7 @@ public class EncodingManager
      */
     public long swapDirection( long flags )
     {
-        for (int i = 0; i < encoderCount; i++)
+        for (int i = 0; i < edgeEncoderCount; i++)
         {
             flags = encoders.get(i).swapDirection(flags);
         }
@@ -291,7 +367,7 @@ public class EncodingManager
     public int analyzeNode( OSMNode node )
     {
         int flags = 0;
-        for (int i = 0; i < encoderCount; i++)
+        for (int i = 0; i < edgeEncoderCount; i++)
         {
             flags |= encoders.get(i).analyzeNodeTags(node);
         }
@@ -302,7 +378,7 @@ public class EncodingManager
     public String getWayInfo( OSMWay way )
     {
         String str = "";
-        for (int i = 0; i < encoderCount; i++)
+        for (int i = 0; i < edgeEncoderCount; i++)
         {
             String tmpWayInfo = encoders.get(i).getWayInfo(way);
             if (tmpWayInfo.isEmpty())

--- a/core/src/main/java/com/graphhopper/routing/util/TurnCostEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/TurnCostEncoder.java
@@ -1,0 +1,63 @@
+package com.graphhopper.routing.util;
+
+/**
+ * Encodes and decodes a turn restriction and turn costs 
+ * within a integer flag 
+ * 
+ * @author karl.huebner
+ */
+public interface TurnCostEncoder
+{
+    /**
+     * @return true, if, and only if it is encoded in flag 
+     */
+    boolean isRestricted(int flag);
+    
+    /**
+     * @return the costs in seconds encoded in flag 
+     */
+    int getCosts(int flag);
+    
+    /**
+     * @return the encoded turn restriction and turn costs 
+     */
+    int flags(boolean restricted, int costs);
+    
+    /**
+     * sets the shift and index to encode costs/restrictions
+     */
+    int defineBits( int index, int shift );
+    
+    /**
+     * whether turn costs nor turn restrictions will be encoded by this
+     * encoder, should be used for pedestrians  
+     */
+    static class NoTurnCostsEncoder implements TurnCostEncoder {
+
+        @Override
+        public boolean isRestricted( int flag )
+        {
+            return false;
+        }
+
+        @Override
+        public int getCosts( int flag )
+        {
+            return 0;
+        }
+
+        @Override
+        public int flags( boolean restricted, int costs )
+        {
+            return 0;
+        }
+
+        @Override
+        public int defineBits( int index, int shift )
+        {
+            return shift;
+        }
+        
+    }
+    
+}

--- a/core/src/test/java/com/graphhopper/routing/util/DefaultTurnCostEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/DefaultTurnCostEncoderTest.java
@@ -1,0 +1,135 @@
+package com.graphhopper.routing.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DefaultTurnCostEncoderTest
+{
+
+    @Test
+    public void testEncoding_max127_noBitShift()
+    {
+        TurnCostEncoder encoder = new DefaultTurnCostEncoder(127);
+        testFlags(encoder);
+    }
+
+    @Test
+    public void testEncoding_max127_arbitraryBitShift()
+    {
+        TurnCostEncoder encoder = new DefaultTurnCostEncoder(127);
+        int newShift = encoder.defineBits(1, 13);
+        Assert.assertEquals(13 + 8, newShift);
+
+        testFlags(encoder);
+    }
+
+    @Test
+    public void testEncoding_max31_max50_multipleFlags()
+    {
+        TurnCostEncoder encoder1 = new DefaultTurnCostEncoder(31);
+        int shift = encoder1.defineBits(0, 0);
+        Assert.assertEquals(6, shift);
+
+        TurnCostEncoder encoder2 = new DefaultTurnCostEncoder(50);
+        shift = encoder2.defineBits(1, shift);
+        Assert.assertEquals(6 + 7, shift);
+
+        int flags_100_r42 = encoder1.flags(false, 100) | encoder2.flags(true, 42);
+        int flags_0_128 = encoder1.flags(false, 0) | encoder2.flags(false, 128);
+        int flags_0_r9 = encoder1.flags(false, 0) | encoder2.flags(true, 9);
+        int flags_r100_r200 = encoder1.flags(true, 100) | encoder2.flags(true, 200);
+
+        Assert.assertFalse(encoder1.isRestricted(flags_100_r42));
+        Assert.assertFalse(encoder1.isRestricted(flags_0_128));
+        Assert.assertFalse(encoder1.isRestricted(flags_0_r9));
+        Assert.assertTrue(encoder1.isRestricted(flags_r100_r200));
+
+        Assert.assertTrue(encoder2.isRestricted(flags_100_r42));
+        Assert.assertFalse(encoder2.isRestricted(flags_0_128));
+        Assert.assertTrue(encoder2.isRestricted(flags_0_r9));
+        Assert.assertTrue(encoder2.isRestricted(flags_r100_r200));
+
+        Assert.assertEquals(31, encoder1.getCosts(flags_100_r42)); //max value is 31 for encoder 1, since it has been initialized with max=31(31 needs 5 bits => 2^5-1 = 31)
+        Assert.assertEquals(0, encoder1.getCosts(flags_0_128));
+        Assert.assertEquals(0, encoder1.getCosts(flags_0_r9));
+        Assert.assertEquals(31, encoder1.getCosts(flags_r100_r200)); //max value is 31 for encoder 1, since it has been initialized with max=31 (31 needs 5 bits => 2^5-1 = 31)
+
+        Assert.assertEquals(42, encoder2.getCosts(flags_100_r42));
+        Assert.assertEquals(63, encoder2.getCosts(flags_0_128)); //max value is 63 for encoder 2, since it has been initialized with max=50 (50 needs 6 bits => 2^6-1 = 63)
+        Assert.assertEquals(9, encoder2.getCosts(flags_0_r9));
+        Assert.assertEquals(63, encoder2.getCosts(flags_r100_r200)); //max value is 63 for encoder 2, since it has been initialized with max=50 (50 needs 6 bits => 2^6-1 = 63)
+
+    }
+
+    @Test
+    public void testEncoding_restrictionsOnly()
+    {
+        TurnCostEncoder encoder1 = new DefaultTurnCostEncoder();
+        int shift = encoder1.defineBits(0, 0);
+        Assert.assertEquals(1, shift);
+
+        TurnCostEncoder encoder2 = new DefaultTurnCostEncoder(0);
+        shift = encoder2.defineBits(1, shift);
+        Assert.assertEquals(2, shift);
+
+        int flags_100_r42 = encoder1.flags(false, 100) | encoder2.flags(true, 42);
+        int flags_0_128 = encoder1.flags(false, 0) | encoder2.flags(false, 128);
+        int flags_0_r9 = encoder1.flags(false, 0) | encoder2.flags(true, 9);
+        int flags_r100_r200 = encoder1.flags(true, 100) | encoder2.flags(true, 200);
+
+        Assert.assertFalse(encoder1.isRestricted(flags_100_r42));
+        Assert.assertFalse(encoder1.isRestricted(flags_0_128));
+        Assert.assertFalse(encoder1.isRestricted(flags_0_r9));
+        Assert.assertTrue(encoder1.isRestricted(flags_r100_r200));
+
+        Assert.assertTrue(encoder2.isRestricted(flags_100_r42));
+        Assert.assertFalse(encoder2.isRestricted(flags_0_128));
+        Assert.assertTrue(encoder2.isRestricted(flags_0_r9));
+        Assert.assertTrue(encoder2.isRestricted(flags_r100_r200));
+
+        Assert.assertEquals(0, encoder1.getCosts(flags_100_r42));
+        Assert.assertEquals(0, encoder1.getCosts(flags_0_128));
+        Assert.assertEquals(0, encoder1.getCosts(flags_0_r9));
+        Assert.assertEquals(0, encoder1.getCosts(flags_r100_r200));
+
+        Assert.assertEquals(0, encoder2.getCosts(flags_100_r42));
+        Assert.assertEquals(0, encoder2.getCosts(flags_0_128));
+        Assert.assertEquals(0, encoder2.getCosts(flags_0_r9));
+        Assert.assertEquals(0, encoder2.getCosts(flags_r100_r200));
+
+    }
+
+    public void testFlags( TurnCostEncoder encoder )
+    {
+        int flags_0 = encoder.flags(false, 0);
+        int flags_100 = encoder.flags(false, 100);
+        int flags_127 = encoder.flags(false, 127);
+        int flags_128 = encoder.flags(false, 128);
+
+        int flags_r_0 = encoder.flags(true, 0);
+        int flags_r_100 = encoder.flags(true, 100);
+        int flags_r_127 = encoder.flags(true, 127);
+        int flags_r_128 = encoder.flags(true, 128);
+
+        Assert.assertFalse(encoder.isRestricted(flags_0));
+        Assert.assertFalse(encoder.isRestricted(flags_100));
+        Assert.assertFalse(encoder.isRestricted(flags_127));
+        Assert.assertFalse(encoder.isRestricted(flags_128));
+
+        Assert.assertTrue(encoder.isRestricted(flags_r_0));
+        Assert.assertTrue(encoder.isRestricted(flags_r_100));
+        Assert.assertTrue(encoder.isRestricted(flags_r_127));
+        Assert.assertTrue(encoder.isRestricted(flags_r_128));
+
+        Assert.assertEquals(0, encoder.getCosts(flags_0));
+        Assert.assertEquals(100, encoder.getCosts(flags_100));
+        Assert.assertEquals(127, encoder.getCosts(flags_127));
+        Assert.assertEquals(127, encoder.getCosts(flags_128));
+
+        Assert.assertEquals(0, encoder.getCosts(flags_r_0));
+        Assert.assertEquals(100, encoder.getCosts(flags_r_100));
+        Assert.assertEquals(127, encoder.getCosts(flags_r_127));
+        Assert.assertEquals(127, encoder.getCosts(flags_r_128));
+    }
+
+}

--- a/core/src/test/java/com/graphhopper/routing/util/EncodingManagerTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/EncodingManagerTest.java
@@ -43,7 +43,7 @@ public class EncodingManagerTest
         FootFlagEncoder foot2 = new FootFlagEncoder()
         {
         };
-        manager2.register(foot2);
+        manager2.registerEdgeFlagEncoder(foot2);
         assertNotEquals(foot, foot2);
         assertNotEquals(foot.hashCode(), foot2.hashCode());
 
@@ -51,7 +51,7 @@ public class EncodingManagerTest
         FootFlagEncoder foot3 = new FootFlagEncoder()
         {
         };
-        manager3.register(foot3);
+        manager3.registerEdgeFlagEncoder(foot3);
         assertEquals(foot3, foot2);
         assertEquals(foot3.hashCode(), foot2.hashCode());
 
@@ -71,13 +71,13 @@ public class EncodingManagerTest
         EncodingManager manager = new EncodingManager();
         for (int i = 0; i < 4; i++)
         {
-            manager.register(new FootFlagEncoder()
+            manager.registerEdgeFlagEncoder(new FootFlagEncoder()
             {
             });
         }
         try
         {
-            manager.register(new FootFlagEncoder()
+            manager.registerEdgeFlagEncoder(new FootFlagEncoder()
             {
             });
             assertTrue(false);


### PR DESCRIPTION
The second step of the integration of support of turn restrictions: The turn costs are stored within the graph by using turn tables (nope, not those ones DJs use, instead see #133). Now we need the turn cost values to be encoded depending on the vehicle type being used. In line with FlagEncoders this is handled the same way: for different vehicle types (such as CAR, BIKE, or FOOT) different turnCostEncoders will be used. Those encoders store their encoded turn cost value within ONE integer flag, which is stored in the turn cost table.

Some details:
Next to FlagEncoders for edge properties, TurnCostEncoders are now held by the EncodingManager. A TurnCostEncoder encodes and decodes turn restrictions/turn costs of several vehicle types into an integer flag,
like FlagEncoders do. For CAR, BIKE a DefaultTurnCostEncoder has been
declared, which stores turn restrictions only (DefaultTurnCostEncoder is ready for turn costs as well, but we don't need them yet). For FOOT a NoTurnRestrictionEncoder has been defined, which encodes neither restrictions nor costs. To define which TurnCostEncoders should be used, the EncodingManager accepts a second list of turnCostEncoders, which can be defined the same way as edgeFlagEncoders are defined.

However, those TurnCostEncoders are not being used anywhere in the code. This is just preparation for turn restriction support, which will be introduces step by step.
