### PR TITLE
Make Java 9 JDK update on Travis-CI work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,7 @@ before_install:
    - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ "$JVM" == "latest" ]; then
          sudo apt-get update -qq;
          sudo /bin/echo -e oracle-java9-installer shared/accepted-oracle-license-v1-1 select true | sudo debconf-set-selections;
-         sudo apt-get install -y oracle-java9-installer;
-         sudo apt-get install -y oracle-java9-unlimited-jce-policy;
+         sudo apt-get -o Dpkg::Options::="--force-confnew" install -y oracle-java9-installer oracle-java9-set-default oracle-java9-unlimited-jce-policy;
          sudo update-java-alternatives -s java-9-oracle;
      fi
    - if [ "$TRAVIS_JDK_VERSION" == oraclejdk9 ]; then


### PR DESCRIPTION
Something changed in the Java apt packages making the upgrade of the Java 9 JDK package [wait for userinput](https://travis-ci.org/graphhopper/graphhopper/jobs/170577756#L433); now it will just use the package provided files and run along.