### PR TITLE
ExtendedStorageManager for an arbitrary amount of ExtendedStorage

### DIFF
--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -788,7 +788,7 @@ public class GraphHopper implements GraphHopperAPI
 
         if (encoder.supportsTurnCosts())
         {
-            result = new TurnWeighting(result, encoder, (TurnCostStorage) graph.getExtendedStorage());
+            result = new TurnWeighting(result, encoder, (TurnCostStorage) graph.getExtendedStorage(TurnCostStorage.IDENTIFIER));
         }
         return result;
     }

--- a/core/src/main/java/com/graphhopper/reader/OSMReader.java
+++ b/core/src/main/java/com/graphhopper/reader/OSMReader.java
@@ -444,7 +444,7 @@ public class OSMReader implements DataReader
             OSMTurnRelation turnRelation = createTurnRelation(relation);
             if (turnRelation != null)
             {
-                ExtendedStorage extendedStorage = graphStorage.getExtendedStorage();
+                ExtendedStorage extendedStorage = graphStorage.getExtendedStorage(TurnCostStorage.IDENTIFIER);
                 if (extendedStorage instanceof TurnCostStorage)
                 {
                     TurnCostStorage tcs = (TurnCostStorage) extendedStorage;

--- a/core/src/main/java/com/graphhopper/routing/QueryGraph.java
+++ b/core/src/main/java/com/graphhopper/routing/QueryGraph.java
@@ -302,11 +302,11 @@ public class QueryGraph implements Graph
         }
 
         @Override
-        public int getAdditionalNodeField( int nodeId )
+        public int getAdditionalNodeField( String identifier, int nodeId )
         {
             if (nodeId >= mainNodes)
                 return 0;
-            return mainNodeAccess.getAdditionalNodeField(nodeId);
+            return mainNodeAccess.getAdditionalNodeField(identifier, nodeId);
         }
 
         @Override
@@ -322,7 +322,7 @@ public class QueryGraph implements Graph
         }
 
         @Override
-        public void setAdditionalNodeField( int nodeId, int additionalValue )
+        public void setAdditionalNodeField( String identifier, int nodeId, int additionalValue )
         {
             throw new UnsupportedOperationException("Not supported yet.");
         }
@@ -653,15 +653,15 @@ public class QueryGraph implements Graph
         }
 
         @Override
-        public int getAdditionalField()
+        public int getAdditionalField( String storageIdentifier )
         {
-            return edges.get(current).getAdditionalField();
+            return edges.get(current).getAdditionalField(storageIdentifier);
         }
 
         @Override
-        public EdgeIteratorState setAdditionalField( int value )
+        public EdgeIteratorState setAdditionalField( String storageIdentifier, int value )
         {
-            return edges.get(current).setAdditionalField(value);
+            return edges.get(current).setAdditionalField(storageIdentifier, value);
         }
 
         @Override
@@ -706,6 +706,18 @@ public class QueryGraph implements Graph
         public void setSkippedEdges( int edge1, int edge2 )
         {
             throw new UnsupportedOperationException("Not supported.");
+        }
+
+        @Override
+        public void setReferenceToExtendedStorage( int value )
+        {
+            edges.get(current).setReferenceToExtendedStorage(value);
+        }
+
+        @Override
+        public int getReferenceToExtendedStorage()
+        {
+            return edges.get(current).getReferenceToExtendedStorage();
         }
     }
 
@@ -834,7 +846,7 @@ public class QueryGraph implements Graph
         }
 
         @Override
-        public int getAdditionalField()
+        public int getAdditionalField( String identifier )
         {
             throw new UnsupportedOperationException("Not supported.");
         }
@@ -864,7 +876,7 @@ public class QueryGraph implements Graph
         }
 
         @Override
-        public EdgeIteratorState setAdditionalField( int value )
+        public EdgeIteratorState setAdditionalField( String identifier, int value )
         {
             throw new UnsupportedOperationException("Not supported.");
         }
@@ -885,6 +897,18 @@ public class QueryGraph implements Graph
         public double getWeight()
         {
             throw new UnsupportedOperationException("Not supported.");
+        }
+
+        @Override
+        public void setReferenceToExtendedStorage( int value )
+        {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public int getReferenceToExtendedStorage()
+        {
+            throw new UnsupportedOperationException("Not supported yet.");
         }
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/QueryGraph.java
+++ b/core/src/main/java/com/graphhopper/routing/QueryGraph.java
@@ -902,13 +902,13 @@ public class QueryGraph implements Graph
         @Override
         public void setReferenceToExtendedStorage( int value )
         {
-            throw new UnsupportedOperationException("Not supported yet.");
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public int getReferenceToExtendedStorage()
         {
-            throw new UnsupportedOperationException("Not supported yet.");
+            throw new UnsupportedOperationException("Not supported.");
         }
     }
 }

--- a/core/src/main/java/com/graphhopper/storage/ExtendedStorage.java
+++ b/core/src/main/java/com/graphhopper/storage/ExtendedStorage.java
@@ -66,7 +66,7 @@ public interface ExtendedStorage
     /**
      * flushes all additional data storages
      */
-    void flush();
+    void flush( StorableProperties properties );
 
     /**
      * closes all additional data storages
@@ -140,7 +140,7 @@ public interface ExtendedStorage
         }
 
         @Override
-        public void flush()
+        public void flush( StorableProperties properties )
         {
             // noop
         }
@@ -168,6 +168,6 @@ public interface ExtendedStorage
         public String toString()
         {
             return "NoExt";
-        }       
+        }
     }
 }

--- a/core/src/main/java/com/graphhopper/storage/ExtendedStorageAccess.java
+++ b/core/src/main/java/com/graphhopper/storage/ExtendedStorageAccess.java
@@ -1,0 +1,29 @@
+/*
+ *  Licensed to GraphHopper and Peter Karich under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for 
+ *  additional information regarding copyright ownership.
+ * 
+ *  GraphHopper licenses this file to you under the Apache License, 
+ *  Version 2.0 (the "License"); you may not use this file except in 
+ *  compliance with the License. You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.storage;
+
+public interface ExtendedStorageAccess
+{
+    void writeToExtendedNodeStorage( String storageName, int nodeId, int value );
+
+    int readFromExtendedNodeStorage( String storageName, int nodeId );
+
+    void writeToExtendedEdgeStorage( String storageName, int edgeId, int value );
+
+    int readFromExtendedEdgeStorage( String storageName, int edgeId );
+}

--- a/core/src/main/java/com/graphhopper/storage/ExtendedStorageAccess.java
+++ b/core/src/main/java/com/graphhopper/storage/ExtendedStorageAccess.java
@@ -17,10 +17,14 @@
  */
 package com.graphhopper.storage;
 
