### PR TITLE
Reproducing & fixing reverse speed error

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,11 +1,11 @@
 [Members](https://github.com/graphhopper?tab=members) and [Contributors](https://github.com/graphhopper/graphhopper/contributors)
 
- * ammagamma, improvements like #700
+ * ammagamma, several improvements like #700, #703
  * AnahitaS, docs for Android, Android, Tomcat
  * andreaswolf, flag encoder versioning and more
  * agouge, discussion and API refactoring
  * b3nn0, Android improvements
- * boldtrn, motorcycle and improvements like conditional tag parsing etc
+ * boldtrn, motorcycle and improvements like conditional tag parsing, round trips and a lot more
  * cgarreau, increase of routing success rate via subnetwork cleanup
  * ChristianSeitzer, motorcycle improvements
  * daisy1754, fixed usage of graphhopper.sh script

--- a/core/files/changelog.txt
+++ b/core/files/changelog.txt
@@ -1,4 +1,5 @@
 0.7
+    refactored FlagEncoder.handleFerryWay to getFerrySpeed to make it possible to fix #665
     removed setWeightLimit as too unspecific for arbitrary weights, use setMaxVisitedNodes instead
     missing renames for Path.setEdgeEntry -> setSPTEntry and AbstractAlgorithm.createEdgeEntry -> createSPTEntry
 

--- a/core/src/main/java/com/graphhopper/routing/util/AbstractFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/AbstractFlagEncoder.java
@@ -475,7 +475,7 @@ public abstract class AbstractFlagEncoder implements FlagEncoder, TurnCostEncode
     /**
      * Special handling for ferry ways.
      */
-    protected long handleFerryTags( OSMWay way, double unknownSpeed, double shortTripsSpeed, double longTripsSpeed )
+    protected double getFerrySpeed( OSMWay way, double unknownSpeed, double shortTripsSpeed, double longTripsSpeed )
     {
         long duration = 0;
         try
@@ -511,8 +511,7 @@ public abstract class AbstractFlagEncoder implements FlagEncoder, TurnCostEncode
                             if (shortTripsSpeed > getMaxSpeed())
                                 shortTripsSpeed = getMaxSpeed();
                             longTripsSpeed = shortTripsSpeed;
-                        }
-                        else
+                        } else
                         {
                             // Now we set to the lowest possible still accessible speed. 
                             shortTripsSpeed = speedEncoder.factor / 2;
@@ -531,14 +530,14 @@ public abstract class AbstractFlagEncoder implements FlagEncoder, TurnCostEncode
         if (durationInHours == 0)
         {
             // unknown speed -> put penalty on ferry transport
-            return setSpeed(0, unknownSpeed);
+            return unknownSpeed;
         } else if (durationInHours > 1)
         {
             // lengthy ferries should be faster than short trip ferry
-            return setSpeed(0, longTripsSpeed);
+            return longTripsSpeed;
         } else
         {
-            return setSpeed(0, shortTripsSpeed);
+            return shortTripsSpeed;
         }
     }
 
@@ -655,11 +654,8 @@ public abstract class AbstractFlagEncoder implements FlagEncoder, TurnCostEncode
         {
             if (costs != 0 || Double.isInfinite(costs))
                 throw new IllegalArgumentException("Restricted turn can only have infinite costs (or use 0)");
-        } else
-        {
-            if (costs >= maxTurnCosts)
-                throw new IllegalArgumentException("Cost is too high. Or specifiy restricted == true");
-        }
+        } else if (costs >= maxTurnCosts)
+            throw new IllegalArgumentException("Cost is too high. Or specifiy restricted == true");
 
         if (costs < 0)
             throw new IllegalArgumentException("Turn costs cannot be negative");
