### PR TITLE
More turn instructions

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/Path.java
+++ b/core/src/main/java/com/graphhopper/routing/Path.java
@@ -541,12 +541,12 @@ public class Path
                     prevName = name;
                     prevAnnotation = annotation;
 
-                } else if ((!name.equals(prevName)) || (!annotation.equals(prevAnnotation)))
+                } else
                 {
-                    prevOrientation = AC.calcOrientation(doublePrevLat, doublePrevLong, prevLat, prevLon);
+                    double tmpPrevOrientation = AC.calcOrientation(doublePrevLat, doublePrevLong, prevLat, prevLon);
                     double orientation = AC.calcOrientation(prevLat, prevLon, latitude, longitude);
-                    orientation = AC.alignOrientation(prevOrientation, orientation);
-                    double delta = orientation - prevOrientation;
+                    orientation = AC.alignOrientation(tmpPrevOrientation, orientation);
+                    double delta = orientation - tmpPrevOrientation;
                     double absDelta = Math.abs(delta);
                     int sign;
 
@@ -575,10 +575,15 @@ public class Path
                         sign = Instruction.TURN_SHARP_LEFT;
                     else
                         sign = Instruction.TURN_SHARP_RIGHT;
-                    prevInstruction = new Instruction(sign, name, annotation, new PointList(10, nodeAccess.is3D()));
-                    ways.add(prevInstruction);
-                    prevName = name;
-                    prevAnnotation = annotation;
+                    
+                    if (!name.equals(prevName) || !annotation.equals(prevAnnotation) || sign != Instruction.CONTINUE_ON_STREET)
+                    {
+                        prevOrientation = tmpPrevOrientation;
+                        prevInstruction = new Instruction(sign, name, annotation, new PointList(10, nodeAccess.is3D()));
+                        ways.add(prevInstruction);
+                        prevName = name;
+                        prevAnnotation = annotation;
+                    }
                 }
 
                 updatePointsAndInstruction(edge, wayGeo);

--- a/core/src/test/java/com/graphhopper/routing/PathTest.java
+++ b/core/src/test/java/com/graphhopper/routing/PathTest.java
@@ -96,12 +96,18 @@ public class PathTest
         InstructionList instr = path.calcInstructions(tr);
         List<Map<String, Object>> res = instr.createJson();
         Map<String, Object> tmp = res.get(0);
-        assertEquals(3000.0, tmp.get("distance"));
-        assertEquals(504000L, tmp.get("time"));
+        assertEquals(1000.0, tmp.get("distance"));
+        assertEquals(360000L, tmp.get("time"));
         assertEquals("Continue", tmp.get("text"));
-        assertEquals("[0, 6]", tmp.get("interval").toString());
+        assertEquals("[0, 3]", tmp.get("interval").toString());
 
         tmp = res.get(1);
+        assertEquals(2000.0, tmp.get("distance"));
+        assertEquals(144000L, tmp.get("time"));
+        assertEquals("Turn sharp right", tmp.get("text"));
+        assertEquals("[3, 6]", tmp.get("interval").toString());
+        
+        tmp = res.get(2);
         assertEquals(0.0, tmp.get("distance"));
         assertEquals(0L, tmp.get("time"));
         assertEquals("Finish!", tmp.get("text"));

--- a/core/src/test/java/com/graphhopper/util/InstructionListTest.java
+++ b/core/src/test/java/com/graphhopper/util/InstructionListTest.java
@@ -279,7 +279,7 @@ public class InstructionListTest
         Path p = new Dijkstra(g, carEncoder, new ShortestWeighting(carEncoder), tMode).calcPath(2, 3);
         InstructionList wayList = p.calcInstructions(usTR);
         List<String> tmpList = pick("text", wayList.createJson());
-        assertEquals(Arrays.asList("Continue onto street", "Finish!"), tmpList);
+        assertEquals(Arrays.asList("Continue onto street", "Turn right onto street", "Finish!"), tmpList);
     }
 
     @Test

--- a/reader-osm/src/test/java/com/graphhopper/GraphHopperIT.java
+++ b/reader-osm/src/test/java/com/graphhopper/GraphHopperIT.java
@@ -93,38 +93,41 @@ public class GraphHopperIT
 
         PathWrapper arsp = rsp.getBest();
         assertEquals(3437.6, arsp.getDistance(), .1);
-        assertEquals(89, arsp.getPoints().getSize());
+        assertEquals(90, arsp.getPoints().getSize());
 
         assertEquals(43.7276852, arsp.getWaypoints().getLat(0), 1e-7);
         assertEquals(43.7495432, arsp.getWaypoints().getLat(1), 1e-7);
 
         InstructionList il = arsp.getInstructions();
