### PR TITLE
Center vehicle icons vertically in buttons + minor JS code refactor

### DIFF
--- a/web/src/main/webapp/css/style.css
+++ b/web/src/main/webapp/css/style.css
@@ -180,7 +180,7 @@ body {
 #footer {
     position: fixed;
     bottom: 5px;
-    left: 30px;    
+    left: 30px;
 }
 
 #hosting a, .footer-link {
@@ -244,6 +244,7 @@ td img.pic {
 .vehicle-btn img {
     width: 24px;
     height: 24px;
+    vertical-align: middle;
 }
 
 .selectvehicle {
@@ -338,7 +339,7 @@ td img.pic {
 }
 
 #donate_form {
-    padding: 0;    
+    padding: 0;
 }
 
 #donate_form_button {

--- a/web/src/main/webapp/js/config/tileLayers.js
+++ b/web/src/main/webapp/js/config/tileLayers.js
@@ -1,12 +1,10 @@
 var osmAttr = '&copy; <a href="http://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a> contributors';
 
-var tp = "ls";
-if (L.Browser.retina)
-    tp = "lr";
+// Automatically enable high-DPI tiles if provider and browser support it.
+var retinaTiles = L.Browser.retina;
 
-var lyrk = L.tileLayer('https://tiles.lyrk.org/' + tp + '/{z}/{x}/{y}?apikey=6e8cfef737a140e2a58c8122aaa26077', {
-    attribution: osmAttr + ', <a href="https://geodienste.lyrk.de/">Lyrk</a>',
-    subdomains: ['a', 'b', 'c']
+var lyrk = L.tileLayer('https://tiles.lyrk.org/' + (retinaTiles ? 'lr' : 'ls') + '/{z}/{x}/{y}?apikey=6e8cfef737a140e2a58c8122aaa26077', {
+    attribution: osmAttr + ', <a href="https://geodienste.lyrk.de/">Lyrk</a>'
 });
 
 var omniscale = L.tileLayer.wms('https://maps.omniscale.net/v1/mapsgraph-bf48cc0b/tile', {
@@ -14,42 +12,39 @@ var omniscale = L.tileLayer.wms('https://maps.omniscale.net/v1/mapsgraph-bf48cc0
     attribution: osmAttr + ', &copy; <a href="http://maps.omniscale.com/">Omniscale</a>'
 });
 
-var mapquest = L.tileLayer('http://{s}.mqcdn.com/tiles/1.0.0/osm/{z}/{x}/{y}.png', {
+var mapquest = L.tileLayer('http://otile{s}.mqcdn.com/tiles/1.0.0/osm/{z}/{x}/{y}.png', {
     attribution: osmAttr + ', <a href="http://open.mapquest.co.uk" target="_blank">MapQuest</a>',
-    subdomains: ['otile1', 'otile2', 'otile3', 'otile4']
+    subdomains: '1234'
 });
 
-var mapquestAerial = L.tileLayer('http://{s}.mqcdn.com/tiles/1.0.0/sat/{z}/{x}/{y}.png', {
+var mapquestAerial = L.tileLayer('http://otile{s}.mqcdn.com/tiles/1.0.0/sat/{z}/{x}/{y}.png', {
     attribution: osmAttr + ', <a href="http://open.mapquest.co.uk" target="_blank">MapQuest</a>',
-    subdomains: ['otile1', 'otile2', 'otile3', 'otile4']
+    subdomains: '1234'
 });
 
 var openMapSurfer = L.tileLayer('http://korona.geog.uni-heidelberg.de/tiles/roads/x={x}&y={y}&z={z}', {
     attribution: osmAttr + ', <a href="http://korona.geog.uni-heidelberg.de/contact.html">GIScience Heidelberg</a>'
 });
 
-// not an option as too fast over limit
-//    var mapbox= L.tileLayer('https://{s}.tiles.mapbox.com/v4/peterk.map-vkt0kusv/{z}/{x}/{y}.png?access_token=pk.eyJ1IjoicGV0ZXJrIiwiYSI6IkdFc2FJd2MifQ.YUd7dS_gOpT3xrQnB8_K-w', {
-//        attribution: osmAttr + ', <a href="https://www.mapbox.com/about/maps/">&copy; MapBox</a>'
-//    });
+// Not an option as too fast over limit.
+// var mapbox= L.tileLayer('https://{s}.tiles.mapbox.com/v4/peterk.map-vkt0kusv/{z}/{x}/{y}' + (retinaTiles ? '@2x' : '') + '.png?access_token=pk.eyJ1IjoicGV0ZXJrIiwiYSI6IkdFc2FJd2MifQ.YUd7dS_gOpT3xrQnB8_K-w', {
+//     attribution: osmAttr + ', <a href="https://www.mapbox.com/about/maps/">&copy; MapBox</a>'
+// });
 
 var sorbianLang = L.tileLayer('http://map.dgpsonline.eu/osmsb/{z}/{x}/{y}.png', {
     attribution: osmAttr + ', <a href="http://www.alberding.eu/">&copy; Alberding GmbH, CC-BY-SA</a>'
 });
 
 var thunderTransport = L.tileLayer('https://{s}.tile.thunderforest.com/transport/{z}/{x}/{y}.png', {
-    attribution: osmAttr + ', <a href="http://www.thunderforest.com/transport/" target="_blank">Thunderforest Transport</a>',
-    subdomains: ['a', 'b', 'c']
+    attribution: osmAttr + ', <a href="http://www.thunderforest.com/transport/" target="_blank">Thunderforest Transport</a>'
 });
 
 var thunderCycle = L.tileLayer('https://{s}.tile.thunderforest.com/cycle/{z}/{x}/{y}.png', {
-    attribution: osmAttr + ', <a href="http://www.thunderforest.com/opencyclemap/" target="_blank">Thunderforest Cycle</a>',
-    subdomains: ['a', 'b', 'c']
+    attribution: osmAttr + ', <a href="http://www.thunderforest.com/opencyclemap/" target="_blank">Thunderforest Cycle</a>'
 });
 
 var thunderOutdoors = L.tileLayer('https://{s}.tile.thunderforest.com/outdoors/{z}/{x}/{y}.png', {
-    attribution: osmAttr + ', <a href="http://www.thunderforest.com/outdoors/" target="_blank">Thunderforest Outdoors</a>',
-    subdomains: ['a', 'b', 'c']
+    attribution: osmAttr + ', <a href="http://www.thunderforest.com/outdoors/" target="_blank">Thunderforest Outdoors</a>'
 });
 
 var wrk = L.tileLayer('http://{s}.wanderreitkarte.de/topo/{z}/{x}/{y}.png', {
@@ -62,8 +57,7 @@ var osm = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
 });
 
 var osmde = L.tileLayer('http://{s}.tile.openstreetmap.de/tiles/osmde/{z}/{x}/{y}.png', {
-    attribution: osmAttr,
-    subdomains: ['a', 'b', 'c']
+    attribution: osmAttr
 });
 
 var mapLink = '<a href="http://www.esri.com/">Esri</a>';


### PR DESCRIPTION
This PR will move down vehicle icons 1 or 2 px down, so they are centered inside their button.

Use Mapbox retina tiles when possible. It’s commented out here. For people who register their own API token and uncomment.

Simplify subdomains of tiles URL. In Leaflet, value “abc” is already default for {s}.