### PR TITLE
Android Maven: compiler compliance level 1.7

### DIFF
--- a/android/app/pom.xml
+++ b/android/app/pom.xml
@@ -113,15 +113,14 @@
         <finalName>${project.artifactId}</finalName>        
         
         <plugins>     
-            <!-- android (apache harmony) is nearly java but not really 1.6 -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <!-- <compilerArgument>-Xlint:unchecked</compilerArgument>
                     -->
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>       
             <plugin>


### PR DESCRIPTION
Advance the compiler compliance level for the Android to the max permitted 1.7.
That way we'll be able to use any Java 7 language features, if needed.