### PR TITLE
Change graph based on overlay data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ local.properties
 *.zip
 .DS_Store
 /core/nbproject/
+/reader-overlay-data/nbproject/

--- a/pom.xml
+++ b/pom.xml
@@ -10,9 +10,7 @@
     <packaging>pom</packaging> 
     <url>https://graphhopper.com</url> 
     <inceptionYear>2012</inceptionYear>
-    <description>
-        Super pom of GraphHopper core, a fast Java road routing engine.
-    </description>
+    <description>Super pom of GraphHopper, the fast and flexible routing engine</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -79,6 +77,7 @@
         <module>tools-lgpl</module>
         <module>core</module>
         <module>reader-osm</module>
+        <module>reader-overlay-data</module>
         <module>tools</module>
         <module>web</module>
     </modules>

--- a/reader-overlay-data/pom.xml
+++ b/reader-overlay-data/pom.xml
@@ -4,10 +4,10 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.graphhopper</groupId>
-    <artifactId>graphhopper-reader-osm</artifactId>
+    <artifactId>graphhopper-reader-overlay-data</artifactId>
     <version>0.8-SNAPSHOT</version>
     <packaging>jar</packaging>
-    <name>GraphHopper Reader for OpenStreetMap Data</name>
+    <name>GraphHopper Reader for Overlay Data</name>
 
     <parent>
         <groupId>com.graphhopper</groupId>
@@ -21,18 +21,13 @@
             <artifactId>graphhopper-core</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
-        
         <dependency>
