### PR TITLE
Use Weighting.calcMillis instead of Path.calcMillis, fixes #393

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/AStar.java
+++ b/core/src/main/java/com/graphhopper/routing/AStar.java
@@ -147,7 +147,8 @@ public class AStar extends AbstractRoutingAlgorithm {
 
     @Override
     protected Path extractPath() {
-        return new Path(graph, flagEncoder).setWeight(currEdge.weight).setSPTEntry(currEdge).extract();
+        return new Path(graph, weighting).
+                setWeight(currEdge.weight).setSPTEntry(currEdge).extract();
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/AStarBidirection.java
+++ b/core/src/main/java/com/graphhopper/routing/AStarBidirection.java
@@ -153,7 +153,7 @@ public class AStarBidirection extends AbstractBidirAlgo {
 
     @Override
     protected Path createAndInitPath() {
-        bestPath = new PathBidirRef(graph, flagEncoder);
+        bestPath = new PathBidirRef(graph, flagEncoder, weighting);
         return bestPath;
     }
 

--- a/core/src/main/java/com/graphhopper/routing/AbstractRoutingAlgorithm.java
+++ b/core/src/main/java/com/graphhopper/routing/AbstractRoutingAlgorithm.java
@@ -118,7 +118,7 @@ public abstract class AbstractRoutingAlgorithm implements RoutingAlgorithm {
     }
 
     protected Path createEmptyPath() {
-        return new Path(graph, flagEncoder);
+        return new Path(graph, weighting);
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/AlternativeRoute.java
+++ b/core/src/main/java/com/graphhopper/routing/AlternativeRoute.java
@@ -423,7 +423,7 @@ public class AlternativeRoute implements RoutingAlgorithm {
 
                         // plateaus.add(new PlateauInfo(altName, plateauEdges));
                         if (sortBy < worstSortBy || alternatives.size() < maxPaths) {
-                            Path path = new PathBidirRef(graph, flagEncoder).
+                            Path path = new PathBidirRef(graph, flagEncoder, weighting).
                                     setSPTEntryTo(toSPTEntry).setSPTEntry(fromSPTEntry).
                                     setWeight(weight);
                             path.extract();

--- a/core/src/main/java/com/graphhopper/routing/Dijkstra.java
+++ b/core/src/main/java/com/graphhopper/routing/Dijkstra.java
@@ -122,7 +122,8 @@ public class Dijkstra extends AbstractRoutingAlgorithm {
         if (currEdge == null || !finished())
             return createEmptyPath();
 
-        return new Path(graph, flagEncoder).setWeight(currEdge.weight).setSPTEntry(currEdge).extract();
+        return new Path(graph, weighting).
+                setWeight(currEdge.weight).setSPTEntry(currEdge).extract();
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/DijkstraBidirectionRef.java
+++ b/core/src/main/java/com/graphhopper/routing/DijkstraBidirectionRef.java
@@ -101,7 +101,7 @@ public class DijkstraBidirectionRef extends AbstractBidirAlgo {
 
     @Override
     protected Path createAndInitPath() {
-        bestPath = new PathBidirRef(graph, flagEncoder);
+        bestPath = new PathBidirRef(graph, flagEncoder, weighting);
         return bestPath;
     }
 

--- a/core/src/main/java/com/graphhopper/routing/DijkstraOneToMany.java
+++ b/core/src/main/java/com/graphhopper/routing/DijkstraOneToMany.java
@@ -76,7 +76,7 @@ public class DijkstraOneToMany extends AbstractRoutingAlgorithm {
 
     @Override
     public Path extractPath() {
-        PathNative p = new PathNative(graph, flagEncoder, parents, edgeIds);
+        PathNative p = new PathNative(graph, flagEncoder, weighting, parents, edgeIds);
         if (endNode >= 0)
             p.setWeight(weights[endNode]);
         p.setFromNode(fromNode);

--- a/core/src/main/java/com/graphhopper/routing/Path.java
+++ b/core/src/main/java/com/graphhopper/routing/Path.java
@@ -220,7 +220,7 @@ public class Path {
         double dist = iter.getDistance();
         distance += dist;
         // TODO calculate time based on weighting -> weighting.calcMillis
-        time += calcMillis(dist, iter.getFlags(), false);
+        time += calcMillis(iter, false);
         addEdge(edgeId);
     }
 
@@ -228,7 +228,8 @@ public class Path {
      * Calculates the time in millis for the specified distance in meter and speed (in km/h) via
      * flags.
      */
-    protected long calcMillis(double distance, long flags, boolean revert) {
+    protected long calcMillis(EdgeIteratorState edge, boolean revert) {
+        long flags = edge.getFlags();
         if (revert && !encoder.isBackward(flags)
                 || !revert && !encoder.isForward(flags))
             throw new IllegalStateException("Calculating time should not require to read speed from edge in wrong direction. "
@@ -241,6 +242,7 @@ public class Path {
         if (speed == 0)
             throw new IllegalStateException("Speed cannot be 0 for unblocked edge, use access properties to mark edge blocked! Should only occur for shortest path calculation. See #242.");
 
+        double distance = edge.getDistance();
         return (long) (distance * 3600 / speed);
     }
 
@@ -562,8 +564,7 @@ public class Path {
                 }
                 double newDist = edge.getDistance();
                 prevInstruction.setDistance(newDist + prevInstruction.getDistance());
-                long flags = edge.getFlags();
-                prevInstruction.setTime(calcMillis(newDist, flags, false) + prevInstruction.getTime());
+                prevInstruction.setTime(calcMillis(edge, false) + prevInstruction.getTime());
             }
         });
 

--- a/core/src/main/java/com/graphhopper/routing/Path.java
+++ b/core/src/main/java/com/graphhopper/routing/Path.java
@@ -19,6 +19,7 @@ package com.graphhopper.routing;
 
 import com.graphhopper.routing.util.DefaultEdgeFilter;
 import com.graphhopper.routing.util.FlagEncoder;
+import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.Graph;
 import com.graphhopper.storage.NodeAccess;
 import com.graphhopper.storage.SPTEntry;
@@ -54,6 +55,7 @@ public class Path {
     protected SPTEntry sptEntry;
     protected int endNode = -1;
     private List<String> description;
+    private Weighting weighting;
     private FlagEncoder encoder;
     private boolean found;
     private int fromNode = -1;
@@ -61,11 +63,12 @@ public class Path {
     private double weight;
     private NodeAccess nodeAccess;
 
-    public Path(Graph graph, FlagEncoder encoder) {
+    public Path(Graph graph, Weighting weighting) {
         this.weight = Double.MAX_VALUE;
         this.graph = graph;
         this.nodeAccess = graph.getNodeAccess();
-        this.encoder = encoder;
+        this.weighting = weighting;
+        this.encoder = weighting.getFlagEncoder();
         this.edgeIds = new TIntArrayList();
     }
 
@@ -73,7 +76,7 @@ public class Path {
      * Populates an unextracted path instances from the specified path p.
      */
     Path(Path p) {
-        this(p.graph, p.encoder);
+        this(p.graph, p.weighting);
         weight = p.weight;
         edgeIds = new TIntArrayList(p.edgeIds);
         sptEntry = p.sptEntry;
@@ -182,9 +185,11 @@ public class Path {
 
         extractSW.start();
         SPTEntry goalEdge = sptEntry;
+        int prevEdge = EdgeIterator.NO_EDGE;
         setEndNode(goalEdge.adjNode);
         while (EdgeIterator.Edge.isValid(goalEdge.edge)) {
-            processEdge(goalEdge.edge, goalEdge.adjNode);
+            processEdge(goalEdge.edge, goalEdge.adjNode, prevEdge);
+            prevEdge = goalEdge.edge;
             goalEdge = goalEdge.parent;
         }
 
@@ -215,35 +220,21 @@ public class Path {
     /**
      * Calls getDistance and adds the edgeId.
      */
-    protected void processEdge(int edgeId, int adjNode) {
+    protected void processEdge(int edgeId, int adjNode, int prevEdgeId) {
         EdgeIteratorState iter = graph.getEdgeIteratorState(edgeId, adjNode);
-        double dist = iter.getDistance();
-        distance += dist;
-        // TODO calculate time based on weighting -> weighting.calcMillis
-        time += calcMillis(iter, false);
+        distance += iter.getDistance();
+        time += weighting.calcMillis(iter, false, prevEdgeId);
         addEdge(edgeId);
     }
 
     /**
      * Calculates the time in millis for the specified distance in meter and speed (in km/h) via
      * flags.
+     *
+     * @deprecated use Weighting
      */
-    protected long calcMillis(EdgeIteratorState edge, boolean revert) {
-        long flags = edge.getFlags();
-        if (revert && !encoder.isBackward(flags)
-                || !revert && !encoder.isForward(flags))
-            throw new IllegalStateException("Calculating time should not require to read speed from edge in wrong direction. "
-                    + "Reverse:" + revert + ", fwd:" + encoder.isForward(flags) + ", bwd:" + encoder.isBackward(flags));
-
-        double speed = revert ? encoder.getReverseSpeed(flags) : encoder.getSpeed(flags);
-        if (Double.isInfinite(speed) || Double.isNaN(speed) || speed < 0)
-            throw new IllegalStateException("Invalid speed stored in edge! " + speed);
-
-        if (speed == 0)
-            throw new IllegalStateException("Speed cannot be 0 for unblocked edge, use access properties to mark edge blocked! Should only occur for shortest path calculation. See #242.");
-
-        double distance = edge.getDistance();
-        return (long) (distance * 3600 / speed);
+    protected long calcMillis(EdgeIteratorState edge, boolean reverse) {
+        return weighting.calcMillis(edge, reverse, EdgeIterator.NO_EDGE);
     }
 
     /**

--- a/core/src/main/java/com/graphhopper/routing/PathBidirRef.java
+++ b/core/src/main/java/com/graphhopper/routing/PathBidirRef.java
@@ -18,6 +18,7 @@
 package com.graphhopper.routing;
 
 import com.graphhopper.routing.util.FlagEncoder;
+import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.Graph;
 import com.graphhopper.storage.SPTEntry;
 import com.graphhopper.util.EdgeIterator;
@@ -32,8 +33,8 @@ public class PathBidirRef extends Path {
     protected SPTEntry edgeTo;
     private boolean switchWrapper = false;
 
-    public PathBidirRef(Graph g, FlagEncoder encoder) {
-        super(g, encoder);
+    public PathBidirRef(Graph g, FlagEncoder encoder, Weighting weighting) {
+        super(g, weighting);
     }
 
     PathBidirRef(PathBidirRef p) {
@@ -70,9 +71,11 @@ public class PathBidirRef extends Path {
             edgeTo = ee;
         }
 
+        int prevEdge = EdgeIterator.NO_EDGE;
         SPTEntry currEdge = sptEntry;
         while (EdgeIterator.Edge.isValid(currEdge.edge)) {
-            processEdge(currEdge.edge, currEdge.adjNode);
+            processEdge(currEdge.edge, currEdge.adjNode, prevEdge);
+            prevEdge = currEdge.edge;
             currEdge = currEdge.parent;
         }
         setFromNode(currEdge.adjNode);
@@ -81,7 +84,7 @@ public class PathBidirRef extends Path {
         int tmpEdge = currEdge.edge;
         while (EdgeIterator.Edge.isValid(tmpEdge)) {
             currEdge = currEdge.parent;
-            processEdge(tmpEdge, currEdge.adjNode);
+            processEdge(tmpEdge, currEdge.adjNode, currEdge.edge);
             tmpEdge = currEdge.edge;
         }
         setEndNode(currEdge.adjNode);

--- a/core/src/main/java/com/graphhopper/routing/PathNative.java
+++ b/core/src/main/java/com/graphhopper/routing/PathNative.java
@@ -18,6 +18,7 @@
 package com.graphhopper.routing;
 
 import com.graphhopper.routing.util.FlagEncoder;
+import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.Graph;
 import com.graphhopper.util.EdgeIterator;
 
@@ -31,8 +32,8 @@ public class PathNative extends Path {
     private final int[] parentNodes;
     private final int[] parentEdges;
 
-    public PathNative(Graph g, FlagEncoder encoder, int[] parentNodes, int[] parentEdges) {
-        super(g, encoder);
+    public PathNative(Graph g, FlagEncoder encoder, Weighting weighting, int[] parentNodes, int[] parentEdges) {
+        super(g, weighting);
         this.parentNodes = parentNodes;
         this.parentEdges = parentEdges;
     }
@@ -44,13 +45,15 @@ public class PathNative extends Path {
     public Path extract() {
         if (endNode < 0)
             return this;
-
+        
+        int prevEdge = EdgeIterator.NO_EDGE;        
         while (true) {
             int edgeId = parentEdges[endNode];
             if (!EdgeIterator.Edge.isValid(edgeId))
                 break;
 
-            processEdge(edgeId, endNode);
+            processEdge(edgeId, endNode, prevEdge);
+            prevEdge = edgeId;
             endNode = parentNodes[endNode];
         }
         reverseOrder();

--- a/core/src/main/java/com/graphhopper/routing/ch/Path4CH.java
+++ b/core/src/main/java/com/graphhopper/routing/ch/Path4CH.java
@@ -49,7 +49,7 @@ public class Path4CH extends PathBidirRef {
             double dist = mainEdgeState.getDistance();
             distance += dist;
             long flags = mainEdgeState.getFlags();
-            time += calcMillis(dist, flags, reverse);
+            time += calcMillis(mainEdgeState, reverse);
             addEdge(mainEdgeState.getEdge());
             return;
         }

--- a/core/src/main/java/com/graphhopper/routing/ch/Path4CH.java
+++ b/core/src/main/java/com/graphhopper/routing/ch/Path4CH.java
@@ -19,6 +19,7 @@ package com.graphhopper.routing.ch;
 
 import com.graphhopper.routing.PathBidirRef;
 import com.graphhopper.routing.util.FlagEncoder;
+import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.Graph;
 import com.graphhopper.util.CHEdgeIteratorState;
 
@@ -32,13 +33,13 @@ import com.graphhopper.util.CHEdgeIteratorState;
 public class Path4CH extends PathBidirRef {
     private final Graph routingGraph;
 
-    public Path4CH(Graph routingGraph, Graph baseGraph, FlagEncoder encoder) {
-        super(baseGraph, encoder);
+    public Path4CH(Graph routingGraph, Graph baseGraph, FlagEncoder encoder, Weighting weighting) {
+        super(baseGraph, encoder, weighting);
         this.routingGraph = routingGraph;
     }
 
     @Override
-    protected final void processEdge(int tmpEdge, int endNode) {
+    protected final void processEdge(int tmpEdge, int endNode, int prevEdgeId) {
         // Shortcuts do only contain valid weight so first expand before adding
         // to distance and time
         expandEdge((CHEdgeIteratorState) routingGraph.getEdgeIteratorState(tmpEdge, endNode), false);

--- a/core/src/main/java/com/graphhopper/routing/ch/PreparationWeighting.java
+++ b/core/src/main/java/com/graphhopper/routing/ch/PreparationWeighting.java
@@ -53,6 +53,11 @@ public class PreparationWeighting implements Weighting {
     }
 
     @Override
+    public long calcMillis(EdgeIteratorState edgeState, boolean reverse, int prevOrNextEdgeId) {
+        return userWeighting.calcMillis(edgeState, reverse, prevOrNextEdgeId);
+    }
+
+    @Override
     public FlagEncoder getFlagEncoder() {
         return userWeighting.getFlagEncoder();
     }

--- a/core/src/main/java/com/graphhopper/routing/ch/PrepareContractionHierarchies.java
+++ b/core/src/main/java/com/graphhopper/routing/ch/PrepareContractionHierarchies.java
@@ -678,7 +678,7 @@ public class PrepareContractionHierarchies extends AbstractAlgoPreparation imple
 
             @Override
             protected Path createAndInitPath() {
-                bestPath = new Path4CH(graph, graph.getBaseGraph(), flagEncoder);
+                bestPath = new Path4CH(graph, graph.getBaseGraph(), flagEncoder, weighting);
                 return bestPath;
             }
 
@@ -715,7 +715,7 @@ public class PrepareContractionHierarchies extends AbstractAlgoPreparation imple
 
             @Override
             protected Path createAndInitPath() {
-                bestPath = new Path4CH(graph, graph.getBaseGraph(), flagEncoder);
+                bestPath = new Path4CH(graph, graph.getBaseGraph(), flagEncoder, weighting);
                 return bestPath;
             }
 

--- a/core/src/main/java/com/graphhopper/routing/util/DataFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/DataFlagEncoder.java
@@ -448,9 +448,7 @@ public class DataFlagEncoder extends AbstractFlagEncoder {
 
     @Override
     public double getSpeed(long flags) {
-        // TODO fix Path.calcMillis(Path.java:255)
-        // use pluggable weighting.calcMillis but include reverse somehow
-        return 50;
+        throw new UnsupportedOperationException("Calculate speed via more customizable Weighting.calcMillis method");
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/util/TurnCostEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/TurnCostEncoder.java
@@ -45,8 +45,7 @@ public interface TurnCostEncoder {
     long getTurnFlags(boolean restricted, double costs);
 
     /**
-     * whether turn costs nor turn restrictions will be encoded by this encoder, should be used for
-     * pedestrians
+     * No turn costs will be enabled by this encoder, should be used for pedestrians
      */
     class NoTurnCostsEncoder implements TurnCostEncoder {
 

--- a/core/src/main/java/com/graphhopper/routing/weighting/AbstractAdjustedWeighting.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/AbstractAdjustedWeighting.java
@@ -19,6 +19,7 @@ package com.graphhopper.routing.weighting;
 
 import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.routing.util.HintsMap;
+import com.graphhopper.util.EdgeIteratorState;
 
 /**
  * The AdjustedWeighting wraps another Weighting.
@@ -32,6 +33,11 @@ public abstract class AbstractAdjustedWeighting implements Weighting {
         if (superWeighting == null)
             throw new IllegalArgumentException("No super weighting set");
         this.superWeighting = superWeighting;
+    }
+
+    @Override
+    public long calcMillis(EdgeIteratorState edgeState, boolean reverse, int prevOrNextEdgeId) {
+        return superWeighting.calcMillis(edgeState, reverse, prevOrNextEdgeId);
     }
 
     /**

--- a/core/src/main/java/com/graphhopper/routing/weighting/FastestWeighting.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/FastestWeighting.java
@@ -36,11 +36,13 @@ public class FastestWeighting extends AbstractWeighting {
      */
     protected final static double SPEED_CONV = 3.6;
     private final double headingPenalty;
+    private final long headingPenaltyMillis;
     private final double maxSpeed;
 
     public FastestWeighting(FlagEncoder encoder, PMap pMap) {
         super(encoder);
         headingPenalty = pMap.getDouble(Routing.HEADING_PENALTY, Routing.DEFAULT_HEADING_PENALTY);
+        headingPenaltyMillis = Math.round(headingPenalty * 1000);
         maxSpeed = encoder.getMaxSpeed() / SPEED_CONV;
     }
 
@@ -67,6 +69,17 @@ public class FastestWeighting extends AbstractWeighting {
             time += headingPenalty;
 
         return time;
+    }
+
+    @Override
+    public long calcMillis(EdgeIteratorState edgeState, boolean reverse, int prevOrNextEdgeId) {
+        // TODO move this to AbstractWeighting?
+        long time = 0;
+        boolean unfavoredEdge = edgeState.getBool(EdgeIteratorState.K_UNFAVORED_EDGE, false);
+        if (unfavoredEdge)
+            time += headingPenaltyMillis;
+
+        return time + super.calcMillis(edgeState, reverse, prevOrNextEdgeId);
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/weighting/TurnWeighting.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/TurnWeighting.java
@@ -86,6 +86,26 @@ public class TurnWeighting implements Weighting {
         return weight + turnCosts;
     }
 
+    @Override
+    public long calcMillis(EdgeIteratorState edgeState, boolean reverse, int prevOrNextEdgeId) {
+        long millis = superWeighting.calcMillis(edgeState, reverse, prevOrNextEdgeId);
+        if (prevOrNextEdgeId == EdgeIterator.NO_EDGE)
+            return millis;
+
+        // TODO for now assume turn costs are returned in milliseconds?
+        // should we also separate weighting vs. time for turn? E.g. a fast but dangerous turn - is this common?
+        long turnCostsInMillis;
+        if (reverse)
+            turnCostsInMillis = (long) calcTurnWeight(edgeState.getEdge(), edgeState.getBaseNode(), prevOrNextEdgeId);
+        else
+            turnCostsInMillis = (long) calcTurnWeight(prevOrNextEdgeId, edgeState.getBaseNode(), edgeState.getEdge());
+
+        return millis + turnCostsInMillis;
+    }
+
+    /**
+     * This method calculates the turn weight separately.
+     */
     public double calcTurnWeight(int edgeFrom, int nodeVia, int edgeTo) {
         long turnFlags = turnCostExt.getTurnCostFlags(edgeFrom, nodeVia, edgeTo);
         if (turnCostEncoder.isTurnRestricted(turnFlags))

--- a/core/src/main/java/com/graphhopper/routing/weighting/Weighting.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/Weighting.java
@@ -46,7 +46,9 @@ public interface Weighting {
      * +Infinity. Make sure your method does not return NaN which can e.g. occur for 0/0.
      */
     double calcWeight(EdgeIteratorState edgeState, boolean reverse, int prevOrNextEdgeId);
-
+    
+//    double calcMillis(EdgeIteratorState edgeState, boolean reverse, int prevOrNextEdgeId);
+    
     FlagEncoder getFlagEncoder();
 
     String getName();

--- a/core/src/main/java/com/graphhopper/routing/weighting/Weighting.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/Weighting.java
@@ -37,6 +37,11 @@ public interface Weighting {
     double getMinWeight(double distance);
 
     /**
+     * This method calculates the weighting a certain edgeState should be associated. E.g. a high
+     * value indicates that the edge should be avoided. Make sure that this method is very fast and
+     * optimized as this is called potentially millions of times for one route or a lot more for
+     * nearly any preprocessing phase.
+     *
      * @param edgeState        the edge for which the weight should be calculated
      * @param reverse          if the specified edge is specified in reverse direction e.g. from the reverse
      *                         case of a bidirectional search.
@@ -46,9 +51,14 @@ public interface Weighting {
      * +Infinity. Make sure your method does not return NaN which can e.g. occur for 0/0.
      */
     double calcWeight(EdgeIteratorState edgeState, boolean reverse, int prevOrNextEdgeId);
-    
-//    double calcMillis(EdgeIteratorState edgeState, boolean reverse, int prevOrNextEdgeId);
-    
+
+    /**
+     * This method calculates the time taken (in milli seconds) for the specified edgeState and
+     * optionally include the turn costs (in seconds) of the previous (or next) edgeId via
+     * prevOrNextEdgeId. Typically used for post-processing and on only a few thausend edges.
+     */
+    long calcMillis(EdgeIteratorState edgeState, boolean reverse, int prevOrNextEdgeId);
+
     FlagEncoder getFlagEncoder();
 
     String getName();

--- a/core/src/main/java/com/graphhopper/storage/MMapDataAccess.java
+++ b/core/src/main/java/com/graphhopper/storage/MMapDataAccess.java
@@ -169,6 +169,7 @@ public class MMapDataAccess extends AbstractDataAccess {
                     // mini sleep to let JVM do unmapping
                     Thread.sleep(5);
                 } catch (InterruptedException iex) {
+                    throw new IOException(iex);
                 }
             }
         }

--- a/core/src/test/java/com/graphhopper/routing/AbstractRoutingAlgorithmTester.java
+++ b/core/src/test/java/com/graphhopper/routing/AbstractRoutingAlgorithmTester.java
@@ -764,6 +764,13 @@ public abstract class AbstractRoutingAlgorithmTester {
                 return edgeState.getDistance() * 0.8;
             }
 
+            private final Weighting tmpW = new FastestWeighting(carEncoder);
+
+            @Override
+            public long calcMillis(EdgeIteratorState edgeState, boolean reverse, int prevOrNextEdgeId) {
+                return tmpW.calcMillis(edgeState, reverse, prevOrNextEdgeId);
+            }
+
             @Override
             public boolean matches(HintsMap map) {
                 throw new UnsupportedOperationException("Not supported");

--- a/core/src/test/java/com/graphhopper/routing/PathBidirRefTest.java
+++ b/core/src/test/java/com/graphhopper/routing/PathBidirRefTest.java
@@ -21,6 +21,7 @@ import com.graphhopper.routing.util.DefaultEdgeFilter;
 import com.graphhopper.routing.util.EdgeFilter;
 import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.routing.util.FlagEncoder;
+import com.graphhopper.routing.weighting.FastestWeighting;
 import com.graphhopper.storage.Graph;
 import com.graphhopper.storage.GraphBuilder;
 import com.graphhopper.storage.SPTEntry;
@@ -47,7 +48,7 @@ public class PathBidirRefTest {
     public void testExtract() {
         Graph g = createGraph();
         g.edge(1, 2, 10, true);
-        PathBidirRef pw = new PathBidirRef(g, carEncoder);
+        PathBidirRef pw = new PathBidirRef(g, carEncoder, new FastestWeighting(carEncoder));
         EdgeExplorer explorer = g.createEdgeExplorer(carOutEdges);
         EdgeIterator iter = explorer.setBaseNode(1);
         iter.next();
@@ -67,7 +68,7 @@ public class PathBidirRefTest {
         EdgeExplorer explorer = g.createEdgeExplorer(carOutEdges);
         EdgeIterator iter = explorer.setBaseNode(1);
         iter.next();
-        PathBidirRef pw = new PathBidirRef(g, carEncoder);
+        PathBidirRef pw = new PathBidirRef(g, carEncoder, new FastestWeighting(carEncoder));
         pw.sptEntry = new SPTEntry(iter.getEdge(), 2, 10);
         pw.sptEntry.parent = new SPTEntry(EdgeIterator.NO_EDGE, 1, 0);
 

--- a/core/src/test/java/com/graphhopper/routing/PathTest.java
+++ b/core/src/test/java/com/graphhopper/routing/PathTest.java
@@ -18,6 +18,7 @@
 package com.graphhopper.routing;
 
 import com.graphhopper.routing.util.*;
+import com.graphhopper.routing.weighting.FastestWeighting;
 import com.graphhopper.routing.weighting.ShortestWeighting;
 import com.graphhopper.storage.*;
 import com.graphhopper.util.*;
@@ -42,7 +43,7 @@ public class PathTest {
     @Test
     public void testFound() {
         GraphHopperStorage g = new GraphBuilder(carManager).create();
-        Path p = new Path(g, encoder);
+        Path p = new Path(g, new FastestWeighting(encoder));
         assertFalse(p.isFound());
         assertEquals(0, p.getDistance(), 1e-7);
         assertEquals(0, p.calcNodes().size());
@@ -53,7 +54,7 @@ public class PathTest {
     public void testTime() {
         FlagEncoder tmpEnc = new Bike2WeightFlagEncoder();
         GraphHopperStorage g = new GraphBuilder(new EncodingManager(tmpEnc)).create();
-        Path p = new Path(g, tmpEnc);
+        Path p = new Path(g, new FastestWeighting(tmpEnc));
         long flags = tmpEnc.setSpeed(tmpEnc.setReverseSpeed(tmpEnc.setAccess(0, true, true), 10), 15);
         EdgeIteratorState edge = GHUtility.createMockedEdgeIteratorState(100000, flags);
                 
@@ -76,7 +77,7 @@ public class PathTest {
         EdgeIteratorState edge2 = g.edge(2, 1).setDistance(2000).setFlags(encoder.setProperties(50, true, true));
         edge2.setWayGeometry(Helper.createPointList(11, 1, 10, 1));
 
-        Path path = new Path(g, encoder);
+        Path path = new Path(g, new FastestWeighting(encoder));
         SPTEntry e1 = new SPTEntry(edge2.getEdge(), 2, 1);
         e1.parent = new SPTEntry(edge1.getEdge(), 1, 1);
         e1.parent.parent = new SPTEntry(-1, 0, 1);
@@ -102,7 +103,7 @@ public class PathTest {
 
         // force minor change for instructions
         edge2.setName("2");
-        path = new Path(g, encoder);
+        path = new Path(g, new FastestWeighting(encoder));
         e1 = new SPTEntry(edge2.getEdge(), 2, 1);
         e1.parent = new SPTEntry(edge1.getEdge(), 1, 1);
         e1.parent.parent = new SPTEntry(-1, 0, 1);
@@ -126,7 +127,7 @@ public class PathTest {
         assertEquals(path.calcPoints().size() - 1, lastIndex);
 
         // now reverse order
-        path = new Path(g, encoder);
+        path = new Path(g, new FastestWeighting(encoder));
         e1 = new SPTEntry(edge1.getEdge(), 0, 1);
         e1.parent = new SPTEntry(edge2.getEdge(), 1, 1);
         e1.parent.parent = new SPTEntry(-1, 2, 1);
@@ -175,7 +176,7 @@ public class PathTest {
         edge4.setWayGeometry(Helper.createPointList());
         edge4.setName("Street 4");
 
-        Path path = new Path(g, encoder);
+        Path path = new Path(g, new FastestWeighting(encoder));
         SPTEntry e1 = new SPTEntry(edge4.getEdge(), 4, 1);
         e1.parent = new SPTEntry(edge3.getEdge(), 3, 1);
         e1.parent.parent = new SPTEntry(edge2.getEdge(), 2, 1);

--- a/core/src/test/java/com/graphhopper/routing/PathTest.java
+++ b/core/src/test/java/com/graphhopper/routing/PathTest.java
@@ -55,8 +55,10 @@ public class PathTest {
         GraphHopperStorage g = new GraphBuilder(new EncodingManager(tmpEnc)).create();
         Path p = new Path(g, tmpEnc);
         long flags = tmpEnc.setSpeed(tmpEnc.setReverseSpeed(tmpEnc.setAccess(0, true, true), 10), 15);
-        assertEquals(375 * 60 * 1000, p.calcMillis(100000, flags, false));
-        assertEquals(600 * 60 * 1000, p.calcMillis(100000, flags, true));
+        EdgeIteratorState edge = GHUtility.createMockedEdgeIteratorState(100000, flags);
+                
+        assertEquals(375 * 60 * 1000, p.calcMillis(edge, false));
+        assertEquals(600 * 60 * 1000, p.calcMillis(edge, true));
 
         g.close();
     }

--- a/reader-osm/src/main/java/com/graphhopper/reader/osm/pbf/PbfDecoder.java
+++ b/reader-osm/src/main/java/com/graphhopper/reader/osm/pbf/PbfDecoder.java
@@ -58,7 +58,6 @@ public class PbfDecoder implements Runnable {
     private void waitForUpdate() {
         try {
             dataWaitCondition.await();
-
         } catch (InterruptedException e) {
             throw new RuntimeException("Thread was interrupted.", e);
         }

--- a/reader-osm/src/test/java/com/graphhopper/reader/osm/GraphHopperOSMTest.java
+++ b/reader-osm/src/test/java/com/graphhopper/reader/osm/GraphHopperOSMTest.java
@@ -225,6 +225,7 @@ public class GraphHopperOSMTest {
                     latch2.countDown();
                     latch1.await(3, TimeUnit.SECONDS);
                 } catch (InterruptedException ex) {
+                    throw new RuntimeException(ex);
                 }
                 return super.importData();
             }

--- a/tools/src/main/java/com/graphhopper/tools/QueryTorture.java
+++ b/tools/src/main/java/com/graphhopper/tools/QueryTorture.java
@@ -146,7 +146,7 @@ public class QueryTorture {
                     logger.info(getName() + " FINISHED");
                 } catch (RejectedExecutionException ex) {
                     logger.info(getName() + " cannot create threads", ex);
-                } catch (InterruptedException ex) {
+                } catch (InterruptedException ex) {                    
                     // logger.info(getName() + " was interrupted", ex);
                 }
             }


### PR DESCRIPTION
This allows the user to create a custom Weighting which also changes the time calculation and a time delay can be now stored in the edge flags

Fixes #393 

TODOs:

 - [ ] add a test for this new flexibility
 - [ ] test performance

Would highly appreciate feedback as this changes the internals a bit. Also if we should assume for now that turn costs are in seconds or if we need a separate method (getTurnWeight vs. getTurnMillis)