@@ -750,7 +746,7 @@ public abstract class AbstractFlagEncoder implements FlagEncoder, TurnCostEncode
     /**
      * @param way: needed to retrieve OSM tags
      * @param speed: speed guessed e.g. from the road type or other tags
-     * @return The assumed speed. 
+     * @return The assumed speed.
      */
     protected double applyMaxSpeed( OSMWay way, double speed )
     {

--- a/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
@@ -355,34 +355,35 @@ public class BikeCommonFlagEncoder extends AbstractFlagEncoder
         if (!isAccept(allowed))
             return 0;
 
-        long encoded = 0;
+        long flags = 0;
         double wayTypeSpeed = getSpeed(way);
         if (!isFerry(allowed))
         {
             wayTypeSpeed = applyMaxSpeed(way, wayTypeSpeed);
-            encoded = handleSpeed(way, wayTypeSpeed, encoded);
-            encoded = handleBikeRelated(way, encoded, relationFlags > UNCHANGED.getValue());
+            flags = handleSpeed(way, wayTypeSpeed, flags);
+            flags = handleBikeRelated(way, flags, relationFlags > UNCHANGED.getValue());
 
             boolean isRoundabout = way.hasTag("junction", "roundabout");
             if (isRoundabout)
             {
-                encoded = setBool(encoded, K_ROUNDABOUT, true);
+                flags = setBool(flags, K_ROUNDABOUT, true);
             }
 
         } else
         {
-            encoded = handleFerryTags(way,
+            double ferrySpeed = getFerrySpeed(way,
                     highwaySpeeds.get("living_street"),
                     highwaySpeeds.get("track"),
                     highwaySpeeds.get("primary"));
-            encoded |= directionBitMask;
+            flags = handleSpeed(way, ferrySpeed, flags);
+            flags |= directionBitMask;
         }
         int priorityFromRelation = 0;
         if (relationFlags != 0)
             priorityFromRelation = (int) relationCodeEncoder.getValue(relationFlags);
 
-        encoded = priorityWayEncoder.setValue(encoded, handlePriority(way, wayTypeSpeed, priorityFromRelation));
-        return encoded;
+        flags = priorityWayEncoder.setValue(flags, handlePriority(way, wayTypeSpeed, priorityFromRelation));
+        return flags;
     }
 
     int getSpeed( OSMWay way )

--- a/core/src/main/java/com/graphhopper/routing/util/CarFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/CarFlagEncoder.java
@@ -243,7 +243,7 @@ public class CarFlagEncoder extends AbstractFlagEncoder
         if (!isAccept(allowed))
             return 0;
 
-        long encoded;
+        long flags = 0;
         if (!isFerry(allowed))
         {
             // get assumed speed from highway type
@@ -254,11 +254,11 @@ public class CarFlagEncoder extends AbstractFlagEncoder
             if (speed > 30 && way.hasTag("surface", badSurfaceSpeedMap))
                 speed = 30;
 
-            encoded = setSpeed(0, speed);
+            flags = setSpeed(flags, speed);
 
             boolean isRoundabout = way.hasTag("junction", "roundabout");
             if (isRoundabout)
-                encoded = setBool(encoded, K_ROUNDABOUT, true);
+                flags = setBool(flags, K_ROUNDABOUT, true);
 
             boolean isOneway = way.hasTag("oneway", oneways)
                     || way.hasTag("vehicle:backward")
@@ -272,19 +272,20 @@ public class CarFlagEncoder extends AbstractFlagEncoder
                         || way.hasTag("vehicle:forward", "no")
                         || way.hasTag("motor_vehicle:forward", "no");
                 if (isBackward)
-                    encoded |= backwardBit;
+                    flags |= backwardBit;
                 else
-                    encoded |= forwardBit;
+                    flags |= forwardBit;
             } else
-                encoded |= directionBitMask;
+                flags |= directionBitMask;
 
         } else
         {
-            encoded = handleFerryTags(way, defaultSpeedMap.get("living_street"), defaultSpeedMap.get("service"), defaultSpeedMap.get("residential"));
-            encoded |= directionBitMask;
+            double ferrySpeed = getFerrySpeed(way, defaultSpeedMap.get("living_street"), defaultSpeedMap.get("service"), defaultSpeedMap.get("residential"));
+            flags = setSpeed(flags, ferrySpeed);
+            flags |= directionBitMask;
         }
 
-        return encoded;
+        return flags;
     }
 
     public String getWayInfo( OSMWay way )

