### PR TITLE
Added blockFords flag to make blocking on fords optional

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/AbstractFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/AbstractFlagEncoder.java
@@ -81,6 +81,7 @@ public abstract class AbstractFlagEncoder implements FlagEncoder, TurnCostEncode
     protected HashSet<String> potentialBarriers = new HashSet<String>(5);
     // should potential barriers block when no access limits are given?
     protected boolean blockByDefault = true;
+    protected boolean blockFords = true;
     protected int speedBits;
     protected double speedFactor;
 
@@ -225,8 +226,8 @@ public abstract class AbstractFlagEncoder implements FlagEncoder, TurnCostEncode
                 return directionBitMask;
         }
 
-        if ((node.hasTag("highway", "ford")
-                || node.hasTag("ford"))
+        if (blockFords
+                && (node.hasTag("highway", "ford") || node.hasTag("ford"))
                 && !node.hasTag(restrictions, intendedValues))
             return directionBitMask;
 

--- a/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
@@ -246,7 +246,7 @@ public class BikeCommonFlagEncoder extends AbstractFlagEncoder
             return 0;
 
         // do not use fords with normal bikes, flagged fords are in included above
-        if (way.hasTag("highway", "ford") || way.hasTag("ford"))
+        if (blockFords && (way.hasTag("highway", "ford") || way.hasTag("ford")))
             return 0;
 
         // check access restrictions

--- a/core/src/main/java/com/graphhopper/routing/util/CarFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/CarFlagEncoder.java
@@ -188,7 +188,7 @@ public class CarFlagEncoder extends AbstractFlagEncoder
 
         // do not drive street cars into fords
         boolean carsAllowed = way.hasTag(restrictions, intendedValues);
-        if (("ford".equals(highwayValue) || way.hasTag("ford")) && !carsAllowed)
+        if (blockFords && ("ford".equals(highwayValue) || way.hasTag("ford")) && !carsAllowed)
             return 0;
 
         // check access restrictions

--- a/core/src/main/java/com/graphhopper/routing/util/FootFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/FootFlagEncoder.java
@@ -191,7 +191,7 @@ public class FootFlagEncoder extends AbstractFlagEncoder
             return 0;
 
         // do not get our feet wet, "yes" is already included above
-        if (way.hasTag("highway", "ford") || way.hasTag("ford"))
+        if (blockFords && (way.hasTag("highway", "ford") || way.hasTag("ford")))
             return 0;
 
         if (way.hasTag("bicycle", "official"))

--- a/core/src/test/java/com/graphhopper/routing/util/CarFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/CarFlagEncoderTest.java
@@ -413,4 +413,30 @@ public class CarFlagEncoderTest
         way.setTag("maxspeed", "90");
         assertEquals(90, encoder.getMaxSpeed(way), 1e-2);
     }
+
+    @Test
+    public void testFordAccess()
+    {
+        OSMNode node = new OSMNode(0, 0.0, 0.0);
+        node.setTag("ford", "yes");
+
+        OSMWay way = new OSMWay(1);
+        way.setTag("highway", "unclassified");
+        way.setTag("ford", "yes");
+
+        // Node and way are initially blocking
+        assertTrue(encoder.blockFords);
+        assertFalse(encoder.acceptWay(way) > 0);
+        assertTrue(encoder.handleNodeTags(node) > 0);
+
+        try {
+            // Now they are passable
+            encoder.blockFords = false;
+            assertTrue(encoder.acceptWay(way) > 0);
+            assertFalse(encoder.handleNodeTags(node) > 0);
+        } finally {
+            encoder.blockFords = true;
+        }
+    }
+
 }


### PR DESCRIPTION
Due to concerns about seasonality in #236, I thought it might be easier to make blocking fords optional.
This change adds a flag to AbstractFlagEncoder to indicate whether fords should be blocking.

With this flag it's trivial to make our custom CarFlagEncoder which ignores fords.
