### PR TITLE
Elevation control didn't show up

### DIFF
--- a/web/src/main/webapp/js/ghrequest.js
+++ b/web/src/main/webapp/js/ghrequest.js
@@ -315,7 +315,7 @@ GHRequest.prototype.init = function (params) {
 
     // overwrite elevation e.g. important if not supported from feature set
     this.api_params.elevation = false;
-    var featureSet = this.features[this.vehicle];
+    var featureSet = this.features[params.vehicle];
     if (featureSet && featureSet.elevation) {
         if ('elevation' in params)
             this.api_params.elevation = params.elevation;
@@ -353,7 +353,7 @@ GHRequest.prototype.init = function (params) {
 
 GHRequest.prototype.initVehicle = function (vehicle) {
     this.api_params.vehicle = vehicle;
-    var featureSet = this.features[this.vehicle];
+    var featureSet = this.features[vehicle];
 
     if (featureSet && featureSet.elevation)
         this.api_params.elevation = true;


### PR DESCRIPTION
The elevation control in the web GUI does not show up. 8009563b0f7638459006fe6c306dcb579ad5203c was the reason. In `GHRequest.prototype.init = function (params)` parameter  `this.vehicle` was still used, although the assignment was removed. So this should be changed into 'params.vehicle'.

The same is true below in 'GHRequest.prototype.initVehicle = function (vehicle) {` where 'this.vehicle' needs to be replaced with 'vehicle'.