### PR TITLE
Validate the start of a roundtrip

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/template/RoundTripRoutingTemplate.java
+++ b/core/src/main/java/com/graphhopper/routing/template/RoundTripRoutingTemplate.java
@@ -81,6 +81,8 @@ public class RoundTripRoutingTemplate implements RoutingTemplate
         queryResults = new ArrayList<>(2 + strategy.getNumberOfGeneratedPoints());
         EdgeFilter edgeFilter = new DefaultEdgeFilter(encoder);
         QueryResult startQR = locationIndex.findClosest(start.lat, start.lon, edgeFilter);
+        if (!startQR.isValid())
+            ghResponse.addError(new IllegalArgumentException("Cannot find point 0: " + start));
         queryResults.add(startQR);
 
         GHPoint last = points.get(0);


### PR DESCRIPTION
Currently we do not validate the start of a round trip. This can lead to an empty response. Caused by an exception:

```
java.lang.IllegalStateException: Do not call QueryGraph.lookup with invalid QueryResult
```

This PR validates the start point.