+/**
+ * @author Adrian Batzill, Agata Grzybek
+ */
 public interface ExtendedStorageAccess
 {
     /**
      * Write to the node's extended storage
+     * <p>
      * @param storageName the storage identifier to which you want to write
      * @param nodeId the node
      * @param value the value to write
@@ -33,8 +37,8 @@ public interface ExtendedStorageAccess
     int readFromExtendedNodeStorage( String storageName, int nodeId );
 
     /**
-     * Writes to the edge's extended storage. You may also use the EdgeIteratorState's setAdditionalField
-     * method for conveniece, so you don't have to provide an edge ID
+     * Writes to the edge's extended storage. You may also use the EdgeIteratorState's
+     * setAdditionalField method for conveniece, so you don't have to provide an edge ID
      */
     void writeToExtendedEdgeStorage( String storageName, int edgeId, int value );
 

--- a/core/src/main/java/com/graphhopper/storage/ExtendedStorageAccess.java
+++ b/core/src/main/java/com/graphhopper/storage/ExtendedStorageAccess.java
@@ -19,11 +19,27 @@ package com.graphhopper.storage;
 
 public interface ExtendedStorageAccess
 {
+    /**
+     * Write to the node's extended storage
+     * @param storageName the storage identifier to which you want to write
+     * @param nodeId the node
+     * @param value the value to write
+     */
     void writeToExtendedNodeStorage( String storageName, int nodeId, int value );
 
+    /**
+     * Reads previously written values from the node's extended storage
+     */
     int readFromExtendedNodeStorage( String storageName, int nodeId );
 
+    /**
+     * Writes to the edge's extended storage. You may also use the EdgeIteratorState's setAdditionalField
+     * method for conveniece, so you don't have to provide an edge ID
+     */
     void writeToExtendedEdgeStorage( String storageName, int edgeId, int value );
 
+    /**
+     * Reads previously written values from the edge's extended storage
+     */
     int readFromExtendedEdgeStorage( String storageName, int edgeId );
 }

--- a/core/src/main/java/com/graphhopper/storage/ExtendedStorageManager.java
+++ b/core/src/main/java/com/graphhopper/storage/ExtendedStorageManager.java
@@ -19,24 +19,39 @@ package com.graphhopper.storage;
 
 import java.util.*;
 
+/**
+ * ExtendedStorageManager is an ExtendedStorage by itself and can manage multiple sub-storages. For
+ * each ExtendedStorage that is passed to the constructor during graph creation, space will be
+ * created to hold references for this extended storage. When reading a graph from disk, the manager
+ * will check the properties file to check if it is used and if it is, it will restore its state
+ * with the help of the properties file
+ * <p>
+ * @author Adrian Batzill, Agata
+ */
 public class ExtendedStorageManager implements ExtendedStorage
 {
-    private final static String USE="extendedStorageManager.use";
-    private final static String NODE_STORAGES="extendedStorageManager.nodeStorages";
-    private final static String EDGE_STORAGES="extendedStorageManager.edgeStorages";
-    
+    private final static String USE = "extendedStorageManager.use";
+    private final static String NODE_STORAGES = "extendedStorageManager.nodeStorages";
+    private final static String EDGE_STORAGES = "extendedStorageManager.edgeStorages";
+
     private Directory storageDirectory;
     private DataAccess nodeExtStorageRefs;
     private DataAccess edgeExtStorageRefs;
-    private TreeMap<String, ExtendedStorage> extStorages;
-    private HashMap<String, Integer> storageIndicesNodes = new HashMap<String, Integer>();
-    private HashMap<String, Integer> storageIndicesEdges = new HashMap<String, Integer>();
+    private final TreeMap<String, ExtendedStorage> extStorages;
+    private final HashMap<String, Integer> storageIndicesNodes = new HashMap<String, Integer>();
+    private final HashMap<String, Integer> storageIndicesEdges = new HashMap<String, Integer>();
 
     private int refNodeEntryBytes = -1;
     private int refEdgeEntryBytes = -1;
 
     public final static int NO_REFERENCE = -1;
 
+    /**
+     * @param extStorages A TreeMap with maps some arbitrary key to an ExtendedStorage. The key will
+     * later be used to identify the storage. A TreeMap is required, as the file-layout of the
+     * ExtendedStorageManager DataAccess objects will be sorted by the key-string of the
+     * sub-storages
+     */
     public ExtendedStorageManager( TreeMap<String, ExtendedStorage> extStorages )
     {
         this.extStorages = extStorages;
@@ -243,7 +258,7 @@ public class ExtendedStorageManager implements ExtendedStorage
     }
 
     @Override
-    public void flush(StorableProperties properties)
+    public void flush( StorableProperties properties )
     {
         if (isRequireNodeField())
         {

--- a/core/src/main/java/com/graphhopper/storage/ExtendedStorageManager.java
+++ b/core/src/main/java/com/graphhopper/storage/ExtendedStorageManager.java
@@ -1,0 +1,324 @@
+/*
+ *  Licensed to GraphHopper and Peter Karich under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for 
+ *  additional information regarding copyright ownership.
+ * 
+ *  GraphHopper licenses this file to you under the Apache License, 
+ *  Version 2.0 (the "License"); you may not use this file except in 
+ *  compliance with the License. You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.storage;
+
+import java.util.HashMap;
+import java.util.TreeMap;
+
+public class ExtendedStorageManager implements ExtendedStorage
+{
+    private final static String USE="extendedStorageManager.use";
+    private final static String NODE_STORAGES="extendedStorageManager.nodeStorages";
+    private final static String EDGE_STORAGES="extendedStorageManager.edgeStorages";
+    
+    private Directory storageDirectory;
+    private DataAccess nodeExtStorageRefs;
+    private DataAccess edgeExtStorageRefs;
+    private TreeMap<String, ExtendedStorage> extStorages;
+    private HashMap<String, Integer> storageIndicesNodes = new HashMap<String, Integer>();
+    private HashMap<String, Integer> storageIndicesEdges = new HashMap<String, Integer>();
+
+    private int refNodeEntryBytes = -1;
+    private int refEdgeEntryBytes = -1;
+
+    public final static int NO_REFERENCE = -1;
+
+    public ExtendedStorageManager( TreeMap<String, ExtendedStorage> extStorages )
+    {
+        this.extStorages = extStorages;
+        int indexNode = 0;
+        int indexEdge = 0;
+        for (String k : extStorages.keySet())
+        {
+            if (extStorages.get(k).isRequireNodeField())
+            {
+                storageIndicesNodes.put(k, indexNode++);
+            }
+            if (extStorages.get(k).isRequireEdgeField())
+            {
+                storageIndicesEdges.put(k, indexEdge++);
+            }
+        }
+        refNodeEntryBytes = 4 * storageIndicesNodes.size();
+        refEdgeEntryBytes = 4 * storageIndicesEdges.size();
+    }
+
+    public static void loadStorageIndicesFromDisk( StorableProperties properties, ExtendedStorage providedStorage )
+    {
+        String use = properties.get(USE);
+        String nodeStorages = properties.get(NODE_STORAGES);
+        String edgeStorages = properties.get(EDGE_STORAGES);
+
+        if (use == null || use.equals(""))
+        {
+            return;
+        }
+
+        if (!(providedStorage instanceof ExtendedStorageManager))
+        {
+            throw new IllegalStateException("A graph that was created with an ExtendedStorageManager can not be loaded without an ExtendedStorageManager");
+        }
+
+        ExtendedStorageManager manager = (ExtendedStorageManager) providedStorage;
+        String[] nodeIdentifiers = nodeStorages.split(",");
+        String[] edgeIdentifiers = edgeStorages.split(",");
+        for (int i = 0; i < nodeIdentifiers.length; ++i)
+        {
+            if (manager.storageIndicesNodes.containsKey(nodeIdentifiers[i]))
+            {
+                manager.storageIndicesNodes.put(nodeIdentifiers[i], i);
+            }
+        }
+
+        for (int i = 0; i < edgeIdentifiers.length; ++i)
+        {
+            if (manager.storageIndicesEdges.containsKey(edgeIdentifiers[i]))
+            {
+                manager.storageIndicesEdges.put(edgeIdentifiers[i], i);
+            }
+        }
+    }
+
+    public ExtendedStorage getExtendedStorage( String storageName )
+    {
+        return extStorages.get(storageName);
+    }
+
+    @Override
+    public boolean isRequireNodeField()
+    {
+        return storageIndicesNodes.size() > 0;
+    }
+
+    @Override
+    public boolean isRequireEdgeField()
+    {
+        return storageIndicesEdges.size() > 0;
+    }
+
+    @Override
+    public int getDefaultNodeFieldValue()
+    {
+        return NO_REFERENCE;
+    }
+
+    @Override
+    public int getDefaultEdgeFieldValue()
+    {
+        return NO_REFERENCE;
+    }
+
+    @Override
+    public void init( GraphStorage graph )
+    {
+        this.storageDirectory = graph.getDirectory();
+        nodeExtStorageRefs = storageDirectory.find("nodeExtStorageRefs");
+        edgeExtStorageRefs = storageDirectory.find("edgeExtStorageRefs");
+
+        for (ExtendedStorage extStorage : extStorages.values())
+        {
+            extStorage.init(graph);
+        }
+    }
+
+    @Override
+    public void create( long initSize )
+    {
+        for (ExtendedStorage extStorage : extStorages.values())
+        {
+            extStorage.create(initSize);
+        }
+
+        if (isRequireNodeField())
+        {
+            nodeExtStorageRefs.create(initSize);
+        }
+        if (isRequireEdgeField())
+        {
+            edgeExtStorageRefs.create(initSize);
+        }
+    }
+
+    @Override
+    public boolean loadExisting()
+    {
+        nodeExtStorageRefs.loadExisting();
+        edgeExtStorageRefs.loadExisting();
+
+        boolean successAll = true;
+        for (ExtendedStorage extStorage : extStorages.values())
+        {
+            if (!extStorage.loadExisting())
+            {
+                successAll = false;
+            }
+        }
+        return successAll;
+    }
+
+    @Override
+    public void setSegmentSize( int bytes )
+    {
+        nodeExtStorageRefs.setSegmentSize(bytes);
+        edgeExtStorageRefs.setSegmentSize(bytes);
+
+        for (ExtendedStorage extStorage : extStorages.values())
+        {
+            extStorage.setSegmentSize(bytes);
+        }
+    }
+
+    public void ensureNodeCapacity( int nodeId )
+    {
+        nodeExtStorageRefs.incCapacity((nodeId + 1) * refNodeEntryBytes);
+    }
+
+    public void ensureEdgeCapacity( int edgeId )
+    {
+        edgeExtStorageRefs.incCapacity((edgeId + 1) * refEdgeEntryBytes);
+    }
+
+    public int setNodeReference( String storageName, int nodeId, int value )
+    {
+        ensureNodeCapacity(nodeId);
+        long extIndex = storageIndicesNodes.get(storageName);
+        long byteOffset = nodeId * refNodeEntryBytes + extIndex * 4;
+
+        nodeExtStorageRefs.setInt(byteOffset, value);
+        return nodeId;
+    }
+
+    public int getNodeReference( String storageName, int nodeId )
+    {
+        if (nodeExtStorageRefs.getCapacity() < refNodeEntryBytes * (nodeId + 1))
+        {
+            throw new IllegalStateException("Extended storage manager access out of bounds");
+        }
+
+        long extIndex = storageIndicesNodes.get(storageName);
+
+        long byteOffset = nodeId * refNodeEntryBytes + extIndex * 4;
+        return nodeExtStorageRefs.getInt(byteOffset);
+    }
+
+    public int setEdgeReference( String storageName, int edgeId, int value )
+    {
+        ensureEdgeCapacity(edgeId);
+        long extIndex = storageIndicesEdges.get(storageName);
+        long byteOffset = edgeId * refEdgeEntryBytes + extIndex * 4;
+
+        nodeExtStorageRefs.setInt(byteOffset, value);
+        return edgeId;
+    }
+
+    public int getEdgeReference( String storageName, int edgeId )
+    {
+        if (edgeExtStorageRefs.getCapacity() < refEdgeEntryBytes * (edgeId + 1))
+        {
+            throw new IllegalStateException("Extended storage manager access out of bounds");
+        }
+
+        long extIndex = storageIndicesEdges.get(storageName);
+
+        long byteOffset = edgeId * refEdgeEntryBytes + extIndex * 4;
+        return edgeExtStorageRefs.getInt(byteOffset);
+    }
+
+    @Override
+    public void flush(StorableProperties properties)
+    {
+        if (isRequireNodeField())
+        {
+            nodeExtStorageRefs.flush();
+        }
+        if (isRequireEdgeField())
+        {
+            edgeExtStorageRefs.flush();
+        }
+
+        for (ExtendedStorage extStorage : extStorages.values())
+        {
+            extStorage.flush(properties);
+        }
+        
+        properties.put(USE, "true");
+        properties.put(NODE_STORAGES, String.join(",", storageIndicesNodes.keySet()));
+        properties.put(EDGE_STORAGES, String.join(",", storageIndicesEdges.keySet()));
+    }
+
+    @Override
+    public void close()
+    {
+        if (isRequireNodeField())
+        {
+            nodeExtStorageRefs.close();
+        }
+        if (isRequireEdgeField())
+        {
+            edgeExtStorageRefs.close();
+        }
+
+        for (ExtendedStorage extStorage : extStorages.values())
+        {
+            extStorage.close();
+        }
+    }
+
+    @Override
+    public long getCapacity()
+    {
+        long capacity = nodeExtStorageRefs.getCapacity() + edgeExtStorageRefs.getCapacity();
+        for (ExtendedStorage extStorage : extStorages.values())
+        {
+            capacity += extStorage.getCapacity();
+        }
+        return capacity;
+    }
+
+    @Override
+    public ExtendedStorage copyTo( ExtendedStorage extStorage )
+    {
+        if (!(extStorage instanceof ExtendedStorageManager))
+        {
+            throw new IllegalStateException("The extended storage to clone must be the same");
+        }
+
+        ExtendedStorageManager other = (ExtendedStorageManager) extStorage;
+
+        for (String key : extStorages.keySet())
+        {
+            if (other.getExtendedStorage(key) == null)
+            {
+                throw new IllegalStateException("The extended storage manager to clone must have the same extended storages");
+            }
+            extStorages.get(key).copyTo(other.getExtendedStorage(key));
+        }
+
+        if (isRequireNodeField())
+        {
+            nodeExtStorageRefs.copyTo(other.nodeExtStorageRefs);
+        }
+        if (isRequireEdgeField())
+        {
+            edgeExtStorageRefs.copyTo(other.edgeExtStorageRefs);
+        }
+
+        return other;
+    }
+
+}

--- a/core/src/main/java/com/graphhopper/storage/ExtendedStorageManager.java
+++ b/core/src/main/java/com/graphhopper/storage/ExtendedStorageManager.java
@@ -26,7 +26,7 @@ import java.util.*;
  * will check the properties file to check if it is used and if it is, it will restore its state
  * with the help of the properties file
  * <p>
- * @author Adrian Batzill, Agata
+ * @author Adrian Batzill
  */
 public class ExtendedStorageManager implements ExtendedStorage
 {

--- a/core/src/main/java/com/graphhopper/storage/ExtendedStorageManager.java
+++ b/core/src/main/java/com/graphhopper/storage/ExtendedStorageManager.java
@@ -275,8 +275,24 @@ public class ExtendedStorageManager implements ExtendedStorage
         }
 
         properties.put(USE, "true");
-        properties.put(NODE_STORAGES, String.join(",", storageIndicesNodes.keySet()));
-        properties.put(EDGE_STORAGES, String.join(",", storageIndicesEdges.keySet()));
+        properties.put(NODE_STORAGES, createNodeIndicesString(storageIndicesNodes.keySet()));
+        properties.put(EDGE_STORAGES, createNodeIndicesString(storageIndicesEdges.keySet()));
+    }
+
+    public String createNodeIndicesString( Set<String> keySet )
+    {
+        StringBuilder sb = new StringBuilder();
+        boolean first = true;
+        for (String s : keySet)
+        {
+            if (!first)
+            {
+                sb.append(",");
+            }
+            sb.append(s);
+            first = false;
+        }
+        return sb.toString();
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/storage/ExtendedStorageManager.java
+++ b/core/src/main/java/com/graphhopper/storage/ExtendedStorageManager.java
@@ -17,8 +17,7 @@
  */
 package com.graphhopper.storage;
 
-import java.util.HashMap;
-import java.util.TreeMap;
+import java.util.*;
 
 public class ExtendedStorageManager implements ExtendedStorage
 {
@@ -77,6 +76,10 @@ public class ExtendedStorageManager implements ExtendedStorage
         ExtendedStorageManager manager = (ExtendedStorageManager) providedStorage;
         String[] nodeIdentifiers = nodeStorages.split(",");
         String[] edgeIdentifiers = edgeStorages.split(",");
+        Arrays.sort(nodeIdentifiers);
+        Arrays.sort(edgeIdentifiers);
+        manager.refNodeEntryBytes = nodeIdentifiers.length * 4;
+        manager.refEdgeEntryBytes = edgeIdentifiers.length * 4;
         for (int i = 0; i < nodeIdentifiers.length; ++i)
         {
             if (manager.storageIndicesNodes.containsKey(nodeIdentifiers[i]))
@@ -222,7 +225,7 @@ public class ExtendedStorageManager implements ExtendedStorage
         long extIndex = storageIndicesEdges.get(storageName);
         long byteOffset = edgeId * refEdgeEntryBytes + extIndex * 4;
 
-        nodeExtStorageRefs.setInt(byteOffset, value);
+        edgeExtStorageRefs.setInt(byteOffset, value);
         return edgeId;
     }
 
@@ -255,7 +258,7 @@ public class ExtendedStorageManager implements ExtendedStorage
         {
             extStorage.flush(properties);
         }
-        
+
         properties.put(USE, "true");
         properties.put(NODE_STORAGES, String.join(",", storageIndicesNodes.keySet()));
         properties.put(EDGE_STORAGES, String.join(",", storageIndicesEdges.keySet()));

--- a/core/src/main/java/com/graphhopper/storage/ExtendedStorageManager.java
+++ b/core/src/main/java/com/graphhopper/storage/ExtendedStorageManager.java
@@ -26,7 +26,7 @@ import java.util.*;
  * will check the properties file to check if it is used and if it is, it will restore its state
  * with the help of the properties file
  * <p>
- * @author Adrian Batzill
+ * @author Adrian Batzill, Agata Grzybek
  */
 public class ExtendedStorageManager implements ExtendedStorage
 {

--- a/core/src/main/java/com/graphhopper/storage/GHExtendedStorageAccess.java
+++ b/core/src/main/java/com/graphhopper/storage/GHExtendedStorageAccess.java
@@ -26,6 +26,7 @@ public class GHExtendedStorageAccess implements ExtendedStorageAccess
         this.graph = graph;
     }
 
+    @Override
     public void writeToExtendedNodeStorage( String storageName, int nodeId, int value )
     {
         if (graph.extStorage instanceof ExtendedStorageManager)
@@ -43,6 +44,7 @@ public class GHExtendedStorageAccess implements ExtendedStorageAccess
         }
     }
 
+    @Override
     public int readFromExtendedNodeStorage( String storageName, int nodeId )
     {
         int refIndex = graph.nodes.getInt((long) nodeId * graph.nodeEntryBytes + graph.N_ADDITIONAL);

--- a/core/src/main/java/com/graphhopper/storage/GHExtendedStorageAccess.java
+++ b/core/src/main/java/com/graphhopper/storage/GHExtendedStorageAccess.java
@@ -1,0 +1,88 @@
+/*
+ *  Licensed to GraphHopper and Peter Karich under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for 
+ *  additional information regarding copyright ownership.
+ * 
+ *  GraphHopper licenses this file to you under the Apache License, 
+ *  Version 2.0 (the "License"); you may not use this file except in 
+ *  compliance with the License. You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.storage;
+
+public class GHExtendedStorageAccess implements ExtendedStorageAccess
+{
+    GraphHopperStorage graph;
+
+    public GHExtendedStorageAccess( GraphHopperStorage graph )
+    {
+        this.graph = graph;
+    }
+
+    public void writeToExtendedNodeStorage( String storageName, int nodeId, int value )
+    {
+        if (graph.extStorage instanceof ExtendedStorageManager)
+        {
+            ExtendedStorageManager manager = (ExtendedStorageManager) graph.extStorage;
+            int refIndex = manager.setNodeReference(storageName, nodeId, value);
+            long tmp = (long) nodeId * graph.nodeEntryBytes;
+            graph.ensureNodeIndex(nodeId);
+            graph.nodes.setInt(tmp + graph.N_ADDITIONAL, refIndex);
+        } else
+        {
+            graph.ensureNodeIndex(nodeId);
+            long tmp = (long) nodeId * graph.nodeEntryBytes;
+            graph.nodes.setInt(tmp + graph.N_ADDITIONAL, value);
+        }
+    }
+
+    public int readFromExtendedNodeStorage( String storageName, int nodeId )
+    {
+        int refIndex = graph.nodes.getInt((long) nodeId * graph.nodeEntryBytes + graph.N_ADDITIONAL);
+        if (graph.extStorage instanceof ExtendedStorageManager)
+        {
+            ExtendedStorageManager manager = (ExtendedStorageManager) graph.extStorage;
+            return manager.getNodeReference(storageName, refIndex);
+        }
+        return refIndex;
+    }
+
+    @Override
+    public void writeToExtendedEdgeStorage( String storageName, int edgeId, int value )
+    {
+        if (graph.extStorage.isRequireEdgeField() && graph.E_ADDITIONAL >= 0)
+        {
+            if (graph.extStorage instanceof ExtendedStorageManager)
+            {
+                ExtendedStorageManager manager = (ExtendedStorageManager) graph.extStorage;
+                int refIndex = manager.setEdgeReference(storageName, edgeId, value);
+                long tmp = (long) edgeId * graph.edgeEntryBytes;
+                graph.edges.setInt(tmp + graph.E_ADDITIONAL, refIndex);
+            } else
+            {
+                long tmp = (long) edgeId * graph.edgeEntryBytes;
+                graph.edges.setInt(tmp + graph.E_ADDITIONAL, value);
+            }
+        } else
+            throw new AssertionError("This graph does not support an additional edge field.");
+    }
+
+    @Override
+    public int readFromExtendedEdgeStorage( String storageName, int edgeId )
+    {
+        int refIndex = graph.edges.getInt((long) edgeId * graph.edgeEntryBytes + graph.E_ADDITIONAL);
+        if (graph.extStorage instanceof ExtendedStorageManager)
+        {
+            ExtendedStorageManager manager = (ExtendedStorageManager) graph.extStorage;
+            return manager.getEdgeReference(storageName, refIndex);
+        }
+        return refIndex;
+    }
+}

--- a/core/src/main/java/com/graphhopper/storage/GHNodeAccess.java
+++ b/core/src/main/java/com/graphhopper/storage/GHNodeAccess.java
@@ -117,25 +117,31 @@ class GHNodeAccess implements NodeAccess
         return getLongitude(nodeId);
     }
 
+    /**
+     * @deprecated use graph.getExtendedStorageAccess() instead
+     */
+    @Deprecated 
     @Override
-    public final void setAdditionalNodeField( int index, int additionalValue )
+    public final void setAdditionalNodeField( String storageIdentifier, int index, int additionalValue )
     {
         if (that.extStorage.isRequireNodeField() && that.N_ADDITIONAL >= 0)
         {
-            that.ensureNodeIndex(index);
-            long tmp = (long) index * that.nodeEntryBytes;
-            that.nodes.setInt(tmp + that.N_ADDITIONAL, additionalValue);
+            that.getExtendedStorageAccess().writeToExtendedNodeStorage(storageIdentifier, index, additionalValue);
         } else
         {
             throw new AssertionError("This graph does not provide an additional node field");
         }
     }
 
+     /**
+     * @deprecated use graph.getExtendedStorageAccess() instead
+     */
+    @Deprecated
     @Override
-    public final int getAdditionalNodeField( int index )
+    public final int getAdditionalNodeField( String storageIdentifier, int index )
     {
         if (that.extStorage.isRequireNodeField() && that.N_ADDITIONAL >= 0)
-            return that.nodes.getInt((long) index * that.nodeEntryBytes + that.N_ADDITIONAL);
+            return that.getExtendedStorageAccess().readFromExtendedNodeStorage(storageIdentifier, index);
         else
             throw new AssertionError("This graph does not provide an additional node field");
     }

--- a/core/src/main/java/com/graphhopper/storage/GHNodeAccess.java
+++ b/core/src/main/java/com/graphhopper/storage/GHNodeAccess.java
@@ -120,7 +120,7 @@ class GHNodeAccess implements NodeAccess
     /**
      * @deprecated use graph.getExtendedStorageAccess() instead
      */
-    @Deprecated 
+    @Deprecated
     @Override
     public final void setAdditionalNodeField( String storageIdentifier, int index, int additionalValue )
     {
@@ -133,7 +133,7 @@ class GHNodeAccess implements NodeAccess
         }
     }
 
-     /**
+    /**
      * @deprecated use graph.getExtendedStorageAccess() instead
      */
     @Deprecated

--- a/core/src/main/java/com/graphhopper/storage/GraphHopperStorage.java
+++ b/core/src/main/java/com/graphhopper/storage/GraphHopperStorage.java
@@ -88,7 +88,7 @@ public class GraphHopperStorage implements GraphStorage
     private final StorableProperties properties;
     private final BitUtil bitUtil;
     private boolean flagsSizeIsLong;
-    ExtendedStorage extStorage;
+    final ExtendedStorage extStorage;
     private final NodeAccess nodeAccess;
     private final GHExtendedStorageAccess extendedStorageAccess;
 
@@ -1461,7 +1461,7 @@ public class GraphHopperStorage implements GraphStorage
             loadNodesHeader();
             loadEdgesHeader();
             loadWayGeometryHeader();
-            
+
             return true;
         }
         return false;

--- a/core/src/main/java/com/graphhopper/storage/GraphStorage.java
+++ b/core/src/main/java/com/graphhopper/storage/GraphStorage.java
@@ -45,9 +45,11 @@ public interface GraphStorage extends Graph, Storable<GraphStorage>
      * Performs optimization routines like deletion or node rearrangements.
      */
     void optimize();
-    
+
     /**
      * @return the extended storage, e.g. TurnCostStorage to store turn costs
      */
-    ExtendedStorage getExtendedStorage();
+    ExtendedStorage getExtendedStorage( String storageIdentifier );
+
+    ExtendedStorageAccess getExtendedStorageAccess();
 }

--- a/core/src/main/java/com/graphhopper/storage/NodeAccess.java
+++ b/core/src/main/java/com/graphhopper/storage/NodeAccess.java
@@ -39,8 +39,8 @@ public interface NodeAccess extends PointAccess
     int getAdditionalNodeField( String storageIdentifier, int nodeId );
 
     /**
-     * @deprecated use graph.getExtendedStorageAccess() instead
-     * Sets the additional value at the specified node index
+     * @deprecated use graph.getExtendedStorageAccess() instead Sets the additional value at the
+     * specified node index
      * <p>
      * @throws AssertionError if, and only if, the extendedStorage does not require an additional
      * node field

--- a/core/src/main/java/com/graphhopper/storage/NodeAccess.java
+++ b/core/src/main/java/com/graphhopper/storage/NodeAccess.java
@@ -30,17 +30,21 @@ import com.graphhopper.util.PointAccess;
 public interface NodeAccess extends PointAccess
 {
     /**
+     * @deprecated use graph.getExtendedStorageAccess() instead
      * @return the additional value at the specified node index
      * @throws AssertionError if, and only if, the extendedStorage does not require an additional
      * node field
      */
-    int getAdditionalNodeField( int nodeId );
+    @Deprecated
+    int getAdditionalNodeField( String storageIdentifier, int nodeId );
 
     /**
+     * @deprecated use graph.getExtendedStorageAccess() instead
      * Sets the additional value at the specified node index
      * <p>
      * @throws AssertionError if, and only if, the extendedStorage does not require an additional
      * node field
      */
-    void setAdditionalNodeField( int nodeId, int additionalValue );
+    @Deprecated
+    void setAdditionalNodeField( String storageIdentifier, int nodeId, int additionalValue );
 }

--- a/core/src/main/java/com/graphhopper/storage/index/LocationIndexTreeSC.java
+++ b/core/src/main/java/com/graphhopper/storage/index/LocationIndexTreeSC.java
@@ -156,15 +156,15 @@ public class LocationIndexTreeSC extends LocationIndexTree
             }
 
             @Override