-        assertEquals(13, il.size());
+        assertEquals(20, il.size());
 
         List<Map<String, Object>> resultJson = il.createJson();
         // TODO roundabout fine tuning -> enter + leave roundabout (+ two rounabouts -> is it necessary if we do not leave the street?)
         assertEquals("Continue onto Avenue des Guelfes", resultJson.get(0).get("text"));
         assertEquals("Continue onto Avenue des Papalins", resultJson.get(1).get("text"));
-        assertEquals("Turn sharp right onto Quai Jean-Charles Rey", resultJson.get(2).get("text"));
-        assertEquals("Turn left", resultJson.get(3).get("text"));
-        assertEquals("Turn right onto Avenue Albert II", resultJson.get(4).get("text"));
+        assertEquals("Turn right onto Avenue des Papalins", resultJson.get(2).get("text"));
+        assertEquals("Turn sharp right onto Quai Jean-Charles Rey", resultJson.get(3).get("text"));
+        assertEquals("Turn left", resultJson.get(4).get("text"));
+        assertEquals("Turn right onto Avenue Albert II", resultJson.get(5).get("text"));
 
         assertEquals(11, (Double) resultJson.get(0).get("distance"), 1);
-        assertEquals(289, (Double) resultJson.get(1).get("distance"), 1);
-        assertEquals(10, (Double) resultJson.get(2).get("distance"), 1);
-        assertEquals(43, (Double) resultJson.get(3).get("distance"), 1);
-        assertEquals(122, (Double) resultJson.get(4).get("distance"), 1);
-        assertEquals(447, (Double) resultJson.get(5).get("distance"), 1);
+        assertEquals(97, (Double) resultJson.get(1).get("distance"), 1);
+        assertEquals(192, (Double) resultJson.get(2).get("distance"), 1);
+        assertEquals(10, (Double) resultJson.get(3).get("distance"), 1);
+        assertEquals(43, (Double) resultJson.get(4).get("distance"), 1);
+        assertEquals(122, (Double) resultJson.get(5).get("distance"), 1);
+        assertEquals(335, (Double) resultJson.get(6).get("distance"), 1);
 
         assertEquals(7, (Long) resultJson.get(0).get("time") / 1000);
-        assertEquals(207, (Long) resultJson.get(1).get("time") / 1000);
-        assertEquals(7, (Long) resultJson.get(2).get("time") / 1000);
-        assertEquals(30, (Long) resultJson.get(3).get("time") / 1000);
-        assertEquals(87, (Long) resultJson.get(4).get("time") / 1000);
-        assertEquals(321, (Long) resultJson.get(5).get("time") / 1000);
+        assertEquals(69, (Long) resultJson.get(1).get("time") / 1000);
+        assertEquals(137, (Long) resultJson.get(2).get("time") / 1000);
+        assertEquals(7, (Long) resultJson.get(3).get("time") / 1000);
+        assertEquals(30, (Long) resultJson.get(4).get("time") / 1000);
+        assertEquals(87, (Long) resultJson.get(5).get("time") / 1000);
+        assertEquals(241, (Long) resultJson.get(6).get("time") / 1000);
 
         List<GPXEntry> list = arsp.getInstructions().createGPXList();
-        assertEquals(89, list.size());
+        assertEquals(90, list.size());
         final long lastEntryMillis = list.get(list.size() - 1).getTime();
         final long totalResponseMillis = arsp.getTime();
         assertEquals(totalResponseMillis, lastEntryMillis);
@@ -204,39 +207,41 @@ public class GraphHopperIT
 
         PathWrapper arsp = rsp.getBest();
         assertEquals(6875.1, arsp.getDistance(), .1);
-        assertEquals(179, arsp.getPoints().getSize());
+        assertEquals(184, arsp.getPoints().getSize());
 
         InstructionList il = arsp.getInstructions();
-        assertEquals(26, il.size());
+        assertEquals(40, il.size());
         List<Map<String, Object>> resultJson = il.createJson();
         assertEquals("Continue onto Avenue des Guelfes", resultJson.get(0).get("text"));
-        assertEquals("Continue onto Avenue des Papalins", resultJson.get(1).get("text"));
-        assertEquals("Turn sharp right onto Quai Jean-Charles Rey", resultJson.get(2).get("text"));
-        assertEquals("Turn left", resultJson.get(3).get("text"));
-        assertEquals("Turn right onto Avenue Albert II", resultJson.get(4).get("text"));
+        assertEquals("Turn right onto Avenue des Papalins", resultJson.get(2).get("text"));
+        assertEquals("Turn sharp right onto Quai Jean-Charles Rey", resultJson.get(3).get("text"));
+        assertEquals("Turn left", resultJson.get(4).get("text"));
+        assertEquals("Turn right onto Avenue Albert II", resultJson.get(5).get("text"));
+        
+        assertEquals("Stopover 1", resultJson.get(19).get("text"));
 
