### PR TITLE
Added Max Point Distance for Non-Ch Requests

### DIFF
--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -40,8 +40,7 @@ import com.graphhopper.storage.index.QueryResult;
 import com.graphhopper.util.*;
 import com.graphhopper.util.Parameters.CH;
 import com.graphhopper.util.Parameters.Routing;
-import com.graphhopper.util.exceptions.DetailedIllegalArgumentException;
-import com.graphhopper.util.exceptions.MaxPointDistanceExceededException;
+import com.graphhopper.util.exceptions.PointDistanceExceededException;
 import com.graphhopper.util.exceptions.PointOutOfBoundsException;
 import com.graphhopper.util.shapes.BBox;
 import com.graphhopper.util.shapes.GHPoint;
@@ -1098,9 +1097,9 @@ public class GraphHopper implements GraphHopperAPI {
             dist = calc.calcDist(lastPoint.getLat(), lastPoint.getLon(), point.getLat(), point.getLon());
             if (dist > maxNonChPointDistance) {
                 Map<String, Object> detailMap = new HashMap<>(2);
-                detailMap.put("Point1", i-1);
-                detailMap.put("Point2", i);
-                throw new MaxPointDistanceExceededException("Point " + i + " is too far from Point "+(i-1)+": " + point, detailMap);
+                detailMap.put("from", i-1);
+                detailMap.put("to", i);
+                throw new PointDistanceExceededException("Point " + i + " is too far from Point "+(i-1)+": " + point, detailMap);
             }
             lastPoint = point;
         }

--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -88,6 +88,7 @@ public class GraphHopper implements GraphHopperAPI {
     private boolean simplifyResponse = true;
     private TraversalMode traversalMode = TraversalMode.NODE_BASED;
     private int maxVisitedNodes = Integer.MAX_VALUE;
+
     private int maxNonChPointDistance = Integer.MAX_VALUE;
     // for index
     private LocationIndex locationIndex;
@@ -1031,7 +1032,7 @@ public class GraphHopper implements GraphHopperAPI {
                     routingGraph = ghStorage.getGraph(CHGraph.class, weighting);
 
                 } else {
-                    checkIfPointsAreInBounds(points);
+                    checkPointBeelineDistance(points);
                     weighting = createWeighting(hints, encoder);
                     ghRsp.addDebugInfo("tmode:" + tMode.toString());
                 }
@@ -1094,7 +1095,7 @@ public class GraphHopper implements GraphHopperAPI {
         DistanceCalc calc = Helper.DIST_3D;
         for (int i = 1; i < points.size(); i++) {
             point = points.get(i);
-            dist = calc.calcNormalizedDist(lastPoint.getLat(), lastPoint.getLon(), point.getLat(), point.getLon());
+            dist = calc.calcDist(lastPoint.getLat(), lastPoint.getLon(), point.getLat(), point.getLon());
             if (dist > maxNonChPointDistance) {
                 Map<String, Object> detailMap = new HashMap<>(2);
                 detailMap.put("Point1", i-1);
@@ -1205,4 +1206,9 @@ public class GraphHopper implements GraphHopperAPI {
         if (!allowWrites)
             throw new IllegalStateException("Writes are not allowed!");
     }
+
+    public void setMaxNonChPointDistance(int maxNonChPointDistance) {
+        this.maxNonChPointDistance = maxNonChPointDistance;
+    }
+
 }

--- a/core/src/main/java/com/graphhopper/util/Parameters.java
+++ b/core/src/main/java/com/graphhopper/util/Parameters.java
@@ -94,6 +94,7 @@ public class Parameters {
         public static final String EDGE_BASED = "edge_based";
         public static final String MAX_VISITED_NODES = "max_visited_nodes";
         public static final String INIT_MAX_VISITED_NODES = ROUTING_INIT_PREFIX + "max_visited_nodes";
+        public static final String MAX_NON_CH_POINT_DISTANCE = ROUTING_INIT_PREFIX + "max_non_ch_point_distance";
         public static final String INSTRUCTIONS = "instructions";
         public static final String CALC_POINTS = "calc_points";
         public static final String WAY_POINT_MAX_DISTANCE = "way_point_max_distance";

--- a/core/src/main/java/com/graphhopper/util/exceptions/MaxPointDistanceExceededException.java
+++ b/core/src/main/java/com/graphhopper/util/exceptions/MaxPointDistanceExceededException.java
@@ -1,0 +1,31 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.util.exceptions;
+
+import java.util.Map;
+
+/**
+ * If a route cannot be found due to disconnected graphs.
+ *
+ * @author Peter Karich
+ */
+public class MaxPointDistanceExceededException extends DetailedIllegalArgumentException {
+    public MaxPointDistanceExceededException(String var1, Map<String, Object> details) {
+        super(var1, details);
+    }
+}

--- a/core/src/main/java/com/graphhopper/util/exceptions/PointDistanceExceededException.java
+++ b/core/src/main/java/com/graphhopper/util/exceptions/PointDistanceExceededException.java
@@ -24,8 +24,8 @@ import java.util.Map;
  *
  * @author Peter Karich
  */
-public class MaxPointDistanceExceededException extends DetailedIllegalArgumentException {
-    public MaxPointDistanceExceededException(String var1, Map<String, Object> details) {
+public class PointDistanceExceededException extends DetailedIllegalArgumentException {
+    public PointDistanceExceededException(String var1, Map<String, Object> details) {
         super(var1, details);
     }
 }

--- a/reader-osm/src/test/java/com/graphhopper/GraphHopperIT.java
+++ b/reader-osm/src/test/java/com/graphhopper/GraphHopperIT.java
@@ -332,6 +332,29 @@ public class GraphHopperIT {
     }
 
     @Test
+    public void testMonacoMaxPointDistance() {
+        GHPoint from = new GHPoint(43.741069, 7.426854);
+        GHPoint to = new GHPoint(43.727697, 7.419199);
+
+        GHRequest req = new GHRequest().
+                addPoint(from).
+                addPoint(to).
+                setVehicle(vehicle).setWeighting("fastest");
+
+        // Fail since points are too far
+        hopper.setMaxNonChPointDistance(1000);
+        GHResponse rsp = hopper.route(req);
+
+        assertTrue(rsp.hasErrors());
+
+        // Suceed since points are not far anymore
+        hopper.setMaxNonChPointDistance(Integer.MAX_VALUE);
+        rsp = hopper.route(req);
+
+        assertFalse(rsp.hasErrors());
+    }
+
+    @Test
     public void testMonacoStraightVia() {
         GHRequest rq = new GHRequest().
                 addPoint(new GHPoint(43.741069, 7.426854)).


### PR DESCRIPTION
This PR intents to fix #734. It adds the option to define a maximum beeline between two consecutive points. The distance will be only checked for non-ch requests.