### PR TITLE
Travis-CI build enhancements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,12 +45,10 @@ before_install:
          sudo rm /etc/mavenrc;
      fi
 
-install:
-  # install without any testing to get all dependencies in place
-  # - mvn install -Dmaven.test.skip=true -B -V -fae -T2.2C
+install: true
 
 script:
-  - mvn clean test verify
+  - mvn clean test verify -B
   #- ./core/files/travis-build.sh
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,72 @@
 language: java
+sudo: false
+matrix:
+  fast_finish: true
+  include:
+      # Java 9 needs to be manually installed/upgraded
+      # see: https://github.com/travis-ci/travis-ci/issues/2968#issuecomment-149164058
+    - jdk: oraclejdk9
+      env: JVM=latest
+      sudo: required
+      dist: trusty
+      group: edge
+  allow_failures:
+    - jdk: oraclejdk9
+
+env:
+  global:
+    - BASEURL=https://www-eu.apache.org/dist/maven/maven-3/VERSION/binaries/apache-maven-VERSION-bin.zip
+    - FILE=apache-maven-VERSION-bin.zip
+    - DIR=apache-maven-VERSION
+    - VERSION=3.3.9
+    - secure: "CI_DEPLOY_USERNAME=central_username"
+    - secure: "CI_DEPLOY_PASSWORD=central_password"
+
 jdk:
   - oraclejdk8
