### PR TITLE
Wrap coordinates around dateline

### DIFF
--- a/web/src/main/webapp/js/main-template.js
+++ b/web/src/main/webapp/js/main-template.js
@@ -325,14 +325,14 @@ function setToEnd(e) {
 }
 
 function setStartCoord(e) {
-    ghRequest.route.set(e.latlng, 0);
+    ghRequest.route.set(e.latlng.wrap(), 0);
     resolveFrom();
     routeIfAllResolved();
 }
 
 function setIntermediateCoord(e) {
     var index = ghRequest.route.size() - 1;
-    ghRequest.route.add(e.latlng, index);
+    ghRequest.route.add(e.latlng.wrap(), index);
     resolveIndex(index);
     routeIfAllResolved();
 }
@@ -346,7 +346,7 @@ function deleteCoord(e) {
 
 function setEndCoord(e) {
     var index = ghRequest.route.size() - 1;
-    ghRequest.route.set(e.latlng, index);
+    ghRequest.route.set(e.latlng.wrap(), index);
     resolveTo();
     routeIfAllResolved();
 }


### PR DESCRIPTION
When browsing another copy of the world, left or right the central one, after right-clicking on the map to add start, end, or intermediate points, error like this one is displayed:
```
Cannot find point 0: 52.50452,373.351135
Cannot find point 1: 52.516639,373.428383
```
This PR will make all clicks with longitude -180 to +180 degrees.

Uses the [wrap()](http://leafletjs.com/reference.html#latlng-wrap) function from Leaflet.

It's not a complete solution to this issue, as the route is always drawn on the main copy of the world. However it is still an improvement:
* Error is gone
* After routing results success, map is automatically panned to the route anyway (in central copy of world), and brings you back to the main world