-            public int getAdditionalField()
+            public int getAdditionalField( String identifier )
             {
-                return tmpIter.getAdditionalField();
+                return tmpIter.getAdditionalField(identifier);
             }
 
             @Override
-            public EdgeIteratorState setAdditionalField( int value )
+            public EdgeIteratorState setAdditionalField( String identifier, int value )
             {
-                return tmpIter.setAdditionalField(value);
+                return tmpIter.setAdditionalField(identifier, value);
             }
 
             @Override
@@ -177,6 +177,18 @@ public class LocationIndexTreeSC extends LocationIndexTree
             public EdgeIteratorState detach( boolean reverse )
             {
                 return tmpIter.detach(reverse);
+            }
+
+            @Override
+            public void setReferenceToExtendedStorage( int value )
+            {
+                tmpIter.setReferenceToExtendedStorage(value);
+            }
+
+            @Override
+            public int getReferenceToExtendedStorage()
+            {
+                return tmpIter.getReferenceToExtendedStorage();
             }
         };
     }

--- a/core/src/main/java/com/graphhopper/util/EdgeIteratorState.java
+++ b/core/src/main/java/com/graphhopper/util/EdgeIteratorState.java
@@ -79,14 +79,22 @@ public interface EdgeIteratorState
     EdgeIteratorState setFlags( long flags );
 
     /**
+     * @deprecated use ExtendedStorageAccess instead
      * @return the additional field value for this edge
      */
