### PR TITLE
Add support for class:bicycle

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/BikeFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/BikeFlagEncoder.java
@@ -70,6 +70,7 @@ public class BikeFlagEncoder extends BikeCommonFlagEncoder
         preferHighwayTags.add("unclassified");
 
         absoluteBarriers.add("kissing_gate");
+        setSpecificBicycleClass("touring");
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/util/MountainBikeFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/MountainBikeFlagEncoder.java
@@ -143,6 +143,7 @@ public class MountainBikeFlagEncoder extends BikeCommonFlagEncoder
         preferHighwayTags.add("unclassified");
 
         potentialBarriers.add("kissing_gate");
+        setSpecificBicycleClass("mtb");
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/util/RacingBikeFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/RacingBikeFlagEncoder.java
@@ -129,6 +129,7 @@ public class RacingBikeFlagEncoder extends BikeCommonFlagEncoder
         absoluteBarriers.add("kissing_gate");
 
         setAvoidSpeedLimit(81);
+        setSpecificBicycleClass("roadcycling");
 
     }
 

--- a/core/src/test/java/com/graphhopper/routing/util/BikeFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/BikeFlagEncoderTest.java
@@ -502,4 +502,31 @@ public class BikeFlagEncoderTest extends AbstractBikeFlagEncoderTester
         assertFalse(encoder.handleNodeTags(node) == 0);
     }
 
+    @Test
+    public void testclassBicycle()
+    {
+        OSMWay way = new OSMWay(1);
+        way.setTag("highway", "tertiary");
+        way.setTag("class:bicycle", "3");
+        assertPriority(BEST.getValue(), way);
+        way.setTag("class:bicycle", "2");
+        assertPriority(VERY_NICE.getValue(), way);
+        way.setTag("class:bicycle", "1");
+        assertPriority(PREFER.getValue(), way);
+        way.setTag("class:bicycle", "0");
+        assertPriority(UNCHANGED.getValue(), way);
+        way.setTag("class:bicycle", "invalidvalue");
+        assertPriority(UNCHANGED.getValue(), way);
+        way.setTag("class:bicycle", "-1");
+        assertPriority(AVOID_IF_POSSIBLE.getValue(), way);
+        way.setTag("class:bicycle", "-2");
+        assertPriority(REACH_DEST.getValue(), way);
+        way.setTag("class:bicycle", "-3");
+        assertPriority(AVOID_AT_ALL_COSTS.getValue(), way);
+
+        // Now we test overriding by a specific class subtype
+        way.setTag("class:bicycle:touring", "2");
+        assertPriority(VERY_NICE.getValue(), way);
+    }
+
 }

--- a/core/src/test/java/com/graphhopper/routing/util/RacingBikeFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/RacingBikeFlagEncoderTest.java
@@ -263,4 +263,17 @@ public class RacingBikeFlagEncoderTest extends AbstractBikeFlagEncoderTester
         assertPriority(UNCHANGED.getValue(), osmWay);
         
     }
+
+    @Test
+    public void testclassBicycle()
+    {
+        OSMWay way = new OSMWay(1);
+        way.setTag("highway", "tertiary");
+        way.setTag("class:bicycle:roadcycling", "3");
+        assertPriority(BEST.getValue(), way);
+        
+        way.setTag("class:bicycle", "-2");
+        assertPriority(BEST.getValue(), way);
+    }
+
 }


### PR DESCRIPTION
This change adds support for the tag [`class:bicycle'](http://wiki.openstreetmap.org/wiki/Class:bicycle)

The implementation uses the subtypes `touring`, `mtb` and `roadcycling`. 
See also #330. 