### PR TITLE
Move constant CSS from js to css

### DIFF
--- a/web/src/main/webapp/css/style.css
+++ b/web/src/main/webapp/css/style.css
@@ -8,8 +8,10 @@ body {
     min-width: 700px;
 }
 #map {
-    /* set size via JS */
+    /* Size and position ("relative" or "absolute") set via JS. */
     cursor: default;
+    float: right;
+    right: 0;
 }
 
 #input {
@@ -18,7 +20,7 @@ body {
     /*padding-right: 15px; */
 }
 
-#info {    
+#info {
     margin-top: 10px;
     display: none;
     padding: 5px;
@@ -28,7 +30,7 @@ body {
     padding-right: 5px;
 }
 
-.route_results {    
+.route_results {
     max-height: 40%;
 }
 
@@ -221,7 +223,7 @@ tr.instruction {
     border-bottom: #dadada dashed thin;
 }
 
-.instructions {    
+.instructions {
     table-layout:fixed;
     border-collapse: collapse;
     padding-top: 10px;
@@ -255,8 +257,8 @@ td img.pic {
     padding: 0;
     width: 32px;
     height: 32px;
-    -moz-border-radius: 0px;
-    -webkit-border-radius: 0px;
+    -moz-border-radius: 0;
+    -webkit-border-radius: 0;
     background-image: linear-gradient(to bottom, white, #e7e7e7);
 }
 
@@ -268,8 +270,8 @@ td img.pic {
 
 .selectvehicle {
     background-color: #bbb;
-    -moz-border-radius: 0px;
-    -webkit-border-radius: 0px;
+    -moz-border-radius: 0;
+    -webkit-border-radius: 0;
     background-image: linear-gradient(to bottom, #9f9f9f, #e7e7e7);
 }
 
@@ -321,7 +323,7 @@ td img.pic {
 .pointDelete:hover, .pointAdd:hover { cursor: pointer; }
 .pointDelete:disabled {
     background: red;
-} 
+}
 
 .expandDetails {
     color: gray;
@@ -331,8 +333,8 @@ td img.pic {
     width: 20px;
     height: 20px;
     height: 20px;
-    margin: 0px 10px;
-    padding: 0px;
+    margin: 0 10px;
+    padding: 0;
     background-image: linear-gradient(to bottom, white, #e7e7e7);
 }
 #moreButton {
@@ -366,8 +368,8 @@ td img.pic {
 }
 
 #route_result_tabs {
-    list-style: none; 
-    padding: 0; 
+    list-style: none;
+    padding: 0;
     margin: 0;
 }
 
@@ -391,7 +393,7 @@ td img.pic {
 }
 
 .route_result_tab.current {
-    display: block;    
+    display: block;
 }
 
 #donate_form {
@@ -401,7 +403,7 @@ td img.pic {
 #donate_form_button {
     background: none;
     border: none;
-    padding-left: 0px;
+    padding-left: 0;
     margin-top: 5px;
     cursor: pointer;
     float: left;

--- a/web/src/main/webapp/js/map.js
+++ b/web/src/main/webapp/js/map.js
@@ -14,9 +14,9 @@ function adjustMapSize() {
     var width = $(window).width() - 280;
     if (width < 400) {
         width = 400;
-        mapDiv.attr("style", "position: relative; float: right;");
+        mapDiv.attr("style", "position: relative;");
     } else {
-        mapDiv.attr("style", "position: absolute; right: 0;");
+        mapDiv.attr("style", "position: absolute;");
     }
     var height = $(window).height();
     if (height < 500)


### PR DESCRIPTION
These 2 CSS declarations `float: right;` and `right: 0;` are actually constant and can be moved to the css file.

Tested on my dev instance.

Code cosmetic:
- 0 times whatever is 0, so we may omit "px"
- Remove trailing white space (sorry, done automatically by my editor)