### PR TITLE
Added nearest API to snap point to road

### DIFF
--- a/web/src/main/java/com/graphhopper/http/GHServletModule.java
+++ b/web/src/main/java/com/graphhopper/http/GHServletModule.java
@@ -64,5 +64,8 @@ public class GHServletModule extends ServletModule
 
         serve("/route*").with(GraphHopperServlet.class);
         bind(GraphHopperServlet.class).in(Singleton.class);
+        
+        serve("/nearest*").with(NearestServlet.class);
+        bind(NearestServlet.class).in(Singleton.class);
     }
 }

--- a/web/src/main/java/com/graphhopper/http/NearestServlet.java
+++ b/web/src/main/java/com/graphhopper/http/NearestServlet.java
@@ -61,6 +61,7 @@ public class NearestServlet extends GHBaseServlet
     void writeNearest( HttpServletRequest req, HttpServletResponse res ) throws Exception
     {
         String pointStr = getParam(req, "point", null);
+        boolean enableElevation = getBooleanParam(req, "elevation", false);
         
         JSONObject result = new JSONObject();
         if (pointStr != null && !pointStr.equalsIgnoreCase("")) {
@@ -82,6 +83,10 @@ public class NearestServlet extends GHBaseServlet
                 JSONArray coord = new JSONArray();
                 coord.put(snappedPoint.lon);
                 coord.put(snappedPoint.lat);
+                
+                if (hopper.hasElevation() && enableElevation) {
+                    coord.put(snappedPoint.ele);
+                }
 
                 result.put("coordinates", coord);
                 

--- a/web/src/main/java/com/graphhopper/http/NearestServlet.java
+++ b/web/src/main/java/com/graphhopper/http/NearestServlet.java
@@ -1,0 +1,98 @@
+/*
+ *  Licensed to GraphHopper and Peter Karich under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for 
+ *  additional information regarding copyright ownership.
+ * 
+ *  GraphHopper licenses this file to you under the Apache License, 
+ *  Version 2.0 (the "License"); you may not use this file except in 
+ *  compliance with the License. You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.http;
+
+import com.graphhopper.GraphHopper;
+import com.graphhopper.routing.util.EdgeFilter;
+import com.graphhopper.storage.index.LocationIndex;
+import com.graphhopper.storage.index.QueryResult;
+import com.graphhopper.util.DistanceCalcEarth;
+import com.graphhopper.util.shapes.GHPoint;
+import com.graphhopper.util.shapes.GHPoint3D;
+import java.io.IOException;
+import javax.inject.Inject;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static javax.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+/**
+ * @author svantulden
+ */
+public class NearestServlet extends GHBaseServlet
+{
+    @Inject
+    private GraphHopper hopper;
+
+    @Override
+    public void doGet( HttpServletRequest req, HttpServletResponse res ) throws ServletException, IOException
+    {
+        try
+        {
+            writeNearest(req, res);
+        } catch (IllegalArgumentException ex)
+        {
+            writeError(res, SC_BAD_REQUEST, ex.getMessage());
+        } catch (Exception ex)
+        {
+            logger.error("Error while executing request: " + req.getQueryString(), ex);
+            writeError(res, SC_INTERNAL_SERVER_ERROR, "Problem occured:" + ex.getMessage());
+        }
+    }
+
+    void writeNearest( HttpServletRequest req, HttpServletResponse res ) throws Exception
+    {
+        String pointStr = getParam(req, "point", null);
+        
+        JSONObject result = new JSONObject();
+        if (pointStr != null && !pointStr.equalsIgnoreCase("")) {
+            GHPoint place = GHPoint.parse(pointStr);
+            
+            LocationIndex index = hopper.getLocationIndex();
+            QueryResult qr = index.findClosest( place.lat, place.lon, EdgeFilter.ALL_EDGES );
+            
+            GHPoint3D snappedPoint = null;
+            try {
+                snappedPoint = qr.getSnappedPoint();
+            } catch (IllegalStateException ex) {
+                result.put("error", "Nearest point cannot be found!");
+            }
+            
+            if (snappedPoint != null) {
+                JSONArray coord = new JSONArray();
+                coord.put(snappedPoint.lat);
+                coord.put(snappedPoint.lon);
+
+                result.put("point", coord);
+                
+                DistanceCalcEarth calc = new DistanceCalcEarth();
+                double distance = calc.calcDist(place.lat, place.lon, snappedPoint.lat, snappedPoint.lon);
+                
+                // Distance from input to snapped point in meters
+                result.put("distance", distance);
+            }
+        } else {
+            result.put("error", "No lat/lon specified!");
+        }  
+        
+        writeJson(req, res, result);
+    }
+}

--- a/web/src/main/java/com/graphhopper/http/NearestServlet.java
+++ b/web/src/main/java/com/graphhopper/http/NearestServlet.java
@@ -77,11 +77,13 @@ public class NearestServlet extends GHBaseServlet
             }
             
             if (snappedPoint != null) {
+                result.put("type", "Point");
+                
                 JSONArray coord = new JSONArray();
-                coord.put(snappedPoint.lat);
                 coord.put(snappedPoint.lon);
+                coord.put(snappedPoint.lat);
 
-                result.put("point", coord);
+                result.put("coordinates", coord);
                 
                 DistanceCalcEarth calc = new DistanceCalcEarth();
                 double distance = calc.calcDist(place.lat, place.lon, snappedPoint.lat, snappedPoint.lon);

--- a/web/src/test/java/com/graphhopper/http/BaseServletTester.java
+++ b/web/src/test/java/com/graphhopper/http/BaseServletTester.java
@@ -95,12 +95,18 @@ public class BaseServletTester
         server = null;
     }
 
-    protected String getTestAPIUrl()
+    protected String getTestRouteAPIUrl()
     {
         String host = "localhost";
         return "http://" + host + ":" + port + "/route";
     }
-
+    
+    protected String getTestNearestAPIUrl()
+    {
+        String host = "localhost";
+        return "http://" + host + ":" + port + "/nearest";
+    }
+    
     protected JSONObject query( String query ) throws Exception
     {
         String resQuery = "";
@@ -114,8 +120,26 @@ public class BaseServletTester
 
             resQuery += "&";
         }
-        String url = getTestAPIUrl() + "?" + resQuery;
+        String url = getTestRouteAPIUrl() + "?" + resQuery;
         Downloader downloader = new Downloader("web integration tester");
         return new JSONObject(downloader.downloadAsString(url));
-    }    
+    } 
+    
+    protected JSONObject nearestQuery( String query ) throws Exception
+    {
+        String resQuery = "";
+        for (String q : query.split("\\&"))
+        {
+            int index = q.indexOf("=");
+            if (index > 0)
+                resQuery += q.substring(0, index + 1) + WebHelper.encodeURL(q.substring(index + 1));
+            else
+                resQuery += WebHelper.encodeURL(q);
+
+            resQuery += "&";
+        }
+        String url = getTestNearestAPIUrl() + "?" + resQuery;
+        Downloader downloader = new Downloader("web integration tester");
+        return new JSONObject(downloader.downloadAsString(url));
+    } 
 }

