### PR TITLE
Identical expressions should not be used on both sides of a binary operator

### DIFF
--- a/core/src/main/java/com/graphhopper/util/PointList.java
+++ b/core/src/main/java/com/graphhopper/util/PointList.java
@@ -324,7 +324,7 @@ public class PointList implements Iterable<GHPoint3D>, PointAccess
             return false;
 
         PointList other = (PointList) obj;
-        if (other.isEmpty() && other.isEmpty())
+        if (this.isEmpty() && other.isEmpty())
             return true;
 
         if (this.getSize() != other.getSize() || this.is3D() != other.is3D())


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1764 - Identical expressions should not be used on both sides of a binary operator
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1764
Please let me know if you have any questions.
Kirill Vlasov