### PR TITLE
Tuning for bicycles classifications for the sac_scale tag:

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
@@ -257,6 +257,9 @@ public class BikeCommonFlagEncoder extends AbstractFlagEncoder
         String sacScale = way.getTag("sac_scale");
         if (sacScale != null)
         {
+            if ( (way.hasTag("highway", "cycleway")) &&
+                 (way.hasTag("sac_scale", "hiking")) )
+                return 1;  // This combination is fine with every kind of bike, including a racingbike
             if (!allowedSacScale(sacScale))
                 return 0;
         }
@@ -265,8 +268,8 @@ public class BikeCommonFlagEncoder extends AbstractFlagEncoder
 
     boolean allowedSacScale( String sacScale )
     {
-        // other scales are nearly impossible by bike, see http://wiki.openstreetmap.org/wiki/Key:sac_scale
-        return "hiking".equals(sacScale) || "mountain_hiking".equals(sacScale);
+        // other scales are nearly impossible by an ordinary bike, see http://wiki.openstreetmap.org/wiki/Key:sac_scale
+        return "hiking".equals(sacScale);
     }
 
     @Override

--- a/core/src/test/java/com/graphhopper/routing/util/BikeFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/BikeFlagEncoderTest.java
@@ -221,6 +221,31 @@ public class BikeFlagEncoderTest extends AbstractBikeFlagEncoderTester
         long relFlags = encoder.handleRelationTags(osmRel, 0);
         assertPriority(REACH_DEST.getValue(), osmWay, relFlags);
     }
+    
+    @Test
+    public void testSacScale()
+    {
+        OSMWay way = new OSMWay(1);
+        way.setTag("highway", "path");
+        way.setTag("sac_scale", "hiking");
+        // allow
+        assertEquals(1, encoder.acceptWay(way));
+        
+        way.setTag("highway", "path");
+        way.setTag("sac_scale", "mountain_hiking");
+        // disallow
+        assertEquals(0, encoder.acceptWay(way));
+        
+        way.setTag("highway", "cycleway");
+        way.setTag("sac_scale", "hiking");
+        // allow
+        assertTrue(encoder.acceptWay(way) > 0);
+
+        way.setTag("highway", "cycleway");
+        way.setTag("sac_scale", "mountain_hiking");
+        // disallow
+        assertEquals(0, encoder.acceptWay(way));
+    }
 
     @Test
     public void testCalcPriority()

--- a/core/src/test/java/com/graphhopper/routing/util/RacingBikeFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/RacingBikeFlagEncoderTest.java
@@ -74,8 +74,24 @@ public class RacingBikeFlagEncoderTest extends AbstractBikeFlagEncoderTester
     {
         OSMWay way = new OSMWay(1);
         way.setTag("highway", "service");
+        way.setTag("sac_scale", "mountain_hiking");
+        // disallow
+        assertEquals(0, encoder.acceptWay(way));
+        
+        way.setTag("highway", "path");
         way.setTag("sac_scale", "hiking");
         // disallow
+        assertEquals(0, encoder.acceptWay(way));
+        
+        way.setTag("highway", "cycleway");
+        way.setTag("sac_scale", "hiking");
+        // but allow this as there is no reason for not allowing it
+        assertTrue(encoder.acceptWay(way) > 0);
+
+        // This looks to be tagging error:
+        way.setTag("highway", "cycleway");
+        way.setTag("sac_scale", "mountain_hiking");
+        // we are coutious and disallow this
         assertEquals(0, encoder.acceptWay(way));
     }
 


### PR DESCRIPTION
Allow highway=cycleway and sac_scale=hiking for every kind of bike.
Disallow sac_scale=mountain_hiking for every bike except for MTB.
Allow highway=* and sac_scale=hiking for every kind of bike, except for the racebike.