-    int getAdditionalField();
+    @Deprecated
+    int getAdditionalField( String storageIdentifier );
 
     /**
-     * Updates the additional field value for this edge
+     * @deprecated use ExtendedStorageAccess instead Updates the additional field value for this
+     * edge
      */
-    EdgeIteratorState setAdditionalField( int value );
+    @Deprecated
+    EdgeIteratorState setAdditionalField( String storageIdentifier, int value );
+
+    public void setReferenceToExtendedStorage( int value );
+
+    public int getReferenceToExtendedStorage();
 
     String getName();
 

--- a/core/src/main/java/com/graphhopper/util/EdgeIteratorState.java
+++ b/core/src/main/java/com/graphhopper/util/EdgeIteratorState.java
@@ -79,17 +79,13 @@ public interface EdgeIteratorState
     EdgeIteratorState setFlags( long flags );
 
     /**
-     * @deprecated use ExtendedStorageAccess instead
      * @return the additional field value for this edge
      */
-    @Deprecated
     int getAdditionalField( String storageIdentifier );
 
     /**
-     * @deprecated use ExtendedStorageAccess instead Updates the additional field value for this
      * edge
      */
-    @Deprecated
     EdgeIteratorState setAdditionalField( String storageIdentifier, int value );
 
     public void setReferenceToExtendedStorage( int value );

