### PR TITLE
Issue #644

### DIFF
--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -697,7 +697,7 @@ public class GraphHopper implements GraphHopperAPI
      */
     public GraphHopper importOrLoad()
     {
-        if (!load(ghLocation))
+        if (!initializeStorage(ghLocation))
         {
             printInfo();
             process(ghLocation);
@@ -793,6 +793,14 @@ public class GraphHopper implements GraphHopperAPI
      */
     @Override
     public boolean load( String graphHopperFolder )
+    {
+        if (!(new File(graphHopperFolder).exists()))
+            return false;
+
+        return initializeStorage(graphHopperFolder);
+    }
+
+    private boolean initializeStorage(String graphHopperFolder)
     {
         if (Helper.isEmpty(graphHopperFolder))
             throw new IllegalStateException("graphHopperLocation is not specified. call init before");

--- a/core/src/test/java/com/graphhopper/GraphHopperTest.java
+++ b/core/src/test/java/com/graphhopper/GraphHopperTest.java
@@ -455,6 +455,15 @@ public class GraphHopperTest
     }
 
     @Test
+    public void testDoNotCreateEmptyFolderIfLoadingFromNonExistingPath()
+    {
+        instance = new GraphHopper().
+                setEncodingManager(new EncodingManager("CAR"));
+        assertFalse(instance.load(ghLoc));
+        assertFalse(new File(ghLoc).exists());
+    }
+
+    @Test
     public void testFailsForMissingParameters() throws IOException
     {
         // missing load of graph


### PR DESCRIPTION
Prevents the creation of an empty folder when loading a Graph from a non-existent path.

The directory is created in GraphHopper.load() at line 837:

`        GHDirectory dir = new GHDirectory(ghLocation, dataAccessType);`

The directory is created before it is checked if the graph loading was successful. Therefore we can not simply omit the mkdirs call if the graph loading failed unless there would be a possibility to create the storage without creating the directory).
Also GraphHopper.load() is not only used to load an existing graph, but also in GraphHopper.importOrLoad() to initialize the GHStorage etc. (the actual loading is done only later in Graphhopper.process() in this case). 
The solution in this pull request is the least invasive I could come up with.
I check for the existence of the path in load() and then call the old load() method (under the new name
"initializeStorage") if the path exists. Otherwise false is returned. I am not entirely sure if initializeStorage is a good name and there seem to be quite a few things going on in this method.

By the way no exception is thrown if the path does not exist upon calling load(), but only false is returned. The user gets the confusing exception: "Call load or importOrLoad" when calling GraphHopper.route(), which can be seen in GraphHopperTest.testNoNPE_ifLoadNotSuccessful(). This is confusing because the user called load() before but still gets this exception.





