### PR TITLE
When updating geometry, reuse area of existing edge #500

### DIFF
--- a/core/src/main/java/com/graphhopper/storage/BaseGraph.java
+++ b/core/src/main/java/com/graphhopper/storage/BaseGraph.java
@@ -28,8 +28,6 @@ import com.graphhopper.search.NameIndex;
 import com.graphhopper.util.*;
 import static com.graphhopper.util.Helper.nf;
 
-import java.util.Arrays;
-
 import com.graphhopper.util.shapes.BBox;
 
 /**
@@ -839,11 +837,6 @@ class BaseGraph implements Graph
 				final int count = wayGeometry.getInt(existingGeoRefPos);
             	if (len <= count)
             	{
-            		// If old array was smaller, erase contents
-            		if (len < count)
-            		{
-            			eraseWayGeometryAtGeoRef(count, existingGeoRef);
-            		}
             		setWayGeometryAtGeoRef(pillarNodes, edgePointer, reverse, existingGeoRef);
                     return;
             	}
@@ -856,14 +849,6 @@ class BaseGraph implements Graph
             edges.setInt(edgePointer + E_GEO, 0);
         }
     }
-
-	private void eraseWayGeometryAtGeoRef(final int count, long geoRef) {
-        int dim = nodeAccess.getDimension();
-		byte[] eraseBytes = new byte [count*dim*4+4];
-		Arrays.fill(eraseBytes, (byte)0);
-		long geoRefPos = geoRef*4L;
-		wayGeometry.setBytes(geoRefPos, eraseBytes, eraseBytes.length);
-	}
 
 	private void setWayGeometryAtGeoRef(PointList pillarNodes, long edgePointer, boolean reverse, long geoRef) {
         int len = pillarNodes.getSize();


### PR DESCRIPTION
Solves a part of #500 by reusing the geometry area of existing edge if the new point list is not larger.

I had to expose maxGeoRef to be able to test it, I hope it's ok.

I've also decided it would be good to erase existing contents if new point list is smaller than existing. Otherwise we'll have some old coordinates laying around.

Another improvement would be to store the maximum size of the area. Then it would be possible to reuse it even if point list grows but stays beyond that maximum size. Would require storing max size next to count which is probably not so good.