### PR TITLE
Make tan calculation in AngleCalc more precise

### DIFF
--- a/core/src/main/java/com/graphhopper/util/AngleCalc.java
+++ b/core/src/main/java/com/graphhopper/util/AngleCalc.java
@@ -58,7 +58,8 @@ public class AngleCalc
      */
     public double calcOrientation( double lat1, double lon1, double lat2, double lon2 )
     {
-        return atan2((lat2 - lat1), (lon2 - lon1));
+        double factor = Math.cos((lat1 + lat2) * Math.PI / 360);
+        return atan2((lat2 - lat1), factor * (lon2 - lon1));
     }
 
     /**


### PR DESCRIPTION
Previous one is not correct for high lat area.
This one is correct.

Actually it's a Azimuth.
There is a very complex version in geotools, which we don't really need it.