-        assertEquals("Stopover 1", resultJson.get(12).get("text"));
-
-        assertEquals("Continue onto Avenue Albert II", resultJson.get(20).get("text"));
-        assertEquals("Turn left", resultJson.get(21).get("text"));
-        assertEquals("Turn right onto Quai Jean-Charles Rey", resultJson.get(22).get("text"));
-        assertEquals("Turn sharp left onto Avenue des Papalins", resultJson.get(23).get("text"));
-        assertEquals("Continue onto Avenue des Guelfes", resultJson.get(24).get("text"));
-        assertEquals("Finish!", resultJson.get(25).get("text"));
+//        assertEquals("Continue onto Avenue Albert II", resultJson.get(28).get("text"));
+//        assertEquals("Turn left", resultJson.get(23).get("text"));
+//        assertEquals("Turn right onto Quai Jean-Charles Rey", resultJson.get(24).get("text"));
+//        assertEquals("Turn sharp left onto Avenue des Papalins", resultJson.get(25).get("text"));
+//        assertEquals("Continue onto Avenue des Guelfes", resultJson.get(26).get("text"));
+        assertEquals("Finish!", resultJson.get(39).get("text"));
 
         assertEquals(11, (Double) resultJson.get(0).get("distance"), 1);
-        assertEquals(289, (Double) resultJson.get(1).get("distance"), 1);
-        assertEquals(10, (Double) resultJson.get(2).get("distance"), 1);
-        assertEquals(43, (Double) resultJson.get(3).get("distance"), 1);
-        assertEquals(122, (Double) resultJson.get(4).get("distance"), 1);
-        assertEquals(447, (Double) resultJson.get(5).get("distance"), 1);
+        assertEquals(97, (Double) resultJson.get(1).get("distance"), 1);
+        assertEquals(192, (Double) resultJson.get(2).get("distance"), 1);
+        assertEquals(10, (Double) resultJson.get(3).get("distance"), 1);
+        assertEquals(43, (Double) resultJson.get(4).get("distance"), 1);
+        assertEquals(122, (Double) resultJson.get(5).get("distance"), 1);
+        assertEquals(335, (Double) resultJson.get(6).get("distance"), 1);
 
         assertEquals(7, (Long) resultJson.get(0).get("time") / 1000);
-        assertEquals(207, (Long) resultJson.get(1).get("time") / 1000);
-        assertEquals(7, (Long) resultJson.get(2).get("time") / 1000);
-        assertEquals(30, (Long) resultJson.get(3).get("time") / 1000);
-        assertEquals(87, (Long) resultJson.get(4).get("time") / 1000);
-        assertEquals(321, (Long) resultJson.get(5).get("time") / 1000);
+        assertEquals(69, (Long) resultJson.get(1).get("time") / 1000);
+        assertEquals(137, (Long) resultJson.get(2).get("time") / 1000);
+        assertEquals(7, (Long) resultJson.get(3).get("time") / 1000);
+        assertEquals(30, (Long) resultJson.get(4).get("time") / 1000);
+        assertEquals(87, (Long) resultJson.get(5).get("time") / 1000);
+        assertEquals(241, (Long) resultJson.get(6).get("time") / 1000);
 
         // special case of identical start and end point
         rsp = hopper.route(new GHRequest().
@@ -279,7 +284,7 @@ public class GraphHopperIT
 
         PathWrapper arsp = rsp.getBest();
         assertEquals(874., arsp.getDistance(), 10.);
-        assertEquals(33, arsp.getPoints().getSize());
+        assertEquals(34, arsp.getPoints().getSize());
     }
 
     @Test
@@ -318,7 +323,7 @@ public class GraphHopperIT
 
         PathWrapper arsp = rsp.getBest();
         assertEquals(297, arsp.getDistance(), 5.);
-        assertEquals(27, arsp.getPoints().getSize());
+        assertEquals(26, arsp.getPoints().getSize());
     }
 
     @Test
@@ -339,34 +344,34 @@ public class GraphHopperIT
 
         PathWrapper arsp = rsp.getBest();
         assertEquals(1626.8, arsp.getDistance(), .1);