--- a/core/src/main/java/com/graphhopper/routing/util/FootFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/FootFlagEncoder.java
@@ -287,38 +287,39 @@ public class FootFlagEncoder extends AbstractFlagEncoder
         if (!isAccept(allowed))
             return 0;
 
-        long encoded = 0;
+        long flags = 0;
         if (!isFerry(allowed))
         {
             String sacScale = way.getTag("sac_scale");
             if (sacScale != null)
             {
                 if ("hiking".equals(sacScale))
-                    encoded = speedEncoder.setDoubleValue(encoded, MEAN_SPEED);
+                    flags = speedEncoder.setDoubleValue(flags, MEAN_SPEED);
                 else
-                    encoded = speedEncoder.setDoubleValue(encoded, SLOW_SPEED);
+                    flags = speedEncoder.setDoubleValue(flags, SLOW_SPEED);
             } else
             {
-                encoded = speedEncoder.setDoubleValue(encoded, MEAN_SPEED);
+                flags = speedEncoder.setDoubleValue(flags, MEAN_SPEED);
             }
-            encoded |= directionBitMask;
+            flags |= directionBitMask;
 
             boolean isRoundabout = way.hasTag("junction", "roundabout");
             if (isRoundabout)
-                encoded = setBool(encoded, K_ROUNDABOUT, true);
+                flags = setBool(flags, K_ROUNDABOUT, true);
 
         } else
         {
-            encoded = encoded | handleFerryTags(way, SLOW_SPEED, MEAN_SPEED, FERRY_SPEED);
-            encoded |= directionBitMask;
+            double ferrySpeed = getFerrySpeed(way, SLOW_SPEED, MEAN_SPEED, FERRY_SPEED);
+            flags = setSpeed(flags, ferrySpeed);
+            flags |= directionBitMask;
         }
 
         int priorityFromRelation = 0;
         if (relationFlags != 0)
             priorityFromRelation = (int) relationCodeEncoder.getValue(relationFlags);
 
-        encoded = priorityWayEncoder.setValue(encoded, handlePriority(way, priorityFromRelation));
-        return encoded;
+        flags = priorityWayEncoder.setValue(flags, handlePriority(way, priorityFromRelation));
+        return flags;
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/util/MotorcycleFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/MotorcycleFlagEncoder.java
@@ -208,7 +208,7 @@ public class MotorcycleFlagEncoder extends CarFlagEncoder
         if (!isAccept(allowed))
             return 0;
 
-        long encoded = 0;
+        long flags = 0;
         if (!isFerry(allowed))
         {
             // get assumed speed from highway type
@@ -225,39 +225,41 @@ public class MotorcycleFlagEncoder extends CarFlagEncoder
 
             boolean isRoundabout = way.hasTag("junction", "roundabout");
             if (isRoundabout)
-                encoded = setBool(0, K_ROUNDABOUT, true);
+                flags = setBool(0, K_ROUNDABOUT, true);
 
             if (way.hasTag("oneway", oneways) || isRoundabout)
             {
                 if (way.hasTag("oneway", "-1"))
                 {
-                    encoded = setReverseSpeed(encoded, speed);
-                    encoded |= backwardBit;
+                    flags = setReverseSpeed(flags, speed);
+                    flags |= backwardBit;
                 } else
                 {
-                    encoded = setSpeed(encoded, speed);
-                    encoded |= forwardBit;
+                    flags = setSpeed(flags, speed);
+                    flags |= forwardBit;
                 }
             } else
             {
-                encoded = setSpeed(encoded, speed);
-                encoded = setReverseSpeed(encoded, speed);
-                encoded |= directionBitMask;
+                flags = setSpeed(flags, speed);
+                flags = setReverseSpeed(flags, speed);
+                flags |= directionBitMask;
             }
 
         } else
         {
-            encoded = handleFerryTags(way, defaultSpeedMap.get("living_street"), defaultSpeedMap.get("service"), defaultSpeedMap.get("residential"));
-            encoded |= directionBitMask;
+            double ferrySpeed = getFerrySpeed(way, defaultSpeedMap.get("living_street"), defaultSpeedMap.get("service"), defaultSpeedMap.get("residential"));
+            flags = setSpeed(flags, ferrySpeed);
+            flags = setReverseSpeed(flags, ferrySpeed);
+            flags |= directionBitMask;
         }
 
         // relations are not yet stored -> see BikeCommonFlagEncoder.defineRelationBits how to do this
