### PR TITLE
Saving K_TUNNEL and K_BRIDGE edge flags #713

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/AbstractFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/AbstractFlagEncoder.java
@@ -51,6 +51,8 @@ public abstract class AbstractFlagEncoder implements FlagEncoder, TurnCostEncode
     protected long backwardBit;
     protected long directionBitMask;
     protected long roundaboutBit;
+    protected long tunnelBit;
+    protected long bridgeBit;
     protected EncodedDoubleValue speedEncoder;
     // bit to signal that way is accepted
     protected long acceptBit;
@@ -188,6 +190,10 @@ public abstract class AbstractFlagEncoder implements FlagEncoder, TurnCostEncode
         directionBitMask = 3L << shift;
         shift += 2;
         roundaboutBit = 1L << shift;
+        shift++;
+        tunnelBit = 1L << shift;
+        shift++;
+        bridgeBit = 1L << shift;
         shift++;
 
         // define internal flags for parsing
@@ -700,6 +706,10 @@ public abstract class AbstractFlagEncoder implements FlagEncoder, TurnCostEncode
                 return value ? flags | backwardBit : flags & ~backwardBit;
             case K_ROUNDABOUT:
                 return value ? flags | roundaboutBit : flags & ~roundaboutBit;
+            case K_TUNNEL:
+                return value ? flags | tunnelBit : flags & ~tunnelBit;
+            case K_BRIDGE:
+                return value ? flags | bridgeBit : flags & ~bridgeBit;
             default:
                 throw new IllegalArgumentException("Unknown key " + key + " for boolean value");
         }
@@ -716,6 +726,10 @@ public abstract class AbstractFlagEncoder implements FlagEncoder, TurnCostEncode
                 return isBackward(flags);
             case K_ROUNDABOUT:
                 return (flags & roundaboutBit) != 0;
+            case K_TUNNEL:
+                return (flags & tunnelBit) != 0;
+            case K_BRIDGE:
+                return (flags & bridgeBit) != 0;
             default:
                 throw new IllegalArgumentException("Unknown key " + key + " for boolean value");
         }

--- a/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
@@ -356,12 +356,9 @@ public class BikeCommonFlagEncoder extends AbstractFlagEncoder
             flags = handleSpeed(way, wayTypeSpeed, flags);
             flags = handleBikeRelated(way, flags, relationFlags > UNCHANGED.getValue());
 