-            <groupId>com.google.protobuf</groupId>
-            <artifactId>protobuf-java</artifactId>
-            <version>2.6.1</version>
-        </dependency>        
-        <dependency>
-            <groupId>org.openstreetmap.osmosis</groupId>
-            <artifactId>osmosis-osm-binary</artifactId>
-            <version>0.44.1</version>
-        </dependency>
-        
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.6.2</version>
+            <!-- you can provider a different implementation in the future -->
+            <scope>provided</scope>
+        </dependency> 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
@@ -51,37 +46,12 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-compress</artifactId>
-            <version>1.10</version>
-        </dependency>
-        
-        <dependency>
             <groupId>com.graphhopper</groupId>
             <artifactId>graphhopper-core</artifactId>
             <version>${project.parent.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
-        </dependency>        
+        </dependency>   
     </dependencies>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-assembly-plugin</artifactId>                
-                <configuration>
-                    <archive>
-                        <manifest>
-                            <mainClass>com.graphhopper.import.osm.Import</mainClass>
-                        </manifest>
-                    </archive>
-                        	                    
-                    <!-- for standalone usage -->
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
+    
 </project>

--- a/reader-overlay-data/pom.xml
+++ b/reader-overlay-data/pom.xml
@@ -25,8 +25,9 @@
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>2.6.2</version>
-            <!-- you can provider a different implementation in the future -->
-            <scope>provided</scope>
+            <!-- in the future make implementation optional
+                 <scope>provided</scope>
+            -->
         </dependency> 
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/reader-overlay-data/src/main/java/com/graphhopper/json/GHson.java
+++ b/reader-overlay-data/src/main/java/com/graphhopper/json/GHson.java
@@ -1,0 +1,35 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for 
+ *  additional information regarding copyright ownership.
+ * 
+ *  GraphHopper GmbH licenses this file to you under the Apache License, 
+ *  Version 2.0 (the "License"); you may not use this file except in 
+ *  compliance with the License. You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.json;
+
+import java.io.Reader;
+
+/**
+ * A simple JSON (de)serialization facade. E.g. to be easily replaced with platform specific
+ * implementations.
+ *
+ * @author Peter Karich
+ */
+public interface GHson
+{
+    /**
+     * This method reads JSON data from the provided source and creates an instance of the provided
+     * class.
+     */
+    <T> T fromJson( Reader source, Class<T> aClass );
+}

--- a/reader-overlay-data/src/main/java/com/graphhopper/json/GHsonBuilder.java
+++ b/reader-overlay-data/src/main/java/com/graphhopper/json/GHsonBuilder.java
@@ -1,0 +1,43 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for 
+ *  additional information regarding copyright ownership.
+ * 
+ *  GraphHopper GmbH licenses this file to you under the Apache License, 
+ *  Version 2.0 (the "License"); you may not use this file except in 
+ *  compliance with the License. You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.json;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.graphhopper.json.geo.FeatureJsonDeserializer;
+import com.graphhopper.json.geo.JsonFeature;
+
+/**
+ *
+ * @author Peter Karich
+ */
+public class GHsonBuilder
+{
+    public GHson create()
+    {
+        // for now always return Gson implementation        
+        Gson gson = new GsonBuilder()
+                .disableHtmlEscaping()
+                .registerTypeHierarchyAdapter(JsonFeature.class, new FeatureJsonDeserializer())
+                .create();
+        // for geojson we could rely on external libs instead of inventing our own:
+        // https://github.com/filosganga/geogson or https://github.com/3sidedcube/Android-GeoGson
+
+        return new GHsonGson(gson);
+    }
+}

--- a/reader-overlay-data/src/main/java/com/graphhopper/json/GHsonGson.java
+++ b/reader-overlay-data/src/main/java/com/graphhopper/json/GHsonGson.java
@@ -1,0 +1,41 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for 
+ *  additional information regarding copyright ownership.
+ * 
+ *  GraphHopper GmbH licenses this file to you under the Apache License, 
+ *  Version 2.0 (the "License"); you may not use this file except in 
+ *  compliance with the License. You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.json;
+
+import com.google.gson.Gson;
+import java.io.Reader;
+
+/**
+ *
+ * @author Peter Karich
+ */
+public class GHsonGson implements GHson
+{
+    private final Gson gson;
+
+    public GHsonGson( Gson gson )
+    {
+        this.gson = gson;
+    }
+
+    @Override
+    public <T> T fromJson( Reader source, Class<T> aClass )
+    {
+        return gson.fromJson(source, aClass);
+    }
+}

--- a/reader-overlay-data/src/main/java/com/graphhopper/json/geo/FeatureJsonDeserializer.java
+++ b/reader-overlay-data/src/main/java/com/graphhopper/json/geo/FeatureJsonDeserializer.java
@@ -1,0 +1,125 @@
+package com.graphhopper.json.geo;
+
+import com.google.gson.*;
+import com.graphhopper.util.shapes.BBox;
+import java.lang.reflect.Type;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Instructions how to read the different geometry types.
+ *
+ * @author Peter Karich
+ */
+public class FeatureJsonDeserializer implements JsonDeserializer<JsonFeature>
+{
+    @Override
+    public JsonFeature deserialize( JsonElement json, Type type, JsonDeserializationContext context ) throws JsonParseException
+    {
+        JsonFeature feature = new JsonFeature();
+        JsonObject obj = json.getAsJsonObject();
+
+        if (obj.has("id"))        
+            feature.id = obj.getAsString();
+        else        
+            feature.id = UUID.randomUUID().toString();        
+
+        if (obj.has("properties"))
+        {
+            Map<String, Object> map = context.deserialize(obj.get("properties"), Map.class);
+            feature.properties = map;
+        }
+
+        if (obj.has("bbox"))
+            feature.bbox = parseBBox(obj.get("bbox").getAsJsonArray());
+
+        if (obj.has("geometry"))
+        {
+            JsonObject geometry = obj.get("geometry").getAsJsonObject();
+
+            if (geometry.has("coordinates"))
+            {
+                if (!geometry.has("type"))
+                    throw new IllegalArgumentException("No type for non-empty coordinates specified");
+
+                String strType = context.deserialize(geometry.get("type"), String.class);
+                feature.type = strType;
+                if ("Point".equals(strType))
+                {
+                    JsonArray arr = geometry.get("coordinates").getAsJsonArray();
+                    double lon = arr.get(0).getAsDouble();
+                    double lat = arr.get(1).getAsDouble();
+                    if (arr.size() == 3)
+                        feature.geometry = new Point(lat, lon, arr.get(2).getAsDouble());
+                    else
+                        feature.geometry = new Point(lat, lon);
+
+                } else if ("MultiPoint".equals(strType))
+                {
+                    feature.geometry = parseLineString(geometry);
+
+                } else if ("LineString".equals(strType))
+                {
+                    feature.geometry = parseLineString(geometry);
+
+                } else
+                {
+                    throw new IllegalArgumentException("Coordinates type " + strType + " not yet supported");
+                }
+            }
+        }
+
+        return feature;
+    }
+
+    LineString parseLineString( JsonObject geometry )
+    {
+        JsonArray arr = geometry.get("coordinates").getAsJsonArray();
+        boolean is3D = arr.size() == 0 || arr.get(0).getAsJsonArray().size() == 3;
+        LineString lineString = new LineString(arr.size(), is3D);
+
+        for (int i = 0; i < arr.size(); i++)
+        {
+            JsonArray pointArr = arr.get(i).getAsJsonArray();
+            double lon = pointArr.get(0).getAsDouble();
+            double lat = pointArr.get(1).getAsDouble();
+            if (pointArr.size() == 3)
+                lineString.add(lat, lon, pointArr.get(2).getAsDouble());
+            else
+                lineString.add(lat, lon);
+        }
+        return lineString;
+    }
+
+    private BBox parseBBox( JsonArray arr )
+    {
+        // The value of the bbox member must be a 2*n array where n is the number of dimensions represented 
+        // in the contained geometries, with the lowest values for all axes followed by the highest values. 
+        // The axes order of a bbox follows the axes order of geometries => lon,lat,ele
+        if (arr.size() == 6)
+        {
+            double minLon = arr.get(0).getAsDouble();
+            double minLat = arr.get(1).getAsDouble();
+            double minEle = arr.get(2).getAsDouble();
+
+            double maxLon = arr.get(3).getAsDouble();
+            double maxLat = arr.get(4).getAsDouble();
+            double maxEle = arr.get(5).getAsDouble();
+
+            return new BBox(minLon, maxLon, minLat, maxLat, minEle, maxEle);
+
+        } else if (arr.size() == 4)
+        {
+            double minLon = arr.get(0).getAsDouble();
+            double minLat = arr.get(1).getAsDouble();
+
+            double maxLon = arr.get(2).getAsDouble();
+            double maxLat = arr.get(3).getAsDouble();
+
+            return new BBox(minLon, maxLon, minLat, maxLat);
+        } else
+        {
+            throw new IllegalArgumentException("Illegal array dimension (" + arr.size() + ") of bbox " + arr.toString());
+        }
+    }
+}

--- a/reader-overlay-data/src/main/java/com/graphhopper/json/geo/FeatureJsonDeserializer.java
+++ b/reader-overlay-data/src/main/java/com/graphhopper/json/geo/FeatureJsonDeserializer.java
@@ -21,10 +21,10 @@ public class FeatureJsonDeserializer implements JsonDeserializer<JsonFeature>
             JsonFeature feature = new JsonFeature();
             JsonObject obj = json.getAsJsonObject();
 
-            if (obj.has("id") && obj.isJsonPrimitive())
-            {
-                feature.id = obj.getAsString();
-            } else
+            // TODO ensure uniqueness
+            if (obj.has("id"))
+                feature.id = obj.get("id").getAsString();
+            else
                 feature.id = UUID.randomUUID().toString();
 
             if (obj.has("properties"))

--- a/reader-overlay-data/src/main/java/com/graphhopper/json/geo/FeatureJsonDeserializer.java
+++ b/reader-overlay-data/src/main/java/com/graphhopper/json/geo/FeatureJsonDeserializer.java
@@ -1,3 +1,20 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for 
+ *  additional information regarding copyright ownership.
+ * 
+ *  GraphHopper GmbH licenses this file to you under the Apache License, 
+ *  Version 2.0 (the "License"); you may not use this file except in 
+ *  compliance with the License. You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package com.graphhopper.json.geo;
 
 import com.google.gson.*;

--- a/reader-overlay-data/src/main/java/com/graphhopper/json/geo/Geometry.java
+++ b/reader-overlay-data/src/main/java/com/graphhopper/json/geo/Geometry.java
@@ -1,0 +1,21 @@
+package com.graphhopper.json.geo;
+
+import com.graphhopper.util.PointList;
+import com.graphhopper.util.shapes.GHPoint;
+
+/**
+ *
+ * @author Peter Karich
+ */
+public interface Geometry
+{
+    String getType();
+
+    boolean isPoint();
+
+    GHPoint asPoint();
+
+    boolean isPointList();
+
+    PointList asPointList();
+}

--- a/reader-overlay-data/src/main/java/com/graphhopper/json/geo/Geometry.java
+++ b/reader-overlay-data/src/main/java/com/graphhopper/json/geo/Geometry.java
@@ -1,3 +1,20 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for 
+ *  additional information regarding copyright ownership.
+ * 
+ *  GraphHopper GmbH licenses this file to you under the Apache License, 
+ *  Version 2.0 (the "License"); you may not use this file except in 
+ *  compliance with the License. You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package com.graphhopper.json.geo;
 
 import com.graphhopper.util.PointList;

--- a/reader-overlay-data/src/main/java/com/graphhopper/json/geo/JsonFeature.java
+++ b/reader-overlay-data/src/main/java/com/graphhopper/json/geo/JsonFeature.java
@@ -1,0 +1,80 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for 
+ *  additional information regarding copyright ownership.
+ * 
+ *  GraphHopper GmbH licenses this file to you under the Apache License, 
+ *  Version 2.0 (the "License"); you may not use this file except in 
+ *  compliance with the License. You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.json.geo;
+
+import com.graphhopper.util.shapes.BBox;
+import java.util.Map;
+
+/**
+ *
+ * @author Peter Karich
+ */
+public class JsonFeature
+{
+    String id;
+    String type;
+    BBox bbox;
+    Geometry geometry;
+    Map<String, Object> properties;
+
+    public String getId()
+    {
+        return id;
+    }
+
+    public String getType()
+    {
+        return type;
+    }
+
+    public BBox getBBox()
+    {
+        return bbox;
+    }
+
+    public boolean hasGeometry()
+    {
+        return geometry != null;
+    }
+
+    public Geometry getGeometry()
+    {
+        return geometry;
+    }
+
+    public boolean hasProperties()
+    {
+        return properties != null;
+    }
+
+    public Map<String, Object> getProperties()
+    {
+        return properties;
+    }
+
+    public Object getProperty( String key )
+    {
+        return properties.get(key);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "id:" + getId();
+    }
+}

--- a/reader-overlay-data/src/main/java/com/graphhopper/json/geo/JsonFeatureCollection.java
+++ b/reader-overlay-data/src/main/java/com/graphhopper/json/geo/JsonFeatureCollection.java
@@ -1,0 +1,40 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for 
+ *  additional information regarding copyright ownership.
+ * 
+ *  GraphHopper GmbH licenses this file to you under the Apache License, 
+ *  Version 2.0 (the "License"); you may not use this file except in 
+ *  compliance with the License. You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.json.geo;
+
+import java.util.List;
+
+/**
+ *
+ * @author Peter Karich
+ */
+public class JsonFeatureCollection
+{
+    String type;
+    List<JsonFeature> features;
+
+    public String getType()
+    {
+        return type;
+    }
+
+    public List<JsonFeature> getFeatures()
+    {
+        return features;
+    }
+}

--- a/reader-overlay-data/src/main/java/com/graphhopper/json/geo/LineString.java
+++ b/reader-overlay-data/src/main/java/com/graphhopper/json/geo/LineString.java
@@ -1,0 +1,64 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for 
+ *  additional information regarding copyright ownership.
+ * 
+ *  GraphHopper GmbH licenses this file to you under the Apache License, 
+ *  Version 2.0 (the "License"); you may not use this file except in 
+ *  compliance with the License. You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.json.geo;
+
+import com.graphhopper.util.PointList;
+import com.graphhopper.util.shapes.GHPoint;
+
+/**
+ * Wrapper to read a PointList easily from GeoJSON (type=LineString)
+ *
+ * @author Peter Karich
+ */
+public class LineString extends PointList implements Geometry
+{
+    public LineString( int size, boolean is3D )
+    {
+        super(size, is3D);
+    }
+
+    @Override
+    public String getType()
+    {
+        return "LineString";
+    }
+
+    @Override
+    public boolean isPoint()
+    {
+        return false;
+    }
+
+    @Override
+    public GHPoint asPoint()
+    {
+        throw new UnsupportedOperationException("Not supported");
+    }
+
+    @Override
+    public boolean isPointList()
+    {
+        return true;
+    }
+
+    @Override
+    public PointList asPointList()
+    {
+        return this;
+    }
+}

--- a/reader-overlay-data/src/main/java/com/graphhopper/json/geo/Point.java
+++ b/reader-overlay-data/src/main/java/com/graphhopper/json/geo/Point.java
@@ -1,0 +1,76 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for 
+ *  additional information regarding copyright ownership.
+ * 
+ *  GraphHopper GmbH licenses this file to you under the Apache License, 
+ *  Version 2.0 (the "License"); you may not use this file except in 
+ *  compliance with the License. You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.json.geo;
+
+import com.graphhopper.util.PointList;
+import com.graphhopper.util.shapes.GHPoint;
+import com.graphhopper.util.shapes.GHPoint3D;
+
+/**
+ * Wrapper to read a GHPoint3D easily from GeoJSON (type=Point)
+ *
+ * @author Peter Karich
+ */
+public class Point extends GHPoint3D implements Geometry
+{
+    public Point( double lat, double lon )
+    {
+        super(lat, lon, Double.NaN);
+    }
+
+    public Point( double lat, double lon, double ele )
+    {
+        super(lat, lon, ele);
+    }
+
+    @Override
+    public String toString()
+    {
+        return lat + ", " + lon;
+    }
+
+    @Override
+    public boolean isPoint()
+    {
+        return true;
+    }
+
+    @Override
+    public GHPoint asPoint()
+    {
+        return this;
+    }
+
+    @Override
+    public boolean isPointList()
+    {
+        return false;
+    }
+
+    @Override
+    public PointList asPointList()
+    {
+        throw new UnsupportedOperationException("Not supported");
+    }
+
+    @Override
+    public String getType()
+    {
+        return "Point";
+    }
+}

--- a/reader-overlay-data/src/main/java/com/graphhopper/reader/overlaydata/FeedOverlayData.java
+++ b/reader-overlay-data/src/main/java/com/graphhopper/reader/overlaydata/FeedOverlayData.java
@@ -1,0 +1,191 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for 
+ *  additional information regarding copyright ownership.
+ * 
+ *  GraphHopper GmbH licenses this file to you under the Apache License, 
+ *  Version 2.0 (the "License"); you may not use this file except in 
+ *  compliance with the License. You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.reader.overlaydata;
+
+import com.graphhopper.json.GHson;
+import com.graphhopper.json.geo.Geometry;
+import com.graphhopper.json.geo.JsonFeature;
+import com.graphhopper.json.geo.JsonFeatureCollection;
+import com.graphhopper.routing.util.DefaultEdgeFilter;
+import com.graphhopper.routing.util.EdgeFilter;
+import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.routing.util.FlagEncoder;
+import com.graphhopper.storage.Graph;
+import com.graphhopper.storage.NodeAccess;
+import com.graphhopper.storage.index.LocationIndex;
+import com.graphhopper.storage.index.QueryResult;
+import com.graphhopper.util.BreadthFirstSearch;
+import com.graphhopper.util.EdgeIteratorState;
+import com.graphhopper.util.Helper;
+import com.graphhopper.util.PointList;
+import com.graphhopper.util.shapes.BBox;
+import com.graphhopper.util.shapes.GHPoint;
+import gnu.trove.iterator.TIntIterator;
+import gnu.trove.set.TIntSet;
+import gnu.trove.set.hash.TIntHashSet;
+import java.io.Reader;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Peter Karich
+ */
+public class FeedOverlayData
+{
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final Graph graph;
+    private final LocationIndex locationIndex;
+    private final GHson ghson;
+    private final EncodingManager em;
+
+    public FeedOverlayData( Graph graph, EncodingManager em, LocationIndex locationIndex, GHson ghson )
+    {
+        this.ghson = ghson;
+        this.graph = graph;
+        this.em = em;
+        this.locationIndex = locationIndex;
+    }
+
+    /**
+     * This method applies changes to the graph, specified by the reader.
+     *
+     * @return number of successfully applied edge changes
+     */
+    public int applyChanges( Reader reader )
+    {
+        // read full file, later support one json feature or collection per line to avoid high mem consumption
+        JsonFeatureCollection data = ghson.fromJson(reader, JsonFeatureCollection.class);
+        int updates = 0;
+        for (JsonFeature jsonFeature : data.getFeatures())
+        {
+            if (!jsonFeature.hasProperties())
+                throw new IllegalArgumentException("One feature has no properties, please specify properties e.g. speed or access");
+
+            String encoderStr = (String) jsonFeature.getProperty("vehicle");
+            FlagEncoder encoder = Helper.isEmpty(encoderStr) ? em.fetchEdgeEncoders().get(0) : em.getEncoder(encoderStr);
+
+            EdgeFilter filter = new DefaultEdgeFilter(encoder);
+            TIntSet edges = new TIntHashSet();
+            if (jsonFeature.hasGeometry())
+            {
+                fillEdgeIDs(edges, jsonFeature.getGeometry(), filter);
+            } else if (jsonFeature.getBBox() != null)
+            {
+                fillEdgeIDs(edges, jsonFeature.getBBox(), filter);
+            } else
+                throw new IllegalArgumentException("Feature " + jsonFeature.getId() + " has no geometry and no bbox");
+
+            TIntIterator iter = edges.iterator();
+            Map<String, Object> props = jsonFeature.getProperties();
+            while (iter.hasNext())
+            {
+                int edgeId = iter.next();
+                EdgeIteratorState edge = graph.getEdgeIteratorState(edgeId, Integer.MIN_VALUE);
+
+                if (props.containsKey("access"))
+                {
+                    boolean value = (boolean) props.get("access");
+                    updates++;
+                    logger.info("Access change at " + jsonFeature.getId());
+                    edge.setFlags(encoder.setAccess(edge.getFlags(), value, value));
+
+                } else if (props.containsKey("speed"))
+                {
+                    // TODO use different speed for the different directions (see e.g. Bike2WeightFlagEncoder)
+                    double value = ((Number) props.get("speed")).doubleValue();
+                    double oldSpeed = encoder.getSpeed(edge.getFlags());
+                    if (oldSpeed != value)
+                    {
+                        updates++;
+                        logger.info("Speed change at " + jsonFeature.getId() + ". Old: " + oldSpeed + ", new:" + value);
+                        edge.setFlags(encoder.setSpeed(edge.getFlags(), value));
+                    }
+                }
+            }
+        }
+
+        return updates;
+    }
+
+    public void fillEdgeIDs( TIntSet edgeIds, Geometry geometry, EdgeFilter filter )
+    {
+        if (geometry.isPoint())
+        {
+            GHPoint point = geometry.asPoint();
+            QueryResult qr = locationIndex.findClosest(point.lat, point.lon, filter);
+            if (qr.isValid())
+                edgeIds.add(qr.getClosestEdge().getEdge());
+        } else if (geometry.isPointList())
+        {
+            PointList pl = geometry.asPointList();
+            if (geometry.getType().equals("LineString"))
+            {
+                // TODO do map matching or routing
+                int lastIdx = pl.size() - 1;
+                if (pl.size() >= 2)
+                {
+                    double meanLat = (pl.getLatitude(0) + pl.getLatitude(lastIdx)) / 2;
+                    double meanLon = (pl.getLongitude(0) + pl.getLongitude(lastIdx)) / 2;
+                    QueryResult qr = locationIndex.findClosest(meanLat, meanLon, filter);
+                    if (qr.isValid())
+                        edgeIds.add(qr.getClosestEdge().getEdge());
+                }
+            } else
+            {
+                for (int i = 0; i < pl.size(); i++)
+                {
+                    QueryResult qr = locationIndex.findClosest(pl.getLatitude(i), pl.getLongitude(i), filter);
+                    if (qr.isValid())
+                        edgeIds.add(qr.getClosestEdge().getEdge());
+                }
+            }
+        }
+    }
+
+    public void fillEdgeIDs( final TIntSet edgeIds, final BBox bbox, EdgeFilter filter )
+    {
+        QueryResult qr = locationIndex.findClosest((bbox.maxLat + bbox.minLat) / 2, (bbox.maxLon + bbox.minLon) / 2, filter);
+        if (!qr.isValid())
+            return;
+
+        BreadthFirstSearch bfs = new BreadthFirstSearch()
+        {
+            final NodeAccess na = graph.getNodeAccess();
+            final BBox localBBox = bbox;
+
+            @Override
+            protected boolean goFurther( int nodeId )
+            {
+                return localBBox.contains(na.getLatitude(nodeId), na.getLongitude(nodeId));
+            }
+
+            @Override
+            protected boolean checkAdjacent( EdgeIteratorState edge )
+            {
+                if (localBBox.contains(na.getLatitude(edge.getAdjNode()), na.getLongitude(edge.getAdjNode())))
+                {
+                    edgeIds.add(edge.getEdge());
+                    return true;
+                }
+                return false;
+            }
+        };
+        bfs.start(graph.createEdgeExplorer(filter), qr.getClosestNode());
+    }
+}

--- a/reader-overlay-data/src/main/java/com/graphhopper/reader/overlaydata/FeedOverlayData.java
+++ b/reader-overlay-data/src/main/java/com/graphhopper/reader/overlaydata/FeedOverlayData.java
@@ -160,7 +160,7 @@ public class FeedOverlayData
                 boolean value = (boolean) props.get("access");
                 updates++;
                 if (enableLogging)
-                    logger.info(encoder.toString() + " - access change at " + jsonFeature.getId());
+                    logger.info(encoder.toString() + " - access change via feature " + jsonFeature.getId());
                 edge.setFlags(encoder.setAccess(edge.getFlags(), value, value));
 
             } else if (props.containsKey("speed"))