-        encoded = priorityWayEncoder.setValue(encoded, handlePriority(way, priorityFromRelation));
+        flags = priorityWayEncoder.setValue(flags, handlePriority(way, priorityFromRelation));
 
         // Set the curvature to the Maximum
-        encoded = curvatureEncoder.setValue(encoded, 10);
+        flags = curvatureEncoder.setValue(flags, 10);
 
-        return encoded;
+        return flags;
     }
 
     @Override

--- a/core/src/test/java/com/graphhopper/reader/OSMReaderTest.java
+++ b/core/src/test/java/com/graphhopper/reader/OSMReaderTest.java
@@ -36,8 +36,11 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.graphhopper.GraphHopper;
+import com.graphhopper.GHRequest;
+import com.graphhopper.GHResponse;
 import com.graphhopper.reader.dem.ElevationProvider;
 import com.graphhopper.reader.dem.SRTMProvider;
+import com.graphhopper.routing.DijkstraBidirectionRef;
 import com.graphhopper.routing.util.*;
 import com.graphhopper.storage.*;
 import com.graphhopper.storage.index.QueryResult;
@@ -64,6 +67,7 @@ public class OSMReaderTest
     // test-osm6.pbf was created by running "osmconvert test-osm6.xml --timestamp=2014-01-02T00:10:14Z -o=test-osm6.pbf"
     // The osmconvert tool can be found here: http://wiki.openstreetmap.org/wiki/Osmconvert
     private final String file6 = "test-osm6.pbf";
+    private final String file7 = "test-osm7.xml";
     private final String fileNegIds = "test-osm-negative-ids.xml";
     private final String fileBarriers = "test-barriers.xml";
     private final String fileTurnRestrictions = "test-restrictions.xml";
@@ -853,5 +857,21 @@ public class OSMReaderTest
         assertEquals(0.1, qr.getSnappedPoint().lat, 0.1);
         assertEquals(-179.6, qr.getSnappedPoint().lon, 0.1);
         assertEquals(56, qr.getClosestEdge().getDistance() / 1000, 1);
+    }
+
+    public void testRoutingRequestFails_issue665()
+    {
+        GraphHopper hopper = new GraphHopper();
+        hopper.setOSMFile("src/test/resources/com/graphhopper/reader/" + file7);
+        hopper.setEncodingManager(new EncodingManager("car,motorcycle"));
+        hopper.setCHEnable(false);
+        hopper.setGraphHopperLocation(dir);
+        hopper.importOrLoad();
+        GHRequest req = new GHRequest(48.97725592769741, 8.256896138191223, 48.978875552977684, 8.25486302375793).
+                setWeighting("curvature").
+                setVehicle("motorcycle");
+
+        GHResponse ghRsp = hopper.route(req);
+        assertFalse(ghRsp.getErrors().toString(), ghRsp.hasErrors());
     }
 }

--- a/core/src/test/java/com/graphhopper/routing/util/Bike2WeightFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/Bike2WeightFlagEncoderTest.java
@@ -20,9 +20,7 @@ package com.graphhopper.routing.util;
 
 import com.graphhopper.reader.OSMWay;
 import com.graphhopper.storage.*;
-import com.graphhopper.util.EdgeIteratorState;
-import com.graphhopper.util.GHUtility;
-import com.graphhopper.util.Helper;
+import com.graphhopper.util.*;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -93,5 +91,44 @@ public class Bike2WeightFlagEncoderTest extends BikeFlagEncoderTest
         assertEquals(10, encoder.getReverseSpeed(flags), .1);
         assertFalse(encoder.isForward(flags));
         assertTrue(encoder.isBackward(flags));