--- a/core/src/main/java/com/graphhopper/util/EdgeIteratorState.java
+++ b/core/src/main/java/com/graphhopper/util/EdgeIteratorState.java
@@ -84,7 +84,7 @@ public interface EdgeIteratorState
     int getAdditionalField( String storageIdentifier );
 
     /**
-     * edge
+     * Updates the additional field value for this edge
      */
     EdgeIteratorState setAdditionalField( String storageIdentifier, int value );
 

--- a/core/src/main/java/com/graphhopper/util/GHUtility.java
+++ b/core/src/main/java/com/graphhopper/util/GHUtility.java
@@ -455,13 +455,13 @@ public class GHUtility
         }
 
         @Override
-        public int getAdditionalField()
+        public int getAdditionalField(String identifier)
         {
             throw new UnsupportedOperationException("Not supported. Edge is empty.");
         }
 
         @Override
-        public EdgeIteratorState setAdditionalField( int value )
+        public EdgeIteratorState setAdditionalField(String identifier, int value )
         {
             throw new UnsupportedOperationException("Not supported. Edge is empty.");
         }
@@ -480,6 +480,18 @@ public class GHUtility
 
         @Override
         public EdgeSkipIterState setWeight( double weight )
+        {
+            throw new UnsupportedOperationException("Not supported. Edge is empty.");
+        }
+
+        @Override
+        public void setReferenceToExtendedStorage( int value )
+        {
+            throw new UnsupportedOperationException("Not supported. Edge is empty.");
+        }
+
+        @Override
+        public int getReferenceToExtendedStorage()
         {
             throw new UnsupportedOperationException("Not supported. Edge is empty.");
         }

