### PR TITLE
Add missing support for tag bicycle:forward=no detected during test a…

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/Bike2WeightFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/Bike2WeightFlagEncoder.java
@@ -92,25 +92,14 @@ public class Bike2WeightFlagEncoder extends BikeFlagEncoder
     public long handleSpeed( OSMWay way, double speed, long encoded )
     {
         // handle oneways
-        if ((way.hasTag("oneway", oneways) || way.hasTag("junction", "roundabout"))
-                && !way.hasTag("oneway:bicycle", "no")
-                && !way.hasTag("cycleway", oppositeLanes))
+        encoded = super.handleSpeed(way, speed, encoded);
+        if (isBackward(encoded))
         {
-
-            if (way.hasTag("oneway", "-1"))
-            {
-                encoded |= backwardBit;
-                encoded = setReverseSpeed(encoded, speed);
-            } else
-            {
-                encoded |= forwardBit;
-                encoded = setSpeed(encoded, speed);
-            }
-        } else
-        {
-            encoded |= directionBitMask;
-            encoded = setSpeed(encoded, speed);
             encoded = setReverseSpeed(encoded, speed);
+        }
+        if (isForward(encoded))
+        {   
+            encoded = setSpeed(encoded, speed);
         }
         return encoded;
     }

--- a/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
@@ -614,6 +614,7 @@ public class BikeCommonFlagEncoder extends AbstractFlagEncoder
 
         // handle oneways        
         boolean isOneway = way.hasTag("oneway", oneways)
+                || way.hasTag("oneway:bicycle", oneways)
                 || way.hasTag("vehicle:backward")
                 || way.hasTag("vehicle:forward")
                 || way.hasTag("bicycle:forward");
@@ -624,6 +625,7 @@ public class BikeCommonFlagEncoder extends AbstractFlagEncoder
                 && !way.hasTag("cycleway", oppositeLanes))
         {
             boolean isBackward = way.hasTag("oneway", "-1")
+                    || way.hasTag("oneway:bicycle", "-1")
                     || way.hasTag("vehicle:forward", "no")
                     || way.hasTag("bicycle:forward", "no");
             if (isBackward)

--- a/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
@@ -615,7 +615,8 @@ public class BikeCommonFlagEncoder extends AbstractFlagEncoder
         // handle oneways        
         boolean isOneway = way.hasTag("oneway", oneways)
                 || way.hasTag("vehicle:backward")
-                || way.hasTag("vehicle:forward");
+                || way.hasTag("vehicle:forward")
+                || way.hasTag("bicycle:forward");
 
         if ((isOneway || way.hasTag("junction", "roundabout"))
                 && !way.hasTag("oneway:bicycle", "no")
@@ -623,7 +624,8 @@ public class BikeCommonFlagEncoder extends AbstractFlagEncoder
                 && !way.hasTag("cycleway", oppositeLanes))
         {
             boolean isBackward = way.hasTag("oneway", "-1")
-                    || way.hasTag("vehicle:forward", "no");
+                    || way.hasTag("vehicle:forward", "no")
+                    || way.hasTag("bicycle:forward", "no");
             if (isBackward)
                 encoded |= backwardBit;
             else

--- a/core/src/test/java/com/graphhopper/routing/util/BikeFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/BikeFlagEncoderTest.java
@@ -177,6 +177,13 @@ public class BikeFlagEncoderTest extends AbstractBikeFlagEncoderTester
         way.clearTags();
 
         way.setTag("highway", "tertiary");
+        way.setTag("bicycle:forward", "no");
+        flags = encoder.handleWayTags(way, encoder.acceptWay(way), 0);
+        assertFalse(encoder.isForward(flags));
+        assertTrue(encoder.isBackward(flags));
+        way.clearTags();
+        
+        way.setTag("highway", "tertiary");
         way.setTag("vehicle:backward", "no");
         flags = encoder.handleWayTags(way, encoder.acceptWay(way), 0);
         assertTrue(encoder.isForward(flags));

--- a/core/src/test/java/com/graphhopper/routing/util/BikeFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/BikeFlagEncoderTest.java
@@ -162,6 +162,12 @@ public class BikeFlagEncoderTest extends AbstractBikeFlagEncoderTester
         assertTrue(encoder.isForward(flags));
         assertFalse(encoder.isBackward(flags));
         way.clearTags();
+        way.setTag("highway", "tertiary");        
+        way.setTag("oneway:bicycle", "yes");
+        flags = encoder.handleWayTags(way, encoder.acceptWay(way), 0);
+        assertTrue(encoder.isForward(flags));
+        assertFalse(encoder.isBackward(flags));
+        way.clearTags();
 
         way.setTag("highway", "tertiary");
         flags = encoder.handleWayTags(way, encoder.acceptWay(way), 0);


### PR DESCRIPTION
As a result of the OSM note discussion http://www.openstreetmap.org/note/319765 and the resolution with bicycle:forward=no I detected that graphhopper does currently not support this tag.

This change does two things:

1) Add missing support for tag bicycle:forward=no detected during test after OSM issue http://www.openstreetmap.org/note/319765 got fixed. 
2) Utilize the basic oneway logic in bike2 and handle the bike2 specific stuff afterwards such that we don't have to maintain the oneway stuff handling for bikes twice.
 