### PR TITLE
Bicycle improvement: Add support for tag "segregated"

### DIFF
--- a/reader-osm/src/test/java/com/graphhopper/routing/RoutingAlgorithmWithOSMIT.java
+++ b/reader-osm/src/test/java/com/graphhopper/routing/RoutingAlgorithmWithOSMIT.java
@@ -366,7 +366,7 @@ public class RoutingAlgorithmWithOSMIT {
     public void testMonacoMountainBike() {
         List<OneRun> list = new ArrayList<OneRun>();
         list.add(new OneRun(43.730864, 7.420771, 43.727687, 7.418737, 2322, 110));
-        list.add(new OneRun(43.727687, 7.418737, 43.74958, 7.436566, 3613, 178));
+        list.add(new OneRun(43.727687, 7.418737, 43.74958, 7.436566, 3655, 176));
         list.add(new OneRun(43.728677, 7.41016, 43.739213, 7.427806, 2331, 121));
         // hard to select between secondary and primary (both are AVOID for mtb)
         list.add(new OneRun(43.733802, 7.413433, 43.739662, 7.424355, 1459, 88));
@@ -400,7 +400,7 @@ public class RoutingAlgorithmWithOSMIT {
         List<OneRun> list = new ArrayList<OneRun>();
         list.add(new OneRun(48.409523, 15.602394, 48.375466, 15.72916, 12491, 159));
         // 3109m is better as cyclepath is used
-        list.add(new OneRun(48.410061, 15.63951, 48.411386, 15.604899, 3077, 79));
+        list.add(new OneRun(48.410061, 15.63951, 48.411386, 15.604899, 3112, 87));
         list.add(new OneRun(48.412294, 15.62007, 48.398306, 15.609667, 3965, 94));
 
         runAlgo(testCollector, DIR + "/krems.osm.gz", "target/krems-gh",
@@ -496,7 +496,7 @@ public class RoutingAlgorithmWithOSMIT {
     public void testHarsdorf() {
         List<OneRun> list = new ArrayList<OneRun>();
         // choose Unterloher Weg and the following residential + cycleway
-        list.add(new OneRun(50.004333, 11.600254, 50.044449, 11.543434, 6931, 184));
+        list.add(new OneRun(50.004333, 11.600254, 50.044449, 11.543434, 6952, 190));
         runAlgo(testCollector, DIR + "/north-bayreuth.osm.gz", "target/north-bayreuth-gh",
                 list, "bike", true, "bike", "fastest", false);
         assertEquals(testCollector.toString(), 0, testCollector.errors.size());


### PR DESCRIPTION
Implementation for #656.
Additionally now assume network "lcn" for a bicycle relation in case that the network tag is missing.