### PR TITLE
Multilingual graphs: preferred language on import, #259

### DIFF
--- a/config-example.properties
+++ b/config-example.properties
@@ -32,6 +32,9 @@ graph.dataaccess=RAM_STORE
 # if you want to reduce storage size and you don't need instructions for the resulting path use:
 # osmreader.instructions=false
 
+# will write way names in the preferred language (language code as defined in ISO 639-1 or ISO 639-2):
+# osmreader.preferred-language=en
+
 #### Speed-up Mode vs. Flexibility Mode ####
 #
 # By default the speed-up mode with the 'fastest' weighting is used. Internally a graph preparation via

--- a/core/files/changelog.txt
+++ b/core/files/changelog.txt
@@ -1,3 +1,6 @@
+0.6
+    specify the preferred-language for way names during graph import (ISO 639-1 or ISO 639-2)
+
 0.5
     Several names have changed see #466, #467, #468
     GraphHopper.optimize removed use postProcessing instead

--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -31,6 +31,7 @@ import com.graphhopper.storage.index.LocationIndexTree;
 import com.graphhopper.storage.index.QueryResult;
 import com.graphhopper.util.*;
 import com.graphhopper.util.shapes.GHPoint;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,6 +66,7 @@ public class GraphHopper implements GraphHopperAPI
     private final String fileLockName = "gh.lock";
     private boolean allowWrites = true;
     boolean enableInstructions = true;
+    private String preferredLanguage = "";
     private boolean fullyLoaded = false;
     // for routing
     private double defaultWeightLimit = Double.MAX_VALUE;
@@ -396,6 +398,30 @@ public class GraphHopper implements GraphHopperAPI
     }
 
     /**
+     * This method specifies the preferred language for way names during import.
+     * <p>
+     * Language code as defined in ISO 639-1 or ISO 639-2.
+     * <ul>
+     * <li>If no preferred language is specified, only the default language with no tag will be imported.</li>
+     * <li>If a language is specified, it will be imported if its tag is found, otherwise fall back to default language.</li>
+     * </ul>
+     */
+    public GraphHopper setPreferredLanguage( String preferredLanguage )
+    {
+    	ensureNotLoaded();
+    	if (preferredLanguage == null)
+    		throw new IllegalArgumentException("preferred language cannot be null");
+
+    	this.preferredLanguage = preferredLanguage;
+    	return this;
+    }
+
+    public String getPreferredLanguage()
+    {
+    	return preferredLanguage;
+    }
+
+    /**
      * This methods enables gps point calculation. If disabled only distance will be calculated.
      */
     public GraphHopper setEnableCalcPoints( boolean b )
@@ -607,6 +633,7 @@ public class GraphHopper implements GraphHopperAPI
 
         workerThreads = args.getInt("osmreader.workerThreads", workerThreads);
         enableInstructions = args.getBool("osmreader.instructions", enableInstructions);
+        preferredLanguage = args.get("osmreader.preferred-language", preferredLanguage);
 
         // index
         preciseIndexResolution = args.getInt("index.highResolution", preciseIndexResolution);
@@ -689,6 +716,7 @@ public class GraphHopper implements GraphHopperAPI
                     + " but also cannot import from OSM file as it wasn't specified!");
 
         encodingManager.setEnableInstructions(enableInstructions);
+        encodingManager.setPreferredLanguage(preferredLanguage);
         DataReader reader = createReader(ghStorage);
         logger.info("using " + ghStorage.toString() + ", memory:" + Helper.getMemInfo());
         reader.readGraph();

--- a/core/src/main/java/com/graphhopper/routing/util/EncodingManager.java
+++ b/core/src/main/java/com/graphhopper/routing/util/EncodingManager.java
@@ -18,6 +18,7 @@
 package com.graphhopper.routing.util;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import com.graphhopper.reader.OSMNode;
@@ -29,8 +30,6 @@ import com.graphhopper.storage.StorableProperties;
 import com.graphhopper.util.EdgeIteratorState;
 import com.graphhopper.util.Helper;
 import com.graphhopper.util.PMap;
