### PR TITLE
fastest weight calculation should return seconds

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/FastestWeighting.java
+++ b/core/src/main/java/com/graphhopper/routing/util/FastestWeighting.java
@@ -53,7 +53,7 @@ public class FastestWeighting implements Weighting
         double speed = reverse ? encoder.getReverseSpeed(edge.getFlags()) : encoder.getSpeed(edge.getFlags());
         if (speed == 0)
             return Double.POSITIVE_INFINITY;
-        return edge.getDistance() / (speed * SPEED_CONV);
+        return edge.getDistance() / speed * SPEED_CONV;
     }
 
     @Override


### PR DESCRIPTION
it's just a small issue.
The speed is in KPH. the distance is meter.
weight should be in seconds.

Ah... almost all the tests failed.