### PR TITLE
Issue #644 / PR #700 follow-up

### DIFF
--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -1038,7 +1038,7 @@ public class GraphHopper implements GraphHopperAPI
     protected List<Path> calcPaths( GHRequest request, GHResponse ghRsp )
     {
         if (ghStorage == null || !fullyLoaded)
-            throw new IllegalStateException("Call load or importOrLoad before routing");
+            throw new IllegalStateException("Do a successful call to load or importOrLoad before routing");
 
         if (ghStorage.isClosed())
             throw new IllegalStateException("You need to create a new GraphHopper instance as it is already closed");

--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -795,7 +795,7 @@ public class GraphHopper implements GraphHopperAPI
     public boolean load( String graphHopperFolder )
     {
         if (!(new File(graphHopperFolder).exists()))
-            return false;
+            throw new IllegalStateException("Path \"" + graphHopperFolder + "\" does not exist");
 
         return initializeStorage(graphHopperFolder);
     }

--- a/core/src/test/java/com/graphhopper/GraphHopperAPITest.java
+++ b/core/src/test/java/com/graphhopper/GraphHopperAPITest.java
@@ -112,7 +112,7 @@ public class GraphHopperAPITest
             assertTrue(false);
         } catch (Exception ex)
         {
-            assertTrue(ex.getMessage(), ex.getMessage().startsWith("Call load or importOrLoad before routing"));
+            assertTrue(ex.getMessage(), ex.getMessage().startsWith("Do a successful call to load or importOrLoad before routing"));
         }
 
         instance = new GraphHopper().setEncodingManager(encodingManager);
@@ -122,7 +122,7 @@ public class GraphHopperAPITest
             assertTrue(false);
         } catch (Exception ex)
         {
-            assertTrue(ex.getMessage(), ex.getMessage().startsWith("Call load or importOrLoad before routing"));
+            assertTrue(ex.getMessage(), ex.getMessage().startsWith("Do a successful call to load or importOrLoad before routing"));
         }
     }
 }

--- a/core/src/test/java/com/graphhopper/GraphHopperTest.java
+++ b/core/src/test/java/com/graphhopper/GraphHopperTest.java
@@ -451,7 +451,7 @@ public class GraphHopperTest
             assertTrue(false);
         } catch (IllegalStateException ex)
         {
-            assertEquals("Call load or importOrLoad before routing", ex.getMessage());
+            assertEquals("Do a successful call to load or importOrLoad before routing", ex.getMessage());
         }
     }
 

--- a/core/src/test/java/com/graphhopper/GraphHopperTest.java
+++ b/core/src/test/java/com/graphhopper/GraphHopperTest.java
@@ -439,12 +439,13 @@ public class GraphHopperTest
     @Test
     public void testNoNPE_ifLoadNotSuccessful()
     {
-        // missing import of graph
         instance = new GraphHopper().
                 setStoreOnFlush(true).
                 setEncodingManager(new EncodingManager("CAR"));
         try
         {
+            // loading from empty directory
+            new File(ghLoc).mkdirs();
             assertFalse(instance.load(ghLoc));
             instance.route(new GHRequest(10, 40, 12, 32));
             assertTrue(false);
@@ -455,11 +456,18 @@ public class GraphHopperTest
     }
 
     @Test
-    public void testDoNotCreateEmptyFolderIfLoadingFromNonExistingPath()
+    public void testFailsAndDoesNotCreateEmptyFolderIfLoadingFromNonExistingPath()
     {
         instance = new GraphHopper().
                 setEncodingManager(new EncodingManager("CAR"));
-        assertFalse(instance.load(ghLoc));
+        try
+        {
+            instance.load(ghLoc);
+            assertTrue(false);
+        } catch (IllegalStateException ex)
+        {
+            assertEquals("Path \"" + ghLoc + "\" does not exist", ex.getMessage());
+        }
         assertFalse(new File(ghLoc).exists());
     }
 


### PR DESCRIPTION
First commit throws exception when using non-existent path in GraphHopper.load(),
second commit adjusts error message as discussed here: [#700](https://github.com/graphhopper/graphhopper/pull/700)