### PR TITLE
Fix GraphHopperWeb to pass alternative_route hints to the server

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/FootFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/FootFlagEncoder.java
@@ -103,15 +103,25 @@ public class FootFlagEncoder extends AbstractFlagEncoder
         safeHighwayTags.add("track");
         safeHighwayTags.add("residential");
         safeHighwayTags.add("service");
+        
+        safeHighwayTags.add("trunk");
+        safeHighwayTags.add("trunk_link");
+        safeHighwayTags.add("primary");
+        safeHighwayTags.add("primary_link");
+        safeHighwayTags.add("secondary");
+        safeHighwayTags.add("secondary_link");
+        safeHighwayTags.add("tertiary");
+        safeHighwayTags.add("tertiary_link");
+        
 
-        avoidHighwayTags.add("trunk");
-        avoidHighwayTags.add("trunk_link");
-        avoidHighwayTags.add("primary");
-        avoidHighwayTags.add("primary_link");
-        avoidHighwayTags.add("secondary");
-        avoidHighwayTags.add("secondary_link");
-        avoidHighwayTags.add("tertiary");
-        avoidHighwayTags.add("tertiary_link");
+//        avoidHighwayTags.add("trunk");
+//        avoidHighwayTags.add("trunk_link");
+//        avoidHighwayTags.add("primary");
+//        avoidHighwayTags.add("primary_link");
+//        avoidHighwayTags.add("secondary");
+//        avoidHighwayTags.add("secondary_link");
+//        avoidHighwayTags.add("tertiary");
+//        avoidHighwayTags.add("tertiary_link");
 
         // for now no explicit avoiding #257
         //avoidHighwayTags.add("cycleway"); 

--- a/web/src/main/java/com/graphhopper/http/GraphHopperWeb.java
+++ b/web/src/main/java/com/graphhopper/http/GraphHopperWeb.java
@@ -23,9 +23,10 @@ import com.graphhopper.GHResponse;
 import com.graphhopper.GraphHopperAPI;
 import com.graphhopper.util.*;
 import com.graphhopper.util.shapes.GHPoint;
-import java.util.ArrayList;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -127,11 +128,16 @@ public class GraphHopperWeb implements GraphHopperAPI
 
             if (!tmpKey.isEmpty())
                 url += "&key=" + tmpKey;
-            int altMax = request.getHints().getInt("alternative_route.max_num", 0);
-            if (altMax != 0)
-            {
-                url += "&alternative_route.max_num=" + altMax;
-            }
+            
+            Set<String> keys = request.getHints().toMap().keySet();
+            for(String key:keys){
+            	if(key.startsWith("alternative_route.")){
+            		String val = request.getHints().get(key, null);
+            		if(val!=null){
+            			url += "&"+key+"=" + val;
+            		}
+            	}            	
+            }            
 
             String str = downloader.downloadAsString(url, true);
             JSONObject json = new JSONObject(str);


### PR DESCRIPTION
Passing all hints that starts with alternative_route as quay parameters on the route request