### PR TITLE
Increase of priority influence for bike encoders

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
@@ -785,4 +785,10 @@ public class BikeCommonFlagEncoder extends AbstractFlagEncoder
     {
         specificBicycleClass = "class:bicycle:" + subkey;
     }
+    
+    @Override
+    public double defaultPriorityBoostLevel()
+    {
+        return 2.0;
+    }
 }

--- a/core/src/main/java/com/graphhopper/routing/util/CarFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/CarFlagEncoder.java
@@ -317,6 +317,12 @@ public class CarFlagEncoder extends AbstractFlagEncoder
         else
             return "destination: " + str;
     }
+    
+    @Override
+    public double defaultPriorityBoostLevel()
+    {
+        return 1.0;
+    }
 
     @Override
     public String toString()

--- a/core/src/main/java/com/graphhopper/routing/util/FlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/FlagEncoder.java
@@ -132,4 +132,9 @@ public interface FlagEncoder extends TurnCostEncoder
      * @return true if already registered in an EncodingManager
      */
     boolean isRegistered();
+
+    /**
+     * @return the default boost level for the priority
+     */
+    public double defaultPriorityBoostLevel();
 }

--- a/core/src/main/java/com/graphhopper/routing/util/FootFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/FootFlagEncoder.java
@@ -385,6 +385,12 @@ public class FootFlagEncoder extends AbstractFlagEncoder
 
         return PriorityWeighting.class.isAssignableFrom(feature);
     }
+    
+    @Override
+    public double defaultPriorityBoostLevel()
+    {
+        return 1.0;
+    }
 
     @Override
     public String toString()

--- a/core/src/main/java/com/graphhopper/routing/util/PriorityWeighting.java
+++ b/core/src/main/java/com/graphhopper/routing/util/PriorityWeighting.java
@@ -32,6 +32,7 @@ public class PriorityWeighting extends FastestWeighting
      * For now used only in BikeCommonFlagEncoder, FootEncoder and MotorcycleFlagEncoder
      */
     public static final int KEY = 101;
+    private double prioBoost;
     private final double minFactor;
 
     public PriorityWeighting( FlagEncoder encoder )
@@ -42,8 +43,9 @@ public class PriorityWeighting extends FastestWeighting
     public PriorityWeighting( FlagEncoder encoder, PMap pMap )
     {
         super(encoder, pMap);
+        prioBoost = encoder.defaultPriorityBoostLevel();
         double maxPriority = 1; // BEST / BEST
-        minFactor = 1 / (0.5 + maxPriority);
+        minFactor = 1 / ( 0.5 / prioBoost + prioBoost * maxPriority);
     }
 
     @Override
@@ -58,6 +60,6 @@ public class PriorityWeighting extends FastestWeighting
         double weight = super.calcWeight(edgeState, reverse, prevOrNextEdgeId);
         if (Double.isInfinite(weight))
             return Double.POSITIVE_INFINITY;
-        return weight / (0.5 + flagEncoder.getDouble(edgeState.getFlags(), KEY));
+        return weight / ( 0.5 / prioBoost + prioBoost * flagEncoder.getDouble(edgeState.getFlags(), KEY));
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/util/RacingBikeFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/RacingBikeFlagEncoder.java
@@ -176,7 +176,13 @@ public class RacingBikeFlagEncoder extends BikeCommonFlagEncoder
         // for racing bike it is only allowed if empty
         return false;
     }
