### PR TITLE
Do not decrease preference for highway=track with maxSpeed >= avoidSpeedLimit

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
@@ -499,16 +499,10 @@ public class BikeCommonFlagEncoder extends AbstractFlagEncoder
                 if (way.hasTag("tunnel", intendedValues))
                     weightToPrioMap.put(40d, UNCHANGED.getValue());
             }
-            else
-            {
-                weightToPrioMap.put(40d, AVOID_IF_POSSIBLE.getValue());
-                if (way.hasTag("tunnel", intendedValues))
-                    weightToPrioMap.put(40d, REACH_DEST.getValue());
-            }
         }
         else
         {
-            if (avoidHighwayTags.contains(highway) || maxSpeed >= avoidSpeedLimit)
+            if (avoidHighwayTags.contains(highway) || ( (maxSpeed >= avoidSpeedLimit)&&(highway!="track")))
             {
                 weightToPrioMap.put(50d, REACH_DEST.getValue());
                 if (way.hasTag("tunnel", intendedValues))

--- a/core/src/test/java/com/graphhopper/routing/util/BikeFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/BikeFlagEncoderTest.java
@@ -416,7 +416,13 @@ public class BikeFlagEncoderTest extends AbstractBikeFlagEncoderTester
         way.setTag("highway", "tertiary");
         way.setTag("maxspeed", "90");
         assertEquals(20, encoder.getSpeed(encoder.setSpeed(0, encoder.applyMaxSpeed(way, 20, false))), 1e-1);
-        assertPriority(AVOID_IF_POSSIBLE.getValue(), way);
+        assertPriority(UNCHANGED.getValue(), way);
+        
+        way = new OSMWay(1);
+        way.setTag("highway", "track");
+        way.setTag("maxspeed", "90");
+        assertEquals(20, encoder.getSpeed(encoder.setSpeed(0, encoder.applyMaxSpeed(way, 20, false))), 1e-1);
+        assertPriority(UNCHANGED.getValue(), way);
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/routing/util/RacingBikeFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/RacingBikeFlagEncoderTest.java
@@ -221,11 +221,11 @@ public class RacingBikeFlagEncoderTest extends AbstractBikeFlagEncoderTester
 
         osmWay.setTag("maxspeed", "90");
         assertEquals(20, encoder.getSpeed(encoder.setSpeed(0, encoder.applyMaxSpeed(osmWay, 20, false))), 1e-1);
-        assertPriority(AVOID_IF_POSSIBLE.getValue(), osmWay);
+        assertPriority(UNCHANGED.getValue(), osmWay);
         
         osmWay.setTag("maxspeed", "120");
         assertEquals(20, encoder.getSpeed(encoder.setSpeed(0, encoder.applyMaxSpeed(osmWay, 20, false))), 1e-1);
-        assertPriority(AVOID_IF_POSSIBLE.getValue(), osmWay);
+        assertPriority(UNCHANGED.getValue(), osmWay);
 
         osmWay.setTag("highway", "motorway");
         assertEquals(20, encoder.getSpeed(encoder.setSpeed(0, encoder.applyMaxSpeed(osmWay, 20, false))), 1e-1);


### PR DESCRIPTION
The preference should not decrease for the following case: `highway=track` and `maxspeed=100` . This was detected as feedback for the change at #414 on the https://lists.openstreetmap.org/pipermail/talk-de/2015-May/111195.html for highway=track.
According to taginfo there are indeed some ways tagged in this combination. 
-> Now we do not decrease the preference for this case and cases where the highway type is in the prefered highway type list.