### PR TITLE
More appropriate MIME type for GPX exports

### DIFF
--- a/web/src/main/java/com/graphhopper/http/GraphHopperServlet.java
+++ b/web/src/main/java/com/graphhopper/http/GraphHopperServlet.java
@@ -199,7 +199,7 @@ public class GraphHopperServlet extends GHBaseServlet
         boolean withTrack = getBooleanParam(req, "gpx.track", true);
         boolean withWayPoints = getBooleanParam(req, "gpx.waypoints", false);
         res.setCharacterEncoding("UTF-8");
-        res.setContentType("application/xml");
+        res.setContentType("application/gpx+xml");
         String trackName = getParam(req, "trackname", "GraphHopper Track");
         res.setHeader("Content-Disposition", "attachment;filename=" + "GraphHopper.gpx");
         long time = getLongParam(req, "millis", System.currentTimeMillis());


### PR DESCRIPTION
There is no [official assignment](http://www.iana.org/assignments/media-types/media-types.xhtml) for the GPX format., however [Wikipedia](https://en.wikipedia.org/wiki/GPS_Exchange_Format) and several others use `application/gpx+xml`.