### PR TITLE
Make SRTMProvider resolution independent, fixes #544 and #543

### DIFF
--- a/core/src/main/java/com/graphhopper/reader/dem/SRTMProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/SRTMProvider.java
@@ -64,7 +64,8 @@ public class SRTMProvider implements ElevationProvider
 
     private static final BitUtil BIT_UTIL = BitUtil.BIG;
     private final Logger logger = LoggerFactory.getLogger(getClass());
-    private final int WIDTH = 1201;
+    private final int DEFAULT_WIDTH = 1201;
+    private final int WIDTH_BYTE_INDEX = 0;
     private Directory dir;
     private DAType daType = DAType.MMAP;
     private Downloader downloader = new Downloader("GraphHopper SRTMReader").setTimeout(10000);
@@ -221,93 +222,110 @@ public class SRTMProvider implements ElevationProvider
         lon = (int) (lon * precision) / precision;
         int intKey = calcIntKey(lat, lon);
         HeightTile demProvider = cacheData.get(intKey);
-        if (demProvider == null)
+        if (demProvider != null)
         {
-            if (!cacheDir.exists())
-                cacheDir.mkdirs();
-
-            String fileDetails = getFileString(lat, lon);
-            if (fileDetails == null)
-                return 0;
-
-            int minLat = down(lat);
-            int minLon = down(lon);
-            demProvider = new HeightTile(minLat, minLon, WIDTH, precision, 1);
-            demProvider.setCalcMean(calcMean);
-            cacheData.put(intKey, demProvider);
-            DataAccess heights = getDirectory().find("dem" + intKey);
-            demProvider.setHeights(heights);
-            boolean loadExisting = false;
-            try
-            {
-                loadExisting = heights.loadExisting();
-            } catch (Exception ex)
-            {
-                logger.warn("cannot load dem" + intKey + ", error:" + ex.getMessage());
-            }
-
-            if (!loadExisting)
-            {
-                byte[] bytes = new byte[2 * WIDTH * WIDTH];
-                heights.create(bytes.length);
-                try
-                {
-                    String zippedURL = baseUrl + "/" + fileDetails + ".hgt.zip";
-                    File file = new File(cacheDir, new File(zippedURL).getName());
-                    InputStream is;
-                    // get zip file if not already in cacheDir - unzip later and in-memory only!
-                    if (!file.exists())
-                    {
-                        for (int i = 0; i < 3; i++)
-                        {
-                            try
-                            {
-                                downloader.downloadFile(zippedURL, file.getAbsolutePath());
-                                break;
-                            } catch (SocketTimeoutException ex)
-                            {
-                                // just try again after a little nap
-                                Thread.sleep(2000);
-                                continue;
-                            } catch (FileNotFoundException ex)
-                            {
-                                // now try different URL (without point!), necessary if mirror is used
-                                zippedURL = baseUrl + "/" + fileDetails + "hgt.zip";
-                                continue;
-                            }
-                        }
-                    }
-
-                    is = new FileInputStream(file);
-                    ZipInputStream zis = new ZipInputStream(is);
-                    zis.getNextEntry();
-                    BufferedInputStream buff = new BufferedInputStream(zis);
-                    int len;
-                    while ((len = buff.read(bytes)) > 0)
-                    {
-                        for (int bytePos = 0; bytePos < len; bytePos += 2)
-                        {
-                            short val = BIT_UTIL.toShort(bytes, bytePos);
-                            if (val < -1000 || val > 12000)
-                                val = Short.MIN_VALUE;
-
-                            heights.setShort(bytePos, val);
-                        }
-                    }
-                    heights.flush();
-
-                    // demProvider.toImage("x" + file.getName() + ".png");
-                    // TODO remove hgt and zip?
-                } catch (Exception ex)
-                {
-                    throw new RuntimeException(ex);
-                }
-            } // loadExisting
+            return demProvider.getHeight(lat, lon);
         }
+        if (!cacheDir.exists())
+            cacheDir.mkdirs();
 