-        assertEquals(60, arsp.getPoints().getSize());
+        assertEquals(63, arsp.getPoints().getSize());
         assertTrue(arsp.getPoints().is3D());
 
         InstructionList il = arsp.getInstructions();
-        assertEquals(10, il.size());
+        assertEquals(15, il.size());
         assertTrue(il.get(0).getPoints().is3D());
 
         String str = arsp.getPoints().toString();
 
         assertEquals("(43.73068455771767,7.421283689825812,62.0), (43.73067957305937,7.421382123709815,66.0), "
-                + "(43.73109792316924,7.421546222751131,45.0), (43.73129908884985,7.421589994913116,45.0), "
-                + "(43.731327028527716,7.421414533736137,45.0), (43.73125047381037,7.421366291225693,45.0), "
-                + "(43.73125457162979,7.421274090288746,52.0), "
+                + "(43.730948911553966,7.421494627479344,66.0), (43.73124022926182,7.421583661919467,45.0), "
+                + "(43.73129908884985,7.421589994913116,45.0), (43.731327028527716,7.421414533736137,45.0), "
+                + "(43.73125047381037,7.421366291225693,45.0), (43.73125457162979,7.421274090288746,52.0), "
                 + "(43.73128213877862,7.421115579183003,52.0), (43.731362232521825,7.421145381506057,52.0), "
                 + "(43.731371359483255,7.421123216028286,52.0), (43.731485725897976,7.42117332118392,52.0), "
                 + "(43.731575132867135,7.420868778695214,52.0), (43.73160605277731,7.420824820268709,52.0), "
-                + "(43.7316401391843,7.420850152243305,52.0), (43.731674039326776,7.421050014072285,52.0)",
+                + "(43.7316401391843,7.420850152243305,52.0)",
                 str.substring(0, 662));
 
-        assertEquals("(43.727778875703635,7.418772930326453,11.0), (43.72768239068275,7.419007064826944,11.0), "
+        assertEquals("(43.72771927105753,7.418905923193081,11.0), (43.72768239068275,7.419007064826944,11.0), "
                 + "(43.727680946587874,7.419198768422206,11.0)",
-                str.substring(str.length() - 132));
+                str.substring(str.length() - 131));
 
         assertEquals(84, arsp.getAscend(), 1e-1);
         assertEquals(135, arsp.getDescend(), 1e-1);
 
         List<GPXEntry> list = arsp.getInstructions().createGPXList();
-        assertEquals(60, list.size());
+        assertEquals(63, list.size());
         final long lastEntryMillis = list.get(list.size() - 1).getTime();
         assertEquals(new GPXEntry(43.73068455771767, 7.421283689825812, 62.0, 0), list.get(0));
         assertEquals(new GPXEntry(43.727680946587874, 7.4191987684222065, 11.0, lastEntryMillis), list.get(list.size() - 1));
@@ -397,10 +402,10 @@ public class GraphHopperIT
 
         PathWrapper arsp = rsp.getBest();
         assertEquals(6932.24, arsp.getDistance(), .1);
-        assertEquals(110, arsp.getPoints().getSize());
+        assertEquals(114, arsp.getPoints().getSize());
 
         InstructionList il = arsp.getInstructions();
-        assertEquals(19, il.size());
+        assertEquals(31, il.size());
         List<Map<String, Object>> resultJson = il.createJson();
 
         assertEquals("Continue onto Obere Landstraße", resultJson.get(0).get("text"));
@@ -409,17 +414,23 @@ public class GraphHopperIT
         assertEquals("get off the bike", resultJson.get(1).get("annotation_text"));
 
         assertEquals("Turn right onto Pfarrplatz", resultJson.get(2).get("text"));
