### PR TITLE
Hint change for Java API

### DIFF
--- a/config-example.properties
+++ b/config-example.properties
@@ -48,7 +48,7 @@ prepare.min_one_way_network_size=200
 # connection between two points wihtin the given visited nodes. The default is Integer.MAX_VALUE. Useful for flexibility mode
 # routing.max_visited_nodes = 1000000
 
-# If enabled, allows a user to run flexibility requests even if speed-up mode is enabled. Every request then has to include a hint routing.flexibleMode.force=true.
+# If enabled, allows a user to run flexibility requests even if speed-up mode is enabled. Every request then has to include a hint routing.ch.disable=true.
 # Attention, non-CH route calculations take way more time and resources, compared to CH routing.
 # A possible attacker might exploit this to slow down your service. Only enable it if you need it and with routing.maxVisitedNodes
 # routing.ch.disabling_allowed=true


### PR DESCRIPTION
`config.properties` refers to a request hint that must be set to force the use of flexible mode.  The hint mentioned in the comment does not appear to be correct (does not work).  The correct hint should be `routing.ch.disable=true`