### PR TITLE
Incorporate filter search into the finding of the closest node search.

### DIFF
--- a/core/src/main/java/com/graphhopper/storage/index/LocationIndexTree.java
+++ b/core/src/main/java/com/graphhopper/storage/index/LocationIndexTree.java
@@ -849,8 +849,6 @@ public class LocationIndexTree implements LocationIndex
                 new XFirstSearchCheck(queryLat, queryLon, checkBitset, edgeFilter)
                 {
                     @Override
-                    @Override
-                    @Override
                     protected double getQueryDistance()
                     {
                         return closestMatch.getQueryDistance();


### PR DESCRIPTION
The problem is as I discussed about the filtering. It's not a question of does the expanded search find a node or not, it's does the expanded search find a node that passes my filter. Inside of findClosest the findNetworkEntries returns a set of node ids, then we loop through these nodes using the edge explorer and the supplied filter. The basic search does not find a node that passes my filter so findClosest returns a "null" QueryResult. If I try and expand the search further I still don't find my node because no matter what value of maxRegionSearch, findNetworkEntries returns the first set of nodes that it finds but I already know those don't pass my filter, so once again they don't pass my filter and I get a "null" result. 

I've added the boolean to allow the filtering of the edges to be built into the search mechanism. I only added it to maintain backwards compatibility. I honestly don't see why this is not just done automatically.
