### PR TITLE
Random Round Tours

### DIFF
--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -1118,7 +1118,8 @@ public class GraphHopper implements GraphHopperAPI
         // Every alternative path makes one AltResponse BUT if via points exists then reuse the altResponse object
         PathWrapper altResponse = new PathWrapper();
         ghRsp.add(altResponse);
-        boolean isRoundTrip = AlgorithmOptions.ROUND_TRIP_ALT.equalsIgnoreCase(algoOpts.getAlgorithm());
+        boolean isRandomRoundTrip = AlgorithmOptions.ROUND_TRIP.equalsIgnoreCase(algoOpts.getAlgorithm());
+        boolean isRoundTrip = AlgorithmOptions.ROUND_TRIP_ALT.equalsIgnoreCase(algoOpts.getAlgorithm()) || isRandomRoundTrip;
         boolean isAlternativeRoute = AlgorithmOptions.ALT_ROUTE.equalsIgnoreCase(algoOpts.getAlgorithm());
 
         if ((isAlternativeRoute || isRoundTrip) && points.size() > 2)
@@ -1151,6 +1152,9 @@ public class GraphHopper implements GraphHopperAPI
 
             sw = new StopWatch().start();
             RoutingAlgorithm algo = tmpAlgoFactory.createAlgo(queryGraph, algoOpts);
+            if(algo instanceof RoundTripAlgorithm){
+                ((RoundTripAlgorithm) algo).prepare(locationIndex, new DefaultEdgeFilter(encoder), points.get(0));
+            }
             algo.setWeightLimit(weightLimit);
             String debug = ", algoInit:" + sw.stop().getSeconds() + "s";
 