@@ -172,7 +172,7 @@ public class FeedOverlayData
                 {
                     updates++;
                     if (enableLogging)
-                        logger.info(encoder.toString() + " - speed change at " + jsonFeature.getId() + ". Old: " + oldSpeed + ", new:" + value);
+                        logger.info(encoder.toString() + " - speed change via feature " + jsonFeature.getId() + ". Old: " + oldSpeed + ", new:" + value);
                     edge.setFlags(encoder.setSpeed(edge.getFlags(), value));
                 }
             }

--- a/reader-overlay-data/src/test/java/com/graphhopper/json/geo/JsonFeatureCollectionTest.java
+++ b/reader-overlay-data/src/test/java/com/graphhopper/json/geo/JsonFeatureCollectionTest.java
@@ -41,6 +41,7 @@ public class JsonFeatureCollectionTest
         assertEquals(3, data.getFeatures().size());
 
         JsonFeature f1 = data.getFeatures().get(0);
+        assertEquals("1", f1.getId());
         assertEquals("value0", f1.getProperty("prop0"));
         assertEquals(0.5, f1.getGeometry().asPoint().lat, .1);
         assertEquals(102.0, f1.getGeometry().asPoint().lon, .1);
@@ -59,7 +60,7 @@ public class JsonFeatureCollectionTest
 
     JsonFeatureCollection getJson( String name )
     {
-        Reader reader = new InputStreamReader(getClass().getResourceAsStream(name), Helper.UTF_CS);        
+        Reader reader = new InputStreamReader(getClass().getResourceAsStream(name), Helper.UTF_CS);
         return ghson.fromJson(reader, JsonFeatureCollection.class);
     }
 

