### PR TITLE
Set ContentType to application/gpx+xml

### DIFF
--- a/web/src/main/java/com/graphhopper/http/GraphHopperServlet.java
+++ b/web/src/main/java/com/graphhopper/http/GraphHopperServlet.java
@@ -199,7 +199,7 @@ public class GraphHopperServlet extends GHBaseServlet
         boolean withTrack = getBooleanParam(req, "gpx.track", true);
         boolean withWayPoints = getBooleanParam(req, "gpx.waypoints", false);
         res.setCharacterEncoding("UTF-8");
-        res.setContentType("application/xml");
+        res.setContentType("application/gpx+xml");
         String trackName = getParam(req, "trackname", "GraphHopper Track");
         res.setHeader("Content-Disposition", "attachment;filename=" + "GraphHopper.gpx");
         long time = getLongParam(req, "millis", System.currentTimeMillis());


### PR DESCRIPTION
The ContentType for .gpx files should be `application/gpx+xml`. Also see here for more details: https://en.wikipedia.org/wiki/GPS_Exchange_Format

I had a small amount of users that received the file as `filename.gpx.xml`. It seems like this fixes the issue. 