### PR TITLE
Update config-example.properties

### DIFF
--- a/config-example.properties
+++ b/config-example.properties
@@ -29,7 +29,7 @@ graph.flagEncoders=car
 # MMAP_STORE_SYNC could be used otherwise but will be a lot slower
 graph.dataaccess=RAM_STORE
 
-# if you want to reduce storage size and you don't need instructions for the resulting path use:
+# if you don't need turn instruction, you can reduce storage size by not storing way names:
 # osmreader.instructions=false
 
 # will write way names in the preferred language (language code as defined in ISO 639-1 or ISO 639-2):


### PR DESCRIPTION
I didn't get the essence of that property and needed to look it up in the code. It was not obvious to me that we don't store the way names if we set this setting to false. I hope other users don't struggle with that anymore.