--- a/reader-overlay-data/src/test/java/com/graphhopper/json/geo/JsonFeatureCollectionTest.java
+++ b/reader-overlay-data/src/test/java/com/graphhopper/json/geo/JsonFeatureCollectionTest.java
@@ -47,6 +47,8 @@ public class JsonFeatureCollectionTest
         assertEquals(102.0, f1.getGeometry().asPoint().lon, .1);
 
         JsonFeature f2 = data.getFeatures().get(1);
+        // read as string despite the 2 (not a string) in json
+        assertEquals("2", f2.getId());
         assertEquals(4, f2.getGeometry().asPointList().size());
         assertEquals(0.0, f2.getGeometry().asPointList().getLat(0), .1);
         assertEquals(102.0, f2.getGeometry().asPointList().getLon(0), .1);

--- a/reader-overlay-data/src/test/java/com/graphhopper/json/geo/JsonFeatureCollectionTest.java
+++ b/reader-overlay-data/src/test/java/com/graphhopper/json/geo/JsonFeatureCollectionTest.java
@@ -1,0 +1,66 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for 
+ *  additional information regarding copyright ownership.
+ * 
+ *  GraphHopper GmbH licenses this file to you under the Apache License, 
+ *  Version 2.0 (the "License"); you may not use this file except in 
+ *  compliance with the License. You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.json.geo;
+
+import com.graphhopper.json.GHson;
+import com.graphhopper.json.GHsonBuilder;
+import com.graphhopper.util.Helper;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.util.Map;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ *
+ * @author Peter Karich
+ */
+public class JsonFeatureCollectionTest
+{
+    private final GHson ghson = new GHsonBuilder().create();
+
+    @Test
+    public void testDeserialization()
+    {
+        JsonFeatureCollection data = getJson("geojson1.json");
+        assertEquals(3, data.getFeatures().size());
+
+        JsonFeature f1 = data.getFeatures().get(0);
+        assertEquals("value0", f1.getProperty("prop0"));
+        assertEquals(0.5, f1.getGeometry().asPoint().lat, .1);
+        assertEquals(102.0, f1.getGeometry().asPoint().lon, .1);
+
+        JsonFeature f2 = data.getFeatures().get(1);
+        assertEquals(4, f2.getGeometry().asPointList().size());
+        assertEquals(0.0, f2.getGeometry().asPointList().getLat(0), .1);
+        assertEquals(102.0, f2.getGeometry().asPointList().getLon(0), .1);
+        assertEquals(1.0, f2.getGeometry().asPointList().getLat(1), .1);
+        assertEquals(103.0, f2.getGeometry().asPointList().getLon(1), .1);
+
+        JsonFeature f3 = data.getFeatures().get(2);
+        assertEquals("0.0,102.0,1.0,103.0", f3.getBBox().toString());
+        assertEquals("a", ((Map) f3.getProperty("prop1")).get("test"));
+    }
+
+    JsonFeatureCollection getJson( String name )
+    {
+        Reader reader = new InputStreamReader(getClass().getResourceAsStream(name), Helper.UTF_CS);        
+        return ghson.fromJson(reader, JsonFeatureCollection.class);
+    }
+
+}

