### PR TITLE
Android Sample: perform cleanup on exit, improvements at manifest

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,29 +1,29 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.graphhopper.android"
-          android:versionCode="1"
-          android:versionName="0.1" >
+    package="com.graphhopper.android"
+    android:versionCode="1"
+    android:versionName="0.1" >
 
     <!-- mapsforge cache and saving maps -->
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-    
+
     <!-- necessary to easily download maps via wifi -->
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />    
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <uses-sdk
-        android:minSdkVersion="8"
-        android:targetSdkVersion="19" />
+        android:minSdkVersion="10"
+        android:targetSdkVersion="22" />
 
     <application
         android:allowBackup="true"
+        android:hardwareAccelerated="false"
         android:icon="@drawable/logo"
-        android:label="@string/app_name"        
+        android:label="@string/app_name"
         android:theme="@style/AppTheme" >
-        
         <activity
             android:name=".MainActivity"
-            android:label="@string/title_activity_main" 
-            android:screenOrientation="portrait">
+            android:label="@string/title_activity_main"
+            android:screenOrientation="portrait" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/android/app/src/main/java/com/graphhopper/android/MainActivity.java
+++ b/android/app/src/main/java/com/graphhopper/android/MainActivity.java
@@ -77,6 +77,7 @@ public class MainActivity extends Activity
     private String downloadURL;
     private File mapsFolder;
     private TileCache tileCache;
+    private TileRendererLayer tileRendererLayer;
 
     protected boolean onMapTap( LatLong tapLatLong, Point layerXY, Point tapXY )
     {
@@ -177,6 +178,14 @@ public class MainActivity extends Activity
         hopper = null;
         // necessary?
         System.gc();
+
+        // Cleanup Mapsforge
+        this.mapView.getLayerManager().getLayers().remove(this.tileRendererLayer);
+        this.tileRendererLayer.onDestroy();
+        this.tileCache.destroy();
+        this.mapView.getModel().mapViewPosition.destroy();
+        this.mapView.destroy();
+        AndroidGraphicFactory.clearResourceMemoryCache();
     }
 
     boolean isReady()
@@ -403,7 +412,7 @@ public class MainActivity extends Activity
 
         mapView.getLayerManager().getLayers().clear();
 
-        TileRendererLayer tileRendererLayer = new TileRendererLayer(tileCache, mapDataStore,
+        tileRendererLayer = new TileRendererLayer(tileCache, mapDataStore,
                 mapView.getModel().mapViewPosition, false, true, AndroidGraphicFactory.INSTANCE)
         {
             @Override


### PR DESCRIPTION
As users have posted in our [forum](https://groups.google.com/forum/#!topic/mapsforge-dev/Br1UQiMDwkk), at GH Android Sample there isn't any Mapsforge cleanup on app exit.
This PR handles this.

Also since Mapsforge doesn't yet support hardware acceleration (we're working on that) I set it to false in manifest, along with updating the sdk versions.