+    }
+
+    @Test
+    public void testRoutingFailsWithInvalidGraph_issue665()
+    {
+        GraphHopperStorage graph = new GraphHopperStorage(
+                new RAMDirectory(), em, true, new GraphExtension.NoOpExtension());
+        graph.create(100);
+
+        OSMWay way = new OSMWay(0);
+        way.setTag("route", "ferry");
+
+        long includeWay = em.acceptWay(way);
+        long relationFlags = 0;
+        long wayFlags = em.handleWayTags(way, includeWay, relationFlags);
+        graph.edge(0, 1).setDistance(247).setFlags(wayFlags);
+
+        assertTrue(isGraphValid(graph, encoder));
+    }
+
+    private boolean isGraphValid( Graph graph, FlagEncoder encoder )
+    {
+        EdgeExplorer explorer = graph.createEdgeExplorer();
+
+        // iterator at node 0 considers the edge 0-1 to be undirected
+        EdgeIterator iter0 = explorer.setBaseNode(0);
+        iter0.next();
+        boolean iter0flag
+                = iter0.getBaseNode() == 0 && iter0.getAdjNode() == 1
+                && iter0.isForward(encoder) && iter0.isBackward(encoder);
+
+        // iterator at node 1 considers the edge 1-0 to be directed
+        EdgeIterator iter1 = explorer.setBaseNode(1);
+        iter1.next();
+        boolean iter1flag
+                = iter1.getBaseNode() == 1 && iter1.getAdjNode() == 0
+                && iter1.isForward(encoder) && iter1.isBackward(encoder);
+
+        return iter0flag && iter1flag;
     }
 }

--- a/core/src/test/java/com/graphhopper/routing/util/CarFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/CarFlagEncoderTest.java
@@ -385,7 +385,7 @@ public class CarFlagEncoderTest
         // accept
         assertTrue(encoder.acceptWay(way) > 0);
         // calculate speed from estimated_distance and duration
-        assertEquals(60, encoder.getSpeed(encoder.handleFerryTags(way, 20, 30, 40)), 1e-1);
+        assertEquals(61, encoder.getFerrySpeed(way, 20, 30, 40), 1e-1);
 
         //Test for very short and slow 0.5km/h still realisitic ferry
         way = new OSMWay(1);
@@ -397,8 +397,9 @@ public class CarFlagEncoderTest
         // accept
         assertTrue(encoder.acceptWay(way) > 0);
         // We can't store 0.5km/h, but we expect the lowest possible speed (5km/h)
-        assertEquals(5, encoder.getSpeed(encoder.handleFerryTags(way, 20, 30, 40)), 1e-1);
-
+        assertEquals(2.5, encoder.getFerrySpeed(way, 20, 30, 40), 1e-1);
+        assertEquals(5, encoder.getSpeed(encoder.setSpeed(0, 2.5)), 1e-1);
+        
         //Test for an unrealisitic long duration
         way = new OSMWay(1);
         way.setTag("route", "ferry");
@@ -409,8 +410,7 @@ public class CarFlagEncoderTest
         // accept
         assertTrue(encoder.acceptWay(way) > 0);
         // We have ignored the unrealisitc long duration and take the unknown speed
-        assertEquals(20, encoder.getSpeed(encoder.handleFerryTags(way, 20, 30, 40)), 1e-1);
-
+        assertEquals(20, encoder.getFerrySpeed(way, 20, 30, 40), 1e-1);
     }
 
     @Test