--- a/reader-overlay-data/src/test/java/com/graphhopper/reader/overlaydata/FeedOverlayDataTest.java
+++ b/reader-overlay-data/src/test/java/com/graphhopper/reader/overlaydata/FeedOverlayDataTest.java
@@ -66,7 +66,7 @@ public class FeedOverlayDataTest
 
         FeedOverlayData instance = new FeedOverlayData(graph, encodingManager, locationIndex, ghson);
         Reader reader = new InputStreamReader(getClass().getResourceAsStream("overlaydata1.json"), Helper.UTF_CS);
-        int updates = instance.applyChanges(reader);
+        long updates = instance.applyChanges(reader);
         assertEquals(2, updates);
 
         // assert changed speed and access

--- a/reader-overlay-data/src/test/java/com/graphhopper/reader/overlaydata/FeedOverlayDataTest.java
+++ b/reader-overlay-data/src/test/java/com/graphhopper/reader/overlaydata/FeedOverlayDataTest.java
@@ -1,0 +1,78 @@
+package com.graphhopper.reader.overlaydata;
+
+import com.graphhopper.json.GHson;
+import com.graphhopper.json.GHsonBuilder;
+import com.graphhopper.routing.AbstractRoutingAlgorithmTester;
+import com.graphhopper.routing.util.AllEdgesIterator;
+import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.routing.util.FlagEncoder;
+import com.graphhopper.storage.GraphBuilder;
+import com.graphhopper.storage.GraphHopperStorage;
+import com.graphhopper.storage.RAMDirectory;
+import com.graphhopper.storage.index.LocationIndex;
+import com.graphhopper.storage.index.LocationIndexTree;
+import com.graphhopper.util.GHUtility;
+import com.graphhopper.util.Helper;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.Before;
+
+/**
+ * @author Peter Karich
+ */
+public class FeedOverlayDataTest
+{
+    private EncodingManager encodingManager;
+    private GraphHopperStorage graph;
+    private GHson ghson;
+
+    @Before
+    public void setUp()
+    {
+        encodingManager = new EncodingManager("car");
+        graph = new GraphBuilder(encodingManager).create();
+        ghson = new GHsonBuilder().create();
+    }
+
+    @Test
+    public void testApplyChanges()
+    {
+        // 0-1-2
+        // | |
+        // 3-4
+        graph.edge(0, 1, 1, true);
+        graph.edge(1, 2, 1, true);
+        graph.edge(3, 4, 1, true);
+        graph.edge(0, 3, 1, true);
+        graph.edge(1, 4, 1, true);
+        AbstractRoutingAlgorithmTester.updateDistancesFor(graph, 0, 0.01, 0.00);
+        AbstractRoutingAlgorithmTester.updateDistancesFor(graph, 1, 0.01, 0.01);
+        AbstractRoutingAlgorithmTester.updateDistancesFor(graph, 2, 0.01, 0.02);
+        AbstractRoutingAlgorithmTester.updateDistancesFor(graph, 3, 0.00, 0.00);
+        AbstractRoutingAlgorithmTester.updateDistancesFor(graph, 4, 0.00, 0.01);
+        LocationIndex locationIndex = new LocationIndexTree(graph, new RAMDirectory()).prepareIndex();
+
+        FlagEncoder encoder = encodingManager.getEncoder("car");
+        double defaultSpeed = encoder.getSpeed(GHUtility.getEdge(graph, 0, 1).getFlags());
+        AllEdgesIterator iter = graph.getAllEdges();
+        while (iter.next())
+        {
+            long flags = GHUtility.getEdge(graph, 0, 1).getFlags();
+            assertEquals(defaultSpeed, encoder.getSpeed(flags), .1);
+            assertTrue(encoder.isForward(flags));
+        }
+
+        FeedOverlayData instance = new FeedOverlayData(graph, encodingManager, locationIndex, ghson);
+        Reader reader = new InputStreamReader(getClass().getResourceAsStream("overlaydata1.json"), Helper.UTF_CS);
+        int updates = instance.applyChanges(reader);
+        assertEquals(2, updates);
+
+        // assert changed speed and access
+        double newSpeed = encoder.getSpeed(GHUtility.getEdge(graph, 0, 1).getFlags());
+        assertEquals(10, newSpeed, .1);
+        assertTrue(newSpeed < defaultSpeed);
+        assertFalse(encoder.isForward(GHUtility.getEdge(graph, 3, 4).getFlags()));
+    }
+}