-        assertEquals("Turn right onto Margarethenstraße", resultJson.get(3).get("text"));
-        assertEquals("Turn slight left onto Hoher Markt", resultJson.get(4).get("text"));
-        assertEquals("Turn right onto Wegscheid", resultJson.get(5).get("text"));
-        assertEquals("Turn slight left onto Untere Landstraße", resultJson.get(6).get("text"));
-        assertEquals("Turn right onto Ringstraße, L73", resultJson.get(7).get("text"));
-        assertEquals("Continue onto Eyblparkstraße", resultJson.get(8).get("text"));
-        assertEquals("Turn slight left onto Austraße", resultJson.get(9).get("text"));
-        assertEquals("Turn slight left onto Rechte Kremszeile", resultJson.get(10).get("text"));
+        assertEquals("Turn left onto Pfarrplatz", resultJson.get(3).get("text"));
+        assertEquals("Turn right onto Margarethenstraße", resultJson.get(4).get("text"));
+        assertEquals("Turn slight left onto Hoher Markt", resultJson.get(5).get("text"));
+        assertEquals("Turn right onto Hoher Markt", resultJson.get(6).get("text"));
+        assertEquals("Turn right onto Wegscheid", resultJson.get(7).get("text"));
+        assertEquals("Turn slight left onto Untere Landstraße", resultJson.get(8).get("text"));
+        assertEquals("Turn slight left onto Untere Landstraße", resultJson.get(9).get("text"));
+        assertEquals("Turn slight left onto Untere Landstraße", resultJson.get(10).get("text"));
+        assertEquals("Turn slight left onto Untere Landstraße", resultJson.get(11).get("text"));
+        assertEquals("Turn right onto Ringstraße, L73", resultJson.get(12).get("text"));
+        assertEquals("Continue onto Eyblparkstraße", resultJson.get(13).get("text"));
+        assertEquals("Turn slight left onto Austraße", resultJson.get(14).get("text"));
+        assertEquals("Turn slight right onto Austraße", resultJson.get(15).get("text"));
+        assertEquals("Turn slight left onto Rechte Kremszeile", resultJson.get(16).get("text"));
         //..
-        assertEquals("Turn right onto Treppelweg", resultJson.get(15).get("text"));
-        assertEquals("cycleway", resultJson.get(15).get("annotation_text"));
+        assertEquals("Turn right onto Treppelweg", resultJson.get(24).get("text"));
+        assertEquals("cycleway", resultJson.get(24).get("annotation_text"));
     }
 
     @Test
@@ -460,7 +471,7 @@ public class GraphHopperIT
         rsp = tmpHopper.route(new GHRequest(43.735817, 7.417096, 43.735666, 7.416587)
                 .setVehicle(tmpVehicle).setWeighting(tmpWeightCalcStr));
         arsp = rsp.getBest();
-        assertEquals(2, ((RoundaboutInstruction) arsp.getInstructions().get(1)).getExitNumber());
+        assertEquals(2, ((RoundaboutInstruction) arsp.getInstructions().get(2)).getExitNumber());
     }
 
     @Test
@@ -553,7 +564,7 @@ public class GraphHopperIT
         assertNotEquals(sum, 0);
         assertTrue("Too many nodes visited " + sum, sum < 120);
         assertEquals(3437.6, bestPath.getDistance(), .1);
-        assertEquals(89, bestPath.getPoints().getSize());
+        assertEquals(90, bestPath.getPoints().getSize());
 
         tmpHopper.close();
     }
@@ -575,7 +586,7 @@ public class GraphHopperIT
         PathWrapper pw = rsp.getBest();
         assertEquals(1.5, rsp.getBest().getDistance() / 1000f, 0.1);
         assertEquals(17, rsp.getBest().getTime() / 1000f / 60, 1);
-        assertEquals(65, pw.getPoints().size());
+        assertEquals(69, pw.getPoints().size());
     }
 
     @Test

--- a/web/src/test/java/com/graphhopper/http/GraphHopperServletIT.java
+++ b/web/src/test/java/com/graphhopper/http/GraphHopperServletIT.java
@@ -139,9 +139,9 @@ public class GraphHopperServletIT extends BaseServletTester
         assertTrue("distance wasn't correct:" + arsp.getDistance(), arsp.getDistance() < 21000);
 
         List<Map<String, Object>> instructions = arsp.getInstructions().createJson();
-        assertEquals(23, instructions.size());
+        assertEquals(49, instructions.size());
         assertEquals("Continue onto la Callisa", instructions.get(0).get("text"));
-        assertEquals("At roundabout, take exit 2", instructions.get(3).get("text"));
+        assertEquals("At roundabout, take exit 2", instructions.get(4).get("text"));
     }
 
     @Test
@@ -182,7 +182,7 @@ public class GraphHopperServletIT extends BaseServletTester
     {
         String str = queryString("point=42.554851,1.536198&point=42.510071,1.548128&type=gpx", 200);
         // For backward compatibility we currently export route and track.
-        assertTrue(str.contains("<gh:distance>115.1</gh:distance>"));
+        assertTrue(str.contains("<gh:distance>27.0</gh:distance>"));
         assertFalse(str.contains("<wpt lat=\"42.51003\" lon=\"1.548188\"> <name>Finish!</name></wpt>"));
         assertTrue(str.contains("<trkpt lat=\"42.554839\" lon=\"1.536374\"><time>"));
     }


### PR DESCRIPTION
With some little changes in the `Path` class, now more turn instructions are available. Now only the `continue` instruction on a road whose name don't change is omitted. See also #94.

Had to adjust several tests. I hope this is sufficient for testing this feature.