--- a/core/src/main/java/com/graphhopper/util/GHUtility.java
+++ b/core/src/main/java/com/graphhopper/util/GHUtility.java
@@ -231,7 +231,7 @@ public class GHUtility
                 @Override
                 protected boolean goFurther( int nodeId )
                 {
-                    list.set(nodeId, ref.incrementAndGet());                    
+                    list.set(nodeId, ref.incrementAndGet());
                     return super.goFurther(nodeId);
                 }
             }.start(explorer, startNode);
@@ -455,13 +455,13 @@ public class GHUtility
         }
 
         @Override
-        public int getAdditionalField(String identifier)
+        public int getAdditionalField( String identifier )
         {
             throw new UnsupportedOperationException("Not supported. Edge is empty.");
         }
 
         @Override
-        public EdgeIteratorState setAdditionalField(String identifier, int value )
+        public EdgeIteratorState setAdditionalField( String identifier, int value )
         {
             throw new UnsupportedOperationException("Not supported. Edge is empty.");
         }

--- a/core/src/test/java/com/graphhopper/reader/OSMReaderTest.java
+++ b/core/src/test/java/com/graphhopper/reader/OSMReaderTest.java
@@ -523,8 +523,8 @@ public class OSMReaderTest
                 importOrLoad();
         GraphStorage graph = hopper.getGraph();
         assertEquals(15, graph.getNodes());
-        assertTrue(graph.getExtendedStorage() instanceof TurnCostStorage);
-        TurnCostStorage tcStorage = (TurnCostStorage) graph.getExtendedStorage();
+        assertTrue(graph.getExtendedStorage(TurnCostStorage.IDENTIFIER) instanceof TurnCostStorage);
+        TurnCostStorage tcStorage = (TurnCostStorage) graph.getExtendedStorage(TurnCostStorage.IDENTIFIER);
         
         int n2 = AbstractGraphStorageTester.getIdOf(graph, 52, 10);
         int n3 = AbstractGraphStorageTester.getIdOf(graph, 52, 11);