@@ -1193,7 +1197,7 @@ public class GraphHopper implements GraphHopperAPI
             }
         } else if (isRoundTrip)
         {
-            if (points.size() != altPaths.size())
+            if (points.size() != altPaths.size() && !isRandomRoundTrip)
                 throw new RuntimeException("There should be the same number of points as paths. points:" + points.size() + ", paths:" + altPaths.size());
 
             pathMerger.doWork(altResponse, altPaths, tr);

--- a/core/src/main/java/com/graphhopper/routing/AlgorithmOptions.java
+++ b/core/src/main/java/com/graphhopper/routing/AlgorithmOptions.java
@@ -62,6 +62,10 @@ public class AlgorithmOptions
     /**
      * round trip algorithm based on alternative route algorithm
      */
+    public static final String ROUND_TRIP = "roundTrip";
+    /**
+     * round trip algorithm based on alternative route algorithm
+     */
     public static final String ROUND_TRIP_ALT = "roundTripAlt";
     private String algorithm = DIJKSTRA_BI;
     private Weighting weighting;

--- a/core/src/main/java/com/graphhopper/routing/RoundTripAlgorithm.java
+++ b/core/src/main/java/com/graphhopper/routing/RoundTripAlgorithm.java
@@ -1,0 +1,124 @@
+/*
+ *  Licensed to GraphHopper and Peter Karich under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for 
+ *  additional information regarding copyright ownership.
+ * 
+ *  GraphHopper licenses this file to you under the Apache License, 
+ *  Version 2.0 (the "License"); you may not use this file except in 
+ *  compliance with the License. You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.routing;
+
+import com.graphhopper.routing.util.EdgeFilter;
+import com.graphhopper.routing.util.UniquePathWeighting;
+import com.graphhopper.routing.util.Weighting;
+import com.graphhopper.routing.util.tour.TourWayPointGenerator;
+import com.graphhopper.storage.Graph;
+import com.graphhopper.storage.index.LocationIndex;
+import com.graphhopper.util.shapes.GHPoint;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This class implements the round trip calculation via randomly generated points
+ * <p>
+ * @author Robin Boldt
+ */
+public class RoundTripAlgorithm implements RoutingAlgorithm
+{
+    private final Weighting weighting;
+    private LocationIndex locationIndex = null;
+    private EdgeFilter edgeFilter = null;
+    private GHPoint from = null;
+    private final double distanceInKm;
+    private Graph g;
+    private AlgorithmOptions opts;
+    private int numberOfVisitedNodes = 0;
+    private double weightLimit;
+
+    public RoundTripAlgorithm( Weighting weighting, double distanceInKm, Graph g, AlgorithmOptions opts )
+    {
+        this.distanceInKm = distanceInKm;
+        this.g = g;
+        this.opts = opts;
+        if (!(weighting instanceof UniquePathWeighting))
+            weighting = new UniquePathWeighting(weighting);
+        this.weighting = weighting;
+    }
+
+    public void prepare( LocationIndex locationIndex, EdgeFilter edgeFilter, GHPoint from )
+    {
+        this.locationIndex = locationIndex;
+        this.edgeFilter = edgeFilter;
+        this.from = from;
+    }
+
+    private RoutingAlgorithm getRoutingAlgorithm()
+    {
+        return new DijkstraBidirectionRef(g, opts.getFlagEncoder(), this.weighting, opts.getTraversalMode());
+    }
+
+    public List<Path> calcRoundTrips()
+    {
+        List<Integer> points = TourWayPointGenerator.generateTour(from, locationIndex, edgeFilter, this.distanceInKm);
+        List<Path> pathList = new ArrayList<Path>(points.size() - 1);
+        RoutingAlgorithm routingAlgorithm;
+
+        for (int i = 1; i < points.size(); i++)
+        {
+            routingAlgorithm = this.getRoutingAlgorithm();
+            routingAlgorithm.setWeightLimit(weightLimit);
+            Path path = routingAlgorithm.calcPath(points.get(i - 1), points.get(i));
+            pathList.add(path);
+            this.numberOfVisitedNodes += routingAlgorithm.getVisitedNodes();
+            if (weighting instanceof UniquePathWeighting)
+                ((UniquePathWeighting) weighting).addPath(path);
+        }
+
+        return pathList;
+    }
+
+    @Override
+    public Path calcPath( int notNeeded, int notNeededAsWell )
+    {
+        throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    public List<Path> calcPaths( int notNeeded, int notNeededAsWell )
+    {
+        if (locationIndex == null)
+        {
+            throw new IllegalStateException("You have to call prepare before calculating Paths");
+        }
+        return calcRoundTrips();
+    }
+
+    @Override
+    public void setWeightLimit( double weightLimit )
+    {
+        this.weightLimit = weightLimit;
+    }
+
+    @Override
+    public String getName()
+    {
+        return AlgorithmOptions.ROUND_TRIP;
+    }
+
+    @Override
+    public int getVisitedNodes()
+    {
+        return this.numberOfVisitedNodes;
+    }
+
+}

--- a/core/src/main/java/com/graphhopper/routing/RoutingAlgorithmFactorySimple.java
+++ b/core/src/main/java/com/graphhopper/routing/RoutingAlgorithmFactorySimple.java
@@ -63,6 +63,10 @@ public class RoutingAlgorithmFactorySimple implements RoutingAlgorithmFactory
             altRouteAlgo.setMinPlateauFactor(opts.getHints().getDouble("alternative_route.min_plateau_factor", 0.2));
             altRouteAlgo.setMaxExplorationFactor(opts.getHints().getDouble("alternative_route.max_exploration_factor", 1));
             return altRouteAlgo;
+        } else if (AlgorithmOptions.ROUND_TRIP.equalsIgnoreCase(algoStr))
+        {
+            double distanceInKm = opts.getHints().getDouble("round_trip.distance", 1);
+            return new RoundTripAlgorithm(opts.getWeighting(), distanceInKm, g, opts);
         } else if (AlgorithmOptions.ROUND_TRIP_ALT.equalsIgnoreCase(algoStr))
         {
             RoundTripAltAlgorithm altRouteAlgo = new RoundTripAltAlgorithm(g, opts.getFlagEncoder(), opts.getWeighting(), opts.getTraversalMode());

--- a/core/src/main/java/com/graphhopper/routing/util/AbstractAdjustedWeighting.java
+++ b/core/src/main/java/com/graphhopper/routing/util/AbstractAdjustedWeighting.java
@@ -1,0 +1,53 @@
+/*
+ *  Licensed to GraphHopper and Peter Karich under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.routing.util;
+
+/**
+ * The AdjustedWeighting wraps another Weighting.
+ *
+ * @author Robin Boldt
+ */
+public abstract class AbstractAdjustedWeighting implements Weighting
+{
+
+    protected final Weighting superWeighting;
+
+    public AbstractAdjustedWeighting( Weighting superWeighting )
+    {
+        if (superWeighting == null)
+            throw new IllegalArgumentException("No super weighting set");
+        this.superWeighting = superWeighting;
+    }
+
+    /**
+     * Returns the flagEncoder of the superWeighting. Usually we do not have a Flagencoder here.
+     */
+    @Override
+    public FlagEncoder getFlagEncoder()
+    {
+        return superWeighting.getFlagEncoder();
+    }
+
+    @Override
+    public boolean matches( String weightingAsStr, FlagEncoder encoder )
+    {
+        return getName().equals(weightingAsStr) && encoder == superWeighting.getFlagEncoder();
+    }
+
+}
+

--- a/core/src/main/java/com/graphhopper/routing/util/UniquePathWeighting.java
+++ b/core/src/main/java/com/graphhopper/routing/util/UniquePathWeighting.java
@@ -1,0 +1,74 @@
+/*
+ *  Licensed to GraphHopper and Peter Karich under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.routing.util;
+
+import com.graphhopper.routing.Path;
+import com.graphhopper.util.EdgeIteratorState;
+import gnu.trove.set.TIntSet;
+import gnu.trove.set.hash.TIntHashSet;
+
+/**
+ * Rates already used Paths worse.
+ *
+ * @author RobinBoldt
+ */
+public class UniquePathWeighting extends AbstractAdjustedWeighting
+{
+    // Contains the EdgeIds of the already visisted Edges
+    protected final TIntSet visitedEdges = new TIntHashSet();
+
+    public static int ALREADY_VISISTED_EDGES_PENALTY = 5;
+
+    public UniquePathWeighting( Weighting superWeighting )
+    {
+        super(superWeighting);
+    }
+
+    public void addPath( Path path )
+    {
+        for (EdgeIteratorState edge : path.calcEdges())
+        {
+            visitedEdges.add(edge.getEdge());
+        }
+    }
+
+    @Override
+    public double getMinWeight( double distance )
+    {
+        return superWeighting.getMinWeight(distance);
+    }
+
+    @Override
+    public double calcWeight( EdgeIteratorState edgeState, boolean reverse, int prevOrNextEdgeId )
+    {
+        double weight = superWeighting.calcWeight(edgeState, reverse, prevOrNextEdgeId);
+
+        if (visitedEdges.contains(edgeState.getEdge()))
+        {
+            weight = weight * ALREADY_VISISTED_EDGES_PENALTY;
+        }
+
+        return weight;
+    }
+
+    @Override
+    public String getName()
+    {
+        return "unique_path";
+    }
+}

--- a/core/src/main/java/com/graphhopper/routing/util/tour/SinglePointTour.java
+++ b/core/src/main/java/com/graphhopper/routing/util/tour/SinglePointTour.java
@@ -1,0 +1,51 @@
+/*
+ *  Licensed to GraphHopper and Peter Karich under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.routing.util.tour;
+
+/**
+ * Generate only a single points
+ *
+ * @author Robin Boldt
+ */
+public class SinglePointTour extends TourStrategy
+{
+
+
+    public SinglePointTour( double overallDistance )
+    {
+        super(overallDistance);
+    }
+
+    @Override
+    public int numberOfGeneratedPoints()
+    {
+        return 1;
+    }
+
+    @Override
+    public double getDistanceForIteration( int iteration )
+    {
+        return slightlyModifyDistance(overallDistance / 3);
+    }
+
+    @Override
+    double getBearingForIteration( int iteration )
+    {
+        return random.nextInt(360);
+    }
+}

--- a/core/src/main/java/com/graphhopper/routing/util/tour/TourStrategy.java
+++ b/core/src/main/java/com/graphhopper/routing/util/tour/TourStrategy.java
@@ -1,0 +1,63 @@
+/*
+ *  Licensed to GraphHopper and Peter Karich under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.routing.util.tour;
+
+import java.util.Random;
+
+/**
+ * Defines the Strategy of creating Tours.
+ *
+ * @author Robin Boldt
+ */
+abstract class TourStrategy
+{
+
+    protected static Random random = new Random();
+    protected double overallDistance;
+
+    public TourStrategy(double overallDistance){
+        this.overallDistance = overallDistance;
+    }
+
+    /**
+     * Defines the number of points that are generated
+     */
+    abstract int numberOfGeneratedPoints();
+
+    /**
+     * Returns the distance in KM that is used for the generated point #iteration
+     */
+    abstract double getDistanceForIteration(int iteration);
+
+    /**
+     * Returns the bearing between 0 and 360 for the current #iteration
+     */
+    abstract double getBearingForIteration(int iteration);
+
+
+    /**
+     * Modifies the Distance up to +-10%
+     */
+    protected double slightlyModifyDistance(double distance){
+        double distanceModification = random.nextDouble() * .1 * distance;
+        if (random.nextBoolean())
+            distanceModification = -distanceModification;
+        return distance + distanceModification;
+    }
+
+}

--- a/core/src/main/java/com/graphhopper/routing/util/tour/TourStrategy.java
+++ b/core/src/main/java/com/graphhopper/routing/util/tour/TourStrategy.java
@@ -60,4 +60,19 @@ abstract class TourStrategy
         return distance + distanceModification;
     }
 
+    /**
+     * Allows to add a value to the current bearing. If the value becomse greater than 360 start from 0.
+     */
+    protected double addToBearing(double bearing, double add){
+        // Fix initial values
+        add = add % 360;
+        bearing = bearing % 360;
+
+        bearing = bearing + add;
+        if(bearing < 0)
+            bearing = 360 + bearing; // + since the number is negative
+
+        return bearing % 360;
+    }
+
 }