-
-import java.util.*;
 
 /**
  * Manager class to register encoder, assign their flag values and check objects with all encoders
@@ -58,6 +57,7 @@ public class EncodingManager
     private final int bitsForEdgeFlags;
     private final int bitsForTurnFlags = 8 * 4;
     private boolean enableInstructions = true;
+    private String preferredLanguage = "";
 
     /**
      * Instantiate manager with the given list of encoders. The manager knows the default encoders:
@@ -379,6 +379,15 @@ public class EncodingManager
         return this;
     }
 
+    public EncodingManager setPreferredLanguage( String preferredLanguage )
+    {
+    	if (preferredLanguage == null)
+    		throw new IllegalArgumentException("preferred language cannot be null");
+
+    	this.preferredLanguage = preferredLanguage;
+    	return this;
+    }
+
     public void applyWayTags( OSMWay way, EdgeIteratorState edge )
     {
         // storing the road name does not yet depend on the flagEncoder so manage it directly
@@ -386,7 +395,11 @@ public class EncodingManager
         {
             // String wayInfo = carFlagEncoder.getWayInfo(way);
             // http://wiki.openstreetmap.org/wiki/Key:name
-            String name = fixWayName(way.getTag("name"));
+        	String name = null;
+        	if (!preferredLanguage.isEmpty())
+        		name = fixWayName(way.getTag("name:" + preferredLanguage));
+        	if (Helper.isEmpty(name))
+        		name = fixWayName(way.getTag("name"));
             // http://wiki.openstreetmap.org/wiki/Key:ref
             String refName = fixWayName(way.getTag("ref"));
             if (!Helper.isEmpty(refName))

--- a/core/src/test/java/com/graphhopper/reader/OSMReaderTest.java
+++ b/core/src/test/java/com/graphhopper/reader/OSMReaderTest.java
@@ -127,6 +127,7 @@ public class OSMReaderTest
         @Override
         protected DataReader importData() throws IOException
         {
+            getEncodingManager().setPreferredLanguage(getPreferredLanguage());
             GraphHopperStorage tmpGraph = newGraph(dir, getEncodingManager(), hasElevation(),
                     getEncodingManager().needsTurnCostsSupport());
             setGraphHopperStorage(tmpGraph);
@@ -799,5 +800,24 @@ public class OSMReaderTest
                 assertEquals(10, bike.getTurnCost(entry.flags), 1e-1);
             }
         }
+    }
+
+    @Test
+    public void testPreferredLanguage()
+    {
+    	GraphHopper hopper = new GraphHopperTest(file1).setPreferredLanguage("de").importOrLoad();
+    	GraphHopperStorage graph = hopper.getGraphHopperStorage();
+    	int n20 = AbstractGraphStorageTester.getIdOf(graph, 52);
+    	EdgeIterator iter = carOutExplorer.setBaseNode(n20);
+    	assertTrue(iter.next());
+    	assertEquals("straße 123, B 122", iter.getName());
+
+    	hopper = new GraphHopperTest(file1).setPreferredLanguage("el").importOrLoad();
+    	graph = hopper.getGraphHopperStorage();
+    	n20 = AbstractGraphStorageTester.getIdOf(graph, 52);
+    	iter = carOutExplorer.setBaseNode(n20);
+    	assertTrue(iter.next());
+    	assertTrue(iter.next());
+    	assertEquals("διαδρομή 666", iter.getName());
     }
 }

--- a/core/src/test/resources/com/graphhopper/reader/test-osm.xml
+++ b/core/src/test/resources/com/graphhopper/reader/test-osm.xml
@@ -34,6 +34,7 @@
         <nd ref="20"/>        
         <nd ref="30"/>
         <tag k="name" v="route 666" />
+        <tag k="name:el" v="διαδρομή 666" />
         <tag k="highway" v="motorway_link" />
         <tag k="destination" v="hof;fürth" />
     </way> 
@@ -43,6 +44,7 @@
         <nd ref="40"/>
         <nd ref="50"/>        
         <tag k="name" v="street 123;B 122" />
+        <tag k="name:de" v="straße 123;B 122" />
         <tag k="highway" v="service" />
     </way>
 </osm>


### PR DESCRIPTION
First step for multilingual graphs #259.

Specify the ```preferred-language``` for way names during graph import.
I followed our methodology in Mapsforge [map-writer](https://github.com/mapsforge/mapsforge/blob/master/docs/Getting-Started-Map-Writer.md#basic-options).
Language code as defined in ISO 639-1 or ISO 639-2.

* If no preferred language is specified, only the default language with no tag will be imported.
* If a language is specified, it will be imported if its tag is found, otherwise fall back to default language.