-            boolean isRoundabout = way.hasTag("junction", "roundabout");
-            if (isRoundabout)
-            {
-                flags = setBool(flags, K_ROUNDABOUT, true);
-            }
-
+            flags = way.hasTag("junction", "roundabout") ? setBool(flags, K_ROUNDABOUT, true) : flags;
+            flags = way.hasTag("tunnel", "yes") ? setBool(flags, K_TUNNEL, true) : flags;
+            flags = way.hasTag("bridge", "yes") ? setBool(flags, K_BRIDGE, true) : flags;
         } else
         {
             double ferrySpeed = getFerrySpeed(way,

--- a/core/src/main/java/com/graphhopper/routing/util/CarFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/CarFlagEncoder.java
@@ -257,6 +257,9 @@ public class CarFlagEncoder extends AbstractFlagEncoder
             if (isRoundabout)
                 flags = setBool(flags, K_ROUNDABOUT, true);
 
+            flags = way.hasTag("tunnel", "yes") ? setBool(flags, K_TUNNEL, true) : flags;
+            flags = way.hasTag("bridge", "yes") ? setBool(flags, K_BRIDGE, true) : flags;
+
             if (isOneway(way) || isRoundabout)
             {
                 if (isBackwardOneway(way))
@@ -266,6 +269,7 @@ public class CarFlagEncoder extends AbstractFlagEncoder
                     flags |= forwardBit;
             } else
                 flags |= directionBitMask;
+            
 
         } else
         {

--- a/core/src/main/java/com/graphhopper/routing/util/EncodingManager.java
+++ b/core/src/main/java/com/graphhopper/routing/util/EncodingManager.java
@@ -58,8 +58,14 @@ public class EncodingManager
      */
     public EncodingManager( String flagEncodersStr )
     {
-        this(FlagEncoderFactory.DEFAULT, flagEncodersStr, 4);
+        this(flagEncodersStr, 4);
     }
+    
+    public EncodingManager( String flagEncodersStr, int bytesForEdgeFlags )
+    {
+        this(FlagEncoderFactory.DEFAULT, flagEncodersStr, bytesForEdgeFlags);
+    }
+    
 
     public EncodingManager( FlagEncoderFactory factory, String flagEncodersStr, int bytesForEdgeFlags )
     {

--- a/core/src/main/java/com/graphhopper/routing/util/FlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/FlagEncoder.java
@@ -94,6 +94,14 @@ public interface FlagEncoder extends TurnCostEncoder
      * Reports whether this edge is part of a roundabout.
      */
     static final int K_ROUNDABOUT = 2;
+    /**
+     * Reports whether this edge is part of a tunnel.
+     */
+    static final int K_TUNNEL = 3;
+    /**
+     * Reports whether this edge is part of a bridge.
+     */
+    static final int K_BRIDGE = 4;
 
     /**
      * Returns arbitrary boolean value identified by the specified key.

--- a/core/src/main/java/com/graphhopper/routing/util/FootFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/FootFlagEncoder.java
@@ -306,9 +306,9 @@ public class FootFlagEncoder extends AbstractFlagEncoder
             }
             flags |= directionBitMask;
 
-            boolean isRoundabout = way.hasTag("junction", "roundabout");
-            if (isRoundabout)
-                flags = setBool(flags, K_ROUNDABOUT, true);
+            flags = way.hasTag("junction", "roundabout") ? setBool(flags, K_ROUNDABOUT, true) : flags;
+            flags = way.hasTag("tunnel", "yes") ? setBool(flags, K_TUNNEL, true) : flags;
+            flags = way.hasTag("bridge", "yes") ? setBool(flags, K_BRIDGE, true) : flags;
 
         } else
         {

--- a/core/src/main/java/com/graphhopper/routing/util/MotorcycleFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/MotorcycleFlagEncoder.java
@@ -223,8 +223,11 @@ public class MotorcycleFlagEncoder extends CarFlagEncoder
 
             boolean isRoundabout = way.hasTag("junction", "roundabout");
             if (isRoundabout)
-                flags = setBool(0, K_ROUNDABOUT, true);
+                flags = setBool(flags, K_ROUNDABOUT, true);
 
+            flags = way.hasTag("tunnel", "yes") ? setBool(flags, K_TUNNEL, true) : flags;
+            flags = way.hasTag("bridge", "yes") ? setBool(flags, K_BRIDGE, true) : flags;
+            
             if (way.hasTag("oneway", oneways) || isRoundabout)
             {
                 if (way.hasTag("oneway", "-1"))

--- a/core/src/test/java/com/graphhopper/routing/util/Bike2WeightFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/Bike2WeightFlagEncoderTest.java
@@ -29,7 +29,7 @@ import static org.junit.Assert.*;
  */
 public class Bike2WeightFlagEncoderTest extends BikeFlagEncoderTest
 {
-    private final EncodingManager em = new EncodingManager("bike,bike2");
+    private final EncodingManager em = new EncodingManager("bike,bike2", 8);
 
     @Override
     protected BikeCommonFlagEncoder createBikeEncoder()

--- a/core/src/test/java/com/graphhopper/routing/util/BikeFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/BikeFlagEncoderTest.java
@@ -248,6 +248,18 @@ public class BikeFlagEncoderTest extends AbstractBikeFlagEncoderTester
         way.setTag("highway", "tertiary");
         long flags = encoder.handleWayTags(way, encoder.acceptWay(way), 0);
         assertTrue(encoder.isBool(flags, FlagEncoder.K_ROUNDABOUT));
+
+        way.clearTags();
+        way.setTag("tunnel", "yes");
+        way.setTag("highway", "tertiary");
+        flags = encoder.handleWayTags(way, encoder.acceptWay(way), 0);
+        assertTrue(encoder.isBool(flags, FlagEncoder.K_TUNNEL));
+
+        way.clearTags();
+        way.setTag("bridge", "yes");
+        way.setTag("highway", "tertiary");
+        flags = encoder.handleWayTags(way, encoder.acceptWay(way), 0);
+        assertTrue(encoder.isBool(flags, FlagEncoder.K_BRIDGE));
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/routing/util/CarFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/CarFlagEncoderTest.java
@@ -32,7 +32,7 @@ import static org.junit.Assert.*;
  */
 public class CarFlagEncoderTest
 {
-    private final EncodingManager em = new EncodingManager("car,bike,foot");
+    private final EncodingManager em = new EncodingManager("car,bike,foot", 8);
     private final CarFlagEncoder encoder = (CarFlagEncoder) em.getEncoder("car");
 
     @Test
@@ -342,6 +342,47 @@ public class CarFlagEncoderTest
         assertFalse(encoder.isBackward(flags));
         assertTrue(encoder.isBool(flags, FlagEncoder.K_ROUNDABOUT));
     }
+    
+    @Test
+    public void testTunnel()
+    {
+        long flags = encoder.setAccess(0, true, true);
+        long resFlags = encoder.setBool(flags, FlagEncoder.K_TUNNEL, true);
+        assertTrue(encoder.isBool(resFlags, FlagEncoder.K_TUNNEL));
+
+        resFlags = encoder.setBool(flags, FlagEncoder.K_TUNNEL, false);
+        assertFalse(encoder.isBool(resFlags, FlagEncoder.K_TUNNEL));
+
+        ReaderWay way = new ReaderWay(1);
+        way.setTag("highway", "motorway");
+        flags = encoder.handleWayTags(way, encoder.acceptBit, 0);
+        assertFalse(encoder.isBool(flags, FlagEncoder.K_TUNNEL));
+
+        way.setTag("tunnel", "yes");
+        flags = encoder.handleWayTags(way, encoder.acceptBit, 0);
+        assertTrue(encoder.isBool(flags, FlagEncoder.K_TUNNEL));
+    }
+    
+    @Test
+    public void testBridge()
+    {
+        long flags = encoder.setAccess(0, true, true);
+        long resFlags = encoder.setBool(flags, FlagEncoder.K_BRIDGE, true);
+        assertTrue(encoder.isBool(resFlags, FlagEncoder.K_BRIDGE));
+
+        resFlags = encoder.setBool(flags, FlagEncoder.K_BRIDGE, false);
+        assertFalse(encoder.isBool(resFlags, FlagEncoder.K_BRIDGE));
+
+        ReaderWay way = new ReaderWay(1);
+        way.setTag("highway", "motorway");
+        flags = encoder.handleWayTags(way, encoder.acceptBit, 0);
+        assertFalse(encoder.isBool(flags, FlagEncoder.K_BRIDGE));
+
+        way.setTag("bridge", "yes");
+        flags = encoder.handleWayTags(way, encoder.acceptBit, 0);
+        assertTrue(encoder.isBool(flags, FlagEncoder.K_BRIDGE));
+    }    
+    
 
     @Test
     public void testRailway()

--- a/core/src/test/java/com/graphhopper/routing/util/EncodingManagerTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/EncodingManagerTest.java
@@ -41,7 +41,7 @@ public class EncodingManagerTest
     @Test
     public void testCompatibility()
     {
-        EncodingManager manager = new EncodingManager("car,bike,foot");
+        EncodingManager manager = new EncodingManager("car,bike,foot", 8);
         BikeFlagEncoder bike = (BikeFlagEncoder) manager.getEncoder("bike");
         CarFlagEncoder car = (CarFlagEncoder) manager.getEncoder("car");
         FootFlagEncoder foot = (FootFlagEncoder) manager.getEncoder("foot");

--- a/core/src/test/java/com/graphhopper/routing/util/FootFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/FootFlagEncoderTest.java
@@ -37,7 +37,7 @@ import static org.junit.Assert.*;
  */
 public class FootFlagEncoderTest
 {
-    private final EncodingManager encodingManager = new EncodingManager("car,bike,foot");
+    private final EncodingManager encodingManager = new EncodingManager("car,bike,foot", 8);
     private final FootFlagEncoder footEncoder = (FootFlagEncoder) encodingManager.getEncoder("foot");
 
     @Test
@@ -355,6 +355,26 @@ public class FootFlagEncoderTest
         way.setTag("highway", "tertiary");
         long flags = footEncoder.handleWayTags(way, footEncoder.acceptWay(way), 0);
         assertTrue(footEncoder.isBool(flags, FlagEncoder.K_ROUNDABOUT));
+    }
+
+    @Test
+    public void handleWayTagsTunnel()
+    {
+        ReaderWay way = new ReaderWay(1);
+        way.setTag("tunnel", "yes");
+        way.setTag("highway", "tertiary");
+        long flags = footEncoder.handleWayTags(way, footEncoder.acceptWay(way), 0);
+        assertTrue(footEncoder.isBool(flags, FlagEncoder.K_TUNNEL));
+    }
+
+    @Test
+    public void handleWayTagsBridge()
+    {
+        ReaderWay way = new ReaderWay(1);
+        way.setTag("bridge", "yes");
+        way.setTag("highway", "tertiary");
+        long flags = footEncoder.handleWayTags(way, footEncoder.acceptWay(way), 0);
+        assertTrue(footEncoder.isBool(flags, FlagEncoder.K_BRIDGE));
     }
 
     public void testFord()

--- a/core/src/test/java/com/graphhopper/routing/util/MotorcycleFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/MotorcycleFlagEncoderTest.java
@@ -34,7 +34,7 @@ import static org.junit.Assert.*;
  */
 public class MotorcycleFlagEncoderTest
 {
-    private final EncodingManager em = new EncodingManager("motorcycle,foot");
+    private final EncodingManager em = new EncodingManager("motorcycle,foot", 8);
     private final MotorcycleFlagEncoder encoder = (MotorcycleFlagEncoder) em.getEncoder("motorcycle");
 
     private Graph initExampleGraph()

--- a/core/src/test/java/com/graphhopper/storage/AbstractGraphStorageTester.java
+++ b/core/src/test/java/com/graphhopper/storage/AbstractGraphStorageTester.java
@@ -1040,7 +1040,7 @@ public abstract class AbstractGraphStorageTester
     {
         Directory dir = new RAMDirectory();
         List<FlagEncoder> list = new ArrayList<FlagEncoder>();
-        list.add(new TmpCarFlagEncoder(29, 0.001, 0)
+        list.add(new TmpCarFlagEncoder(27, 0.001, 0)
         {
             @Override
             public String toString()
@@ -1048,7 +1048,7 @@ public abstract class AbstractGraphStorageTester
                 return "car2";
             }
         });
-        list.add(new TmpCarFlagEncoder(29, 0.001, 0));
+        list.add(new TmpCarFlagEncoder(27, 0.001, 0));
         EncodingManager manager = new EncodingManager(list, 8);
         graph = new GraphHopperStorage(dir, manager, false, new GraphExtension.NoOpExtension()).create(defaultSize);
 

--- a/reader-osm/src/test/java/com/graphhopper/reader/osm/GraphHopperOSMTest.java
+++ b/reader-osm/src/test/java/com/graphhopper/reader/osm/GraphHopperOSMTest.java
@@ -882,7 +882,7 @@ public class GraphHopperOSMTest
         for (int threadCount = 1; threadCount < 6; threadCount++)
         {
             EncodingManager em = new EncodingManager(Arrays.asList(new CarFlagEncoder(), new MotorcycleFlagEncoder(),
-                    new MountainBikeFlagEncoder(), new RacingBikeFlagEncoder(), new FootFlagEncoder()),
+                    new MountainBikeFlagEncoder(), new RacingBikeFlagEncoder()),
                     8);
 
             GraphHopper tmpGH = new GraphHopperOSM().setStoreOnFlush(false).
@@ -893,7 +893,7 @@ public class GraphHopperOSMTest
 
             tmpGH.importOrLoad();
 
-            assertEquals(5, tmpGH.getCHFactoryDecorator().getPreparations().size());
+            assertEquals(4, tmpGH.getCHFactoryDecorator().getPreparations().size());
             for (RoutingAlgorithmFactory raf : tmpGH.getCHFactoryDecorator().getPreparations())
             {
                 PrepareContractionHierarchies pch = (PrepareContractionHierarchies) raf;

--- a/reader-osm/src/test/java/com/graphhopper/reader/osm/OSMReaderTest.java
+++ b/reader-osm/src/test/java/com/graphhopper/reader/osm/OSMReaderTest.java
@@ -127,7 +127,7 @@ public class OSMReaderTest
 
             footEncoder = new FootFlagEncoder();
 
-            setEncodingManager(new EncodingManager(footEncoder, carEncoder, bikeEncoder));
+            setEncodingManager(new EncodingManager(Arrays.asList(footEncoder, carEncoder, bikeEncoder), 8));
         }
 
         @Override
@@ -746,7 +746,7 @@ public class OSMReaderTest
         CarFlagEncoder car = new CarFlagEncoder(5, 5, 24);
         FootFlagEncoder foot = new FootFlagEncoder();
         BikeFlagEncoder bike = new BikeFlagEncoder(4, 2, 24);
-        EncodingManager manager = new EncodingManager(Arrays.asList(bike, foot, car), 4);
+        EncodingManager manager = new EncodingManager(Arrays.asList(bike, foot, car), 8);
 
         GraphHopperStorage ghStorage = new GraphBuilder(manager).create();
         OSMReader reader = new OSMReader(ghStorage)


### PR DESCRIPTION
This PR saves `tunnel:yes` and `bridge:yes` in two additional generic flags (just like `K_ROUNDABOUT`).

The drawback is that since these are generic flags, they are currently duplicated among all the flag encoders. As a result, users will need 64-bit edge flags in most cases (2+ encoders).