--- a/core/src/main/java/com/graphhopper/routing/util/tour/TourStrategyFactory.java
+++ b/core/src/main/java/com/graphhopper/routing/util/tour/TourStrategyFactory.java
@@ -1,0 +1,31 @@
+/*
+ *  Licensed to GraphHopper and Peter Karich under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.routing.util.tour;
+
+/**
+ * @author Robin Boldt
+ */
+public class TourStrategyFactory
+{
+
+    public static TourStrategy getStrategy( double distanceInKm )
+    {
+        return new SinglePointTour(distanceInKm);
+    }
+
+}

--- a/core/src/main/java/com/graphhopper/routing/util/tour/TourWayPointGenerator.java
+++ b/core/src/main/java/com/graphhopper/routing/util/tour/TourWayPointGenerator.java
@@ -1,0 +1,99 @@
+/*
+ *  Licensed to GraphHopper and Peter Karich under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.routing.util.tour;
+
+import com.graphhopper.routing.util.EdgeFilter;
+import com.graphhopper.storage.index.LocationIndex;
+import com.graphhopper.storage.index.QueryResult;
+import com.graphhopper.util.CoordinateProjection;
+import com.graphhopper.util.shapes.GHPoint;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TourWayPointGenerator
+{
+
+    public static int INITIAL_TRIES = 40;
+    public static int RESET_TRIES = 2;
+    public static int MAX_TRIES = 50;
+
+    private static final Logger logger = LoggerFactory.getLogger(TourWayPointGenerator.class);
+
+    public static List<Integer> generateTour( GHPoint start, LocationIndex locationIndex, EdgeFilter edgeFilter, double distanceInKm)
+    {
+        return generateTour(start, locationIndex, edgeFilter, TourStrategyFactory.getStrategy(distanceInKm));
+    }
+
+    public static List<Integer> generateTour( GHPoint start, LocationIndex locationIndex, EdgeFilter edgeFilter, TourStrategy strategy )
+    {
+        List<Integer> tour = new ArrayList<Integer>(2 + strategy.numberOfGeneratedPoints());
+        int startIndex = locationIndex.findClosest(start.lat, start.lon, edgeFilter).getClosestNode();
+        tour.add(startIndex);
+
+        GHPoint last = start;
+        QueryResult result;
+        for (int i = 0; i < strategy.numberOfGeneratedPoints(); i++)
+        {
+            result = generateValidPoint(last, strategy.getDistanceForIteration(i), strategy.getBearingForIteration(i), locationIndex, edgeFilter, INITIAL_TRIES);
+            last = result.getSnappedPoint();
+            tour.add(result.getClosestNode());
+        }
+
+        tour.add(startIndex);
+        return tour;
+    }
+
+    private static QueryResult generateValidPoint( GHPoint from, double distanceInKm, double bearing, LocationIndex locationIndex, EdgeFilter edgeFilter, int triesAvailable )
+    {
+        int counter = 0;
+        while (true)
+        {
+            GHPoint generatedPoint = CoordinateProjection.projectCoordinate(from.getLat(), from.getLon(), distanceInKm, bearing);
+            QueryResult qr = locationIndex.findClosest(generatedPoint.getLat(), generatedPoint.getLon(), edgeFilter);
+            if (qr.isValid())
+            {
+                return qr;
+            }
+
+            triesAvailable--;
+            counter++;
+
+            // The idea is that if we cannot find any valid points around a coordinate, we reduce the distance, because it could be that there are no points in the area
+            if (triesAvailable <= 0)
+            {
+                triesAvailable = RESET_TRIES;
+                distanceInKm = distanceInKm / 3;
+                logger.debug("Cannot find anything, reducing the distance to: " + distanceInKm);
+            }
+
+            // Last try with 1km distance
+            if (counter == MAX_TRIES)
+            {
+                distanceInKm = 1;
+            }
+
+            if (counter >= MAX_TRIES)
+            {
+                throw new IllegalStateException("Could not find a valid point after " + counter + " iterations, for the Point:" + from);
+            }
+        }
+    }
+}

--- a/core/src/main/java/com/graphhopper/util/CoordinateProjection.java
+++ b/core/src/main/java/com/graphhopper/util/CoordinateProjection.java
@@ -1,0 +1,74 @@
+/*
+ *  Licensed to GraphHopper and Peter Karich under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.util;
+
+import com.graphhopper.util.shapes.GHPoint;
+
+import java.util.Random;
+
+/**
+ * Projects coordinates to a new location using a given distance and bearing.
+ */
+public class CoordinateProjection
+{
+
+    private static final double EARTH_RADIUS_IN_KM = 6371;
+    private static Random random = new Random();
+
+    /**
+     * This methods projects a point given in lat and long (in degrees) into a direction, given as bearing, measured
+     * clockwise from north in degrees. The distance is passed in km.
+     *
+     * This formula is taken from: http://www.movable-type.co.uk/scripts/latlong.html
+     *
+     *   lat2 = asin( sin φ1 ⋅ cos δ + cos φ1 ⋅ sin δ ⋅ cos θ )
+     *   lon2 = λ1 + atan2( sin θ ⋅ sin δ ⋅ cos φ1, cos δ − sin φ1 ⋅ sin φ2 )
+     *
+     */
+    public static GHPoint projectCoordinate( double latInDeg, double lonInDeg, double distanceInKm, double bearingClockwiseFromNorth )
+    {
+        double angularDistance = distanceInKm / EARTH_RADIUS_IN_KM;
+
+        double latInRadians = Math.toRadians(latInDeg);
+        double lonInRadians = Math.toRadians(lonInDeg);
+        double bearingInRadians = Math.toRadians(bearingClockwiseFromNorth);
+
+        double projectedLat = Math.asin(Math.sin(latInRadians) * Math.cos(angularDistance) +
+                Math.cos(latInRadians) * Math.sin(angularDistance) * Math.cos(bearingInRadians));
+        double projectedLon = lonInRadians + Math.atan2(Math.sin(bearingInRadians) * Math.sin(angularDistance) * Math.cos(latInRadians),
+                Math.cos(angularDistance) - Math.sin(latInRadians) * Math.sin(projectedLat));
+
+        projectedLon = (projectedLon + 3 * Math.PI) % (2 * Math.PI) - Math.PI; // normalise to -180..+180°
+
+        projectedLat = Math.toDegrees(projectedLat);
+        projectedLon = Math.toDegrees(projectedLon);
+
+        return new GHPoint(projectedLat, projectedLon);
+    }
+
+    public static GHPoint projectCoordinateRandomBearingAndModifiedDistance( double latInDeg, double lonInDeg, double distanceInKm )
+    {
+        double bearing = random.nextInt(360);
+        double distanceModification = random.nextDouble() * .1 * distanceInKm;
+        if (random.nextBoolean())
+            distanceModification = -distanceModification;
+        distanceInKm = distanceInKm + distanceModification;
+        return projectCoordinate(latInDeg, lonInDeg, distanceInKm, bearing);
+    }
+
+}

