### PR TITLE
Maven version updated to 3.2.5

### DIFF
--- a/graphhopper.sh
+++ b/graphhopper.sh
@@ -70,8 +70,8 @@ function ensureMaven {
       if [ ! -f "$MAVEN_HOME/bin/mvn" ]; then
         echo "No Maven found in the PATH. Now downloading+installing it to $MAVEN_HOME"
         cd "$GH_HOME"
-        MVN_PACKAGE=apache-maven-3.2.3
-        wget -O maven.zip http://www.eu.apache.org/dist/maven/maven-3/3.2.3/binaries/$MVN_PACKAGE-bin.zip
+        MVN_PACKAGE=apache-maven-3.2.5
+        wget -O maven.zip http://www.eu.apache.org/dist/maven/maven-3/3.2.5/binaries/$MVN_PACKAGE-bin.zip
         unzip maven.zip
         mv $MVN_PACKAGE maven
         rm maven.zip


### PR DESCRIPTION
I just changed the the version of maven to 3.2.5 as 3.2.3 is no longer available und the listed address. If 3.2.3 is required amother host should be selected.