### PR TITLE
Adding of comments for artificial way tag "estimated_distance"

### DIFF
--- a/core/src/main/java/com/graphhopper/reader/OSMElement.java
+++ b/core/src/main/java/com/graphhopper/reader/OSMElement.java
@@ -127,7 +127,7 @@ public abstract class OSMElement
     }
 
     /**
-     * Chaeck that the object has a given tag with a given value.
+     * Check that the object has a given tag with a given value.
      */
     public boolean hasTag( String key, Object value )
     {

--- a/core/src/main/java/com/graphhopper/reader/OSMReader.java
+++ b/core/src/main/java/com/graphhopper/reader/OSMReader.java
@@ -352,8 +352,8 @@ public class OSMReader implements DataReader
         long relationFlags = getRelFlagsMap().get(way.getId());
 
         // TODO move this after we have created the edge and know the coordinates => encodingManager.applyWayTags
-        // estimate length of the track e.g. for ferry speed calculation
         TLongList osmNodeIds = way.getNodes();
+        // Estimate length of ways containing a route tag e.g. for ferry speed calculation
         if (osmNodeIds.size() > 1)
         {
             int first = getNodeMap().get(osmNodeIds.get(0));
@@ -363,6 +363,7 @@ public class OSMReader implements DataReader
             if (!Double.isNaN(firstLat) && !Double.isNaN(firstLon) && !Double.isNaN(lastLat) && !Double.isNaN(lastLon))
             {
                 double estimatedDist = distCalc.calcDist(firstLat, firstLon, lastLat, lastLon);
+                // Add artificial tag for the estamated distance and center
                 way.setTag("estimated_distance", estimatedDist);
                 way.setTag("estimated_center", new GHPoint((firstLat + lastLat) / 2, (firstLon + lastLon) / 2));
             }

--- a/core/src/test/resources/com/graphhopper/reader/test-osm2.xml
+++ b/core/src/test/resources/com/graphhopper/reader/test-osm2.xml
@@ -8,7 +8,7 @@
     <node id="20" lat="52.0" lon="9" uid="24854">
         <tag k="name" v="Halbendorf-Spree" />
     </node>
-    
+
     <node id="21" lat="52.1" lon="9.1" uid="24854">
         <tag k="name" v="Next-Halbendorf-Spree" />
     </node>
@@ -24,44 +24,44 @@
     <node id="30" lat="51.2" lon="9.4" uid="24855">
         <tag k="name" v="Dresden" />
     </node>
-    
+
     <node id="40" lat="54.0" lon="10.1">
         <tag k="name" v="Ferry End" />
-    </node>  
+    </node>
     <node id="50" lat="55.0" lon="10.2">
         <tag k="name" v="Ferry Start" />
     </node>
-    
+
     <node id="60" lat="56.0" lon="10.1">
         <tag k="name" v="Start" />
-    </node>  
+    </node>
     <node id="70" lat="57.0" lon="10.2">
         <tag k="name" v="End" />
     </node>
-             
+
     <node id="80" lat="54.1" lon="11.1">
         <tag k="name" v="Ferry2 End" />
-    </node>  
+    </node>
     <node id="90" lat="55.1" lon="11.2">
         <tag k="name" v="Ferry2 Start" />
-    </node>         
+    </node>
     
     <way id="10" uid="85761">
         <!-- 0-1, 1-2 -->
         <nd ref="10"/>
-        <nd ref="20"/>        
+        <nd ref="20"/>
         <nd ref="30"/>
         <tag k="oneway" v="true" />
         <tag k="highway" v="motorway" />
-    </way>    
-    
+    </way>
+
     <way id="11" uid="85761">
         <nd ref="21"/>
         <nd ref="20"/>
         <tag k="oneway" v="yes" />
         <tag k="highway" v="motorway" />
-    </way>    
-    
+    </way>
+
     <way id="12" uid="85761">
         <nd ref="20"/>
         <nd ref="22"/>
@@ -77,24 +77,25 @@
     </way>
 
     <way id="15" uid="85762">
-        <nd ref="50"/>        
+        <nd ref="50"/>
         <nd ref="40"/>
         <tag k="route" v="ferry"/>
-        <tag k="motorcar" v="yes"/>         
+        <tag k="motorcar" v="yes"/>
         <tag k="foot" v="yes"/>
-        <tag k="duration" v="01:10"/>        
+        <tag k="duration" v="01:10"/>
     </way>
-    
-    <way id="15" uid="85762">
-        <nd ref="80"/>        
+
+    <way id="16" uid="85762">
+        <nd ref="80"/>
         <nd ref="90"/>
-        <tag k="route" v="ferry"/>              
+        <tag k="route" v="ferry"/>
     </way>
-    
-    <way id="20">          
+
+    <way id="20">
         <nd ref="60"/>
-        <nd ref="70"/>  
+        <nd ref="70"/>
         <tag k="highway" v="motorway" />
         <tag k="maxspeed" v="40" />
     </way>
+
 </osm>


### PR DESCRIPTION
During adding of support for duration in ISO 8601 format I discovered that the calculation of the artificial estimated_distance way tag is unnecessary most of the time. Now we compute it only in case that a way contains a "route" tag. This change should decrease the graph preparation time a little bit.
Additionally some comments about the estimated_distance handling are added or fixed.