### PR TITLE
Fix parsing of duration tag for hh:mm:ss format.

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/AbstractFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/AbstractFlagEncoder.java
@@ -462,13 +462,14 @@ public abstract class AbstractFlagEncoder implements FlagEncoder, TurnCostEncode
     }
 
     /**
-     * This method parses a string ala "00:00" (hours and minutes) or "0:00:00" (days, hours and
-     * minutes).
+     * This method parses a string ala 'hh:mm', format for hours and minutes 'mm', 'hh:mm' or 'hh:mm:ss'
+     * FIXME: Add support for ISO_8601 
      * <p>
      * @return duration value in minutes
      */
     protected static int parseDuration( String str )
     {
+        int minutes = 0;
         if (str == null)
             return 0;
 
@@ -478,7 +479,7 @@ public abstract class AbstractFlagEncoder implements FlagEncoder, TurnCostEncode
             // because P1M != PT1M but there are wrong edits in OSM! e.g. http://www.openstreetmap.org/way/24791405
             // http://wiki.openstreetmap.org/wiki/Key:duration
             if (str.startsWith("P"))
-                return 0;
+                return minutes;
 
             int index = str.indexOf(":");
             if (index > 0)
@@ -486,14 +487,10 @@ public abstract class AbstractFlagEncoder implements FlagEncoder, TurnCostEncode
                 String hourStr = str.substring(0, index);
                 String minStr = str.substring(index + 1);
                 index = minStr.indexOf(":");
-                int minutes = 0;
                 if (index > 0)
                 {
-                    // string contains hours too
-                    String dayStr = hourStr;
-                    hourStr = minStr.substring(0, index);
-                    minStr = minStr.substring(index + 1);
-                    minutes = Integer.parseInt(dayStr) * 60 * 24;
+                    // string contains seconds too: we ignore them
+                    minStr = minStr.substring(0, index);
                 }
 
                 minutes += Integer.parseInt(hourStr) * 60;
@@ -507,7 +504,7 @@ public abstract class AbstractFlagEncoder implements FlagEncoder, TurnCostEncode
         {
             logger.warn("Cannot parse " + str + " using 0 minutes");
         }
-        return 0;
+        return minutes;
     }
 
     /**

--- a/core/src/test/java/com/graphhopper/routing/util/AbstractFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/AbstractFlagEncoderTest.java
@@ -55,7 +55,7 @@ public class AbstractFlagEncoderTest
         assertEquals(0, AbstractFlagEncoder.parseDuration("oh"));
         assertEquals(0, AbstractFlagEncoder.parseDuration(null));
         assertEquals(60 * 20, AbstractFlagEncoder.parseDuration("20:00"));
-        assertEquals(60 * 20, AbstractFlagEncoder.parseDuration("0:20:00"));
-        assertEquals(60 * 24 * 2 + 60 * 20 + 2, AbstractFlagEncoder.parseDuration("02:20:02"));
+        assertEquals(20, AbstractFlagEncoder.parseDuration("0:20:00"));
+        assertEquals(60 * 2 + 20, AbstractFlagEncoder.parseDuration("02:20:02"));
     }
 }


### PR DESCRIPTION
According to http://wiki.openstreetmap.org/wiki/Key:duration there is no dd:hh:mm format, instead this format needs to be interpreted as hh:mm:ss

The modification also fixes issue #501