--- a/reader-overlay-data/src/test/resources/com/graphhopper/json/geo/geojson1.json
+++ b/reader-overlay-data/src/test/resources/com/graphhopper/json/geo/geojson1.json
@@ -2,6 +2,7 @@
     "type": "FeatureCollection",
     "features": [
         {
+            "id": "1",
             "type": "Feature",
             "geometry": {
                 "type": "Point",

--- a/reader-overlay-data/src/test/resources/com/graphhopper/json/geo/geojson1.json
+++ b/reader-overlay-data/src/test/resources/com/graphhopper/json/geo/geojson1.json
@@ -13,6 +13,7 @@
             }
         },
         {
+            "id": 2,
             "type": "Feature",
             "geometry": {
                 "type": "LineString",

--- a/reader-overlay-data/src/test/resources/com/graphhopper/json/geo/geojson1.json
+++ b/reader-overlay-data/src/test/resources/com/graphhopper/json/geo/geojson1.json
@@ -1,0 +1,36 @@
+{
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [102.0, 0.5]
+            },
+            "properties": {
+                "prop0": "value0"
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "LineString",
+                "coordinates": [[102.0, 0.0], [103.0, 1.0], [104.0, 0.0], [105.0, 1.0]]
+            },
+            "properties": {
+                "prop0": "value1",
+                "prop1": 2
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [0.0, 1, 102.0, 103.0],
+            "properties": {
+                "prop0": "value0",
+                "prop1": {
+                    "test": "a"
+                }
+            }
+        }
+    ]
+}

--- a/reader-overlay-data/src/test/resources/com/graphhopper/reader/overlaydata/overlaydata1.json
+++ b/reader-overlay-data/src/test/resources/com/graphhopper/reader/overlaydata/overlaydata1.json
@@ -8,11 +8,13 @@
                 "coordinates": [0.005, 0.01]
             },
             "properties": {
+                "vehicles": ["car"],
                 "speed": 10,
                 "assert_nodes": [0, 1]
             }
         },
         {
+            "id": "2",
             "type": "Feature",
             "bbox": [-0.01, -0.01, 0.015, 0.005],
             "properties": {

--- a/reader-overlay-data/src/test/resources/com/graphhopper/reader/overlaydata/overlaydata1.json
+++ b/reader-overlay-data/src/test/resources/com/graphhopper/reader/overlaydata/overlaydata1.json
@@ -1,0 +1,24 @@
+{
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [0.005, 0.01]
+            },
+            "properties": {
+                "speed": 10,
+                "assert_nodes": [0, 1]
+            }
+        },
+        {
+            "type": "Feature",
+            "bbox": [-0.01, -0.01, 0.015, 0.005],
+            "properties": {
+                "access": false,
+                "assert_nodes": [3, 4]
+            }
+        }
+    ]
+}