--- a/core/src/test/resources/com/graphhopper/reader/test-osm7.xml
+++ b/core/src/test/resources/com/graphhopper/reader/test-osm7.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm version="0.6" generator="CGImap 0.4.0 (21273 thorn-02.openstreetmap.org)" copyright="OpenStreetMap and contributors" attribution="http://www.openstreetmap.org/copyright" license="http://opendatacommons.org/licenses/odbl/1-0/">
+ <bounds minlat="48.9772300" minlon="8.2547700" maxlat="48.9789600" maxlon="8.2570200"/>
+ <node id="15230524" visible="true" version="10" changeset="31551591" timestamp="2015-05-28T23:31:48Z" user="maction" uid="62423" lat="48.9788809" lon="8.2548809">
+  <tag k="amenity" v="ferry_terminal"/>
+  <tag k="cargo" v="passengers;vehicle"/>
+  <tag k="name" v="Rheinfähre Neuburg"/>
+  <tag k="TMC:cid_58:tabcd_1:Class" v="Point"/>
+  <tag k="TMC:cid_58:tabcd_1:LCLversion" v="9.00"/>
+  <tag k="TMC:cid_58:tabcd_1:LocationCode" v="53045"/>
+  <tag k="TMC:cid_58:tabcd_1:NextLocationCode" v="54998"/>
+ </node>
+ <node id="1422857309" visible="true" version="1" changeset="9207458" timestamp="2011-09-04T10:34:59Z" user="KK-O" uid="14228" lat="48.9788068" lon="8.2554001"/>
+  <node id="1422857311" visible="true" version="1" changeset="9207458" timestamp="2011-09-04T10:34:59Z" user="KK-O" uid="14228" lat="48.9781625" lon="8.2562316"/>
+ <node id="1422857313" visible="true" version="1" changeset="9207458" timestamp="2011-09-04T10:34:59Z" user="KK-O" uid="14228" lat="48.9776344" lon="8.2568485"/>
+  <node id="15237462" visible="true" version="8" changeset="27528220" timestamp="2014-12-17T12:00:56Z" user="guenz" uid="176514" lat="48.9772732" lon="8.2569129">
+  <tag k="amenity" v="ferry_terminal"/>
+  <tag k="cargo" v="passengers;vehicle"/>
+  <tag k="name" v="Rheinfähre Neuburg"/>
+  <tag k="TMC:cid_58:tabcd_1:Class" v="Point"/>
+  <tag k="TMC:cid_58:tabcd_1:LCLversion" v="9.00"/>
+  <tag k="TMC:cid_58:tabcd_1:LocationCode" v="53046"/>
+  <tag k="TMC:cid_58:tabcd_1:PrevLocationCode" v="54998"/>
+ </node>
+ <way id="3500103" visible="true" version="13" changeset="34403208" timestamp="2015-10-03T08:12:50Z" user="W0lle" uid="2111313">
+  <nd ref="15230524"/>
+  <nd ref="1422857309"/>
+  <nd ref="1422857311"/>
+  <nd ref="1422857313"/>
+  <nd ref="15237462"/>
+  <tag k="duration" v="00:04"/>
+  <tag k="fee" v="yes"/>
+  <tag k="motorcar" v="yes"/>
+  <tag k="motor_vehicle" v="yes"/>
+  <tag k="name" v="Rheinfähre Neuburg"/>
+  <tag k="note" v="Fährverbindung März - Nov"/>
+  <tag k="ref" v="F3"/>
+  <tag k="route" v="ferry"/>
+  <tag k="tmc" v="DE:53045+54998;DE:54998-53045"/>
+  <tag k="TMC:cid_58:tabcd_1:Class" v="Point"/>
+  <tag k="TMC:cid_58:tabcd_1:LCLversion" v="9.00"/>
+  <tag k="TMC:cid_58:tabcd_1:LocationCode" v="54998"/>
+  <tag k="TMC:cid_58:tabcd_1:NextLocationCode" v="53046"/>
+  <tag k="TMC:cid_58:tabcd_1:PrevLocationCode" v="53045"/>
+  <tag k="website" v="http://www.rheinfaehre-neuburg.de/Home.html"/>
+ </way>
+</osm>

--- a/docs/core/create-new-flagencoder.md
+++ b/docs/core/create-new-flagencoder.md
@@ -25,6 +25,7 @@ see Bike2WeightFlagEncoder for an example. You'll have to overwrite the followin
  * setProperties
  * reverseFlags
  * setLowSpeed
+ * always set reverse speed explicitely, see #665
 
 ## Elevation
 


### PR DESCRIPTION
This fixes the bug in #665. The work to find this was done in #703.

This bug could be reproduced also for `bike2` which is very strange as I've never seen this failing in 'real world'.

The important part now is to set the flags for both speeds explicitly via
```java
flags = handleSpeed(way, ferrySpeed, flags);
```

or in motorcycle encoder via setSpeed&setReverseSpeed.

This is explicitly mentioned now in the create-new-flagencoder.md guide but the whole process should be made easier later on too.