### PR TITLE
GPX: fix timestamp representation

### DIFF
--- a/core/src/main/java/com/graphhopper/util/InstructionList.java
+++ b/core/src/main/java/com/graphhopper/util/InstructionList.java
@@ -18,7 +18,6 @@
 package com.graphhopper.util;
 
 import java.text.SimpleDateFormat;
-
 import java.util.*;
 
 /**
@@ -168,7 +167,7 @@ public class InstructionList implements Iterable<Instruction>
      */
     public String createGPX()
     {
-        return createGPX("GraphHopper", 0);
+        return createGPX("GraphHopper", new Date().getTime());
     }
 
     public String createGPX( String trackName, long startTimeMillis )

--- a/core/src/main/java/com/graphhopper/util/InstructionList.java
+++ b/core/src/main/java/com/graphhopper/util/InstructionList.java
@@ -179,7 +179,7 @@ public class InstructionList implements Iterable<Instruction>
 
     public String createGPX( String trackName, long startTimeMillis, String timeZoneId, boolean includeElevation )
     {
-        SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
+        SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
         TimeZone tz = TimeZone.getDefault();
         if (!Helper.isEmpty(timeZoneId))
             tz = TimeZone.getTimeZone(timeZoneId);
@@ -196,7 +196,7 @@ public class InstructionList implements Iterable<Instruction>
                 + "<link href='http://graphhopper.com'>"
                 + "<text>GraphHopper GPX</text>"
                 + "</link>"
-                + "<time>" + tzHack(formatter.format(startTimeMillis)) + "</time>"
+                + "<time>" + formatter.format(startTimeMillis) + "</time>"
                 + "</metadata>";
         StringBuilder track = new StringBuilder(header);
         if (!isEmpty())
@@ -223,7 +223,7 @@ public class InstructionList implements Iterable<Instruction>
             track.append("' lon='").append(Helper.round6(entry.getLon())).append("'>");
             if (includeElevation)
                 track.append("<ele>").append(Helper.round2(entry.getEle())).append("</ele>");
-            track.append("<time>").append(tzHack(formatter.format(startTimeMillis + entry.getMillis()))).append("</time>");
+            track.append("<time>").append(formatter.format(startTimeMillis + entry.getMillis())).append("</time>");
             track.append("</trkpt>");
         }
         track.append("</trkseg>");
@@ -232,14 +232,6 @@ public class InstructionList implements Iterable<Instruction>
         // we could now use 'wpt' for via points
         track.append("</gpx>");
         return track.toString().replaceAll("\\'", "\"");
-    }
-
-    /**
-     * Hack to form valid timezone ala +01:00 instead +0100
-     */
-    private static String tzHack( String str )
-    {
-        return str.substring(0, str.length() - 2) + ":" + str.substring(str.length() - 2);
     }
 
     private void createRteptBlock( StringBuilder output, Instruction instruction, Instruction nextI )

--- a/core/src/main/java/com/graphhopper/util/InstructionList.java
+++ b/core/src/main/java/com/graphhopper/util/InstructionList.java
@@ -168,23 +168,20 @@ public class InstructionList implements Iterable<Instruction>
      */
     public String createGPX()
     {
-        return createGPX("GraphHopper", 0, "GMT");
+        return createGPX("GraphHopper", 0);
     }
 
-    public String createGPX( String trackName, long startTimeMillis, String timeZoneId )
+    public String createGPX( String trackName, long startTimeMillis )
     {
         boolean includeElevation = getSize() > 0 ? get(0).getPoints().is3D() : false;
-        return createGPX(trackName, startTimeMillis, timeZoneId, includeElevation);
+        return createGPX(trackName, startTimeMillis, includeElevation);
     }
 
