### PR TITLE
Improve avoidance of ways with high maxspeed values for cars

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/RacingBikeFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/RacingBikeFlagEncoder.java
@@ -127,6 +127,9 @@ public class RacingBikeFlagEncoder extends BikeCommonFlagEncoder
         setCyclingNetworkPreference("mtb", PriorityCode.UNCHANGED.getValue());
 
         absoluteBarriers.add("kissing_gate");
+
+        setAvoidSpeedLimit(81);
+
     }
 
     @Override

--- a/core/src/test/java/com/graphhopper/routing/util/AbstractBikeFlagEncoderTester.java
+++ b/core/src/test/java/com/graphhopper/routing/util/AbstractBikeFlagEncoderTester.java
@@ -353,17 +353,12 @@ public abstract class AbstractBikeFlagEncoderTester
     }
 
     @Test
-    public void testMaxAndMinSpeed()
+    public void testPreferenceForSlowSpeed()
     {
         OSMWay osmWay = new OSMWay(1);
         osmWay.setTag("highway", "tertiary");
         assertEquals(30, encoder.getSpeed(encoder.setSpeed(0, encoder.applyMaxSpeed(osmWay, 49, false))), 1e-1);
         assertPriority(PREFER.getValue(), osmWay);
-
-        osmWay.setTag("highway", "tertiary");
-        osmWay.setTag("maxspeed", "90");
-        assertEquals(20, encoder.getSpeed(encoder.setSpeed(0, encoder.applyMaxSpeed(osmWay, 20, false))), 1e-1);
-        assertPriority(REACH_DEST.getValue(), osmWay);
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/routing/util/BikeFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/BikeFlagEncoderTest.java
@@ -411,6 +411,12 @@ public class BikeFlagEncoderTest extends AbstractBikeFlagEncoderTester
         long allowed = encoder.acceptWay(way);
         long encoded = encoder.handleWayTags(way, allowed, 0);
         assertEquals(10, encoder.getSpeed(encoded), 1e-1);
+
+        way = new OSMWay(1);
+        way.setTag("highway", "tertiary");
+        way.setTag("maxspeed", "90");
+        assertEquals(20, encoder.getSpeed(encoder.setSpeed(0, encoder.applyMaxSpeed(way, 20, false))), 1e-1);
+        assertPriority(AVOID_IF_POSSIBLE.getValue(), way);
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/routing/util/RacingBikeFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/RacingBikeFlagEncoderTest.java
@@ -201,4 +201,66 @@ public class RacingBikeFlagEncoderTest extends AbstractBikeFlagEncoderTester
         assertPriority(AVOID_AT_ALL_COSTS.getValue(), osmWay, relFlags);
         assertEquals("get off the bike, unpaved", getWayTypeFromFlags(osmWay, relFlags));
     }
+
+ @Test
+    public void testAvoidanceOfHighMaxSpeed()
+    {
+        OSMWay osmWay = new OSMWay(1);
+        osmWay.setTag("highway", "tertiary");
+        osmWay.setTag("maxspeed", "50");
+        assertEquals(20, encoder.getSpeed(encoder.setSpeed(0, encoder.applyMaxSpeed(osmWay, 20, false))), 1e-1);
+        assertPriority(PREFER.getValue(), osmWay);
+
+        osmWay.setTag("maxspeed", "60");
+        assertEquals(20, encoder.getSpeed(encoder.setSpeed(0, encoder.applyMaxSpeed(osmWay, 20, false))), 1e-1);
+        assertPriority(PREFER.getValue(), osmWay);
+
+        osmWay.setTag("maxspeed", "80");
+        assertEquals(20, encoder.getSpeed(encoder.setSpeed(0, encoder.applyMaxSpeed(osmWay, 20, false))), 1e-1);
+        assertPriority(PREFER.getValue(), osmWay);
+
+        osmWay.setTag("maxspeed", "90");
+        assertEquals(20, encoder.getSpeed(encoder.setSpeed(0, encoder.applyMaxSpeed(osmWay, 20, false))), 1e-1);
+        assertPriority(AVOID_IF_POSSIBLE.getValue(), osmWay);
+        
+        osmWay.setTag("maxspeed", "120");
+        assertEquals(20, encoder.getSpeed(encoder.setSpeed(0, encoder.applyMaxSpeed(osmWay, 20, false))), 1e-1);
+        assertPriority(AVOID_IF_POSSIBLE.getValue(), osmWay);
+
+        osmWay.setTag("highway", "motorway");
+        assertEquals(20, encoder.getSpeed(encoder.setSpeed(0, encoder.applyMaxSpeed(osmWay, 20, false))), 1e-1);
+        assertPriority(REACH_DEST.getValue(), osmWay);
+        
+        osmWay.setTag("tunnel", "yes");
+        assertEquals(20, encoder.getSpeed(encoder.setSpeed(0, encoder.applyMaxSpeed(osmWay, 20, false))), 1e-1);
+        assertPriority(AVOID_AT_ALL_COSTS.getValue(), osmWay);
+
+        osmWay.clearTags();
+        osmWay.setTag("highway", "motorway");
+        osmWay.setTag("tunnel", "yes");
+        osmWay.setTag("maxspeed", "80");
+        assertEquals(20, encoder.getSpeed(encoder.setSpeed(0, encoder.applyMaxSpeed(osmWay, 20, false))), 1e-1);
+        assertPriority(AVOID_AT_ALL_COSTS.getValue(), osmWay);
+
+        osmWay.clearTags();
+        osmWay.setTag("highway", "motorway");
+        osmWay.setTag("tunnel", "yes");
+        osmWay.setTag("maxspeed", "120");
+        assertEquals(20, encoder.getSpeed(encoder.setSpeed(0, encoder.applyMaxSpeed(osmWay, 20, false))), 1e-1);
+        assertPriority(AVOID_AT_ALL_COSTS.getValue(), osmWay);
+
+        osmWay.clearTags();
+        osmWay.setTag("highway", "notdefined");
+        osmWay.setTag("tunnel", "yes");
+        osmWay.setTag("maxspeed", "120");
+        assertEquals(20, encoder.getSpeed(encoder.setSpeed(0, encoder.applyMaxSpeed(osmWay, 20, false))), 1e-1);
+        assertPriority(AVOID_AT_ALL_COSTS.getValue(), osmWay);
+
+        osmWay.clearTags();
+        osmWay.setTag("highway", "notdefined");
+        osmWay.setTag("maxspeed", "50");
+        assertEquals(20, encoder.getSpeed(encoder.setSpeed(0, encoder.applyMaxSpeed(osmWay, 20, false))), 1e-1);
+        assertPriority(UNCHANGED.getValue(), osmWay);
+        
+    }
 }


### PR DESCRIPTION
This change was triggered by a discussion on the mailing list , see https://lists.openstreetmap.org/pipermail/graphhopper/2015-May/001964.html .

Improve avoidance of ways with high maxspeed values for cars and control the avoidance with one car speed on AVOID_IF_POSSIBLE level and another speed limit for the REACH_DEST avoidance.

The AVOID_IF_POSSIBLE max car speed is now defined as 71 km/h for all bike types except for the racingbike.
The REACH_DEST max car speed is now defined as 81 km/h for all bike types except for the racingbike.
The AVOID_IF_POSSIBLE max car speed is defined as 81 km/h for the racingbike.
The REACH_DEST max car speed is defined as 101 km/h for the racingbike.