### PR DESCRIPTION
This PR makes it possible to feed external speed or access changes via GeoJSON. For now it is not yet integrated in e.g. GraphHopper core or web. But you can easily add it via:

```java
GraphHopper myHopper = new GraphHopperOSM() {

    public void postProcessing()
    {
        super.postProcessing();
        FeedOverlayData instance = new FeedOverlayData(getGraphHopperStorage(), 
                getEncodingManager(), getLocationIndex(), new GHsonBuilder().create());
        long updates = instance.applyChanges(fileOrFolderAsString);
    }
}
```
pom.xml:
```xml
        <dependency>
            <groupId>com.graphhopper</groupId>
            <artifactId>graphhopper-reader-overlay-data</artifactId>
            <version>0.8-SNAPSHOT</version>           
        </dependency>
```

E.g. see FeedOverlayDataTest or an [example json file](https://raw.githubusercontent.com/graphhopper/graphhopper/reader-overlay-data/reader-overlay-data/src/test/resources/com/graphhopper/reader/overlaydata/overlaydata1.json)

Keep in mind that the order of any coordinate array is lon,lat and e.g. the bbox is min_lon,min_lat,max_lon,max_lat like specified in the [Geojson spec](http://geojson.org/geojson-spec.html). Also currently only three cases for a Feature are implemented:
 * `type=Point`, 
 * `type=MultiPoint` and 
 * no `type` and no `properties.coordinates` entry but with a bounding box entry `bbox`

It furthermore introduces a Json reader wrapper as discussed in #773 backed by Gson.

The overlay change functionality will stay in separate module `reader-overlay-data`. It goes even further and as we need map matching functionality in this reader module, we potentially have to move the currently separate [map matching component](https://github.com/graphhopper/map-matching) into this repository here. Keeping it necessary and still depend on it would not work well.

Keep in mind: the feeding mechanism is not thread safe, so you should **not** use this for real time updates without some locking. And it would work only for non-CH, but this method here is before the preparation and works with CH as applied only once.