### PR TITLE
Use regular weighting if no CH weighting is available

### DIFF
--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -1069,8 +1069,12 @@ public class GraphHopper implements GraphHopperAPI
             boolean forceCHHeading = request.getHints().getBool("force_heading_ch", false);
             if (!forceCHHeading && request.hasFavoredHeading(0))
                 throw new IllegalStateException("Heading is not (fully) supported for CHGraph. See issue #483");
-            weighting = getWeightingForCH(request.getHints(), encoder);
-            routingGraph = ghStorage.getGraph(CHGraph.class, weighting);
+            try{
+                weighting = getWeightingForCH(request.getHints(), encoder);
+                routingGraph = ghStorage.getGraph(CHGraph.class, weighting);
+            }catch (IllegalStateException e){
+                weighting = createWeighting(request.getHints(), encoder);
+            }
         } else
             weighting = createWeighting(request.getHints(), encoder);
 


### PR DESCRIPTION
This PR allows to use weightings that are not prepared with CH to be used instead of throwing an Exception.

A possible use-case could be a routing that considers live-traffic, but in general most routes are calculated without considering live-traffic (this would be CH weighting).

In general, I think falling back to a regular weighting is better than throwing an exception (at least in most cases).