--- a/core/src/test/java/com/graphhopper/GraphHopperIT.java
+++ b/core/src/test/java/com/graphhopper/GraphHopperIT.java
@@ -532,4 +532,22 @@ public class GraphHopperIT
         assertEquals(89, arsp.getPoints().getSize());
         tmpHopper.close();
     }
+
+    @Test
+    public void testRoundTour()
+    {
+        GHRequest rq = new GHRequest().
+                addPoint(new GHPoint(43.741069, 7.426854)).
+                addPoint(new GHPoint(43.741069, 7.426854)).
+                setVehicle(vehicle).setWeighting("fastest").
+                setAlgorithm("roundTrip")
+                ;
+        rq.getHints().put("round_trip.distance", 1);
+        GHResponse rsp = hopper.route(rq);
+
+        for (PathWrapper altRsp: rsp.getAll()){
+            assertTrue(altRsp.getPoints().size() > 2);
+        }
+    }
+
 }

--- a/core/src/test/java/com/graphhopper/routing/util/tour/SinglePointTourTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/tour/SinglePointTourTest.java
@@ -1,0 +1,45 @@
+/*
+ *  Licensed to GraphHopper and Peter Karich under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for 
+ *  additional information regarding copyright ownership.
+ * 
+ *  GraphHopper licenses this file to you under the Apache License, 
+ *  Version 2.0 (the "License"); you may not use this file except in 
+ *  compliance with the License. You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.routing.util.tour;
+
+import org.junit.Test;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
+
+
+/**
+ * @author Robin Boldt
+ */
+public class SinglePointTourTest
+{
+
+    @Test
+    public void testBasics(){
+
+        SinglePointTour tour = new SinglePointTour(100);
+        assertEquals(1, tour.numberOfGeneratedPoints());
+
+        assertTrue(0 <= tour.getBearingForIteration(0));
+        assertTrue(360 >= tour.getBearingForIteration(0));
+
+        assertTrue(29 <= tour.getDistanceForIteration(0));
+        assertTrue(37 >= tour.getDistanceForIteration(0));
+    }
+
+}


### PR DESCRIPTION
This PR contains the possibility to create random round tours. When passing `tour_length=APPROX_DISTANCE_IN_KM` to the request it returns a roundtour of approximately the requested distance. The actual distances can vary a lot, since I only calculate the beeline distance of the waypoints.

The current results are ok, but not good. Especially because the unique_paths PR is not included here (this will probably improve the results.

Currently this feature is not available in the GUI. We just use the first waypoint and create a route.

Something that could be added as well is to calculate a number of tours and select the best one, to remove bad results created by this approach.