### PR TITLE
Updated SRTM URL to kurviger.de

### DIFF
--- a/core/src/main/java/com/graphhopper/reader/dem/SRTMProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/SRTMProvider.java
@@ -80,7 +80,7 @@ public class SRTMProvider implements ElevationProvider
     // possible alternatives see #451
     // http://mirror.ufs.ac.za/datasets/SRTM3/
     //"http://dds.cr.usgs.gov/srtm/version2_1/SRTM3/"
-    private String baseUrl = "http://srtm.motoroute.me/SRTM3/";
+    private String baseUrl = "https://srtm.kurviger.de/SRTM3/";
     private boolean calcMean = false;
 
     public SRTMProvider()


### PR DESCRIPTION
Since I renamed my motorcycle route planer to Kurviger I had to change the base URL to [Kurviger.de](https://kurviger.de/). The old url will be still valid for the foreseeable future.