-
+    
+    @Override
+    public double defaultPriorityBoostLevel()
+    {
+        return 1.5;
+    }
+    
     @Override
     public String toString()
     {

--- a/core/src/test/java/com/graphhopper/GraphHopperIT.java
+++ b/core/src/test/java/com/graphhopper/GraphHopperIT.java
@@ -398,8 +398,8 @@ public class GraphHopperIT
         rsp = tmpHopper.route(new GHRequest(43.73005, 7.415707, 43.741522, 7.42826)
                 .setVehicle("bike"));
         assertFalse("bike routing for " + str + " should not have errors:" + rsp.getErrors(), rsp.hasErrors());
-        assertEquals(494, rsp.getTime() / 1000f, 1);
-        assertEquals(2192, rsp.getDistance(), 1);
+        assertEquals(529, rsp.getTime() / 1000f, 1);
+        assertEquals(2523, rsp.getDistance(), 1);
 
         rsp = tmpHopper.route(new GHRequest(43.73005, 7.415707, 43.741522, 7.42826)
                 .setVehicle("foot"));

--- a/core/src/test/java/com/graphhopper/routing/RoutingAlgorithmIT.java
+++ b/core/src/test/java/com/graphhopper/routing/RoutingAlgorithmIT.java
@@ -353,17 +353,17 @@ public class RoutingAlgorithmIT
         // 1. alternative: go over steps 'Rampe Major' => 1.7km vs. around 2.7km
         list.add(new OneRun(43.730864, 7.420771, 43.727687, 7.418737, 2710, 118));
         // 2.
-        list.add(new OneRun(43.728499, 7.417907, 43.74958, 7.436566, 3777, 194));
+        list.add(new OneRun(43.728499, 7.417907, 43.74958, 7.436566, 4272, 219));
         // 3.
         list.add(new OneRun(43.728677, 7.41016, 43.739213, 7.427806, 2776, 167));
         // 4.
-        list.add(new OneRun(43.733802, 7.413433, 43.739662, 7.424355, 1544, 84));
+        list.add(new OneRun(43.733802, 7.413433, 43.739662, 7.424355, 1567, 84));
 
         // try reverse direction
         // 1.
         list.add(new OneRun(43.727687, 7.418737, 43.730864, 7.420771, 2599, 115));
-        list.add(new OneRun(43.74958, 7.436566, 43.728499, 7.417907, 4199, 165));
-        list.add(new OneRun(43.739213, 7.427806, 43.728677, 7.41016, 3261, 177));
+        list.add(new OneRun(43.74958, 7.436566, 43.728499, 7.417907, 3924, 165));
+        list.add(new OneRun(43.739213, 7.427806, 43.728677, 7.41016, 2805, 145));
         // 4. avoid tunnel(s)!
         list.add(new OneRun(43.739662, 7.424355, 43.733802, 7.413433, 2452, 112));
         runAlgo(testCollector, "files/monaco.osm.gz", "target/monaco-gh",
@@ -388,11 +388,11 @@ public class RoutingAlgorithmIT
     public void testMonacoMountainBike()
     {
         List<OneRun> list = new ArrayList<OneRun>();
-        list.add(new OneRun(43.730864, 7.420771, 43.727687, 7.418737, 2322, 110));
-        list.add(new OneRun(43.727687, 7.418737, 43.74958, 7.436566, 3613, 178));
+        list.add(new OneRun(43.730864, 7.420771, 43.727687, 7.418737, 2593, 110));
+        list.add(new OneRun(43.727687, 7.418737, 43.74958, 7.436566, 3654, 178));
         list.add(new OneRun(43.728677, 7.41016, 43.739213, 7.427806, 2331, 121));
         // hard to select between secondary and primary (both are AVOID for mtb)
-        list.add(new OneRun(43.733802, 7.413433, 43.739662, 7.424355, 1459, 88));
+        list.add(new OneRun(43.733802, 7.413433, 43.739662, 7.424355, 1471, 93));
         runAlgo(testCollector, "files/monaco.osm.gz", "target/monaco-gh",
                 list, "MTB", true, "MTB", "fastest", false);
         assertEquals(testCollector.toString(), 0, testCollector.errors.size());
@@ -425,7 +425,7 @@ public class RoutingAlgorithmIT
         List<OneRun> list = new ArrayList<OneRun>();
         list.add(new OneRun(48.409523, 15.602394, 48.375466, 15.72916, 12491, 159));
         // 3109m is better as cyclepath is used
-        list.add(new OneRun(48.410061, 15.63951, 48.411386, 15.604899, 3113, 87));
+        list.add(new OneRun(48.410061, 15.63951, 48.411386, 15.604899, 3077, 79));
         list.add(new OneRun(48.412294, 15.62007, 48.398306, 15.609667, 3965, 94));
 
         runAlgo(testCollector, "files/krems.osm.gz", "target/krems-gh",
@@ -529,7 +529,7 @@ public class RoutingAlgorithmIT
     {
         List<OneRun> list = new ArrayList<OneRun>();
         // choose Unterloher Weg and the following residential + cycleway
-        list.add(new OneRun(50.004333, 11.600254, 50.044449, 11.543434, 6931, 184));
+        list.add(new OneRun(50.004333, 11.600254, 50.044449, 11.543434, 7023, 184));
         runAlgo(testCollector, "files/north-bayreuth.osm.gz", "target/north-bayreuth-gh",
                 list, "bike", true, "bike", "fastest", false);
         assertEquals(testCollector.toString(), 0, testCollector.errors.size());

--- a/core/src/test/java/com/graphhopper/routing/util/EncodingManagerTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/EncodingManagerTest.java
@@ -139,6 +139,12 @@ public class EncodingManagerTest
             {
                 return 0;
             }
+
+            @Override
+            public double defaultPriorityBoostLevel()
+            {
+                return 1.0;
+            }
         };
 
         EncodingManager subject = new EncodingManager(encoder);


### PR DESCRIPTION
This change doubles the influence of the priority influence for the bicycles encoders bike and mtb. The priority influence for the racebike is increased by factor 1.5. See #597, #598 and #600.