### PR TITLE
Partial fix for #86 - removing dead-end small subnetworks

### DIFF
--- a/core/src/main/java/com/graphhopper/storage/NativeFSLockFactory.java
+++ b/core/src/main/java/com/graphhopper/storage/NativeFSLockFactory.java
@@ -46,9 +46,6 @@ public class NativeFSLockFactory implements LockFactory
     @Override
     public void setLockDir( File lockDir )
     {
-        if (!lockDir.isDirectory())
-            throw new IllegalArgumentException("lockDir has to be a directory");
-
         this.lockDir = lockDir;
     }
 
@@ -104,6 +101,9 @@ public class NativeFSLockFactory implements LockFactory
                 if (!lockDir.mkdirs())
                     throw new RuntimeException("Directory " + lockDir + " does not exist and cannot created to place lock file there: " + lockFile);
             }
+
+            if (!lockDir.isDirectory())
+                throw new IllegalArgumentException("lockDir has to be a directory: " + lockDir);
 
             try
             {

--- a/core/src/main/java/com/graphhopper/storage/SimpleFSLockFactory.java
+++ b/core/src/main/java/com/graphhopper/storage/SimpleFSLockFactory.java
@@ -91,7 +91,7 @@ public class SimpleFSLockFactory implements LockFactory
 
             // this test can only be performed after the dir has created!
             if (!lockDir.isDirectory())
-                throw new IllegalArgumentException("lockDir has to be a directory");
+                throw new IllegalArgumentException("lockDir has to be a directory: " + lockDir);
 
             try
             {

--- a/core/src/test/java/com/graphhopper/GraphHopperTest.java
+++ b/core/src/test/java/com/graphhopper/GraphHopperTest.java
@@ -29,8 +29,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import org.junit.After;
 import org.junit.Test;
 import static org.junit.Assert.*;
@@ -137,7 +135,7 @@ public class GraphHopperTest
                 {
                     latch.await();
                 } catch (InterruptedException ex)
-                {                   
+                {
                 }
                 return super.importData();
             }
@@ -168,7 +166,7 @@ public class GraphHopperTest
         try
         {
             // let thread reach the CountDownLatch
-            Thread.sleep(10);
+            Thread.sleep(30);
             // now importOrLoad should have create a lock which this load call does not like
             instance2.load(ghLoc);
             assertTrue(false);
@@ -178,12 +176,12 @@ public class GraphHopperTest
             assertTrue(ex.getMessage(), ex.getMessage().startsWith("To avoid reading partial data"));
         } finally
         {
-            latch.countDown();
             instance2.close();
+            latch.countDown();
+            // make sure the import process wasn't interrupted and no other error happened
+            thread.join();
         }
 
-        // make sure the import process wasn't interrupted and no other error happened
-        thread.join();
         if (ar.get() != null)
             assertNull(ar.get().getMessage(), ar.get());
         instance1.close();

--- a/core/src/test/java/com/graphhopper/routing/RoutingAlgorithmIT.java
+++ b/core/src/test/java/com/graphhopper/routing/RoutingAlgorithmIT.java
@@ -254,7 +254,7 @@ public class RoutingAlgorithmIT
         assertEquals(testCollector.toString(), 0, testCollector.errors.size());
 
         runAlgo(testCollector, "files/monaco.osm.gz", "target/monaco-gh",
-                list, "CAR,BIKE,RACINGBIKE", false, "RACINGBIKE", "fastest", false);
+                list, "CAR,RACINGBIKE", false, "RACINGBIKE", "fastest", false);
         assertEquals(testCollector.toString(), 0, testCollector.errors.size());
     }
 
@@ -271,7 +271,7 @@ public class RoutingAlgorithmIT
         assertEquals(testCollector.toString(), 0, testCollector.errors.size());
 
         runAlgo(testCollector, "files/krems.osm.gz", "target/krems-gh",
-                list, "CAR,BIKE,MTB", false, "BIKE", "fastest", false);
+                list, "CAR,BIKE", false, "BIKE", "fastest", false);
         assertEquals(testCollector.toString(), 0, testCollector.errors.size());
     }
 
@@ -288,7 +288,7 @@ public class RoutingAlgorithmIT
         assertEquals(testCollector.toString(), 0, testCollector.errors.size());
 
         runAlgo(testCollector, "files/krems.osm.gz", "target/krems-gh",
-                list, "CAR,BIKE,MTB", false, "MTB", "fastest", false);
+                list, "CAR,MTB", false, "MTB", "fastest", false);
         assertEquals(testCollector.toString(), 0, testCollector.errors.size());
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,7 @@
                     <execution>
                         <goals>
                             <goal>integration-test</goal>
+                            <goal>verify</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
Partial fix for #86

This implements a solution to the "route not found" issues when the nearest point is link to a dead-end subnetworks.

The algorithm is the following:
- First loop on nodes using a one-way explorer ;
- It gives a list of all the sub-networks with their size ;
- Sort the list by size (bigger first) in order to keep the big networks and kill all small networks (size < minNetworkSize).
- For each sub-network (identified by its first nodeid) explore all nodes starting from this nodeId and not in the big networks (>minNetworkSize) and remove them ;

The algorithm is done twice (forward and backward).

We do it only for mono-encoding manager.
Tested on worldwide map. it fixes all issues we have identified (a few hundred of routes among a test file of 5000).
