### PR TITLE
DijkstraOneToMany - isWeightLimitReached

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/DijkstraOneToMany.java
+++ b/core/src/main/java/com/graphhopper/routing/DijkstraOneToMany.java
@@ -205,7 +205,7 @@ public class DijkstraOneToMany extends AbstractRoutingAlgorithm
 
     protected boolean isWeightLimitReached()
     {
-        return weights[currNode] >= weightLimit;
+        return weights[currNode] > weightLimit;
     }
 
     public void close()

--- a/core/src/test/java/com/graphhopper/routing/ch/PrepareContractionHierarchiesTest.java
+++ b/core/src/test/java/com/graphhopper/routing/ch/PrepareContractionHierarchiesTest.java
@@ -534,6 +534,54 @@ public class PrepareContractionHierarchiesTest
         return g;
     }
 
+
+    public static LevelGraph initShortcutsGraph2( LevelGraph g)
+    {
+        //      0----1
+        //     /     |
+        //    7--    |
+        //   /   |   |
+        //   6---5   |
+        //   |   |   |
+        //   4---3---2
+
+        g.edge(0, 1, 1, true);
+        g.edge(1, 2, 1, true);
+
+        g.edge(3, 2, 1, true);
+        g.edge(3, 5, 1, true);
+        g.edge(5, 7, 1, true);
+        g.edge(3, 4, 1, true);
+        g.edge(4, 6, 1, true);
+        g.edge(6, 7, 1, true);
+        g.edge(6, 5, 1, true);
+        g.edge(0, 7, 1, true);
+        return g;
+    }
+
+    @Test
+    public void testLimitWeightBug()
+    {
+        LevelGraphStorage g = (LevelGraphStorage) createGraph();
+        initShortcutsGraph2(g);
+        DijkstraOneToMany prepareAlgo = new DijkstraOneToMany(g, carEncoder, weighting, tMode);
+        prepareAlgo.setEdgeFilter(new PrepareContractionHierarchies.IgnoreNodeFilter(g, g.getNodes() + 1).setAvoidNode(2));
+
+        PrepareContractionHierarchies prepare = new PrepareContractionHierarchies(g, carEncoder, weighting, tMode);
+        prepare.initFromGraph().prepareNodes();
+        prepareAlgo.setWeightLimit(3);
+
+        int endNode = prepareAlgo.findEndNode(0, 4);
+        assertEquals(4, endNode);
+        assertEquals(3.0, prepareAlgo.getWeight(4), 1e-6);
+
+        prepareAlgo.clear();
+
+        endNode = prepareAlgo.findEndNode(0, 3);
+        assertEquals(3, endNode);
+        assertEquals(3.0, prepareAlgo.getWeight(3), 1e-6);
+    }
+
 //    public static void printEdges(LevelGraph g) {
 //        RawEdgeIterator iter = g.getAllEdges();
 //        while (iter.next()) {


### PR DESCRIPTION
Hi, i found this algo may return NOT_FOUND in case, where desired node is presented in heap and we reached earlier other node with same weight as desired and its weight equals to limit. Also this fix affects other 2 preparation tests.