### PR TITLE
Update NameIndex.java

### DIFF
--- a/core/src/main/java/com/graphhopper/search/NameIndex.java
+++ b/core/src/main/java/com/graphhopper/search/NameIndex.java
@@ -56,7 +56,7 @@ public class NameIndex implements Storable<NameIndex>
     {
         if (names.loadExisting())
         {
-            bytePointer = BitUtil.LITTLE.combineIntsToLong(names.getHeader(0), names.getHeader(1));
+            bytePointer = BitUtil.LITTLE.combineIntsToLong(names.getHeader(0), names.getHeader(4));
             return true;
         }
 


### PR DESCRIPTION
When write it, the address is in byte, not integer.
        names.setHeader(0, BitUtil.LITTLE.getIntLow(bytePointer));
        names.setHeader(4, BitUtil.LITTLE.getIntHigh(bytePointer));