--- a/web/src/test/java/com/graphhopper/http/GraphHopperServletIT.java
+++ b/web/src/test/java/com/graphhopper/http/GraphHopperServletIT.java
@@ -89,7 +89,7 @@ public class GraphHopperServletIT extends BaseServletTester
     public void testGraphHopperWeb() throws Exception
     {
         GraphHopperAPI hopper = new GraphHopperWeb();
-        assertTrue(hopper.load(getTestAPIUrl()));
+        assertTrue(hopper.load(getTestRouteAPIUrl()));
         GHResponse rsp = hopper.route(new GHRequest(42.554851, 1.536198, 42.510071, 1.548128));
         assertTrue(rsp.getErrors().toString(), rsp.getErrors().isEmpty());
         assertTrue("distance wasn't correct:" + rsp.getDistance(), rsp.getDistance() > 9000);
@@ -116,7 +116,7 @@ public class GraphHopperServletIT extends BaseServletTester
         Throwable ex;
 
         GraphHopperAPI hopper = new GraphHopperWeb();
-        assertTrue(hopper.load(getTestAPIUrl()));
+        assertTrue(hopper.load(getTestRouteAPIUrl()));
 
         // IllegalStateException (Wrong Request)
         rsp = hopper.route(new GHRequest());

--- a/web/src/test/java/com/graphhopper/http/NearestServletIT.java
+++ b/web/src/test/java/com/graphhopper/http/NearestServletIT.java
@@ -1,0 +1,72 @@
+/*
+ *  Licensed to GraphHopper and Peter Karich under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for 
+ *  additional information regarding copyright ownership.
+ * 
+ *  GraphHopper licenses this file to you under the Apache License, 
+ *  Version 2.0 (the "License"); you may not use this file except in 
+ *  compliance with the License. You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.http;
+
+import com.graphhopper.GHRequest;
+import com.graphhopper.GHResponse;
+import com.graphhopper.GraphHopperAPI;
+import static com.graphhopper.http.BaseServletTester.shutdownJetty;
+import com.graphhopper.util.CmdArgs;
+import com.graphhopper.util.Helper;
+import com.graphhopper.util.shapes.GHPoint;
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ * @author svantulden
+ */
+public class NearestServletIT extends BaseServletTester
+{
+    private static final String dir = "./target/andorra-gh/";
+
+    @AfterClass
+    public static void cleanUp()
+    {
+        Helper.removeDir(new File(dir));
+        shutdownJetty(true);
+    }
+
+    @Before
+    public void setUp()
+    {
+        CmdArgs args = new CmdArgs().
+                put("config", "../config-example.properties").
+                put("osmreader.osm", "../core/files/andorra.osm.pbf").
+                put("graph.location", dir);
+        setUpJetty(args);
+    }
+
+    @Test
+    public void testBasicNearestQuery() throws Exception
+    {
+        JSONObject json = nearestQuery("point=42.554851,1.536198");
+        assertFalse(json.has("error"));
+        JSONArray point = json.getJSONArray("point");
+        assertTrue("returned point is not 2D: " + point, point.length() == 2);
+        double lat = point.getDouble(0);
+        double lon = point.getDouble(1);
+        assertTrue("nearest point wasn't correct: lat=" + lat + ", lon=" + lon, lat == 42.55483907636756 && lon == 1.5363742288086868);
+    }
+}

--- a/web/src/test/java/com/graphhopper/http/NearestServletIT.java
+++ b/web/src/test/java/com/graphhopper/http/NearestServletIT.java
@@ -17,16 +17,10 @@
  */
 package com.graphhopper.http;
 
-import com.graphhopper.GHRequest;
-import com.graphhopper.GHResponse;
-import com.graphhopper.GraphHopperAPI;
 import static com.graphhopper.http.BaseServletTester.shutdownJetty;
 import com.graphhopper.util.CmdArgs;
 import com.graphhopper.util.Helper;
-import com.graphhopper.util.shapes.GHPoint;
 import java.io.File;
-import java.util.List;
-import java.util.Map;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.AfterClass;
@@ -63,10 +57,10 @@ public class NearestServletIT extends BaseServletTester
     {
         JSONObject json = nearestQuery("point=42.554851,1.536198");
         assertFalse(json.has("error"));
-        JSONArray point = json.getJSONArray("point");
+        JSONArray point = json.getJSONArray("coordinates");
         assertTrue("returned point is not 2D: " + point, point.length() == 2);
-        double lat = point.getDouble(0);
-        double lon = point.getDouble(1);
+        double lon = point.getDouble(0);
+        double lat = point.getDouble(1);
         assertTrue("nearest point wasn't correct: lat=" + lat + ", lon=" + lon, lat == 42.55483907636756 && lon == 1.5363742288086868);
     }
 }