--- a/core/src/test/java/com/graphhopper/routing/EdgeBasedRoutingAlgorithmTest.java
+++ b/core/src/test/java/com/graphhopper/routing/EdgeBasedRoutingAlgorithmTest.java
@@ -141,7 +141,7 @@ public class EdgeBasedRoutingAlgorithmTest
     {
         GraphStorage g = createGraph(createEncodingManager(true));
         initGraph(g);
-        TurnCostStorage tcs = (TurnCostStorage) g.getExtendedStorage();
+        TurnCostStorage tcs = (TurnCostStorage) g.getExtendedStorage(TurnCostStorage.IDENTIFIER);
         initTurnRestrictions(g, tcs, carEncoder);
         Path p = prepareGraph(g, carEncoder, createWeighting(carEncoder, tcs), TraversalMode.EDGE_BASED_2DIR).
                 createAlgo().calcPath(5, 1);
@@ -162,7 +162,7 @@ public class EdgeBasedRoutingAlgorithmTest
     {
         GraphStorage g = createGraph(createEncodingManager(true));
         initGraph(g);
-        TurnCostStorage tcs = (TurnCostStorage) g.getExtendedStorage();
+        TurnCostStorage tcs = (TurnCostStorage) g.getExtendedStorage(TurnCostStorage.IDENTIFIER);
 
         long tflags = carEncoder.getTurnFlags(true, 0);
 
@@ -192,7 +192,7 @@ public class EdgeBasedRoutingAlgorithmTest
     {
         GraphStorage g = createGraph(createEncodingManager(false));
         initGraph(g);
-        TurnCostStorage tcs = (TurnCostStorage) g.getExtendedStorage();
+        TurnCostStorage tcs = (TurnCostStorage) g.getExtendedStorage(TurnCostStorage.IDENTIFIER);
         Path p = prepareGraph(g, carEncoder, createWeighting(carEncoder, tcs), TraversalMode.EDGE_BASED_1DIR).
                 createAlgo().calcPath(5, 1);
 

--- a/core/src/test/java/com/graphhopper/storage/ExtendedStorageManagerTest.java
+++ b/core/src/test/java/com/graphhopper/storage/ExtendedStorageManagerTest.java
@@ -1,0 +1,95 @@
+/*
+ *  Licensed to GraphHopper and Peter Karich under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for 
+ *  additional information regarding copyright ownership.
+ * 
+ *  GraphHopper licenses this file to you under the Apache License, 
+ *  Version 2.0 (the "License"); you may not use this file except in 
+ *  compliance with the License. You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.storage;
+
+import com.graphhopper.routing.util.EncodingManager;
+import java.util.TreeMap;
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+public class ExtendedStorageManagerTest
+{
+    private ExtendedStorageManager manager;
+
+    protected GraphStorage newGraph( Directory dir )
+    {
+        TreeMap extStorages = new TreeMap();
+        extStorages.put(TurnCostStorage.IDENTIFIER, new TurnCostStorage());
+        manager = new ExtendedStorageManager(extStorages);
+        GraphStorage graph = new GraphHopperStorage(dir, new EncodingManager("CAR"), false, manager);
+        graph.create(0);
+        graph.getNodeAccess().setNode(0, 0, 0);
+        graph.getNodeAccess().setNode(1, 1, 4);
+        graph.getNodeAccess().setNode(2, 2, 3);
+        graph.getNodeAccess().setNode(3, 3, 2);
+        graph.getNodeAccess().setNode(4, 4, 1);
+        graph.edge(0, 1, 1, true);
+        graph.edge(1, 2, 1, true);
+        graph.edge(0, 2, 1, true);
+        graph.edge(2, 3, 1, true);
+        graph.edge(3, 4, 1, true);
+
+        return graph;
+    }
+
+    @Test
+    public void testSingleExtendedStorage()
+    {
+        String defaultGraphLoc = "./target/graphstorage/default";
+        Directory dir = new RAMDirectory(defaultGraphLoc, false);
+        GraphStorage graph = newGraph(dir);
+
+        ExtendedStorageAccess access = graph.getExtendedStorageAccess();
+        access.writeToExtendedNodeStorage(TurnCostStorage.IDENTIFIER, 0, 3);
+        access.writeToExtendedNodeStorage(TurnCostStorage.IDENTIFIER, 1, 2);
+        access.writeToExtendedNodeStorage(TurnCostStorage.IDENTIFIER, 2, 1);
+        access.writeToExtendedNodeStorage(TurnCostStorage.IDENTIFIER, 3, 0);
+
+        assertEquals(3, access.readFromExtendedNodeStorage(TurnCostStorage.IDENTIFIER, 0));
+        assertEquals(2, access.readFromExtendedNodeStorage(TurnCostStorage.IDENTIFIER, 1));
+        assertEquals(1, access.readFromExtendedNodeStorage(TurnCostStorage.IDENTIFIER, 2));
+        assertEquals(0, access.readFromExtendedNodeStorage(TurnCostStorage.IDENTIFIER, 3));
+    }
+
+    @Test
+    public void testReloadFromDist()
+    {
+        String defaultGraphLoc = "./target/graphstorage/default";
+        Directory dir = new RAMDirectory(defaultGraphLoc, true);
+        GraphStorage graph = newGraph(dir);
+
+        ExtendedStorageAccess access = graph.getExtendedStorageAccess();
+        access.writeToExtendedNodeStorage(TurnCostStorage.IDENTIFIER, 0, 3);
+        access.writeToExtendedNodeStorage(TurnCostStorage.IDENTIFIER, 1, 2);
+        access.writeToExtendedNodeStorage(TurnCostStorage.IDENTIFIER, 2, 1);
+        access.writeToExtendedNodeStorage(TurnCostStorage.IDENTIFIER, 3, 0);
+
+        graph.flush();
+        graph.close();
+
+        dir = new RAMDirectory(defaultGraphLoc, true);
+        graph = new GraphHopperStorage(dir, new EncodingManager("CAR"), false, manager);
+        graph.loadExisting();
+        access = graph.getExtendedStorageAccess();
+        assertEquals(3, access.readFromExtendedNodeStorage(TurnCostStorage.IDENTIFIER, 0));
+        assertEquals(2, access.readFromExtendedNodeStorage(TurnCostStorage.IDENTIFIER, 1));
+        assertEquals(1, access.readFromExtendedNodeStorage(TurnCostStorage.IDENTIFIER, 2));
+        assertEquals(0, access.readFromExtendedNodeStorage(TurnCostStorage.IDENTIFIER, 3));
+
+    }
+}

--- a/core/src/test/java/com/graphhopper/storage/ExtendedStorageManagerTest.java
+++ b/core/src/test/java/com/graphhopper/storage/ExtendedStorageManagerTest.java
@@ -22,22 +22,106 @@ import java.util.TreeMap;
 import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 
+class DummyExtendedStorage implements ExtendedStorage
+{
+    private String filename;
+    private boolean requiresNode;
+    private boolean requiresEdge;
+
+    public DummyExtendedStorage( String filename, boolean requiresNode, boolean requiresEdge )
+    {
+        this.filename = filename;
+        this.requiresNode = requiresNode;
+        this.requiresEdge = requiresEdge;
+    }
+
+    @Override
+    public boolean isRequireNodeField()
+    {
+        return requiresNode;
+    }
+
+    @Override
+    public boolean isRequireEdgeField()
+    {
+        return requiresEdge;
+    }
+
+    @Override
+    public int getDefaultNodeFieldValue()
+    {
+        return -1;
+    }
+
+    @Override
+    public int getDefaultEdgeFieldValue()
+    {
+        return -1;
+    }
+
+    @Override
+    public void init( GraphStorage graph )
+    {
+    }
+
+    @Override
+    public void create( long initSize )
+    {
+    }
+
+    @Override
+    public boolean loadExisting()
+    {
+        return true;
+    }
+
+    @Override
+    public void setSegmentSize( int bytes )
+    {
+    }
+
+    @Override
+    public void flush( StorableProperties properties )
+    {
+    }
+
+    @Override
+    public void close()
+    {
+    }
+
+    @Override
+    public long getCapacity()
+    {
+        return 0;
+    }
+
+    @Override
+    public ExtendedStorage copyTo( ExtendedStorage extStorage )
+    {
+        return this;
+    }
+}
+
 public class ExtendedStorageManagerTest
 {
     private ExtendedStorageManager manager;
 
-    protected GraphStorage newGraph( Directory dir )
+    protected GraphStorage newGraph( Directory dir, int numStorages )
     {
         TreeMap extStorages = new TreeMap();
-        extStorages.put(TurnCostStorage.IDENTIFIER, new TurnCostStorage());
+        for (int i = 0; i < numStorages; ++i)
+        {
+            extStorages.put(String.valueOf(i), new DummyExtendedStorage(String.valueOf(i), true, true));
+        }
         manager = new ExtendedStorageManager(extStorages);
         GraphStorage graph = new GraphHopperStorage(dir, new EncodingManager("CAR"), false, manager);
         graph.create(0);
         graph.getNodeAccess().setNode(0, 0, 0);
-        graph.getNodeAccess().setNode(1, 1, 4);
-        graph.getNodeAccess().setNode(2, 2, 3);
-        graph.getNodeAccess().setNode(3, 3, 2);
-        graph.getNodeAccess().setNode(4, 4, 1);
+        graph.getNodeAccess().setNode(1, 1, 0);
+        graph.getNodeAccess().setNode(2, 2, 0);
+        graph.getNodeAccess().setNode(3, 3, 0);
+        graph.getNodeAccess().setNode(4, 4, 0);
         graph.edge(0, 1, 1, true);
         graph.edge(1, 2, 1, true);
         graph.edge(0, 2, 1, true);
@@ -52,32 +136,40 @@ public class ExtendedStorageManagerTest
     {
         String defaultGraphLoc = "./target/graphstorage/default";
         Directory dir = new RAMDirectory(defaultGraphLoc, false);
-        GraphStorage graph = newGraph(dir);
+        GraphStorage graph = newGraph(dir, 1);
 
         ExtendedStorageAccess access = graph.getExtendedStorageAccess();
-        access.writeToExtendedNodeStorage(TurnCostStorage.IDENTIFIER, 0, 3);
-        access.writeToExtendedNodeStorage(TurnCostStorage.IDENTIFIER, 1, 2);
-        access.writeToExtendedNodeStorage(TurnCostStorage.IDENTIFIER, 2, 1);
-        access.writeToExtendedNodeStorage(TurnCostStorage.IDENTIFIER, 3, 0);
+        access.writeToExtendedNodeStorage("0", 0, 3);
+        access.writeToExtendedNodeStorage("0", 1, 2);
+        access.writeToExtendedNodeStorage("0", 2, 1);
+        access.writeToExtendedNodeStorage("0", 3, 0);
 
-        assertEquals(3, access.readFromExtendedNodeStorage(TurnCostStorage.IDENTIFIER, 0));
-        assertEquals(2, access.readFromExtendedNodeStorage(TurnCostStorage.IDENTIFIER, 1));
-        assertEquals(1, access.readFromExtendedNodeStorage(TurnCostStorage.IDENTIFIER, 2));
-        assertEquals(0, access.readFromExtendedNodeStorage(TurnCostStorage.IDENTIFIER, 3));
+        access.writeToExtendedEdgeStorage("0", 0, 3);
+        access.writeToExtendedEdgeStorage("0", 1, 2);
+        access.writeToExtendedEdgeStorage("0", 2, 1);
+
+        assertEquals(3, access.readFromExtendedNodeStorage("0", 0));
+        assertEquals(2, access.readFromExtendedNodeStorage("0", 1));
+        assertEquals(1, access.readFromExtendedNodeStorage("0", 2));
+        assertEquals(0, access.readFromExtendedNodeStorage("0", 3));
+
+        assertEquals(3, access.readFromExtendedEdgeStorage("0", 0));
+        assertEquals(2, access.readFromExtendedEdgeStorage("0", 1));
+        assertEquals(1, access.readFromExtendedEdgeStorage("0", 2));
     }
 
     @Test
-    public void testReloadFromDist()
+    public void testReloadFromDisk()
     {
         String defaultGraphLoc = "./target/graphstorage/default";
         Directory dir = new RAMDirectory(defaultGraphLoc, true);
-        GraphStorage graph = newGraph(dir);
+        GraphStorage graph = newGraph(dir, 1);
 
         ExtendedStorageAccess access = graph.getExtendedStorageAccess();
-        access.writeToExtendedNodeStorage(TurnCostStorage.IDENTIFIER, 0, 3);
-        access.writeToExtendedNodeStorage(TurnCostStorage.IDENTIFIER, 1, 2);
-        access.writeToExtendedNodeStorage(TurnCostStorage.IDENTIFIER, 2, 1);
-        access.writeToExtendedNodeStorage(TurnCostStorage.IDENTIFIER, 3, 0);
+        access.writeToExtendedNodeStorage("0", 0, 3);
+        access.writeToExtendedNodeStorage("0", 1, 2);
+        access.writeToExtendedNodeStorage("0", 2, 1);
+        access.writeToExtendedNodeStorage("0", 3, 0);
 
         graph.flush();
         graph.close();
@@ -86,10 +178,102 @@ public class ExtendedStorageManagerTest
         graph = new GraphHopperStorage(dir, new EncodingManager("CAR"), false, manager);
         graph.loadExisting();
         access = graph.getExtendedStorageAccess();
-        assertEquals(3, access.readFromExtendedNodeStorage(TurnCostStorage.IDENTIFIER, 0));
-        assertEquals(2, access.readFromExtendedNodeStorage(TurnCostStorage.IDENTIFIER, 1));
-        assertEquals(1, access.readFromExtendedNodeStorage(TurnCostStorage.IDENTIFIER, 2));
-        assertEquals(0, access.readFromExtendedNodeStorage(TurnCostStorage.IDENTIFIER, 3));
+        assertEquals(3, access.readFromExtendedNodeStorage("0", 0));
+        assertEquals(2, access.readFromExtendedNodeStorage("0", 1));
+        assertEquals(1, access.readFromExtendedNodeStorage("0", 2));
+        assertEquals(0, access.readFromExtendedNodeStorage("0", 3));
+
+    }
+
+    @Test
+    public void testReloadMultipleFromDisk()
+    {
+        String defaultGraphLoc = "./target/graphstorage/default";
+        Directory dir = new RAMDirectory(defaultGraphLoc, true);
+        GraphStorage graph = newGraph(dir, 2);
+
+        ExtendedStorageAccess access = graph.getExtendedStorageAccess();
+        access.writeToExtendedNodeStorage("0", 0, 1);
+        access.writeToExtendedNodeStorage("0", 1, 2);
+        access.writeToExtendedNodeStorage("1", 0, 3);
+        access.writeToExtendedNodeStorage("1", 1, 4);
+
+        access.writeToExtendedEdgeStorage("0", 0, 5);
+        access.writeToExtendedEdgeStorage("0", 1, 6);
+        access.writeToExtendedEdgeStorage("1", 0, 7);
+        access.writeToExtendedEdgeStorage("1", 1, 8);
+
+        graph.flush();
+        graph.close();
+
+        dir = new RAMDirectory(defaultGraphLoc, true);
+        graph = new GraphHopperStorage(dir, new EncodingManager("CAR"), false, manager);
+        graph.loadExisting();
+        access = graph.getExtendedStorageAccess();
+        assertEquals(1, access.readFromExtendedNodeStorage("0", 0));
+        assertEquals(2, access.readFromExtendedNodeStorage("0", 1));
+        assertEquals(3, access.readFromExtendedNodeStorage("1", 0));
+        assertEquals(4, access.readFromExtendedNodeStorage("1", 1));
+
+        assertEquals(5, access.readFromExtendedEdgeStorage("0", 0));
+        assertEquals(6, access.readFromExtendedEdgeStorage("0", 1));
+        assertEquals(7, access.readFromExtendedEdgeStorage("1", 0));
+        assertEquals(8, access.readFromExtendedEdgeStorage("1", 1));
+    }
+
+    @Test
+    public void testWriteMultipleReloadSingleFromDisk()
+    {
+        String defaultGraphLoc = "./target/graphstorage/default";
+        Directory dir = new RAMDirectory(defaultGraphLoc, true);
+        GraphStorage graph = newGraph(dir, 2);
+
+        ExtendedStorageAccess access = graph.getExtendedStorageAccess();
+        access.writeToExtendedNodeStorage("0", 0, 1);
+        access.writeToExtendedNodeStorage("0", 1, 2);
+        access.writeToExtendedNodeStorage("1", 0, 3);
+        access.writeToExtendedNodeStorage("1", 1, 4);
+
+        access.writeToExtendedEdgeStorage("0", 0, 5);
+        access.writeToExtendedEdgeStorage("0", 1, 6);
+        access.writeToExtendedEdgeStorage("1", 0, 7);
+        access.writeToExtendedEdgeStorage("1", 1, 8);
+
+        graph.flush();
+        graph.close();
+
+        // test access with only loading "0"
+        TreeMap extStorages = new TreeMap();
+        extStorages.put("0", new DummyExtendedStorage("0", true, true));
+        manager = new ExtendedStorageManager(extStorages);
+
+        dir = new RAMDirectory(defaultGraphLoc, true);
+        graph = new GraphHopperStorage(dir, new EncodingManager("CAR"), false, manager);
+        graph.loadExisting();
+        access = graph.getExtendedStorageAccess();
+        assertEquals(1, access.readFromExtendedNodeStorage("0", 0));
+        assertEquals(2, access.readFromExtendedNodeStorage("0", 1));
+
+        assertEquals(5, access.readFromExtendedEdgeStorage("0", 0));
+        assertEquals(6, access.readFromExtendedEdgeStorage("0", 1));
+
+        graph.close();
+
+        // test access with only loading "1"
+        extStorages = new TreeMap();
+        extStorages.put("1", new DummyExtendedStorage("1", true, true));
+        manager = new ExtendedStorageManager(extStorages);
+
+        dir = new RAMDirectory(defaultGraphLoc, true);
+        graph = new GraphHopperStorage(dir, new EncodingManager("CAR"), false, manager);
+        graph.loadExisting();
+        access = graph.getExtendedStorageAccess();
+
+        assertEquals(3, access.readFromExtendedNodeStorage("1", 0));
+        assertEquals(4, access.readFromExtendedNodeStorage("1", 1));
+
+        assertEquals(7, access.readFromExtendedEdgeStorage("1", 0));
+        assertEquals(8, access.readFromExtendedEdgeStorage("1", 1));
 
     }
 }

--- a/core/src/test/java/com/graphhopper/storage/ExtendedStorageManagerTest.java
+++ b/core/src/test/java/com/graphhopper/storage/ExtendedStorageManagerTest.java
@@ -24,13 +24,11 @@ import org.junit.Test;
 
 class DummyExtendedStorage implements ExtendedStorage
 {
-    private String filename;
-    private boolean requiresNode;
-    private boolean requiresEdge;
+    private final boolean requiresNode;
+    private final boolean requiresEdge;
 
-    public DummyExtendedStorage( String filename, boolean requiresNode, boolean requiresEdge )
+    public DummyExtendedStorage( boolean requiresNode, boolean requiresEdge )
     {
-        this.filename = filename;
         this.requiresNode = requiresNode;
         this.requiresEdge = requiresEdge;
     }
@@ -112,7 +110,7 @@ public class ExtendedStorageManagerTest
         TreeMap extStorages = new TreeMap();
         for (int i = 0; i < numStorages; ++i)
         {
-            extStorages.put(String.valueOf(i), new DummyExtendedStorage(String.valueOf(i), true, true));
+            extStorages.put(String.valueOf(i), new DummyExtendedStorage(true, true));
         }
         manager = new ExtendedStorageManager(extStorages);
         GraphStorage graph = new GraphHopperStorage(dir, new EncodingManager("CAR"), false, manager);
@@ -244,7 +242,7 @@ public class ExtendedStorageManagerTest
 
         // test access with only loading "0"
         TreeMap extStorages = new TreeMap();
-        extStorages.put("0", new DummyExtendedStorage("0", true, true));
+        extStorages.put("0", new DummyExtendedStorage(true, true));
         manager = new ExtendedStorageManager(extStorages);
 
         dir = new RAMDirectory(defaultGraphLoc, true);
@@ -261,7 +259,7 @@ public class ExtendedStorageManagerTest
 
         // test access with only loading "1"
         extStorages = new TreeMap();
-        extStorages.put("1", new DummyExtendedStorage("1", true, true));
+        extStorages.put("1", new DummyExtendedStorage(true, true));
         manager = new ExtendedStorageManager(extStorages);
 
         dir = new RAMDirectory(defaultGraphLoc, true);
@@ -274,6 +272,5 @@ public class ExtendedStorageManagerTest
 
         assertEquals(7, access.readFromExtendedEdgeStorage("1", 0));
         assertEquals(8, access.readFromExtendedEdgeStorage("1", 1));
-
     }
 }


### PR DESCRIPTION
Hi,
This introduces an ExtendedStorageManager, which, by itself, is also an ExtendedStorage and can handle an arbitrary amount of sub-storages.
In addition it introduces an ExtendedStorageAccess (similar to NodeAccess) interface (and implementation).
To save space in common situation, during graph creation, one can specify either
a) a normal ExtendedStorage, in this case, it will mainly matche the old behaviour of storing ints directly in the graph or
b) an ExtendedStorageManager. In this case, the in-graph-extended-storage will point to the ExtendedStorageManager, which will then contain the ints.

It is possible to only use a subset of the ExtendedStorages that were provided during Graph creation. The ExtendedStorageManager will then figure out what to do, with the help of some properties that were written to the "properties" file.

The GHExtendedStorageAccess is able to correctly determine if it is working on a normal ExtendedStorage object or if it is working on an ExtendedStorageManager and will act accordingly.

A couple of tests were added to make sure that the ExtendedStorageManager and Access class work as intended.