+        String fileDetails = getFileString(lat, lon);
+        if (fileDetails == null)
+            return 0;
+        
+        DataAccess heights = getDirectory().find("dem" + intKey);
+        boolean loadExisting = false;
+        try
+        {
+            loadExisting = heights.loadExisting();
+        } catch (Exception ex)
+        {
+            logger.warn("cannot load dem" + intKey + ", error:" + ex.getMessage());
+        }
+        
+        if (!loadExisting)
+        {
+            updateHeightsFromZipFile(fileDetails, heights);
+        }
+        int width = (int)(Math.sqrt(heights.getHeader(WIDTH_BYTE_INDEX)) + 0.5);
+        if (width == 0) 
+        {
+            width = DEFAULT_WIDTH;
+        }
+        demProvider = new HeightTile(down(lat), down(lon), width, precision, 1);
+        demProvider.setCalcMean(calcMean);
+        cacheData.put(intKey, demProvider);
+        demProvider.setHeights(heights);
         return demProvider.getHeight(lat, lon);
     }
 
+    private void updateHeightsFromZipFile( String fileDetails, DataAccess heights ) throws RuntimeException
+    {
+        try
+        {
+            byte[] bytes = getByteArrayFromZipFile(fileDetails);
+            heights.create(bytes.length);
+            for (int bytePos = 0; bytePos < bytes.length; bytePos += 2)
+            {
+                short val = BIT_UTIL.toShort(bytes, bytePos);
+                if (val < -1000 || val > 12000)
+                {
+                    val = Short.MIN_VALUE;
+                }
+                
+                heights.setShort(bytePos, val);
+            }
+            heights.setHeader(WIDTH_BYTE_INDEX, bytes.length / 2);
+            heights.flush();
+            
+        } catch (Exception ex)
+        {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    private byte[] getByteArrayFromZipFile( String fileDetails ) throws InterruptedException, FileNotFoundException, IOException
+    {
+        String zippedURL = baseUrl + "/" + fileDetails + ".hgt.zip";
+        File file = new File(cacheDir, new File(zippedURL).getName());
+        InputStream is;
+        // get zip file if not already in cacheDir - unzip later and in-memory only!
+        if (!file.exists())
+        {
+            for (int i = 0; i < 3; i++)
+            {
+                try
+                {
+                    downloader.downloadFile(zippedURL, file.getAbsolutePath());
+                    break;
+                } catch (SocketTimeoutException ex)
+                {
+                    // just try again after a little nap
+                    Thread.sleep(2000);
+                    continue;
+                } catch (FileNotFoundException ex)
+                {
+                    // now try different URL (without point!), necessary if mirror is used
+                    zippedURL = baseUrl + "/" + fileDetails + "hgt.zip";
+                    continue;
+                }
+            }
+        }
+        is = new FileInputStream(file);
+        ZipInputStream zis = new ZipInputStream(is);
+        zis.getNextEntry();
+        BufferedInputStream buff = new BufferedInputStream(zis);
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        byte[] buffer = new byte[0xFFFF];
+        int len;
+        while ((len = buff.read(buffer)) > 0)
+        {
+            os.write(buffer, 0, len);
+        }
+        os.flush();
+        return os.toByteArray();
+    }
+    
     @Override
     public void release()
     {

--- a/core/src/test/java/com/graphhopper/reader/dem/SRTMProviderTest.java
+++ b/core/src/test/java/com/graphhopper/reader/dem/SRTMProviderTest.java
@@ -91,6 +91,7 @@ public class SRTMProviderTest
         // precision = 1e7 => -4
         // assertEquals(161, instance.getEle(55.8943144, -3.0004), 1e-1);
         // assertEquals(161, instance.getEle(55.8943144, -3.0000001), 1e-1);
+        assertEquals(95, instance.getEle(31, 34), 1e-1);
     }
 
     @Test

--- a/graphhopper.sh
+++ b/graphhopper.sh
@@ -79,7 +79,7 @@ function ensureMaven {
   # maven home existent?
   if [ "$MAVEN_HOME" = "" ]; then
     # not existent but probably is maven in the path?
-    MAVEN_HOME=$(mvn -v | grep "Maven home" | cut -d' ' -f3)
+    MAVEN_HOME=$(mvn -v | grep "Maven home" | cut -d' ' -f3,4,5,6)
     if [ "$MAVEN_HOME" = "" ]; then
       # try to detect previous downloaded version
       MAVEN_HOME="$GH_HOME/maven"


### PR DESCRIPTION
Fixes #543 *make SRTMProvider resolution independent* and #544 *fix for graphhopper.sh under windows*

See [discussion](https://discuss.graphhopper.com/t/elevation-data-from-local-files/175)