--- a/web/src/test/java/com/graphhopper/http/NearestServletWithEleIT.java
+++ b/web/src/test/java/com/graphhopper/http/NearestServletWithEleIT.java
@@ -1,0 +1,91 @@
+/*
+ *  Licensed to GraphHopper and Peter Karich under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for 
+ *  additional information regarding copyright ownership.
+ * 
+ *  GraphHopper licenses this file to you under the Apache License, 
+ *  Version 2.0 (the "License"); you may not use this file except in 
+ *  compliance with the License. You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.http;
+
+import static com.graphhopper.http.BaseServletTester.shutdownJetty;
+import com.graphhopper.util.CmdArgs;
+import com.graphhopper.util.Helper;
+import java.io.File;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ * @author svantulden
+ */
+public class NearestServletWithEleIT extends BaseServletTester
+{
+    private static final String dir = "./target/monaco-gh/";
+
+    @AfterClass
+    public static void cleanUp()
+    {
+        Helper.removeDir(new File(dir));
+        shutdownJetty(true);
+    }
+
+    @Before
+    public void setUp()
+    {
+        CmdArgs args = new CmdArgs().
+                put("graph.elevation.provider", "srtm").
+                put("graph.elevation.cachedir", "../core/files/").
+                put("prepare.chWeighting", "no").
+                put("config", "../config-example.properties").
+                put("osmreader.osm", "../core/files/monaco.osm.gz").
+                put("graph.location", dir);
+        setUpJetty(args);
+    }
+
+    @Test
+    public void testWithEleQuery() throws Exception
+    {
+        JSONObject json = nearestQuery("point=43.730864,7.420771&elevation=true");
+        assertFalse(json.has("error"));
+        JSONArray point = json.getJSONArray("coordinates");
+        assertTrue("returned point is not 3D: " + point, point.length() == 3);
+        double lon = point.getDouble(0);
+        double lat = point.getDouble(1);
+        double ele = point.getDouble(2);
+        assertTrue("nearest point wasn't correct: lat=" + lat + ", lon=" + lon + ", ele=" + ele, lat == 43.73070006215647 && lon == 7.421392181993846 && ele == 66.0);
+    }
+    
+    @Test
+    public void testWithoutEleQuery() throws Exception
+    {
+        JSONObject json = nearestQuery("point=43.730864,7.420771&elevation=false");
+        assertFalse(json.has("error"));
+        JSONArray point = json.getJSONArray("coordinates");
+        assertTrue("returned point is not 2D: " + point, point.length() == 2);
+        double lon = point.getDouble(0);
+        double lat = point.getDouble(1);
+        assertTrue("nearest point wasn't correct: lat=" + lat + ", lon=" + lon, lat == 43.73070006215647 && lon == 7.421392181993846);
+        
+        // Default elevation is false        
+        json = nearestQuery("point=43.730864,7.420771");
+        assertFalse(json.has("error"));
+        point = json.getJSONArray("coordinates");
+        assertTrue("returned point is not 2D: " + point, point.length() == 2);
+        lon = point.getDouble(0);
+        lat = point.getDouble(1);
+        assertTrue("nearest point wasn't correct: lat=" + lat + ", lon=" + lon, lat == 43.73070006215647 && lon == 7.421392181993846);
+    }
+}


### PR DESCRIPTION
Hi, 

Added a nearest API call to Graphhopper that returns the nearest point on the prepared graph for your input point. We use this to snap a user's pinpoint to the road. It also gives the distance from the input point to the snapped point. 

You can use it by calling /nearest?point=lat,lon (jsonp is also supported and uses the same code as /route, just add &type=jsonp&callback=x)

All feedback is welcome!