-# do not install anything instead return true via unix command true
-install: true
-script: ./core/files/travis-build.sh
+
+before_install:
+   # update maven
+   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then
+         wget --no-check-certificate $(echo -n $BASEURL | sed -e 's#VERSION#'$VERSION'#g');
+         unzip -qq $(echo -n $FILE | sed -e 's#VERSION#'$VERSION'#');
+         export M2_HOME=$PWD/$(echo -n $DIR | sed -e 's#VERSION#'$VERSION'#');
+         export PATH=$M2_HOME/bin:$PATH;
+     fi
+   # update java 9
+   - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ "$JVM" == "latest" ]; then
+         sudo apt-get update -qq;
+         sudo /bin/echo -e oracle-java9-installer shared/accepted-oracle-license-v1-1 select true | sudo debconf-set-selections;
+         sudo apt-get install -y oracle-java9-installer;
+         sudo apt-get install -y oracle-java9-unlimited-jce-policy;
+         sudo update-java-alternatives -s java-9-oracle;
+     fi
+   - if [ "$TRAVIS_JDK_VERSION" == oraclejdk9 ]; then
+         sudo rm /etc/mavenrc;
+     fi
+
+install:
+  # install without any testing to get all dependencies in place
+  # - mvn install -Dmaven.test.skip=true -B -V -fae -T2.2C
+
+script:
+  - mvn clean test verify
+  #- ./core/files/travis-build.sh
+
+after_success:
+  # deploy snapshot artifacts to maven central
+  - if [ "$TRAVIS_JDK_VERSION" == "oraclejdk8" ] &&
+       [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+         travis_wait mvn deploy --settings core/files/settings.xml -DskipTests=true -B;
+    else
+        echo "Not deploying snapshot artifact for $TRAVIS_BRANCH";
+    fi
+
 notifications:
   email:
     - github@graphhopper.com
 
-# enable container-based stack
-sudo: false
+cache:
+  directories:
+  - $HOME/.m2
+

--- a/core/files/settings.xml
+++ b/core/files/settings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <servers>
+    <server>
+      <id>ossrh</id>
+      <username>${env.CI_DEPLOY_USERNAME}</username>
+      <password>${env.CI_DEPLOY_PASSWORD}</password>
+    </server>
+  </servers>
+</settings>

--- a/core/files/travis-build.sh
+++ b/core/files/travis-build.sh
@@ -1,11 +1,9 @@
 HOME=$(dirname $0)
 cd $HOME/../..
 
-mvn clean test verify
-
 # npm tests disabled due to #632
 # cd $HOME/../../web
-# 
+#
 # sudo chown -R $USER ~/.npm
 # npm install
 # npm test && npm run lint
@@ -14,14 +12,14 @@ mvn clean test verify
 #for module in $modules; do
 #  echo "====== INSTALL $module ====="
 #  mvn -pl $module clean install -DskipTests=true
-#  EXIT_VAL="$?"    
+#  EXIT_VAL="$?"
 #  if [[ "x$EXIT_VAL" != "x0" ]]; then
 #    exit $EXIT_VAL
-#  fi 
-#  
+#  fi
+#
 #  echo "====== TEST $module ====="
 #  # verify necessary for failsafe, otherwise it won't fail the build!?
-#  mvn -pl $module test failsafe:integration-test verify  
+#  mvn -pl $module test failsafe:integration-test verify
 #  EXIT_VAL="$?"
 #  if [[ "x$EXIT_VAL" != "x0" ]]; then
 #    exit $EXIT_VAL

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -7,25 +7,25 @@
     <artifactId>graphhopper-core</artifactId>
     <name>GraphHopper Core</name>
     <version>0.8-SNAPSHOT</version>
-    <packaging>jar</packaging> 
+    <packaging>jar</packaging>
     <description>
-        GraphHopper is a fast and memory efficient Java road routing engine 
+        GraphHopper is a fast and memory efficient Java road routing engine
         working seamlessly with OpenStreetMap data.
     </description>
     <parent>
         <groupId>com.graphhopper</groupId>
-        <artifactId>graphhopper-parent</artifactId>    	
+        <artifactId>graphhopper-parent</artifactId>
         <version>0.8-SNAPSHOT</version>
     </parent>
-        
+
     <properties>
-        <netbeans.hint.license>apache20</netbeans.hint.license>        
+        <netbeans.hint.license>apache20</netbeans.hint.license>
         <!-- Make sure that we use the same format as for Helper.createFormatter.
              We cannot force the UTC TimeZone so it will just throw away the local offset or is this
              fixed due to https://issues.apache.org/jira/browse/MNG-5647 ?
         -->
-        <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ss'Z'</maven.build.timestamp.format>        
-        <builddate>${maven.build.timestamp}</builddate>        
+        <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ss'Z'</maven.build.timestamp.format>
+        <builddate>${maven.build.timestamp}</builddate>
     </properties>
     <licenses>
         <license>
@@ -34,20 +34,20 @@
             <distribution>repo</distribution>
             <comments>A business-friendly OSS license</comments>
         </license>
-    </licenses> 
+    </licenses>
     <dependencies>
         <dependency>
             <groupId>com.graphhopper</groupId>
             <artifactId>graphhopper-tools-lgpl</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
-        
-        <!-- Trove is LGPL and slightly big (~3MB) -->        
+
+        <!-- Trove is LGPL and slightly big (~3MB) -->
         <dependency>
             <groupId>net.sf.trove4j</groupId>
             <artifactId>trove4j</artifactId>
             <version>3.0.3</version>
-        </dependency>        
+        </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
@@ -61,7 +61,7 @@
             <scope>test</scope>
         </dependency>
         -->
-        
+
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
@@ -74,13 +74,13 @@
             <version>${log4j.version}</version>
             <scope>test</scope>
         </dependency>
-        
+
         <!-- for using CGIAR: elevation data importing via tif files-->
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>
             <artifactId>xmlgraphics-commons</artifactId>
             <version>2.1</version>
-        </dependency>        
+        </dependency>
 
         <dependency>
             <groupId>org.json</groupId>
@@ -88,27 +88,29 @@
             <version>${json.org.version}</version>
             <scope>test</scope>
         </dependency>
-        
+
     </dependencies>
-        
+
     <build>
         <pluginManagement>
             <plugins>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
-                    <configuration>                     
+                    <version>2.6</version>
+                    <configuration>
                         <!-- for usage on android -->
                         <descriptors>
                             <descriptor>src/main/assembly/android.xml</descriptor>
                         </descriptors>
                     </configuration>
-                </plugin>                
-                
-                <!-- create jar with test classes to be reused in other projects like external or our reader-osm -->                
+                </plugin>
+
+                <!-- create jar with test classes to be reused in other projects like external or our reader-osm -->
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.0.2</version>
                     <executions>
                         <execution>
                             <goals>
@@ -117,10 +119,10 @@
                         </execution>
                     </executions>
                 </plugin>
-                
+
             </plugins>
         </pluginManagement>
-        
+
         <!-- make version available at runtime via version file -->
         <resources>
             <resource>

--- a/pom.xml
+++ b/pom.xml
@@ -7,8 +7,8 @@
     <artifactId>graphhopper-parent</artifactId>
     <name>GraphHopper Parent Project</name>
     <version>0.8-SNAPSHOT</version>
-    <packaging>pom</packaging> 
-    <url>https://graphhopper.com</url> 
+    <packaging>pom</packaging>
+    <url>https://graphhopper.com</url>
     <inceptionYear>2012</inceptionYear>
     <description>Super pom of GraphHopper, the fast and flexible routing engine</description>
 
@@ -17,7 +17,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <slf4j.version>1.7.21</slf4j.version>
         <log4j.version>1.2.17</log4j.version>
-        <json.org.version>20160212</json.org.version>                
+        <json.org.version>20160212</json.org.version>
 
         <org-netbeans-modules-editor-indent.CodeStyle.project.indent-shift-width>4</org-netbeans-modules-editor-indent.CodeStyle.project.indent-shift-width>
         <org-netbeans-modules-editor-indent.CodeStyle.project.spaces-per-tab>4</org-netbeans-modules-editor-indent.CodeStyle.project.spaces-per-tab>
@@ -35,20 +35,20 @@
         <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.alignMultilineFor>true</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.alignMultilineFor>
         <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.alignMultilineTryResources>true</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.alignMultilineTryResources>
     </properties>
-    
+
     <scm>
         <connection>scm:git:git@github.com:graphhopper/graphhopper.git</connection>
         <developerConnection>scm:git:git@github.com:graphhopper/graphhopper.git</developerConnection>
         <url>git@github.com:graphhopper/graphhopper.git</url>
     </scm>
-    
+
     <licenses>
         <license>
             <name>Apache License, Version 2.0</name>
             <url>http://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
     </licenses>
-    
+
     <developers>
         <developer>
             <id>karussell</id>
@@ -56,7 +56,7 @@
             <email>my.name@graphhopper.com</email>
         </developer>
     </developers>
-    
+
     <mailingLists>
         <mailingList>
             <name>GraphHopper</name>
@@ -76,19 +76,21 @@
         <module>tools</module>
         <module>web</module>
     </modules>
-        
-    <build>        
-        <plugins>       
+    <prerequisites>
+        <maven>3.2</maven>
+    </prerequisites>
+    <build>
+        <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.5.1</version>
                 <configuration>
                     <!--
-                    <compilerArgument>-Xlint:unchecked</compilerArgument>                    
+                    <compilerArgument>-Xlint:unchecked</compilerArgument>
                     <compilerArgument>-Xlint:deprecation</compilerArgument>
                     -->
-                    
+
                     <!-- suppress warning about Unsafe functionality -->
                     <compilerArgument>-XDignore.symbol.file</compilerArgument>
                     <fork>true</fork>
@@ -96,9 +98,9 @@
                     <target>1.7</target>
                 </configuration>
             </plugin>
-            
+
             <!-- to run single tests -->
-            <plugin>                
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.19.1</version>
@@ -106,11 +108,11 @@
                     <argLine>-Xmx100m -Xms100m</argLine>
                 </configuration>
             </plugin>
-                        
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.19</version>
+                <version>2.19.1</version>
                 <executions>
                     <execution>
                         <goals>
@@ -120,21 +122,21 @@
                     </execution>
                 </executions>
             </plugin>
-                        
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.6</version>                    
+                <version>2.6</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.0.2</version>
             </plugin>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.6</version>                
-            </plugin>            
+                <version>3.0.0</version>
+            </plugin>
             <!-- example https://github.com/tananaev/traccar/blob/master/checkstyle.xml
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -145,26 +147,26 @@
                 </configuration>
             </plugin>
             -->
-            
+
             <!-- create html output for findbugs -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
-                <version>3.5</version>
+                <version>3.5.1</version>
                 <configuration>
                     <reportPlugins>
                         <plugin>
                             <groupId>org.codehaus.mojo</groupId>
-                            <artifactId>findbugs-maven-plugin</artifactId>                            
+                            <artifactId>findbugs-maven-plugin</artifactId>
                         </plugin>
                     </reportPlugins>
                 </configuration>
             </plugin>
-            
+
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>findbugs-maven-plugin</artifactId>
-                <version>3.0.3</version>                
+                <version>3.0.4</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -177,24 +179,24 @@
                 -->
             </plugin>
         </plugins>
-    </build>    
-    
+    </build>
+
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>
             <scope>test</scope>
-        </dependency>        
+        </dependency>
     </dependencies>
-    
+
     <distributionManagement>
         <snapshotRepository>
             <id>ossrh</id>
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
-    </distributionManagement> 
-    
+    </distributionManagement>
+
     <!-- mvn clean deploy -P release -->
     <profiles>
         <profile>
@@ -229,11 +231,11 @@
                             <autoReleaseAfterClose>true</autoReleaseAfterClose>
                         </configuration>
                     </plugin>
-            
+
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>2.10.3</version>
+                        <version>2.10.4</version>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>
@@ -246,7 +248,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>3.0.0</version>
+                        <version>3.0.1</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
@@ -259,7 +261,7 @@
                 </plugins>
             </build>
         </profile>
-        
+
         <profile>
             <id>include-android</id>
             <activation>
@@ -270,5 +272,5 @@
             </modules>
         </profile>
     </profiles>
-    
+
 </project>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -9,35 +9,35 @@
     <version>0.8-SNAPSHOT</version>
     <name>GraphHopper Web</name>
     <description>Example on how to use GraphHopper in a web-based application</description>
-        
+
     <parent>
         <groupId>com.graphhopper</groupId>
-        <artifactId>graphhopper-parent</artifactId>    	
+        <artifactId>graphhopper-parent</artifactId>
         <version>0.8-SNAPSHOT</version>
     </parent>
     <properties>
         <jetty.version>9.3.8.v20160314</jetty.version>
     </properties>
-    
+
     <dependencies>
         <dependency>
             <groupId>com.graphhopper</groupId>
             <artifactId>graphhopper-reader-osm</artifactId>
-            <version>${project.parent.version}</version>            
+            <version>${project.parent.version}</version>
         </dependency>
-        
+
         <dependency>
             <groupId>org.json</groupId>
-            <artifactId>json</artifactId>            
+            <artifactId>json</artifactId>
             <version>${json.org.version}</version>
-        </dependency>    
-        
+        </dependency>
+
         <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
             <version>4.0</version>
         </dependency>
-        
+
         <!-- necessary to use guice ('@Inject') in servlets -->
         <dependency>
             <groupId>com.google.inject.extensions</groupId>
@@ -56,7 +56,7 @@
             <version>${slf4j.version}</version>
             <scope>runtime</scope>
         </dependency>
-        
+
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
@@ -69,7 +69,7 @@
             <artifactId>jetty-servlets</artifactId>
             <version>${jetty.version}</version>
         </dependency>
-        
+
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
@@ -80,7 +80,7 @@
             <artifactId>jetty-servlet</artifactId>
             <version>${jetty.version}</version>
         </dependency>
-        
+
         <!-- for integration tests of service -->
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
@@ -88,14 +88,15 @@
             <version>${jetty.version}</version>
             <scope>test</scope>
         </dependency>
-      
+
     </dependencies>
 
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>                
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.5.1</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -104,14 +105,25 @@
             <!-- create a jar file too, so others can use it more easily -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-war-plugin</artifactId>                
+                <artifactId>maven-war-plugin</artifactId>
+                <version>3.0.0</version>
                 <configuration>
                     <attachClasses>true</attachClasses>
                 </configuration>
-            </plugin>            
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
+                <!-- this is an old version but 2.6 fails with java 9
+                see: https://stackoverflow.com/questions/36583118/is-maven-ready-for-jdk9-->
+                <version>2.4.1</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.codehaus.plexus</groupId>
+                        <artifactId>plexus-archiver</artifactId>
+                        <version>2.4.4</version>
+                    </dependency>
+                </dependencies>
                 <configuration>
                     <archive>
                         <manifest>
@@ -128,14 +140,14 @@
                     <execution>
                         <id>make-assembly</id>
                         <!-- bind to verify and not package to pass integration tests before creating assemblies -->
-                        <phase>integration-test</phase> 
+                        <phase>integration-test</phase>
                         <goals>
                             <goal>single</goal>
                         </goals>
                     </execution>
                 </executions>
             </plugin>
- 
+
         </plugins>
     </build>
 


### PR DESCRIPTION
As discussed in  https://github.com/graphhopper/graphhopper/issues/803#issuecomment-249179426 this PR brings JDK 9 builds on Travis-CI and automatic deployment of snapshots to the central repository.

  - [x] Start testing on Java 9 with Maven 3.3.9
  - [x] upgrade maven plugins and require Maven >= 3.2
  - [x] set up for publishing snapshots to maven central

The latter needs to have the secure keys generated and added in the `.travis.yml` (there are some placeholders there now) so that after a succesful build of the master branch the snapshot artifacts are deployed.

This build no longer uses the `/core/files/travis-build.sh` not sure if that can be removed, it has some out-commented npm stuff.


