### PR TITLE
Fixing potential location index lookup issue when filter is provided

### DIFF
--- a/core/src/test/java/com/graphhopper/GraphHopperTest.java
+++ b/core/src/test/java/com/graphhopper/GraphHopperTest.java
@@ -593,8 +593,6 @@ public class GraphHopperTest
     @Test
     public void testGetPathsDirectionEnforcement3()
     {
-        // Test enforce via direction
-
         GraphHopper instance = initSquareGraphInstance(false);
 
         // Start in middle of edge 4-5 

--- a/core/src/test/java/com/graphhopper/storage/index/LocationIndexTreeCHTest.java
+++ b/core/src/test/java/com/graphhopper/storage/index/LocationIndexTreeCHTest.java
@@ -17,6 +17,7 @@
  */
 package com.graphhopper.storage.index;
 
+import com.graphhopper.routing.util.EdgeFilter;
 import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.storage.*;
@@ -163,7 +164,9 @@ public class LocationIndexTreeCHTest extends LocationIndexTreeTest
         LocationIndexTree index = createIndex(g, 100000);
 
         // very close to 2, but should match the edge 0--1
-        TIntHashSet set = index.findNetworkEntries(0.51, 0.2, index.maxRegionSearch);
+        TIntHashSet set = new TIntHashSet();
+        index.findNetworkEntries(0.51, 0.2, set, 0);
+        index.findNetworkEntries(0.51, 0.2, set, 1);
         TIntSet expectedSet = new TIntHashSet();
         expectedSet.add(0);
         expectedSet.add(2);


### PR DESCRIPTION
This fixes #318 

The iteration loop was moved out of findNetworkEntries to recall this method if no matching edges are found (i.e. edges that matches the edgeFilter)