### PR TITLE
Change default precision from 1 m to 10 m for distance label

### DIFF
--- a/web/src/main/webapp/css/style.css
+++ b/web/src/main/webapp/css/style.css
@@ -1,6 +1,6 @@
 body {
     color: #000;
-    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;    
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
     line-height: 1.4;
     color: #111111;
     background-color: white;
@@ -14,7 +14,7 @@ body {
 
 #input {
     float: left;
-    margin-left: 10px; 
+    margin-left: 10px;
     /*padding-right: 15px; */
 }
 
@@ -84,7 +84,7 @@ body {
     padding-bottom: 10px;
     float: left;
 }
-.pointDiv { 
+.pointDiv {
     margin: 6px 0;
 }
 .pointDiv > img {
@@ -160,8 +160,8 @@ body {
     margin-bottom: 5px;
 }
 
-#searchButton:hover { 
-    cursor: pointer; 
+#searchButton:hover {
+    cursor: pointer;
 }
 .clear {
     clear: both;
@@ -219,7 +219,7 @@ td.instr_title {
 }
 td.instr_distance {
     min-width: 50px;
-    float: right;    
+    float: right;
     color: gray;
     text-align: right;
 }
@@ -227,7 +227,7 @@ td.instr_distance {
 #instructions tr .instr_pic {
     width: 20px;
 }
-td img.pic {    
+td img.pic {
     max-height: 24px;
     max-width: 16px;
 }
@@ -251,7 +251,7 @@ td img.pic {
     background-color: #bbb;
     -moz-border-radius: 0px;
     -webkit-border-radius: 0px;
-    background-image: linear-gradient(to bottom, #9f9f9f, #e7e7e7);    
+    background-image: linear-gradient(to bottom, #9f9f9f, #e7e7e7);
 }
 
 #more-vehicle-btn {
@@ -261,11 +261,11 @@ td img.pic {
 .autocomplete {
     border: 1px solid #999;
     background: #FFF;
-    overflow: auto; 
+    overflow: auto;
 }
 .autocomplete strong {
     font-weight: normal;
-    color: #04B431; 
+    color: #04B431;
 }
 .autocomplete-suggestion {
     padding: 5px 5px;

--- a/web/src/main/webapp/js/autocomplete.js
+++ b/web/src/main/webapp/js/autocomplete.js
@@ -1,5 +1,6 @@
 var formatTools = require('./tools/format.js');
 var GHInput = require('./graphhopper/GHInput.js');
+var mapLayer = require('./map.js');
 
 var dataToHtml = function (data, query) {
     var element = "";

--- a/web/src/main/webapp/js/main-template.js
+++ b/web/src/main/webapp/js/main-template.js
@@ -2,9 +2,9 @@ var host;
 
 // Deployment-scripts can insert host here.
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-// We know that you love 'free', we love it too :)! And so our entire software stack is free and even Open Source!      
+// We know that you love 'free', we love it too :)! And so our entire software stack is free and even Open Source!
 // Our routing service is also free for certain applications or smaller volume. Be fair, grab an API key and support us:
-// https://graphhopper.com/#directions-api Misuse of API keys that you don't own is prohibited and you'll be blocked.                    
+// https://graphhopper.com/#directions-api Misuse of API keys that you don't own is prohibited and you'll be blocked.
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 if (!host) {
     if (location.port === '') {
@@ -248,7 +248,7 @@ function resolveCoords(pointsAsStr, doQuery) {
         resolveAll();
         routeLatLng(ghRequest, doQuery);
     } else {
-        // at least one text input from user -> wait for resolve as we need the coord for routing     
+        // at least one text input from user -> wait for resolve as we need the coord for routing
         $.when.apply($, resolveAll()).done(function () {
             routeLatLng(ghRequest, doQuery);
         });
@@ -454,7 +454,7 @@ function routeLatLng(request, doQuery) {
     var urlForHistory = request.createHistoryURL() + "&layer=" + activeLayer;
 
     // not enabled e.g. if no cookies allowed (?)
-    // if disabled we have to do the query and cannot rely on the statechange history event    
+    // if disabled we have to do the query and cannot rely on the statechange history event
     if (!doQuery && History.enabled) {
         // 2. important workaround for encoding problems in history.js
         var params = urlTools.parseUrl(urlForHistory);
@@ -590,3 +590,5 @@ function mySubmit() {
 function isProduction() {
     return host.indexOf("graphhopper.com") > 0;
 }
+
+module.exports.setFlag = setFlag;

--- a/web/src/main/webapp/js/map.js
+++ b/web/src/main/webapp/js/map.js
@@ -1,3 +1,4 @@
+var mainTemplate = require('./main-template.js');
 var tileLayers = require('./config/tileLayers.js');
 
 var routingLayer;
@@ -20,7 +21,7 @@ function adjustMapSize() {
     var height = $(window).height();
     mapDiv.width(width).height(height);
     $("#input").height(height);
-    // reduce info size depending on how heigh the input_header is and reserve space for footer
+    // reduce info size depending on how high the input_header is and reserve space for footer
     $("#info").css("max-height", height - $("#input_header").height() - 58);
 }
 
@@ -177,7 +178,7 @@ function focus(coord, zoom, index) {
             zoom = 11;
         routingLayer.clearLayers();
         map.setView(new L.LatLng(coord.lat, coord.lng), zoom);
-        setFlag(coord, index);
+        mainTemplate.setFlag(coord, index);
     }
 }
 
@@ -221,9 +222,6 @@ module.exports.addElevation = function (geoJsonFeature) {
             theme: "white-theme", //default: lime-theme
             width: 450,
             height: 125,
-            yAxisMin: 0, // set min domain y axis
-            // yAxisMax: 550, // set max domain y axis
-            forceAxisBounds: false,
             margins: {
                 top: 10,
                 right: 20,
@@ -233,8 +231,8 @@ module.exports.addElevation = function (geoJsonFeature) {
             useHeightIndicator: true, //if false a marker is drawn at map position
             interpolation: "linear", //see https://github.com/mbostock/d3/wiki/SVG-Shapes#wiki-area_interpolate
             hoverNumber: {
-                decimalsX: 3, //decimals on distance (always in km)
-                decimalsY: 0, //deciamls on height (always in m)
+                decimalsX: 2, //decimals on distance (always in km)
+                decimalsY: 0, //decimals on height (always in m)
                 formatter: undefined //custom formatter function may be injected
             },
             xTicks: undefined, //number of ticks in x axis, calculated by default according to width


### PR DESCRIPTION
Unless you are looking at directions for a very short distance, say total distance about < 1 km (which is not common), moving the mouse on the elevation profile by just 1 pixel will never make only the 3rd decimal digit change. 2nd decimal digit changes too. Thus 3rd digit is not significant and can be removed.

I'm hesitating about 2nd digit. It could be removed too in most cases. With directions about > 10 km long, the 2 digit is not significant when mousing over the elevation profile.

#### Other minor changes

- ForceAxisBounds = false is default anyway
- Keeping "yAxisMin: 0" alone is useless unless "forceAxisBounds = true"
- Add missing exports
- Remove trailing space