-    public String createGPX( String trackName, long startTimeMillis, String timeZoneId, boolean includeElevation )
+    public String createGPX( String trackName, long startTimeMillis, boolean includeElevation )
     {
         SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
-        TimeZone tz = TimeZone.getDefault();
-        if (!Helper.isEmpty(timeZoneId))
-            tz = TimeZone.getTimeZone(timeZoneId);
+        formatter.setTimeZone(TimeZone.getTimeZone("UTC"));
 
-        formatter.setTimeZone(tz);
         String header = "<?xml version='1.0' encoding='UTF-8' standalone='no' ?>"
                 + "<gpx xmlns='http://www.topografix.com/GPX/1/1' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'"
                 + " creator='Graphhopper' version='1.1'"

--- a/core/src/test/java/com/graphhopper/util/InstructionListTest.java
+++ b/core/src/test/java/com/graphhopper/util/InstructionListTest.java
@@ -327,7 +327,7 @@ public class InstructionListTest
         assertEquals(15.2, wayList.get(3).getFirstLat(), 1e-3);
         assertEquals(9.9, wayList.get(3).getFirstLon(), 1e-3);
 
-        String gpxStr = wayList.createGPX("test", 0, "GMT");
+        String gpxStr = wayList.createGPX("test", 0);
         verifyGPX(gpxStr);
 
         assertTrue(gpxStr, gpxStr.contains("<trkpt lat=\"15.0\" lon=\"10.0\"><time>1970-01-01T00:00:00Z</time>"));
@@ -407,7 +407,7 @@ public class InstructionListTest
                 return fakeList;
             }
         };
-        String gpxStr = il.createGPX("test", 0, "GMT");
+        String gpxStr = il.createGPX("test", 0);
         verifyGPX(gpxStr);
         assertFalse(gpxStr, gpxStr.contains("NaN"));
         assertFalse(gpxStr, gpxStr.contains("<ele>"));
@@ -415,7 +415,7 @@ public class InstructionListTest
         fakeList.clear();
         fakeList.add(new GPXEntry(12, 13, 11, 0));
         fakeList.add(new GPXEntry(12.5, 13, 10, 1000));
-        gpxStr = il.createGPX("test", 0, "GMT", true);
+        gpxStr = il.createGPX("test", 0, true);
 
         assertTrue(gpxStr, gpxStr.contains("<ele>11.0</ele>"));
         assertFalse(gpxStr, gpxStr.contains("NaN"));

--- a/core/src/test/java/com/graphhopper/util/InstructionListTest.java
+++ b/core/src/test/java/com/graphhopper/util/InstructionListTest.java
@@ -327,10 +327,10 @@ public class InstructionListTest
         assertEquals(15.2, wayList.get(3).getFirstLat(), 1e-3);
         assertEquals(9.9, wayList.get(3).getFirstLon(), 1e-3);
 
-        String gpxStr = wayList.createGPX("test", 0, "GMT+1");
+        String gpxStr = wayList.createGPX("test", 0, "GMT");
         verifyGPX(gpxStr);
 
-        assertTrue(gpxStr, gpxStr.contains("<trkpt lat=\"15.0\" lon=\"10.0\"><time>1970-01-01T01:00:00+01:00</time>"));
+        assertTrue(gpxStr, gpxStr.contains("<trkpt lat=\"15.0\" lon=\"10.0\"><time>1970-01-01T00:00:00Z</time>"));
         assertTrue(gpxStr, gpxStr.contains("<extensions>") && gpxStr.contains("</extensions>"));
         assertTrue(gpxStr, gpxStr.contains("<rtept lat=\"15.1\" lon=\"10.0\">"));
         assertTrue(gpxStr, gpxStr.contains("<gh:distance>8000.0</gh:distance>"));

--- a/web/src/main/java/com/graphhopper/http/GraphHopperServlet.java
+++ b/web/src/main/java/com/graphhopper/http/GraphHopperServlet.java
@@ -140,12 +140,11 @@ public class GraphHopperServlet extends GHBaseServlet
         res.setContentType("application/xml");
         String trackName = getParam(req, "track", "GraphHopper Track");
         res.setHeader("Content-Disposition", "attachment;filename=" + "GraphHopper.gpx");
-        String timeZone = getParam(req, "timezone", "GMT");
         long time = getLongParam(req, "millis", System.currentTimeMillis());
         if (rsp.hasErrors())
             return errorsToXML(rsp.getErrors());
         else
-            return rsp.getInstructions().createGPX(trackName, time, timeZone, includeElevation);
+            return rsp.getInstructions().createGPX(trackName, time, includeElevation);
     }
 
     String errorsToXML( List<Throwable> list ) throws Exception


### PR DESCRIPTION
Peter I think that in GPX the timestamps should be in UTC with ISO 8601 representation and end with the 'Z' suffix.
http://www.topografix.com/gpx_manual.asp#time

And to conform with spec, probably it's not necessary to provide the timezone as parameter to the createGPX method.