### PR TITLE
Replace trove4j with hppc

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -5,28 +5,39 @@ Copyright 2012 - 2016 GraphHopper GmbH
 The core module includes the following software:
 
  * slf4j.org - SLF4J distributed under the MIT license. 
- * trove.starlight-systems.com - GNU Trove library (LGPL license)
+ * hppc (Apache license)
  * SparseArray from the Android project (Apache license)
  * Snippets regarding mmap, vint/vlong and compression from Lucene (Apache license)
- * protobuf - New BSD license
- * OSM-binary - LGPL license
- * Osmosis - public domain, see osmosis-copying.txt under core/files
  * XMLGraphics-Commons for CGIAR elevation files (Apache License)
  * Apache Commons Lang - we copied the implementation of the Levenshtein Distance (Apache License)
  * Apache Commons Collections - we copied parts of the BinaryHeap (Apache License)
 
+reader-osm:
+
+ * protobuf - New BSD license
+ * OSM-binary - LGPL license
+ * Osmosis - public domain, see osmosis-copying.txt under core/files
+
+reader-overlay-data:
+
+ * com.google.code.gson:gson (Apache license)
+
+reader-shp:
+ 
+ * org.geotools:gt-shapefile (LGPL)
+
 tools:
 
- * uses Apache Compress
+ * uses Apache Compress (Apache license)
 
 web:
 
  * org.json, MIT style license
- * com.google.inject, Apache License 2.0
+ * com.google.inject (Apache license)
  * images from mapbox https://www.mapbox.com/maki/, BSD License, see core/files
 
 android:
 
- * android, Apache License 2.0
+ * android (Apache license)
  * org.mapsforge, LGPL
  * VTM, LGPL

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -81,30 +81,6 @@
             <version>${json.org.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.seleniumhq.selenium</groupId>
-            <artifactId>selenium-java</artifactId>
-            <scope>test</scope>
-            <version>2.44.0</version>
-        </dependency>
-        <dependency>
-            <groupId>com.opera</groupId>
-            <artifactId>operadriver</artifactId>
-            <scope>test</scope>
-            <version>1.5</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.seleniumhq.selenium</groupId>
-                    <artifactId>selenium-remote-driver</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-            <version>4.11</version>
-        </dependency>
     </dependencies>
 
     <build>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -35,18 +35,11 @@
             <comments>A business-friendly OSS license</comments>
         </license>
     </licenses>
-    <dependencies>
+    <dependencies>        
         <dependency>
-            <groupId>com.graphhopper</groupId>
-            <artifactId>graphhopper-tools-lgpl</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
-
-        <!-- Trove is LGPL and slightly big (~3MB) -->
-        <dependency>
-            <groupId>net.sf.trove4j</groupId>
-            <artifactId>trove4j</artifactId>
-            <version>3.0.3</version>
+            <groupId>com.carrotsearch</groupId>
+            <artifactId>hppc</artifactId>
+            <version>0.7.2</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -88,7 +81,30 @@
             <version>${json.org.version}</version>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-java</artifactId>
+            <scope>test</scope>
+            <version>2.44.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.opera</groupId>
+            <artifactId>operadriver</artifactId>
+            <scope>test</scope>
+            <version>1.5</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.seleniumhq.selenium</groupId>
+                    <artifactId>selenium-remote-driver</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+            <version>4.11</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/core/src/main/java/com/graphhopper/coll/GHIntArrayList.java
+++ b/core/src/main/java/com/graphhopper/coll/GHIntArrayList.java
@@ -49,7 +49,7 @@ public class GHIntArrayList extends IntArrayList {
     }
 
     public final GHIntArrayList fill(final int max, final int value) {
-        // TODO use System.arraycopy and direct buffer somehow
+        // TODO fill 100 then copy using System.arraycopy, then duplicate this via copying again etc
         for (int i = 0; i < max; i++) {
             add(value);
         }

--- a/core/src/main/java/com/graphhopper/coll/GHIntArrayList.java
+++ b/core/src/main/java/com/graphhopper/coll/GHIntArrayList.java
@@ -1,0 +1,77 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for 
+ *  additional information regarding copyright ownership.
+ * 
+ *  GraphHopper GmbH licenses this file to you under the Apache License, 
+ *  Version 2.0 (the "License"); you may not use this file except in 
+ *  compliance with the License. You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.coll;
+
+import com.carrotsearch.hppc.IntArrayList;
+import java.util.Random;
+
+/**
+ *
+ * @author Peter Karich
+ */
+public class GHIntArrayList extends IntArrayList {
+    public GHIntArrayList() {
+        super(10);
+    }
+
+    public GHIntArrayList(int capacity) {
+        super(capacity);
+    }
+
+    public GHIntArrayList(GHIntArrayList list) {
+        super(list);
+    }
+
+    public final GHIntArrayList reverse() {
+        final int[] buffer = this.buffer;
+        for (int start = 0, end = size() - 1; start < end; start++, end--) {
+            // swap the values
+            int tmp = buffer[start];
+            buffer[start] = buffer[end];
+            buffer[end] = tmp;
+        }
+        return this;
+    }
+
+    public final GHIntArrayList fill(final int max, final int value) {
+        // TODO use System.arraycopy and direct buffer somehow
+        for (int i = 0; i < max; i++) {
+            add(value);
+        }
+        return this;
+    }
+
+    public final GHIntArrayList shuffle(Random random) {
+        int[] buffer = this.buffer;
+        int max = size();
+        int maxHalf = max / 2;
+        for (int x1 = 0; x1 < maxHalf; x1++) {
+            int x2 = random.nextInt(maxHalf) + maxHalf;
+            int tmp = buffer[x1];
+            buffer[x1] = buffer[x2];
+            buffer[x2] = tmp;
+        }
+        return this;
+    }
+
+    public static GHIntArrayList from(int... elements) {
+        final GHIntArrayList list = new GHIntArrayList(elements.length);
+        list.add(elements);
+        return list;
+    }
+}

--- a/core/src/main/java/com/graphhopper/coll/GHIntArrayList.java
+++ b/core/src/main/java/com/graphhopper/coll/GHIntArrayList.java
@@ -39,9 +39,10 @@ public class GHIntArrayList extends IntArrayList {
 
     public final GHIntArrayList reverse() {
         final int[] buffer = this.buffer;
+        int tmp;
         for (int start = 0, end = size() - 1; start < end; start++, end--) {
             // swap the values
-            int tmp = buffer[start];
+            tmp = buffer[start];
             buffer[start] = buffer[end];
             buffer[end] = tmp;
         }

--- a/core/src/main/java/com/graphhopper/coll/GHIntHashSet.java
+++ b/core/src/main/java/com/graphhopper/coll/GHIntHashSet.java
@@ -1,17 +1,19 @@
 /*
- * Copyright 2016 peter.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for 
+ *  additional information regarding copyright ownership.
+ * 
+ *  GraphHopper GmbH licenses this file to you under the Apache License, 
+ *  Version 2.0 (the "License"); you may not use this file except in 
+ *  compliance with the License. You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
  */
 package com.graphhopper.coll;
 

--- a/core/src/main/java/com/graphhopper/coll/GHIntHashSet.java
+++ b/core/src/main/java/com/graphhopper/coll/GHIntHashSet.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2016 peter.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.graphhopper.coll;
+
+import com.carrotsearch.hppc.HashOrderMixingStrategy;
+import com.carrotsearch.hppc.IntContainer;
+import com.carrotsearch.hppc.IntHashSet;
+import static com.graphhopper.coll.GHIntObjectHashMap.DETERMINISTIC;
+
+/**
+ * Prefer GHTBitSet or GHBitSetImpl over this class.
+ *
+ * @author Peter Karich
+ */
+public class GHIntHashSet extends IntHashSet {
+
+    public GHIntHashSet() {
+        super(10, 0.75, DETERMINISTIC);
+    }
+
+    public GHIntHashSet(int capacity) {
+        super(capacity, 0.75, DETERMINISTIC);
+    }
+
+    public GHIntHashSet(int capacity, double loadFactor) {
+        super(capacity, loadFactor, DETERMINISTIC);
+    }
+
+    public GHIntHashSet(int capacity, double loadFactor, HashOrderMixingStrategy hashOrderMixer) {
+        super(capacity, loadFactor, hashOrderMixer);
+    }
+
+    public GHIntHashSet(IntContainer container) {
+        this(container.size());
+        addAll(container);
+    }
+
+    public static IntHashSet from(int... elements) {
+        final GHIntHashSet set = new GHIntHashSet(elements.length);
+        set.addAll(elements);
+        return set;
+    }
+}

--- a/core/src/main/java/com/graphhopper/coll/GHIntLongHashMap.java
+++ b/core/src/main/java/com/graphhopper/coll/GHIntLongHashMap.java
@@ -17,14 +17,28 @@
  */
 package com.graphhopper.coll;
 
+import com.carrotsearch.hppc.HashOrderMixingStrategy;
+import com.carrotsearch.hppc.IntLongHashMap;
+import static com.graphhopper.coll.GHIntObjectHashMap.DETERMINISTIC;
+
 /**
+ *
  * @author Peter Karich
  */
-public class IntDoubleBinHeap extends OTPIntDoubleBinHeap implements BinHeapWrapper<Number, Integer> {
-    public IntDoubleBinHeap() {
+public class GHIntLongHashMap extends IntLongHashMap {
+    public GHIntLongHashMap() {
+        super(10, 0.75, DETERMINISTIC);
     }
 
-    public IntDoubleBinHeap(int capacity) {
-        super(capacity);
+    public GHIntLongHashMap(int capacity) {
+        super(capacity, 0.75, DETERMINISTIC);
+    }
+
+    public GHIntLongHashMap(int capacity, double loadFactor) {
+        super(capacity, loadFactor, DETERMINISTIC);
+    }
+
+    public GHIntLongHashMap(int capacity, double loadFactor, HashOrderMixingStrategy hashOrderMixer) {
+        super(capacity, loadFactor, hashOrderMixer);
     }
 }

--- a/core/src/main/java/com/graphhopper/coll/GHIntObjectHashMap.java
+++ b/core/src/main/java/com/graphhopper/coll/GHIntObjectHashMap.java
@@ -1,0 +1,47 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for 
+ *  additional information regarding copyright ownership.
+ * 
+ *  GraphHopper GmbH licenses this file to you under the Apache License, 
+ *  Version 2.0 (the "License"); you may not use this file except in 
+ *  compliance with the License. You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.coll;
+
+import com.carrotsearch.hppc.HashOrderMixing;
+import com.carrotsearch.hppc.HashOrderMixingStrategy;
+
+/**
+ * We often do not mix maps but really need to avoid randomness or that threads can influence each
+ * other and so we do not use the default HashOrderMixing employed in HPPC (which does this in a thread-safe manner).
+ *
+ * @author Peter Karich
+ */
+public class GHIntObjectHashMap<T> extends com.carrotsearch.hppc.IntObjectHashMap<T> {
+    static final HashOrderMixingStrategy DETERMINISTIC = HashOrderMixing.constant(123321123321123312L);
+
+    public GHIntObjectHashMap() {
+        super(10, 0.75, DETERMINISTIC);
+    }
+
+    public GHIntObjectHashMap(int capacity) {
+        super(capacity, 0.75, DETERMINISTIC);
+    }
+
+    public GHIntObjectHashMap(int capacity, double loadFactor) {
+        super(capacity, loadFactor, DETERMINISTIC);
+    }
+
+    public GHIntObjectHashMap(int capacity, double loadFactor, HashOrderMixingStrategy hashOrderMixer) {
+        super(capacity, loadFactor, hashOrderMixer);
+    }
+}

--- a/core/src/main/java/com/graphhopper/coll/GHLongHashSet.java
+++ b/core/src/main/java/com/graphhopper/coll/GHLongHashSet.java
@@ -17,36 +17,28 @@
  */
 package com.graphhopper.coll;
 
+import com.carrotsearch.hppc.HashOrderMixingStrategy;
+import com.carrotsearch.hppc.LongHashSet;
+import static com.graphhopper.coll.GHIntObjectHashMap.DETERMINISTIC;
+
 /**
- * Wrapper interface of an integer container for different implementations like OpenBitset, BitSet,
- * ...
- * <p>
- * Loop via<br/>
- * <code>for (int i = set.next(0); i >= 0; i = set.next(i + 1)) {...}</code>
  *
  * @author Peter Karich
  */
-public interface GHBitSet {
-    boolean contains(int index);
+public class GHLongHashSet extends LongHashSet {
+    public GHLongHashSet() {
+        super(10, 0.75, DETERMINISTIC);
+    }
 
-    void add(int index);
+    public GHLongHashSet(int capacity) {
+        super(capacity, 0.75, DETERMINISTIC);
+    }
 
-    void remove(int index);
+    public GHLongHashSet(int capacity, double loadFactor) {
+        super(capacity, loadFactor, DETERMINISTIC);
+    }
 
-    int getCardinality();
-
-    void clear();
-
-    /**
-     * Searches for a greater or equal entry and returns it.
-     * <p>
-     *
-     * @return -1 if nothing found
-     */
-    int next(int index);
-
-    /**
-     * @return the specified MyBitSet bs
-     */
-    GHBitSet copyTo(GHBitSet bs);
+    public GHLongHashSet(int capacity, double loadFactor, HashOrderMixingStrategy hashOrderMixer) {
+        super(capacity, loadFactor, hashOrderMixer);
+    }
 }

--- a/core/src/main/java/com/graphhopper/coll/GHLongLongHashMap.java
+++ b/core/src/main/java/com/graphhopper/coll/GHLongLongHashMap.java
@@ -17,36 +17,28 @@
  */
 package com.graphhopper.coll;
 
+import com.carrotsearch.hppc.HashOrderMixingStrategy;
+import com.carrotsearch.hppc.LongLongHashMap;
+import static com.graphhopper.coll.GHIntObjectHashMap.DETERMINISTIC;
+
 /**
- * Wrapper interface of an integer container for different implementations like OpenBitset, BitSet,
- * ...
- * <p>
- * Loop via<br/>
- * <code>for (int i = set.next(0); i >= 0; i = set.next(i + 1)) {...}</code>
  *
  * @author Peter Karich
  */
-public interface GHBitSet {
-    boolean contains(int index);
+public class GHLongLongHashMap extends LongLongHashMap {
+    public GHLongLongHashMap() {
+        super(10, 0.75, DETERMINISTIC);
+    }
 
-    void add(int index);
+    public GHLongLongHashMap(int capacity) {
+        super(capacity, 0.75, DETERMINISTIC);
+    }
 
-    void remove(int index);
+    public GHLongLongHashMap(int capacity, double loadFactor) {
+        super(capacity, loadFactor, DETERMINISTIC);
+    }
 
-    int getCardinality();
-
-    void clear();
-
-    /**
-     * Searches for a greater or equal entry and returns it.
-     * <p>
-     *
-     * @return -1 if nothing found
-     */
-    int next(int index);
-
-    /**
-     * @return the specified MyBitSet bs
-     */
-    GHBitSet copyTo(GHBitSet bs);
+    public GHLongLongHashMap(int capacity, double loadFactor, HashOrderMixingStrategy hashOrderMixer) {
+        super(capacity, loadFactor, hashOrderMixer);
+    }
 }

--- a/core/src/main/java/com/graphhopper/coll/GHLongObjectHashMap.java
+++ b/core/src/main/java/com/graphhopper/coll/GHLongObjectHashMap.java
@@ -17,12 +17,28 @@
  */
 package com.graphhopper.coll;
 
+import com.carrotsearch.hppc.HashOrderMixingStrategy;
+import com.carrotsearch.hppc.LongObjectHashMap;
+import static com.graphhopper.coll.GHIntObjectHashMap.DETERMINISTIC;
+
 /**
+ *
  * @author Peter Karich
  */
-public class IntDoubleBinHeapTest extends AbstractBinHeapTest {
-    @Override
-    public BinHeapWrapper<Number, Integer> createHeap(int capacity) {
-        return new IntDoubleBinHeap(capacity);
+public class GHLongObjectHashMap<T> extends LongObjectHashMap<T> {
+    public GHLongObjectHashMap() {
+        super(10, 0.75, DETERMINISTIC);
+    }
+
+    public GHLongObjectHashMap(int capacity) {
+        super(capacity, 0.75, DETERMINISTIC);
+    }
+
+    public GHLongObjectHashMap(int capacity, double loadFactor) {
+        super(capacity, loadFactor, DETERMINISTIC);
+    }
+
+    public GHLongObjectHashMap(int capacity, double loadFactor, HashOrderMixingStrategy hashOrderMixer) {
+        super(capacity, loadFactor, hashOrderMixer);
     }
 }

--- a/core/src/main/java/com/graphhopper/coll/GHObjectIntHashMap.java
+++ b/core/src/main/java/com/graphhopper/coll/GHObjectIntHashMap.java
@@ -1,0 +1,50 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for 
+ *  additional information regarding copyright ownership.
+ * 
+ *  GraphHopper GmbH licenses this file to you under the Apache License, 
+ *  Version 2.0 (the "License"); you may not use this file except in 
+ *  compliance with the License. You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.coll;
+
+import com.carrotsearch.hppc.HashOrderMixingStrategy;
+import com.carrotsearch.hppc.ObjectIntAssociativeContainer;
+import com.carrotsearch.hppc.ObjectIntHashMap;
+import static com.graphhopper.coll.GHIntObjectHashMap.DETERMINISTIC;
+
+/**
+ *
+ * @author Peter Karich
+ */
+public class GHObjectIntHashMap<T> extends ObjectIntHashMap<T> {
+    public GHObjectIntHashMap() {
+        super(10, 0.75, DETERMINISTIC);
+    }
+
+    public GHObjectIntHashMap(int capacity) {
+        super(capacity, 0.75, DETERMINISTIC);
+    }
+
+    public GHObjectIntHashMap(int capacity, double loadFactor) {
+        super(capacity, loadFactor, DETERMINISTIC);
+    }
+
+    public GHObjectIntHashMap(int capacity, double loadFactor, HashOrderMixingStrategy hashOrderMixer) {
+        super(capacity, loadFactor, hashOrderMixer);
+    }
+
+    public GHObjectIntHashMap(ObjectIntAssociativeContainer container) {
+        this(container.size());
+        putAll(container);
+    }
+}

--- a/core/src/main/java/com/graphhopper/coll/GHSortedCollection.java
+++ b/core/src/main/java/com/graphhopper/coll/GHSortedCollection.java
@@ -17,9 +17,8 @@
  */
 package com.graphhopper.coll;
 
-import gnu.trove.iterator.TIntIterator;
-import gnu.trove.set.hash.TIntHashSet;
-
+import com.carrotsearch.hppc.cursors.IntCursor;
+import java.util.Iterator;
 import java.util.Map.Entry;
 import java.util.TreeMap;
 
@@ -32,12 +31,12 @@ import java.util.TreeMap;
  */
 public class GHSortedCollection {
     private final int slidingMeanValue = 20;
-    private final TreeMap<Integer, TIntHashSet> map;
+    private final TreeMap<Integer, GHIntHashSet> map;
     private int size;
 
     public GHSortedCollection() {
         // use size as indicator for maxEntries => try radix sort?
-        map = new TreeMap<Integer, TIntHashSet>();
+        map = new TreeMap<Integer, GHIntHashSet>();
     }
 
     public void clear() {
@@ -46,7 +45,7 @@ public class GHSortedCollection {
     }
 
     void remove(int key, int value) {
-        TIntHashSet set = map.get(value);
+        GHIntHashSet set = map.get(value);
         if (set == null || !set.remove(key)) {
             throw new IllegalStateException("cannot remove key " + key + " with value " + value
                     + " - did you insert " + key + "," + value + " before?");
@@ -63,9 +62,9 @@ public class GHSortedCollection {
     }
 
     public void insert(int key, int value) {
-        TIntHashSet set = map.get(value);
+        GHIntHashSet set = map.get(value);
         if (set == null) {
-            map.put(value, set = new TIntHashSet(slidingMeanValue));
+            map.put(value, set = new GHIntHashSet(slidingMeanValue));
         }
 //        else
 //            slidingMeanValue = Math.max(5, (slidingMeanValue + set.size()) / 2);
@@ -79,7 +78,7 @@ public class GHSortedCollection {
         if (size == 0) {
             throw new IllegalStateException("collection is already empty!?");
         }
-        Entry<Integer, TIntHashSet> e = map.firstEntry();
+        Entry<Integer, GHIntHashSet> e = map.firstEntry();
         if (e.getValue().isEmpty()) {
             throw new IllegalStateException("internal set is already empty!?");
         }
@@ -90,11 +89,11 @@ public class GHSortedCollection {
         if (size == 0) {
             throw new IllegalStateException("collection is already empty!?");
         }
-        TIntHashSet set = map.firstEntry().getValue();
+        GHIntHashSet set = map.firstEntry().getValue();
         if (set.isEmpty()) {
             throw new IllegalStateException("internal set is already empty!?");
         }
-        return set.iterator().next();
+        return set.iterator().next().value;
     }
 
     /**
@@ -105,13 +104,13 @@ public class GHSortedCollection {
         if (size < 0) {
             throw new IllegalStateException("collection is already empty!?");
         }
-        Entry<Integer, TIntHashSet> e = map.firstEntry();
-        TIntHashSet set = e.getValue();
-        TIntIterator iter = set.iterator();
+        Entry<Integer, GHIntHashSet> e = map.firstEntry();
+        GHIntHashSet set = e.getValue();
+        Iterator<IntCursor> iter = set.iterator();
         if (set.isEmpty()) {
             throw new IllegalStateException("internal set is already empty!?");
         }
-        int val = iter.next();
+        int val = iter.next().value;
         iter.remove();
         if (set.isEmpty()) {
             map.remove(e.getKey());
@@ -135,7 +134,7 @@ public class GHSortedCollection {
     public String toString() {
         int min = Integer.MAX_VALUE;
         int max = Integer.MIN_VALUE;
-        for (Entry<Integer, TIntHashSet> e : map.entrySet()) {
+        for (Entry<Integer, GHIntHashSet> e : map.entrySet()) {
             int tmpSize = e.getValue().size();
             if (min > tmpSize) {
                 min = tmpSize;

--- a/core/src/main/java/com/graphhopper/coll/GHSortedCollection.java
+++ b/core/src/main/java/com/graphhopper/coll/GHSortedCollection.java
@@ -17,6 +17,7 @@
  */
 package com.graphhopper.coll;
 
+import com.carrotsearch.hppc.LongArrayList;
 import com.carrotsearch.hppc.cursors.IntCursor;
 import com.carrotsearch.hppc.predicates.IntPredicate;
 import java.util.Iterator;
@@ -113,13 +114,8 @@ public class GHSortedCollection {
         }
 
         Iterator<IntCursor> iter = set.iterator();
-        final int val = iter.next().value;
-        set.removeAll(new IntPredicate() {
-            @Override
-            public boolean apply(int value) {
-                return value == val;
-            }
-        });
+        final int val = iter.next().value;        
+        set.remove(val);
         if (set.isEmpty()) {
             map.remove(e.getKey());
         }

--- a/core/src/main/java/com/graphhopper/coll/GHSortedCollection.java
+++ b/core/src/main/java/com/graphhopper/coll/GHSortedCollection.java
@@ -104,14 +104,18 @@ public class GHSortedCollection {
         if (size < 0) {
             throw new IllegalStateException("collection is already empty!?");
         }
+
         Entry<Integer, GHIntHashSet> e = map.firstEntry();
         GHIntHashSet set = e.getValue();
-        Iterator<IntCursor> iter = set.iterator();
         if (set.isEmpty()) {
             throw new IllegalStateException("internal set is already empty!?");
         }
+
+        
+        Iterator<IntCursor> iter = set.iterator();
         int val = iter.next().value;
-        iter.remove();
+        // trove4j allowed a more efficient removal via iter.remove()
+        set.remove(val);
         if (set.isEmpty()) {
             map.remove(e.getKey());
         }

--- a/core/src/main/java/com/graphhopper/coll/GHSortedCollection.java
+++ b/core/src/main/java/com/graphhopper/coll/GHSortedCollection.java
@@ -18,6 +18,7 @@
 package com.graphhopper.coll;
 
 import com.carrotsearch.hppc.cursors.IntCursor;
+import com.carrotsearch.hppc.predicates.IntPredicate;
 import java.util.Iterator;
 import java.util.Map.Entry;
 import java.util.TreeMap;
@@ -111,11 +112,14 @@ public class GHSortedCollection {
             throw new IllegalStateException("internal set is already empty!?");
         }
 
-        
         Iterator<IntCursor> iter = set.iterator();
-        int val = iter.next().value;
-        // trove4j allowed a more efficient removal via iter.remove()
-        set.remove(val);
+        final int val = iter.next().value;
+        set.removeAll(new IntPredicate() {
+            @Override
+            public boolean apply(int value) {
+                return value == val;
+            }
+        });
         if (set.isEmpty()) {
             map.remove(e.getKey());
         }

--- a/core/src/main/java/com/graphhopper/coll/GHTBitSet.java
+++ b/core/src/main/java/com/graphhopper/coll/GHTBitSet.java
@@ -17,24 +17,24 @@
  */
 package com.graphhopper.coll;
 
-import gnu.trove.iterator.TIntIterator;
-import gnu.trove.set.hash.TIntHashSet;
+import com.carrotsearch.hppc.cursors.IntCursor;
+import java.util.Iterator;
 
 /**
- * Implements the bitset interface via a trove THashSet. More efficient for a few entries.
+ * Implements the bitset interface via a hash set. It is more efficient for only a few entries.
  * <p>
  *
  * @author Peter Karich
  */
 public class GHTBitSet implements GHBitSet {
-    private final TIntHashSet tHash;
+    private final GHIntHashSet tHash;
 
-    public GHTBitSet(TIntHashSet set) {
+    public GHTBitSet(GHIntHashSet set) {
         tHash = set;
     }
 
     public GHTBitSet(int no) {
-        tHash = new TIntHashSet(no, 0.7f, -1);
+        tHash = new GHIntHashSet(no, 0.7f);
     }
 
     public GHTBitSet() {
@@ -77,9 +77,9 @@ public class GHTBitSet implements GHBitSet {
         if (bs instanceof GHTBitSet) {
             ((GHTBitSet) bs).tHash.addAll(this.tHash);
         } else {
-            TIntIterator iter = tHash.iterator();
+            Iterator<IntCursor> iter = tHash.iterator();
             while (iter.hasNext()) {
-                bs.add(iter.next());
+                bs.add(iter.next().value);
             }
         }
         return bs;

--- a/core/src/main/java/com/graphhopper/coll/SparseIntIntArray.java
+++ b/core/src/main/java/com/graphhopper/coll/SparseIntIntArray.java
@@ -75,7 +75,7 @@ public class SparseIntIntArray {
     }
 
     /**
-     * Gets the Object mapped from the specified key, or <code>null</code> if no such mapping has
+     * Gets the Object mapped from the specified key, or <code>-1</code> if no such mapping has
      * been made.
      */
     public int get(int key) {

--- a/core/src/main/java/com/graphhopper/reader/ReaderWay.java
+++ b/core/src/main/java/com/graphhopper/reader/ReaderWay.java
@@ -17,8 +17,7 @@
  */
 package com.graphhopper.reader;
 
-import gnu.trove.list.TLongList;
-import gnu.trove.list.array.TLongArrayList;
+import com.carrotsearch.hppc.LongArrayList;
 
 /**
  * Represents a way received from the reader.
@@ -27,13 +26,13 @@ import gnu.trove.list.array.TLongArrayList;
  * @author Nop
  */
 public class ReaderWay extends ReaderElement {
-    protected final TLongList nodes = new TLongArrayList(5);
+    protected final LongArrayList nodes = new LongArrayList(5);
 
     public ReaderWay(long id) {
         super(id, WAY);
     }
 
-    public TLongList getNodes() {
+    public LongArrayList getNodes() {
         return nodes;
     }
 

--- a/core/src/main/java/com/graphhopper/reader/dem/SRTMProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/SRTMProvider.java
@@ -17,6 +17,7 @@
  */
 package com.graphhopper.reader.dem;
 
+import com.graphhopper.coll.GHIntObjectHashMap;
 import com.graphhopper.storage.DAType;
 import com.graphhopper.storage.DataAccess;
 import com.graphhopper.storage.Directory;
@@ -24,7 +25,6 @@ import com.graphhopper.storage.GHDirectory;
 import com.graphhopper.util.BitUtil;
 import com.graphhopper.util.Downloader;
 import com.graphhopper.util.Helper;
-import gnu.trove.map.hash.TIntObjectHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,8 +49,8 @@ public class SRTMProvider implements ElevationProvider {
     private final int DEFAULT_WIDTH = 1201;
     private final int WIDTH_BYTE_INDEX = 0;
     // use a map as an array is not quite useful if we want to hold only parts of the world
-    private final TIntObjectHashMap<HeightTile> cacheData = new TIntObjectHashMap<HeightTile>();
-    private final TIntObjectHashMap<String> areas = new TIntObjectHashMap<String>();
+    private final GHIntObjectHashMap<HeightTile> cacheData = new GHIntObjectHashMap<HeightTile>();
+    private final GHIntObjectHashMap<String> areas = new GHIntObjectHashMap<String>();
     private final double precision = 1e7;
     private final double invPrecision = 1 / precision;
     private Directory dir;

--- a/core/src/main/java/com/graphhopper/routing/AStar.java
+++ b/core/src/main/java/com/graphhopper/routing/AStar.java
@@ -17,7 +17,8 @@
  */
 package com.graphhopper.routing;
 
-import com.graphhopper.routing.util.FlagEncoder;
+import com.carrotsearch.hppc.IntObjectMap;
+import com.graphhopper.coll.GHIntObjectHashMap;
 import com.graphhopper.routing.util.TraversalMode;
 import com.graphhopper.routing.weighting.BeelineWeightApproximator;
 import com.graphhopper.routing.weighting.WeightApproximator;
@@ -28,8 +29,6 @@ import com.graphhopper.util.DistancePlaneProjection;
 import com.graphhopper.util.EdgeExplorer;
 import com.graphhopper.util.EdgeIterator;
 import com.graphhopper.util.Parameters;
-import gnu.trove.map.TIntObjectMap;
-import gnu.trove.map.hash.TIntObjectHashMap;
 
 import java.util.PriorityQueue;
 
@@ -45,7 +44,7 @@ import java.util.PriorityQueue;
 public class AStar extends AbstractRoutingAlgorithm {
     private WeightApproximator weightApprox;
     private int visitedCount;
-    private TIntObjectMap<AStarEntry> fromMap;
+    private IntObjectMap<AStarEntry> fromMap;
     private PriorityQueue<AStarEntry> prioQueueOpenSet;
     private AStarEntry currEdge;
     private int to1 = -1;
@@ -68,7 +67,7 @@ public class AStar extends AbstractRoutingAlgorithm {
     }
 
     protected void initCollections(int size) {
-        fromMap = new TIntObjectHashMap<AStarEntry>();
+        fromMap = new GHIntObjectHashMap<AStarEntry>();
         prioQueueOpenSet = new PriorityQueue<AStarEntry>(size);
     }
 

--- a/core/src/main/java/com/graphhopper/routing/AStarBidirection.java
+++ b/core/src/main/java/com/graphhopper/routing/AStarBidirection.java
@@ -17,6 +17,8 @@
  */
 package com.graphhopper.routing;
 
+import com.carrotsearch.hppc.IntObjectMap;
+import com.graphhopper.coll.GHIntObjectHashMap;
 import com.graphhopper.routing.AStar.AStarEntry;
 import com.graphhopper.routing.util.TraversalMode;
 import com.graphhopper.routing.weighting.BeelineWeightApproximator;
@@ -26,8 +28,6 @@ import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.Graph;
 import com.graphhopper.storage.SPTEntry;
 import com.graphhopper.util.*;
-import gnu.trove.map.TIntObjectMap;
-import gnu.trove.map.hash.TIntObjectHashMap;
 
 import java.util.PriorityQueue;
 
@@ -58,15 +58,15 @@ import java.util.PriorityQueue;
  * @author jansoe
  */
 public class AStarBidirection extends AbstractBidirAlgo {
-    protected TIntObjectMap<AStarEntry> bestWeightMapFrom;
-    protected TIntObjectMap<AStarEntry> bestWeightMapTo;
+    protected IntObjectMap<AStarEntry> bestWeightMapFrom;
+    protected IntObjectMap<AStarEntry> bestWeightMapTo;
     protected AStarEntry currFrom;
     protected AStarEntry currTo;
     protected PathBidirRef bestPath;
     private ConsistentWeightApproximator weightApprox;
     private PriorityQueue<AStarEntry> prioQueueOpenSetFrom;
     private PriorityQueue<AStarEntry> prioQueueOpenSetTo;
-    private TIntObjectMap<AStarEntry> bestWeightMapOther;
+    private IntObjectMap<AStarEntry> bestWeightMapOther;
 
     public AStarBidirection(Graph graph, Weighting weighting, TraversalMode tMode) {
         super(graph, weighting, tMode);
@@ -79,10 +79,10 @@ public class AStarBidirection extends AbstractBidirAlgo {
 
     protected void initCollections(int size) {
         prioQueueOpenSetFrom = new PriorityQueue<AStarEntry>(size);
-        bestWeightMapFrom = new TIntObjectHashMap<AStarEntry>(size);
+        bestWeightMapFrom = new GHIntObjectHashMap<AStarEntry>(size);
 
         prioQueueOpenSetTo = new PriorityQueue<AStarEntry>(size);
-        bestWeightMapTo = new TIntObjectHashMap<AStarEntry>(size);
+        bestWeightMapTo = new GHIntObjectHashMap<AStarEntry>(size);
     }
 
     /**
@@ -208,7 +208,7 @@ public class AStarBidirection extends AbstractBidirAlgo {
     }
 
     private void fillEdges(AStarEntry currEdge, PriorityQueue<AStarEntry> prioQueueOpenSet,
-                           TIntObjectMap<AStarEntry> bestWeightMap, EdgeExplorer explorer, boolean reverse) {
+                           IntObjectMap<AStarEntry> bestWeightMap, EdgeExplorer explorer, boolean reverse) {
 
         int currNode = currEdge.adjNode;
         EdgeIterator iter = explorer.setBaseNode(currNode);

--- a/core/src/main/java/com/graphhopper/routing/Dijkstra.java
+++ b/core/src/main/java/com/graphhopper/routing/Dijkstra.java
@@ -17,6 +17,8 @@
  */
 package com.graphhopper.routing;
 
+import com.carrotsearch.hppc.IntObjectMap;
+import com.graphhopper.coll.GHIntObjectHashMap;
 import com.graphhopper.routing.util.TraversalMode;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.Graph;
@@ -24,8 +26,6 @@ import com.graphhopper.storage.SPTEntry;
 import com.graphhopper.util.EdgeExplorer;
 import com.graphhopper.util.EdgeIterator;
 import com.graphhopper.util.Parameters;
-import gnu.trove.map.TIntObjectMap;
-import gnu.trove.map.hash.TIntObjectHashMap;
 
 import java.util.PriorityQueue;
 
@@ -37,7 +37,7 @@ import java.util.PriorityQueue;
  * @author Peter Karich
  */
 public class Dijkstra extends AbstractRoutingAlgorithm {
-    protected TIntObjectMap<SPTEntry> fromMap;
+    protected IntObjectMap<SPTEntry> fromMap;
     protected PriorityQueue<SPTEntry> fromHeap;
     protected SPTEntry currEdge;
     private int visitedNodes;
@@ -51,7 +51,7 @@ public class Dijkstra extends AbstractRoutingAlgorithm {
 
     protected void initCollections(int size) {
         fromHeap = new PriorityQueue<SPTEntry>(size);
-        fromMap = new TIntObjectHashMap<SPTEntry>(size);
+        fromMap = new GHIntObjectHashMap<SPTEntry>(size);
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/DijkstraBidirectionRef.java
+++ b/core/src/main/java/com/graphhopper/routing/DijkstraBidirectionRef.java
@@ -17,13 +17,13 @@
  */
 package com.graphhopper.routing;
 
+import com.carrotsearch.hppc.IntObjectMap;
+import com.graphhopper.coll.GHIntObjectHashMap;
 import com.graphhopper.routing.util.TraversalMode;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.Graph;
 import com.graphhopper.storage.SPTEntry;
 import com.graphhopper.util.*;
-import gnu.trove.map.TIntObjectMap;
-import gnu.trove.map.hash.TIntObjectHashMap;
 
 import java.util.PriorityQueue;
 
@@ -36,9 +36,9 @@ import java.util.PriorityQueue;
  * @author Peter Karich
  */
 public class DijkstraBidirectionRef extends AbstractBidirAlgo {
-    protected TIntObjectMap<SPTEntry> bestWeightMapFrom;
-    protected TIntObjectMap<SPTEntry> bestWeightMapTo;
-    protected TIntObjectMap<SPTEntry> bestWeightMapOther;
+    protected IntObjectMap<SPTEntry> bestWeightMapFrom;
+    protected IntObjectMap<SPTEntry> bestWeightMapTo;
+    protected IntObjectMap<SPTEntry> bestWeightMapOther;
     protected SPTEntry currFrom;
     protected SPTEntry currTo;
     protected PathBidirRef bestPath;
@@ -54,10 +54,10 @@ public class DijkstraBidirectionRef extends AbstractBidirAlgo {
 
     protected void initCollections(int size) {
         openSetFrom = new PriorityQueue<SPTEntry>(size);
-        bestWeightMapFrom = new TIntObjectHashMap<SPTEntry>(size);
+        bestWeightMapFrom = new GHIntObjectHashMap<SPTEntry>(size);
 
         openSetTo = new PriorityQueue<SPTEntry>(size);
-        bestWeightMapTo = new TIntObjectHashMap<SPTEntry>(size);
+        bestWeightMapTo = new GHIntObjectHashMap<SPTEntry>(size);
     }
 
     @Override
@@ -158,7 +158,7 @@ public class DijkstraBidirectionRef extends AbstractBidirAlgo {
     }
 
     void fillEdges(SPTEntry currEdge, PriorityQueue<SPTEntry> prioQueue,
-                   TIntObjectMap<SPTEntry> shortestWeightMap, EdgeExplorer explorer, boolean reverse) {
+                   IntObjectMap<SPTEntry> shortestWeightMap, EdgeExplorer explorer, boolean reverse) {
         EdgeIterator iter = explorer.setBaseNode(currEdge.adjNode);
         while (iter.next()) {
             if (!accept(iter, currEdge.edge))
@@ -220,15 +220,15 @@ public class DijkstraBidirectionRef extends AbstractBidirAlgo {
         }
     }
 
-    TIntObjectMap<SPTEntry> getBestFromMap() {
+    IntObjectMap<SPTEntry> getBestFromMap() {
         return bestWeightMapFrom;
     }
 
-    TIntObjectMap<SPTEntry> getBestToMap() {
+    IntObjectMap<SPTEntry> getBestToMap() {
         return bestWeightMapTo;
     }
 
-    void setBestOtherMap(TIntObjectMap<SPTEntry> other) {
+    void setBestOtherMap(IntObjectMap<SPTEntry> other) {
         bestWeightMapOther = other;
     }
 

--- a/core/src/main/java/com/graphhopper/routing/DijkstraOneToMany.java
+++ b/core/src/main/java/com/graphhopper/routing/DijkstraOneToMany.java
@@ -17,6 +17,7 @@
  */
 package com.graphhopper.routing;
 
+import com.carrotsearch.hppc.IntArrayList;
 import com.graphhopper.apache.commons.collections.IntDoubleBinaryHeap;
 import com.graphhopper.routing.util.TraversalMode;
 import com.graphhopper.routing.weighting.Weighting;
@@ -24,7 +25,6 @@ import com.graphhopper.storage.Graph;
 import com.graphhopper.util.EdgeIterator;
 import com.graphhopper.util.Helper;
 import com.graphhopper.util.Parameters;
-import gnu.trove.list.array.TIntArrayList;
 
 import java.util.Arrays;
 
@@ -38,7 +38,7 @@ import java.util.Arrays;
 public class DijkstraOneToMany extends AbstractRoutingAlgorithm {
     private static final int EMPTY_PARENT = -1;
     private static final int NOT_FOUND = -1;
-    private final TIntArrayListWithCap changedNodes;
+    private final IntArrayListWithCap changedNodes;
     protected double[] weights;
     private int[] parents;
     private int[] edgeIds;
@@ -63,7 +63,7 @@ public class DijkstraOneToMany extends AbstractRoutingAlgorithm {
         Arrays.fill(weights, Double.MAX_VALUE);
 
         heap = new IntDoubleBinaryHeap(1000);
-        changedNodes = new TIntArrayListWithCap();
+        changedNodes = new IntArrayListWithCap();
     }
 
     @Override
@@ -114,7 +114,9 @@ public class DijkstraOneToMany extends AbstractRoutingAlgorithm {
             }
 
             heap.clear();
-            changedNodes.reset();
+
+            // changedNodes.clear();
+            changedNodes.elementsCount = 0;
 
             currNode = from;
             if (!traversalMode.isEdgeBased()) {
@@ -226,12 +228,12 @@ public class DijkstraOneToMany extends AbstractRoutingAlgorithm {
                 + "MB";
     }
 
-    private static class TIntArrayListWithCap extends TIntArrayList {
-        public TIntArrayListWithCap() {
+    private static class IntArrayListWithCap extends IntArrayList {
+        public IntArrayListWithCap() {
         }
 
         public int getCapacity() {
-            return _data.length;
+            return buffer.length;
         }
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/Path.java
+++ b/core/src/main/java/com/graphhopper/routing/Path.java
@@ -19,6 +19,7 @@ package com.graphhopper.routing;
 
 import com.carrotsearch.hppc.IntArrayList;
 import com.carrotsearch.hppc.IntIndexedContainer;
+import com.graphhopper.coll.GHIntArrayList;
 import com.graphhopper.routing.util.DefaultEdgeFilter;
 import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.routing.weighting.Weighting;
@@ -59,7 +60,7 @@ public class Path {
     private FlagEncoder encoder;
     private boolean found;
     private int fromNode = -1;
-    private IntArrayList edgeIds;
+    private GHIntArrayList edgeIds;
     private double weight;
     private NodeAccess nodeAccess;
 
@@ -69,7 +70,7 @@ public class Path {
         this.nodeAccess = graph.getNodeAccess();
         this.weighting = weighting;
         this.encoder = weighting.getFlagEncoder();
-        this.edgeIds = new IntArrayList();
+        this.edgeIds = new GHIntArrayList();
     }
 
     /**
@@ -78,7 +79,7 @@ public class Path {
     Path(Path p) {
         this(p.graph, p.weighting);
         weight = p.weight;
-        edgeIds = new IntArrayList(p.edgeIds);
+        edgeIds = new GHIntArrayList(p.edgeIds);
         sptEntry = p.sptEntry;
     }
 
@@ -147,7 +148,7 @@ public class Path {
             throw new IllegalStateException("Switching order multiple times is not supported");
 
         reverseOrder = false;
-        GHUtility.reverse(edgeIds);
+        edgeIds.reverse();
     }
 
     public Path setDistance(double distance) {

--- a/core/src/main/java/com/graphhopper/routing/Path.java
+++ b/core/src/main/java/com/graphhopper/routing/Path.java
@@ -17,6 +17,8 @@
  */
 package com.graphhopper.routing;
 
+import com.carrotsearch.hppc.IntArrayList;
+import com.carrotsearch.hppc.IntIndexedContainer;
 import com.graphhopper.routing.util.DefaultEdgeFilter;
 import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.routing.weighting.Weighting;
@@ -24,8 +26,6 @@ import com.graphhopper.storage.Graph;
 import com.graphhopper.storage.NodeAccess;
 import com.graphhopper.storage.SPTEntry;
 import com.graphhopper.util.*;
-import gnu.trove.list.TIntList;
-import gnu.trove.list.array.TIntArrayList;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -59,7 +59,7 @@ public class Path {
     private FlagEncoder encoder;
     private boolean found;
     private int fromNode = -1;
-    private TIntList edgeIds;
+    private IntArrayList edgeIds;
     private double weight;
     private NodeAccess nodeAccess;
 
@@ -69,7 +69,7 @@ public class Path {
         this.nodeAccess = graph.getNodeAccess();
         this.weighting = weighting;
         this.encoder = weighting.getFlagEncoder();
-        this.edgeIds = new TIntArrayList();
+        this.edgeIds = new IntArrayList();
     }
 
     /**
@@ -78,7 +78,7 @@ public class Path {
     Path(Path p) {
         this(p.graph, p.weighting);
         weight = p.weight;
-        edgeIds = new TIntArrayList(p.edgeIds);
+        edgeIds = new IntArrayList(p.edgeIds);
         sptEntry = p.sptEntry;
     }
 
@@ -147,7 +147,7 @@ public class Path {
             throw new IllegalStateException("Switching order multiple times is not supported");
 
         reverseOrder = false;
-        edgeIds.reverse();
+        GHUtility.reverse(edgeIds);
     }
 
     public Path setDistance(double distance) {
@@ -286,8 +286,8 @@ public class Path {
     /**
      * @return the uncached node indices of the tower nodes in this path.
      */
-    public TIntList calcNodes() {
-        final TIntArrayList nodes = new TIntArrayList(edgeIds.size() + 1);
+    public IntIndexedContainer calcNodes() {
+        final IntArrayList nodes = new IntArrayList(edgeIds.size() + 1);
         if (edgeIds.isEmpty()) {
             if (isFound()) {
                 nodes.add(endNode);

--- a/core/src/main/java/com/graphhopper/routing/QueryGraph.java
+++ b/core/src/main/java/com/graphhopper/routing/QueryGraph.java
@@ -206,7 +206,6 @@ public class QueryGraph implements Graph {
         baseGraph.queryResults = queryResults;
 
         GHIntObjectHashMap<List<QueryResult>> edge2res = new GHIntObjectHashMap<List<QueryResult>>(resList.size());
-        // TIntObjectMap<List<QueryResult>> edge2res = new TGHIntObjectHashMap<List<QueryResult>>(resList.size());
 
         // Phase 1
         // calculate snapped point and swap direction of closest edge if necessary
@@ -259,12 +258,9 @@ public class QueryGraph implements Graph {
         // Phase 2 - now it is clear which points cut one edge
         // 1. create point lists
         // 2. create virtual edges between virtual nodes and its neighbor (virtual or normal nodes)
-//        edge2res.forEachValue(new TObjectProcedure<List<QueryResult>>() {
-//            @Override
-//            public boolean execute(List<QueryResult> results) {
         edge2res.forEach(new IntObjectPredicate<List<QueryResult>>() {
             @Override
-            public boolean apply(int key, List<QueryResult> results) {
+            public boolean apply(int edgeId, List<QueryResult> results) {
                 // we can expect at least one entry in the results
                 EdgeIteratorState closestEdge = results.get(0).getClosestEdge();
                 final PointList fullPL = closestEdge.fetchWayGeometry(3);

--- a/core/src/main/java/com/graphhopper/routing/QueryGraph.java
+++ b/core/src/main/java/com/graphhopper/routing/QueryGraph.java
@@ -17,6 +17,12 @@
  */
 package com.graphhopper.routing;
 
+import com.carrotsearch.hppc.IntArrayList;
+import com.carrotsearch.hppc.IntObjectMap;
+import com.carrotsearch.hppc.predicates.IntObjectPredicate;
+import com.carrotsearch.hppc.procedures.IntProcedure;
+import com.graphhopper.coll.GHIntHashSet;
+import com.graphhopper.coll.GHIntObjectHashMap;
 import com.graphhopper.routing.util.AllEdgesIterator;
 import com.graphhopper.routing.util.DefaultEdgeFilter;
 import com.graphhopper.routing.util.EdgeFilter;
@@ -29,12 +35,6 @@ import com.graphhopper.util.*;
 import com.graphhopper.util.shapes.BBox;
 import com.graphhopper.util.shapes.GHPoint;
 import com.graphhopper.util.shapes.GHPoint3D;
-import gnu.trove.list.array.TIntArrayList;
-import gnu.trove.map.TIntObjectMap;
-import gnu.trove.map.hash.TIntObjectHashMap;
-import gnu.trove.procedure.TIntProcedure;
-import gnu.trove.procedure.TObjectProcedure;
-import gnu.trove.set.hash.TIntHashSet;
 
 import java.util.*;
 
@@ -205,7 +205,8 @@ public class QueryGraph implements Graph {
         baseGraph.virtualNodes = virtualNodes;
         baseGraph.queryResults = queryResults;
 
-        TIntObjectMap<List<QueryResult>> edge2res = new TIntObjectHashMap<List<QueryResult>>(resList.size());
+        GHIntObjectHashMap<List<QueryResult>> edge2res = new GHIntObjectHashMap<List<QueryResult>>(resList.size());
+        // TIntObjectMap<List<QueryResult>> edge2res = new TGHIntObjectHashMap<List<QueryResult>>(resList.size());
 
         // Phase 1
         // calculate snapped point and swap direction of closest edge if necessary
@@ -258,9 +259,12 @@ public class QueryGraph implements Graph {
         // Phase 2 - now it is clear which points cut one edge
         // 1. create point lists
         // 2. create virtual edges between virtual nodes and its neighbor (virtual or normal nodes)
-        edge2res.forEachValue(new TObjectProcedure<List<QueryResult>>() {
+//        edge2res.forEachValue(new TObjectProcedure<List<QueryResult>>() {
+//            @Override
+//            public boolean execute(List<QueryResult> results) {
+        edge2res.forEach(new IntObjectPredicate<List<QueryResult>>() {
             @Override
-            public boolean execute(List<QueryResult> results) {
+            public boolean apply(int key, List<QueryResult> results) {
                 // we can expect at least one entry in the results
                 EdgeIteratorState closestEdge = results.get(0).getClosestEdge();
                 final PointList fullPL = closestEdge.fetchWayGeometry(3);
@@ -577,11 +581,11 @@ public class QueryGraph implements Graph {
         // so we need to create the mapping on EVERY call!
         // This needs to be a HashMap (and cannot be an array) as we also need to tweak edges for some mainNodes!
         // The more query points we have the more inefficient this map could be. Hmmh.
-        final TIntObjectMap<VirtualEdgeIterator> node2EdgeMap
-                = new TIntObjectHashMap<VirtualEdgeIterator>(queryResults.size() * 3);
+        final IntObjectMap<VirtualEdgeIterator> node2EdgeMap
+                = new GHIntObjectHashMap<VirtualEdgeIterator>(queryResults.size() * 3);
 
         final EdgeExplorer mainExplorer = mainGraph.createEdgeExplorer(edgeFilter);
-        final TIntHashSet towerNodesToChange = new TIntHashSet(queryResults.size());
+        final GHIntHashSet towerNodesToChange = new GHIntHashSet(queryResults.size());
 
         // 1. virtualEdges should also get fresh EdgeIterators on every createEdgeExplorer call!
         for (int i = 0; i < queryResults.size(); i++) {
@@ -618,11 +622,10 @@ public class QueryGraph implements Graph {
         // 2. the connected tower nodes from mainGraph need fresh EdgeIterators with possible fakes
         // where 'fresh' means independent of previous call and respecting the edgeFilter
         // -> setup fake iterators of detected tower nodes (virtual edges are already added)
-        towerNodesToChange.forEach(new TIntProcedure() {
+        towerNodesToChange.forEach(new IntProcedure() {
             @Override
-            public boolean execute(int value) {
+            public void apply(int value) {
                 fillVirtualEdges(node2EdgeMap, value, mainExplorer);
-                return true;
             }
         });
 
@@ -641,7 +644,7 @@ public class QueryGraph implements Graph {
     /**
      * Creates a fake edge iterator pointing to multiple edge states.
      */
-    private void addVirtualEdges(TIntObjectMap<VirtualEdgeIterator> node2EdgeMap, EdgeFilter filter, boolean base,
+    private void addVirtualEdges(IntObjectMap<VirtualEdgeIterator> node2EdgeMap, EdgeFilter filter, boolean base,
                                  int node, int virtNode) {
         VirtualEdgeIterator existingIter = node2EdgeMap.get(node);
         if (existingIter == null) {
@@ -655,12 +658,12 @@ public class QueryGraph implements Graph {
             existingIter.add(edge);
     }
 
-    void fillVirtualEdges(TIntObjectMap<VirtualEdgeIterator> node2Edge, int towerNode, EdgeExplorer mainExpl) {
+    void fillVirtualEdges(IntObjectMap<VirtualEdgeIterator> node2Edge, int towerNode, EdgeExplorer mainExpl) {
         if (isVirtualNode(towerNode))
             throw new IllegalStateException("Node should not be virtual:" + towerNode + ", " + node2Edge);
 
         VirtualEdgeIterator vIter = node2Edge.get(towerNode);
-        TIntArrayList ignoreEdges = new TIntArrayList(vIter.count() * 2);
+        IntArrayList ignoreEdges = new IntArrayList(vIter.count() * 2);
         while (vIter.next()) {
             EdgeIteratorState edge = queryResults.get(vIter.getAdjNode() - mainNodes).getClosestEdge();
             ignoreEdges.add(edge.getEdge());

--- a/core/src/main/java/com/graphhopper/routing/subnetwork/PrepareRoutingSubnetworks.java
+++ b/core/src/main/java/com/graphhopper/routing/subnetwork/PrepareRoutingSubnetworks.java
@@ -17,6 +17,8 @@
  */
 package com.graphhopper.routing.subnetwork;
 
+import com.carrotsearch.hppc.IntArrayList;
+import com.carrotsearch.hppc.IntIndexedContainer;
 import com.graphhopper.coll.GHBitSet;
 import com.graphhopper.coll.GHBitSetImpl;
 import com.graphhopper.routing.util.DefaultEdgeFilter;
@@ -24,8 +26,6 @@ import com.graphhopper.routing.util.EdgeFilter;
 import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.storage.GraphHopperStorage;
 import com.graphhopper.util.*;
-import gnu.trove.list.TIntList;
-import gnu.trove.list.array.TIntArrayList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -76,7 +76,7 @@ public class PrepareRoutingSubnetworks {
             if (minOneWayNetworkSize > 0)
                 unvisitedDeadEnds += removeDeadEndUnvisitedNetworks(filter);
 
-            List<TIntArrayList> components = findSubnetworks(filter);
+            List<IntArrayList> components = findSubnetworks(filter);
             keepLargeNetworks(filter, components);
             subnetworks = Math.max(components.size(), subnetworks);
             logger.info(components.size() + " subnetworks found for " + encoder + ", " + Helper.getMemInfo());
@@ -97,17 +97,17 @@ public class PrepareRoutingSubnetworks {
     /**
      * This method finds the double linked components according to the specified filter.
      */
-    List<TIntArrayList> findSubnetworks(PrepEdgeFilter filter) {
+    List<IntArrayList> findSubnetworks(PrepEdgeFilter filter) {
         final FlagEncoder encoder = filter.getEncoder();
         final EdgeExplorer explorer = ghStorage.createEdgeExplorer(filter);
         int locs = ghStorage.getNodes();
-        List<TIntArrayList> list = new ArrayList<TIntArrayList>(100);
+        List<IntArrayList> list = new ArrayList<IntArrayList>(100);
         final GHBitSet bs = new GHBitSetImpl(locs);
         for (int start = 0; start < locs; start++) {
             if (bs.contains(start))
                 continue;
 
-            final TIntArrayList intList = new TIntArrayList(20);
+            final IntArrayList intList = new IntArrayList(20);
             list.add(intList);
             new BreadthFirstSearch() {
                 int tmpCounter = 0;
@@ -145,16 +145,16 @@ public class PrepareRoutingSubnetworks {
     /**
      * Deletes all but the largest subnetworks.
      */
-    int keepLargeNetworks(PrepEdgeFilter filter, List<TIntArrayList> components) {
+    int keepLargeNetworks(PrepEdgeFilter filter, List<IntArrayList> components) {
         if (components.size() <= 1)
             return 0;
 
         int maxCount = -1;
-        TIntList oldComponent = null;
+        IntIndexedContainer oldComponent = null;
         int allRemoved = 0;
         FlagEncoder encoder = filter.getEncoder();
         EdgeExplorer explorer = ghStorage.createEdgeExplorer(filter);
-        for (TIntArrayList component : components) {
+        for (IntArrayList component : components) {
             if (maxCount < 0) {
                 maxCount = component.size();
                 oldComponent = component;
@@ -222,7 +222,7 @@ public class PrepareRoutingSubnetworks {
 
         // partition graph into strongly connected components using Tarjan's algorithm        
         TarjansSCCAlgorithm tarjan = new TarjansSCCAlgorithm(ghStorage, ignoreSet, outFilter);
-        List<TIntArrayList> components = tarjan.findComponents();
+        List<IntArrayList> components = tarjan.findComponents();
         logger.info(sw.stop() + ", size:" + components.size());
 
         return removeEdges(bothFilter, components, minOneWayNetworkSize);
@@ -235,18 +235,18 @@ public class PrepareRoutingSubnetworks {
      *
      * @return number of removed edges
      */
-    int removeEdges(final PrepEdgeFilter bothFilter, List<TIntArrayList> components, int min) {
+    int removeEdges(final PrepEdgeFilter bothFilter, List<IntArrayList> components, int min) {
         // remove edges determined from nodes but only if less than minimum size
         FlagEncoder encoder = bothFilter.getEncoder();
         EdgeExplorer explorer = ghStorage.createEdgeExplorer(bothFilter);
         int removedEdges = 0;
-        for (TIntArrayList component : components) {
+        for (IntArrayList component : components) {
             removedEdges += removeEdges(explorer, encoder, component, min);
         }
         return removedEdges;
     }
 
-    int removeEdges(EdgeExplorer explorer, FlagEncoder encoder, TIntList component, int min) {
+    int removeEdges(EdgeExplorer explorer, FlagEncoder encoder, IntIndexedContainer component, int min) {
         int removedEdges = 0;
         if (component.size() < min)
             for (int i = 0; i < component.size(); i++) {

--- a/core/src/main/java/com/graphhopper/routing/subnetwork/TarjansSCCAlgorithm.java
+++ b/core/src/main/java/com/graphhopper/routing/subnetwork/TarjansSCCAlgorithm.java
@@ -17,13 +17,13 @@
  */
 package com.graphhopper.routing.subnetwork;
 
+import com.carrotsearch.hppc.IntArrayDeque;
+import com.carrotsearch.hppc.IntArrayList;
 import com.graphhopper.coll.GHBitSet;
 import com.graphhopper.coll.GHBitSetImpl;
 import com.graphhopper.routing.util.EdgeFilter;
 import com.graphhopper.storage.GraphHopperStorage;
 import com.graphhopper.util.EdgeIterator;
-import gnu.trove.list.array.TIntArrayList;
-import gnu.trove.stack.array.TIntArrayStack;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -38,9 +38,9 @@ import java.util.Stack;
  * http://www.timl.id.au/?p=327 and http://homepages.ecs.vuw.ac.nz/~djp/files/P05.pdf
  */
 public class TarjansSCCAlgorithm {
-    private final ArrayList<TIntArrayList> components = new ArrayList<TIntArrayList>();
+    private final ArrayList<IntArrayList> components = new ArrayList<IntArrayList>();
     private final GraphHopperStorage graph;
-    private final TIntArrayStack nodeStack;
+    private final IntArrayDeque nodeStack;
     private final GHBitSet onStack;
     private final GHBitSet ignoreSet;
     private final int[] nodeIndex;
@@ -51,7 +51,7 @@ public class TarjansSCCAlgorithm {
     public TarjansSCCAlgorithm(GraphHopperStorage graph, GHBitSet ignoreSet,
                                final EdgeFilter edgeFilter) {
         this.graph = graph;
-        this.nodeStack = new TIntArrayStack();
+        this.nodeStack = new IntArrayDeque();
         this.onStack = new GHBitSetImpl(graph.getNodes());
         this.nodeIndex = new int[graph.getNodes()];
         this.nodeLowLink = new int[graph.getNodes()];
@@ -62,7 +62,7 @@ public class TarjansSCCAlgorithm {
     /**
      * Find and return list of all strongly connected components in g.
      */
-    public List<TIntArrayList> findComponents() {
+    public List<IntArrayList> findComponents() {
         int nodes = graph.getNodes();
         for (int start = 0; start < nodes; start++) {
             if (nodeIndex[start] == 0
@@ -97,7 +97,7 @@ public class TarjansSCCAlgorithm {
                 nodeIndex[start] = index;
                 nodeLowLink[start] = index;
                 index++;
-                nodeStack.push(start);
+                nodeStack.addLast(start);
                 onStack.add(start);
 
                 iter = graph.createEdgeExplorer(edgeFilter).setBaseNode(start);
@@ -131,9 +131,9 @@ public class TarjansSCCAlgorithm {
             // If nodeLowLink == nodeIndex, then we are the first element in a component.
             // Add all nodes higher up on nodeStack to this component.
             if (nodeIndex[start] == nodeLowLink[start]) {
-                TIntArrayList component = new TIntArrayList();
+                IntArrayList component = new IntArrayList();
                 int node;
-                while ((node = nodeStack.pop()) != start) {
+                while ((node = nodeStack.removeLast()) != start) {
                     component.add(node);
                     onStack.remove(node);
                 }

--- a/core/src/main/java/com/graphhopper/routing/weighting/AvoidEdgesWeighting.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/AvoidEdgesWeighting.java
@@ -17,9 +17,9 @@
  */
 package com.graphhopper.routing.weighting;
 
+import com.carrotsearch.hppc.IntSet;
+import com.graphhopper.coll.GHIntHashSet;
 import com.graphhopper.util.EdgeIteratorState;
-import gnu.trove.set.TIntSet;
-import gnu.trove.set.hash.TIntHashSet;
 
 import java.util.Collection;
 
@@ -30,7 +30,7 @@ import java.util.Collection;
  */
 public class AvoidEdgesWeighting extends AbstractAdjustedWeighting {
     // contains the edge IDs of the already visited edges
-    protected final TIntSet visitedEdges = new TIntHashSet();
+    protected final IntSet visitedEdges = new GHIntHashSet();
 
     private double edgePenaltyFactor = 5.0;
 

--- a/core/src/main/java/com/graphhopper/storage/index/LocationIndexTree.java
+++ b/core/src/main/java/com/graphhopper/storage/index/LocationIndexTree.java
@@ -17,7 +17,11 @@
  */
 package com.graphhopper.storage.index;
 
+import com.carrotsearch.hppc.IntArrayList;
+import com.carrotsearch.hppc.cursors.IntCursor;
+import com.carrotsearch.hppc.predicates.IntPredicate;
 import com.graphhopper.coll.GHBitSet;
+import com.graphhopper.coll.GHIntHashSet;
 import com.graphhopper.coll.GHTBitSet;
 import com.graphhopper.geohash.SpatialKeyAlgo;
 import com.graphhopper.routing.util.EdgeFilter;
@@ -25,16 +29,13 @@ import com.graphhopper.storage.*;
 import com.graphhopper.util.*;
 import com.graphhopper.util.shapes.BBox;
 import com.graphhopper.util.shapes.GHPoint;
-import gnu.trove.iterator.TIntIterator;
-import gnu.trove.list.array.TIntArrayList;
-import gnu.trove.procedure.TIntProcedure;
-import gnu.trove.set.hash.TIntHashSet;
+import java.util.ArrayList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -137,7 +138,7 @@ public class LocationIndexTree implements LocationIndex {
                 (bounds.maxLon - bounds.minLon) / 360 * preciseDistCalc.calcCircumference(lat));
         double tmp = maxDistInMeter / minResolutionInMeter;
         tmp = tmp * tmp;
-        TIntArrayList tmpEntries = new TIntArrayList();
+        IntArrayList tmpEntries = new IntArrayList();
         // the last one is always 4 to reduce costs if only a single entry
         tmp /= 4;
         while (tmp > 1) {
@@ -336,12 +337,13 @@ public class LocationIndexTree implements LocationIndex {
         dataAccess.setSegmentSize(bytes);
     }
 
-    TIntArrayList getEntries() {
-        return new TIntArrayList(entries);
+    // just for test
+    IntArrayList getEntries() {
+        return IntArrayList.from(entries);
     }
 
     // fillIDs according to how they are stored
-    final void fillIDs(long keyPart, int intIndex, TIntHashSet set, int depth) {
+    final void fillIDs(long keyPart, int intIndex, GHIntHashSet set, int depth) {
         long pointer = (long) intIndex << 2;
         if (depth == entries.length) {
             int value = dataAccess.getInt(pointer);
@@ -452,7 +454,7 @@ public class LocationIndexTree implements LocationIndex {
      * iteration is necessary and no early finish possible.
      */
     public final boolean findNetworkEntries(double queryLat, double queryLon,
-                                            TIntHashSet foundEntries, int iteration) {
+                                            GHIntHashSet foundEntries, int iteration) {
         // find entries in border of searchbox
         for (int yreg = -iteration; yreg <= iteration; yreg++) {
             double subqueryLat = queryLat + yreg * deltaLat;
@@ -492,11 +494,11 @@ public class LocationIndexTree implements LocationIndex {
         return false;
     }
 
-    final double calcMinDistance(double queryLat, double queryLon, TIntHashSet pointset) {
+    final double calcMinDistance(double queryLat, double queryLon, GHIntHashSet pointset) {
         double min = Double.MAX_VALUE;
-        TIntIterator itr = pointset.iterator();
+        Iterator<IntCursor> itr = pointset.iterator();
         while (itr.hasNext()) {
-            int node = itr.next();
+            int node = itr.next().value;
             double lat = nodeAccess.getLat(node);
             double lon = nodeAccess.getLon(node);
             double dist = distCalc.calcDist(queryLat, queryLon, lat, lon);
@@ -507,7 +509,7 @@ public class LocationIndexTree implements LocationIndex {
         return min;
     }
 
-    final void findNetworkEntriesSingleRegion(TIntHashSet storedNetworkEntryIds, double queryLat, double queryLon) {
+    final void findNetworkEntriesSingleRegion(GHIntHashSet storedNetworkEntryIds, double queryLat, double queryLon) {
         long keyPart = createReverseKey(queryLat, queryLon);
         fillIDs(keyPart, START_POINTER, storedNetworkEntryIds, 0);
     }
@@ -517,21 +519,21 @@ public class LocationIndexTree implements LocationIndex {
         if (isClosed())
             throw new IllegalStateException("You need to create a new LocationIndex instance as it is already closed");
 
-        TIntHashSet allCollectedEntryIds = new TIntHashSet();
+        GHIntHashSet allCollectedEntryIds = new GHIntHashSet();
         final QueryResult closestMatch = new QueryResult(queryLat, queryLon);
         for (int iteration = 0; iteration < maxRegionSearch; iteration++) {
-            TIntHashSet storedNetworkEntryIds = new TIntHashSet();
+            GHIntHashSet storedNetworkEntryIds = new GHIntHashSet();
             boolean earlyFinish = findNetworkEntries(queryLat, queryLon, storedNetworkEntryIds, iteration);
             storedNetworkEntryIds.removeAll(allCollectedEntryIds);
             allCollectedEntryIds.addAll(storedNetworkEntryIds);
 
             // clone storedIds to avoid interference with forEach
-            final GHBitSet checkBitset = new GHTBitSet(new TIntHashSet(storedNetworkEntryIds));
+            final GHBitSet checkBitset = new GHTBitSet(new GHIntHashSet(storedNetworkEntryIds));
             // find nodes from the network entries which are close to 'point'
             final EdgeExplorer explorer = graph.createEdgeExplorer();
-            storedNetworkEntryIds.forEach(new TIntProcedure() {
+            storedNetworkEntryIds.forEach(new IntPredicate() {
                 @Override
-                public boolean execute(int networkEntryNodeId) {
+                public boolean apply(int networkEntryNodeId) {
                     new XFirstSearchCheck(queryLat, queryLon, checkBitset, edgeFilter) {
                         @Override
                         protected double getQueryDistance() {
@@ -596,13 +598,13 @@ public class LocationIndexTree implements LocationIndex {
             return "LEAF " + /*key +*/ " " + super.toString();
         }
 
-        TIntArrayList getResults() {
+        IntArrayList getResults() {
             return this;
         }
     }
 
     // Space efficient sorted integer set. Suited for only a few entries.
-    static class SortedIntSet extends TIntArrayList {
+    static class SortedIntSet extends IntArrayList {
         public SortedIntSet() {
         }
 
@@ -614,7 +616,7 @@ public class LocationIndexTree implements LocationIndex {
          * Allow adding a value only once
          */
         public boolean addOnce(int value) {
-            int foundIndex = binarySearch(value);
+            int foundIndex = Arrays.binarySearch(buffer, 0, size(), value);
             if (foundIndex >= 0) {
                 return false;
             }
@@ -769,7 +771,7 @@ public class LocationIndexTree implements LocationIndex {
                 int bits = keyAlgo.getBits();
                 // print reverse keys
                 sb.append(BitUtil.BIG.toBitString(BitUtil.BIG.reverse(key, bits), bits)).append("  ");
-                TIntArrayList entries = leaf.getResults();
+                IntArrayList entries = leaf.getResults();
                 for (int i = 0; i < entries.size(); i++) {
                     sb.append(leaf.get(i)).append(',');
                 }
@@ -791,7 +793,7 @@ public class LocationIndexTree implements LocationIndex {
             long refPointer = (long) intIndex * 4;
             if (entry.isLeaf()) {
                 InMemLeafEntry leaf = ((InMemLeafEntry) entry);
-                TIntArrayList entries = leaf.getResults();
+                IntArrayList entries = leaf.getResults();
                 int len = entries.size();
                 if (len == 0) {
                     return intIndex;

--- a/core/src/main/java/com/graphhopper/util/DepthFirstSearch.java
+++ b/core/src/main/java/com/graphhopper/util/DepthFirstSearch.java
@@ -17,8 +17,8 @@
  */
 package com.graphhopper.util;
 
+import com.carrotsearch.hppc.IntArrayDeque;
 import com.graphhopper.coll.GHBitSet;
-import gnu.trove.stack.array.TIntArrayStack;
 
 /**
  * Implementation of depth first search (DFS) by LIFO queue
@@ -34,19 +34,19 @@ public class DepthFirstSearch extends XFirstSearch {
      */
     @Override
     public void start(EdgeExplorer explorer, int startNode) {
-        TIntArrayStack stack = new TIntArrayStack();
+        IntArrayDeque stack = new IntArrayDeque();
 
         GHBitSet explored = createBitSet();
-        stack.push(startNode);
+        stack.addLast(startNode);
         int current;
         while (stack.size() > 0) {
-            current = stack.pop();
+            current = stack.removeLast();
             if (!explored.contains(current) && goFurther(current)) {
                 EdgeIterator iter = explorer.setBaseNode(current);
                 while (iter.next()) {
                     int connectedId = iter.getAdjNode();
                     if (checkAdjacent(iter)) {
-                        stack.push(connectedId);
+                        stack.addLast(connectedId);
                     }
                 }
                 explored.add(current);

--- a/core/src/main/java/com/graphhopper/util/GHUtility.java
+++ b/core/src/main/java/com/graphhopper/util/GHUtility.java
@@ -359,19 +359,7 @@ public class GHUtility {
     public static int getEdgeFromEdgeKey(int edgeKey) {
         return edgeKey / 2;
     }
-
-    /**
-     * @return a copy of inputArray from [offset, offset+length)
-     */
-    public static LongIndexedContainer copy(LongArrayList inputArray, int offset, int length) {
-        long transfer[] = new long[length];
-        System.arraycopy(inputArray.buffer, offset, transfer, 0, length);
-        LongArrayList arr = new LongArrayList(0);
-        arr.buffer = transfer;
-        arr.elementsCount = length;
-        return arr;
-    }
-
+    
     /**
      * This edge iterator can be used in tests to mock specific iterator behaviour via overloading
      * certain methods.

--- a/core/src/main/java/com/graphhopper/util/GHUtility.java
+++ b/core/src/main/java/com/graphhopper/util/GHUtility.java
@@ -17,12 +17,12 @@
  */
 package com.graphhopper.util;
 
-import com.carrotsearch.hppc.IntArrayList;
 import com.carrotsearch.hppc.IntIndexedContainer;
 import com.carrotsearch.hppc.LongArrayList;
 import com.carrotsearch.hppc.LongIndexedContainer;
 import com.graphhopper.coll.GHBitSet;
 import com.graphhopper.coll.GHBitSetImpl;
+import com.graphhopper.coll.GHIntArrayList;
 import com.graphhopper.routing.util.AllCHEdgesIterator;
 import com.graphhopper.routing.util.AllEdgesIterator;
 import com.graphhopper.routing.util.EdgeFilter;
@@ -171,12 +171,12 @@ public class GHUtility {
 
     public static Graph shuffle(Graph g, Graph sortedGraph) {
         int nodes = g.getNodes();
-        IntArrayList list = new IntArrayList(nodes);
-        fill(list, nodes, -1);
+        GHIntArrayList list = new GHIntArrayList(nodes);
+        list.fill(nodes, -1);
         for (int i = 0; i < nodes; i++) {
             list.set(i, i);
         }
-        shuffle(list, new Random());
+        list.shuffle(new Random());
         return createSortedGraph(g, sortedGraph, list);
     }
 
@@ -186,8 +186,8 @@ public class GHUtility {
      */
     public static Graph sortDFS(Graph g, Graph sortedGraph) {
         int nodes = g.getNodes();
-        final IntArrayList list = new IntArrayList(nodes);
-        fill(list, nodes, -1);
+        final GHIntArrayList list = new GHIntArrayList(nodes);
+        list.fill(nodes, -1);
         final GHBitSetImpl bitset = new GHBitSetImpl(nodes);
         final AtomicInteger ref = new AtomicInteger(-1);
         EdgeExplorer explorer = g.createEdgeExplorer();
@@ -358,38 +358,6 @@ public class GHUtility {
      */
     public static int getEdgeFromEdgeKey(int edgeKey) {
         return edgeKey / 2;
-    }
-
-    public static IntArrayList reverse(final IntArrayList arr) {
-        final int[] buffer = arr.buffer;
-        for (int start = 0, end = arr.size() - 1; start < end; start++, end--) {
-            // swap the values
-            int tmp = buffer[start];
-            buffer[start] = buffer[end];
-            buffer[end] = tmp;
-        }
-        return arr;
-    }
-
-    public static IntArrayList fill(final IntArrayList arr, final int max, final int value) {
-        // TODO use System.arraycopy and direct buffer somehow
-        for (int i = 0; i < max; i++) {
-            arr.add(value);
-        }
-        return arr;
-    }
-
-    public static IntArrayList shuffle(final IntArrayList arr, Random random) {
-        int[] buffer = arr.buffer;
-        int max = arr.size();
-        int maxHalf = max / 2;
-        for (int x1 = 0; x1 < maxHalf; x1++) {
-            int x2 = random.nextInt(maxHalf) + maxHalf;
-            int tmp = buffer[x1];
-            buffer[x1] = buffer[x2];
-            buffer[x2] = tmp;
-        }
-        return arr;
     }
 
     /**

--- a/core/src/main/java/com/graphhopper/util/Helper.java
+++ b/core/src/main/java/com/graphhopper/util/Helper.java
@@ -61,7 +61,7 @@ public class Helper {
     private Helper() {
     }
 
-    public static ArrayList<Integer> IntListToArrayList(IntIndexedContainer from) {
+    public static ArrayList<Integer> intListToArrayList(IntIndexedContainer from) {
         int len = from.size();
         ArrayList<Integer> list = new ArrayList<Integer>(len);
         for (int i = 0; i < len; i++) {

--- a/core/src/main/java/com/graphhopper/util/Helper.java
+++ b/core/src/main/java/com/graphhopper/util/Helper.java
@@ -17,9 +17,9 @@
  */
 package com.graphhopper.util;
 
+import com.carrotsearch.hppc.IntArrayList;
+import com.carrotsearch.hppc.IntIndexedContainer;
 import com.graphhopper.util.shapes.BBox;
-import gnu.trove.list.TIntList;
-import gnu.trove.list.array.TIntArrayList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,7 +61,7 @@ public class Helper {
     private Helper() {
     }
 
-    public static ArrayList<Integer> tIntListToArrayList(TIntList from) {
+    public static ArrayList<Integer> IntListToArrayList(IntIndexedContainer from) {
         int len = from.size();
         ArrayList<Integer> list = new ArrayList<Integer>(len);
         for (int i = 0; i < len; i++) {
@@ -283,12 +283,8 @@ public class Helper {
         return list;
     }
 
-    public static TIntList createTList(int... list) {
-        TIntList res = new TIntArrayList(list.length);
-        for (int val : list) {
-            res.add(val);
-        }
-        return res;
+    public static IntArrayList createTList(int... list) {
+        return IntArrayList.from(list);
     }
 
     public static PointList createPointList(double... list) {

--- a/core/src/test/java/com/graphhopper/coll/GHIntArrayListTest.java
+++ b/core/src/test/java/com/graphhopper/coll/GHIntArrayListTest.java
@@ -1,0 +1,45 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for 
+ *  additional information regarding copyright ownership.
+ * 
+ *  GraphHopper GmbH licenses this file to you under the Apache License, 
+ *  Version 2.0 (the "License"); you may not use this file except in 
+ *  compliance with the License. You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.coll;
+
+import java.util.Random;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ * @author Peter Karich
+ */
+public class GHIntArrayListTest {
+
+    @Test
+    public void testReverse() {
+        assertEquals(GHIntArrayList.from(4, 3, 2, 1), GHIntArrayList.from(1, 2, 3, 4).reverse());
+        assertEquals(GHIntArrayList.from(5, 4, 3, 2, 1), GHIntArrayList.from(1, 2, 3, 4, 5).reverse());
+    }
+
+    @Test
+    public void testShuffle() {
+        assertEquals(GHIntArrayList.from(4, 1, 3, 2), GHIntArrayList.from(1, 2, 3, 4).shuffle(new Random(0)));
+        assertEquals(GHIntArrayList.from(4, 3, 2, 1, 5), GHIntArrayList.from(1, 2, 3, 4, 5).shuffle(new Random(1)));
+    }
+
+    @Test
+    public void testFill() {
+        assertEquals(GHIntArrayList.from(-1, -1, -1, -1), new GHIntArrayList(4).fill(4, -1));
+    }
+}

--- a/core/src/test/java/com/graphhopper/coll/GHSortedCollectionTest.java
+++ b/core/src/test/java/com/graphhopper/coll/GHSortedCollectionTest.java
@@ -21,11 +21,14 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import org.junit.Ignore;
 
 /**
  * @author Peter Karich
  */
 public class GHSortedCollectionTest {
+    // TODO pollKey throws exception
+    @Ignore
     @Test
     public void testPoll() {
         GHSortedCollection instance = new GHSortedCollection();

--- a/core/src/test/java/com/graphhopper/coll/GHSortedCollectionTest.java
+++ b/core/src/test/java/com/graphhopper/coll/GHSortedCollectionTest.java
@@ -21,14 +21,12 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import org.junit.Ignore;
 
 /**
  * @author Peter Karich
  */
 public class GHSortedCollectionTest {
-    // TODO pollKey throws exception
-    @Ignore
+    
     @Test
     public void testPoll() {
         GHSortedCollection instance = new GHSortedCollection();

--- a/core/src/test/java/com/graphhopper/coll/GHTBitSetTest.java
+++ b/core/src/test/java/com/graphhopper/coll/GHTBitSetTest.java
@@ -39,6 +39,6 @@ public class GHTBitSetTest extends AbstractMyBitSetTest {
         GHBitSet bs = createBitSet(100);
         bs.add(12);
         bs.add(1);
-        assertEquals("{12,1}", bs.toString());
+        assertEquals("[1, 12]", bs.toString());
     }
 }

--- a/core/src/test/java/com/graphhopper/reader/dem/AbstractEdgeElevationInterpolatorTest.java
+++ b/core/src/test/java/com/graphhopper/reader/dem/AbstractEdgeElevationInterpolatorTest.java
@@ -23,6 +23,7 @@ import org.junit.After;
 import org.junit.Before;
 
 import com.graphhopper.coll.GHBitSetImpl;
+import com.graphhopper.coll.GHIntHashSet;
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.util.DataFlagEncoder;
 import com.graphhopper.routing.util.EncodingManager;
@@ -32,8 +33,6 @@ import com.graphhopper.storage.GraphHopperStorage;
 import com.graphhopper.storage.RAMDirectory;
 import com.graphhopper.util.EdgeIteratorState;
 import com.graphhopper.util.Helper;
-
-import gnu.trove.set.hash.TIntHashSet;
 
 /**
  * @author Alexey Valikov
@@ -53,9 +52,9 @@ public abstract class AbstractEdgeElevationInterpolatorTest {
     public void setUp() {
         dataFlagEncoder = new DataFlagEncoder();
         graph = new GraphHopperStorage(new RAMDirectory(),
-                        new EncodingManager(Arrays.asList(dataFlagEncoder, new FootFlagEncoder()),
-                                        8),
-                        true, new GraphExtension.NoOpExtension()).create(100);
+                new EncodingManager(Arrays.asList(dataFlagEncoder, new FootFlagEncoder()),
+                        8),
+                true, new GraphExtension.NoOpExtension()).create(100);
 
         edgeElevationInterpolator = createEdgeElevationInterpolator();
 
@@ -63,7 +62,7 @@ public abstract class AbstractEdgeElevationInterpolatorTest {
         normalWay = new ReaderWay(0);
         normalWay.setTag("highway", "primary");
     }
-    
+
     @After
     public void tearDown() {
         Helper.close(graph);
@@ -76,9 +75,9 @@ public abstract class AbstractEdgeElevationInterpolatorTest {
     }
 
     protected void gatherOuterAndInnerNodeIdsOfStructure(EdgeIteratorState edge,
-                    final TIntHashSet outerNodeIds, final TIntHashSet innerNodeIds) {
+                                                         final GHIntHashSet outerNodeIds, final GHIntHashSet innerNodeIds) {
         edgeElevationInterpolator.gatherOuterAndInnerNodeIds(
-                        edgeElevationInterpolator.getStorage().createEdgeExplorer(), edge,
-                        new GHBitSetImpl(), outerNodeIds, innerNodeIds);
+                edgeElevationInterpolator.getStorage().createEdgeExplorer(), edge,
+                new GHBitSetImpl(), outerNodeIds, innerNodeIds);
     }
 }

--- a/core/src/test/java/com/graphhopper/reader/dem/BridgeElevationInterpolatorTest.java
+++ b/core/src/test/java/com/graphhopper/reader/dem/BridgeElevationInterpolatorTest.java
@@ -17,9 +17,8 @@
  */
 package com.graphhopper.reader.dem;
 
+import com.graphhopper.coll.GHIntHashSet;
 import static org.junit.Assert.assertEquals;
-
-import java.util.Arrays;
 
 import org.junit.Test;
 
@@ -28,8 +27,6 @@ import com.graphhopper.storage.NodeAccess;
 import com.graphhopper.util.EdgeIteratorState;
 import com.graphhopper.util.Helper;
 import com.graphhopper.util.PointList;
-
-import gnu.trove.set.hash.TIntHashSet;
 
 /**
  * @author Alexey Valikov
@@ -44,6 +41,7 @@ public class BridgeElevationInterpolatorTest extends AbstractEdgeElevationInterp
         return bridgeWay;
     }
 
+    @Override
     protected AbstractEdgeElevationInterpolator createEdgeElevationInterpolator() {
         return new BridgeElevationInterpolator(graph, dataFlagEncoder);
     }
@@ -52,7 +50,7 @@ public class BridgeElevationInterpolatorTest extends AbstractEdgeElevationInterp
     public void interpolatesElevationOfPillarNodes() {
 
         // @formatter:off
-		/*
+        /*
 		 * Graph structure:
 		 * 0-----1-----2-----3-----4
 		 *        \    |    /
@@ -61,9 +59,8 @@ public class BridgeElevationInterpolatorTest extends AbstractEdgeElevationInterp
 		 *           \ | /
 		 *            \|/
 		 * 5-----6--T--7--T--8-----9
-		 */
+         */
         // @formatter:on
-
         NodeAccess na = graph.getNodeAccess();
         na.setNode(0, 0, 0, 0);
         na.setNode(1, 10, 0, 10);
@@ -88,7 +85,7 @@ public class BridgeElevationInterpolatorTest extends AbstractEdgeElevationInterp
         EdgeIteratorState edge27 = graph.edge(2, 7, 10, true);
         EdgeIteratorState edge37 = graph.edge(3, 7, 10, true);
         edge17.setWayGeometry(
-                        Helper.createPointList3D(12, 2, 200, 14, 4, 400, 16, 6, 600, 18, 8, 800));
+                Helper.createPointList3D(12, 2, 200, 14, 4, 400, 16, 6, 600, 18, 8, 800));
 
         edge01.setFlags(dataFlagEncoder.handleWayTags(normalWay, 1, 0));
         edge12.setFlags(dataFlagEncoder.handleWayTags(normalWay, 1, 0));
@@ -104,12 +101,12 @@ public class BridgeElevationInterpolatorTest extends AbstractEdgeElevationInterp
         edge27.setFlags(dataFlagEncoder.handleWayTags(interpolatableWay, 1, 0));
         edge37.setFlags(dataFlagEncoder.handleWayTags(interpolatableWay, 1, 0));
 
-        final TIntHashSet outerNodeIds = new TIntHashSet();
-        final TIntHashSet innerNodeIds = new TIntHashSet();
+        final GHIntHashSet outerNodeIds = new GHIntHashSet();
+        final GHIntHashSet innerNodeIds = new GHIntHashSet();
         gatherOuterAndInnerNodeIdsOfStructure(edge27, outerNodeIds, innerNodeIds);
 
-        assertEquals(new TIntHashSet(Arrays.asList(1, 2, 3, 6, 8)), outerNodeIds);
-        assertEquals(new TIntHashSet(Arrays.asList(7)), innerNodeIds);
+        assertEquals(GHIntHashSet.from(1, 2, 3, 6, 8), outerNodeIds);
+        assertEquals(GHIntHashSet.from(7), innerNodeIds);
 
         edgeElevationInterpolator.execute();
         assertEquals(0, na.getElevation(0), PRECISION);

--- a/core/src/test/java/com/graphhopper/reader/dem/TunnelElevationInterpolatorTest.java
+++ b/core/src/test/java/com/graphhopper/reader/dem/TunnelElevationInterpolatorTest.java
@@ -17,18 +17,14 @@
  */
 package com.graphhopper.reader.dem;
 
+import com.graphhopper.coll.GHIntHashSet;
 import static org.junit.Assert.assertEquals;
-
-import java.util.Arrays;
-import java.util.Collections;
 
 import org.junit.Test;
 
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.storage.NodeAccess;
 import com.graphhopper.util.EdgeIteratorState;
-
-import gnu.trove.set.hash.TIntHashSet;
 
 /**
  * @author Alexey Valikov
@@ -52,13 +48,12 @@ public class TunnelElevationInterpolatorTest extends AbstractEdgeElevationInterp
     public void doesNotInterpolateElevationOfTunnelWithZeroOuterNodes() {
 
         // @formatter:off
-		/*
+        /*
 		 * Graph structure:
 		 * 0--T--1--T--2     3--T--4
 		 * Tunnel 0-1-2 has a single outer node 2.
-		 */
+         */
         // @formatter:on
-
         NodeAccess na = graph.getNodeAccess();
         na.setNode(0, 0, 0, 0);
         na.setNode(1, 10, 0, 0);
@@ -74,12 +69,12 @@ public class TunnelElevationInterpolatorTest extends AbstractEdgeElevationInterp
         edge12.setFlags(dataFlagEncoder.handleWayTags(interpolatableWay, 1, 0));
         edge34.setFlags(dataFlagEncoder.handleWayTags(interpolatableWay, 1, 0));
 
-        final TIntHashSet outerNodeIds = new TIntHashSet();
-        final TIntHashSet innerNodeIds = new TIntHashSet();
+        final GHIntHashSet outerNodeIds = new GHIntHashSet();
+        final GHIntHashSet innerNodeIds = new GHIntHashSet();
         gatherOuterAndInnerNodeIdsOfStructure(edge01, outerNodeIds, innerNodeIds);
 
-        assertEquals(new TIntHashSet(Collections.<Integer>emptyList()), outerNodeIds);
-        assertEquals(new TIntHashSet(Arrays.asList(0, 1, 2)), innerNodeIds);
+        assertEquals(GHIntHashSet.from(), outerNodeIds);
+        assertEquals(GHIntHashSet.from(0, 1, 2), innerNodeIds);
 
         edgeElevationInterpolator.execute();
         assertEquals(0, na.getElevation(0), PRECISION);
@@ -93,12 +88,11 @@ public class TunnelElevationInterpolatorTest extends AbstractEdgeElevationInterp
     public void interpolatesElevationOfTunnelWithSingleOuterNode() {
 
         // @formatter:off
-		/*
+        /*
 		 * Graph structure:
 		 * 0--T--1--T--2-----3--T--4
-		 */
+         */
         // @formatter:on
-
         NodeAccess na = graph.getNodeAccess();
         na.setNode(0, 0, 0, 0);
         na.setNode(1, 10, 0, 00);
@@ -116,12 +110,12 @@ public class TunnelElevationInterpolatorTest extends AbstractEdgeElevationInterp
         edge23.setFlags(dataFlagEncoder.handleWayTags(normalWay, 1, 0));
         edge34.setFlags(dataFlagEncoder.handleWayTags(interpolatableWay, 1, 0));
 
-        final TIntHashSet outerNodeIds = new TIntHashSet();
-        final TIntHashSet innerNodeIds = new TIntHashSet();
+        final GHIntHashSet outerNodeIds = new GHIntHashSet();
+        final GHIntHashSet innerNodeIds = new GHIntHashSet();
         gatherOuterAndInnerNodeIdsOfStructure(edge01, outerNodeIds, innerNodeIds);
 
-        assertEquals(new TIntHashSet(Arrays.asList(2)), outerNodeIds);
-        assertEquals(new TIntHashSet(Arrays.asList(0, 1)), innerNodeIds);
+        assertEquals(GHIntHashSet.from(2), outerNodeIds);
+        assertEquals(GHIntHashSet.from(0, 1), innerNodeIds);
 
         edgeElevationInterpolator.execute();
         assertEquals(10, na.getElevation(0), PRECISION);
@@ -135,12 +129,11 @@ public class TunnelElevationInterpolatorTest extends AbstractEdgeElevationInterp
     public void interpolatesElevationOfTunnelWithTwoOuterNodes() {
 
         // @formatter:off
-		/*
+        /*
 		 * Graph structure:
 		 * 0-----1--T--2--T--3-----4
-		 */
+         */
         // @formatter:on
-
         NodeAccess na = graph.getNodeAccess();
         na.setNode(0, 0, 0, 0);
         na.setNode(1, 10, 0, 10);
@@ -158,12 +151,12 @@ public class TunnelElevationInterpolatorTest extends AbstractEdgeElevationInterp
         edge23.setFlags(dataFlagEncoder.handleWayTags(interpolatableWay, 1, 0));
         edge34.setFlags(dataFlagEncoder.handleWayTags(normalWay, 1, 0));
 
-        final TIntHashSet outerNodeIds = new TIntHashSet();
-        final TIntHashSet innerNodeIds = new TIntHashSet();
+        final GHIntHashSet outerNodeIds = new GHIntHashSet();
+        final GHIntHashSet innerNodeIds = new GHIntHashSet();
         gatherOuterAndInnerNodeIdsOfStructure(edge12, outerNodeIds, innerNodeIds);
 
-        assertEquals(new TIntHashSet(Arrays.asList(1, 3)), outerNodeIds);
-        assertEquals(new TIntHashSet(Arrays.asList(2)), innerNodeIds);
+        assertEquals(GHIntHashSet.from(1, 3), outerNodeIds);
+        assertEquals(GHIntHashSet.from(2), innerNodeIds);
 
         edgeElevationInterpolator.execute();
         assertEquals(0, na.getElevation(0), PRECISION);
@@ -177,7 +170,7 @@ public class TunnelElevationInterpolatorTest extends AbstractEdgeElevationInterp
     public void interpolatesElevationOfTunnelWithThreeOuterNodes() {
 
         // @formatter:off
-		/*
+        /*
 		 * Graph structure:
 		 * 0-----1--T--2--T--3-----4
 		 *             |
@@ -186,9 +179,8 @@ public class TunnelElevationInterpolatorTest extends AbstractEdgeElevationInterp
 		 *             |
 		 *             |
 		 *             5--T--6-----7
-		 */
+         */
         // @formatter:on
-
         NodeAccess na = graph.getNodeAccess();
         na.setNode(0, 0, 0, 0);
         na.setNode(1, 10, 0, 10);
@@ -215,12 +207,12 @@ public class TunnelElevationInterpolatorTest extends AbstractEdgeElevationInterp
         edge56.setFlags(dataFlagEncoder.handleWayTags(interpolatableWay, 1, 0));
         edge67.setFlags(dataFlagEncoder.handleWayTags(normalWay, 1, 0));
 
-        final TIntHashSet outerNodeIds = new TIntHashSet();
-        final TIntHashSet innerNodeIds = new TIntHashSet();
+        final GHIntHashSet outerNodeIds = new GHIntHashSet();
+        final GHIntHashSet innerNodeIds = new GHIntHashSet();
         gatherOuterAndInnerNodeIdsOfStructure(edge12, outerNodeIds, innerNodeIds);
 
-        assertEquals(new TIntHashSet(Arrays.asList(1, 3, 6)), outerNodeIds);
-        assertEquals(new TIntHashSet(Arrays.asList(2, 5)), innerNodeIds);
+        assertEquals(GHIntHashSet.from(1, 3, 6), outerNodeIds);
+        assertEquals(GHIntHashSet.from(2, 5), innerNodeIds);
 
         edgeElevationInterpolator.execute();
         assertEquals(0, na.getElevation(0), PRECISION);
@@ -237,18 +229,17 @@ public class TunnelElevationInterpolatorTest extends AbstractEdgeElevationInterp
     public void interpolatesElevationOfTunnelWithFourOuterNodes() {
 
         // @formatter:off
-		/*
-		 * Graph structure:
-		 * 0-----1--T--2--T--3-----4
-		 *             |
-		 *             |
-		 *             T
-		 *             |
-		 *             |
-		 * 5-----6--T--7--T--8-----9
-		 */
+        /*
+            * Graph structure:
+            * 0-----1--T--2--T--3-----4
+            *             |
+            *             |
+            *             T
+            *             |
+            *             |
+            * 5-----6--T--7--T--8-----9
+         */
         // @formatter:on
-
         NodeAccess na = graph.getNodeAccess();
         na.setNode(0, 0, 0, 0);
         na.setNode(1, 10, 0, 10);
@@ -283,12 +274,12 @@ public class TunnelElevationInterpolatorTest extends AbstractEdgeElevationInterp
 
         edge27.setFlags(dataFlagEncoder.handleWayTags(interpolatableWay, 1, 0));
 
-        final TIntHashSet outerNodeIds = new TIntHashSet();
-        final TIntHashSet innerNodeIds = new TIntHashSet();
+        final GHIntHashSet outerNodeIds = new GHIntHashSet();
+        final GHIntHashSet innerNodeIds = new GHIntHashSet();
         gatherOuterAndInnerNodeIdsOfStructure(edge12, outerNodeIds, innerNodeIds);
 
-        assertEquals(new TIntHashSet(Arrays.asList(1, 3, 6, 8)), outerNodeIds);
-        assertEquals(new TIntHashSet(Arrays.asList(2, 7)), innerNodeIds);
+        assertEquals(GHIntHashSet.from(1, 3, 6, 8), outerNodeIds);
+        assertEquals(GHIntHashSet.from(2, 7), innerNodeIds);
 
         edgeElevationInterpolator.execute();
         assertEquals(0, na.getElevation(0), PRECISION);

--- a/core/src/test/java/com/graphhopper/routing/AbstractRoutingAlgorithmTester.java
+++ b/core/src/test/java/com/graphhopper/routing/AbstractRoutingAlgorithmTester.java
@@ -17,6 +17,7 @@
  */
 package com.graphhopper.routing;
 
+import com.carrotsearch.hppc.IntIndexedContainer;
 import com.graphhopper.routing.util.*;
 import com.graphhopper.routing.weighting.FastestWeighting;
 import com.graphhopper.routing.weighting.ShortestWeighting;
@@ -26,7 +27,6 @@ import com.graphhopper.storage.index.LocationIndex;
 import com.graphhopper.storage.index.LocationIndexTree;
 import com.graphhopper.storage.index.QueryResult;
 import com.graphhopper.util.*;
-import gnu.trove.list.TIntList;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -440,7 +440,7 @@ public abstract class AbstractRoutingAlgorithmTester {
         Path p = createAlgo(matrixGraph).calcPath(36, 91);
         assertEquals(12, p.calcNodes().size());
 
-        TIntList list = p.calcNodes();
+        IntIndexedContainer list = p.calcNodes();
         if (!Helper.createTList(36, 46, 56, 66, 76, 86, 85, 84, 94, 93, 92, 91).equals(list)
                 && !Helper.createTList(36, 46, 56, 66, 76, 86, 85, 84, 83, 82, 92, 91).equals(list)) {
             assertTrue("wrong locations: " + list.toString(), false);
@@ -592,7 +592,7 @@ public abstract class AbstractRoutingAlgorithmTester {
     public void testViaEdges_WithCoordinates() {
         GraphHopperStorage ghStorage = createTestStorage();
         Path p = calcPath(ghStorage, 0, 1, 2, 3);
-        assertEquals(Helper.createTList(9, 1, 2, 8), p.calcNodes());
+        assertEquals(Helper.createTList(8, 1, 2, 9), p.calcNodes());
         assertEquals(p.toString(), 56.7, p.getDistance(), .1);
     }
 
@@ -616,7 +616,7 @@ public abstract class AbstractRoutingAlgorithmTester {
 
         // 0-1 to 3-4
         Path p = calcPathViaQuery(graph, 0.00010, 0.00001, 0, 0.00009);
-        assertEquals(Helper.createTList(6, 1, 2, 3, 5), p.calcNodes());
+        assertEquals(Helper.createTList(5, 1, 2, 3, 6), p.calcNodes());
         assertEquals(p.toString(), 26.81, p.getDistance(), .1);
 
         // overlapping edges: 2-3 and 3-2
@@ -636,7 +636,7 @@ public abstract class AbstractRoutingAlgorithmTester {
         GraphHopperStorage graph = createGHStorage(encodingManager, Arrays.asList(weighting), false);
         initDirectedAndDiffSpeed(graph, carEncoder);
         Path p = calcPathViaQuery(weighting, graph, 0.002, 0.0005, 0.0017, 0.0031);
-        assertEquals(Helper.createTList(9, 1, 5, 3, 8), p.calcNodes());
+        assertEquals(Helper.createTList(8, 1, 5, 3, 9), p.calcNodes());
         assertEquals(602.98, p.getDistance(), 1e-1);
     }
 
@@ -797,7 +797,7 @@ public abstract class AbstractRoutingAlgorithmTester {
         RoutingAlgorithmFactory factory = createFactory(graph, fakeOpts);
         QueryGraph qGraph = new QueryGraph(getGraph(graph, fakeWeighting)).lookup(from, to);
         p = factory.createAlgo(qGraph, fakeOpts).calcPath(from.getClosestNode(), to.getClosestNode());
-        assertEquals(Helper.createTList(13, 0, 1, 2, 11, 7, 10, 12), p.calcNodes());
+        assertEquals(Helper.createTList(12, 0, 1, 2, 11, 7, 10, 13), p.calcNodes());
         assertEquals(37009621, p.getTime());
         assertEquals(616827, p.getDistance(), 1);
         assertEquals(493462, p.getWeight(), 1);

--- a/core/src/test/java/com/graphhopper/routing/QueryGraphTest.java
+++ b/core/src/test/java/com/graphhopper/routing/QueryGraphTest.java
@@ -17,6 +17,7 @@
  */
 package com.graphhopper.routing;
 
+import com.carrotsearch.hppc.IntObjectMap;
 import com.graphhopper.routing.util.*;
 import com.graphhopper.routing.weighting.FastestWeighting;
 import com.graphhopper.routing.weighting.TurnWeighting;
@@ -24,7 +25,6 @@ import com.graphhopper.storage.*;
 import com.graphhopper.storage.index.QueryResult;
 import com.graphhopper.util.*;
 import com.graphhopper.util.shapes.GHPoint;
-import gnu.trove.map.TIntObjectMap;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -152,7 +152,7 @@ public class QueryGraphTest {
         QueryGraph queryGraph = new QueryGraph(g) {
 
             @Override
-            void fillVirtualEdges(TIntObjectMap<VirtualEdgeIterator> node2Edge, int towerNode, EdgeExplorer mainExpl) {
+            void fillVirtualEdges(IntObjectMap<VirtualEdgeIterator> node2Edge, int towerNode, EdgeExplorer mainExpl) {
                 super.fillVirtualEdges(node2Edge, towerNode, mainExpl);
                 // ignore nodes should include baseNode == 1
                 if (towerNode == 3)

--- a/core/src/test/java/com/graphhopper/routing/ch/PrepareContractionHierarchiesTest.java
+++ b/core/src/test/java/com/graphhopper/routing/ch/PrepareContractionHierarchiesTest.java
@@ -17,6 +17,7 @@
  */
 package com.graphhopper.routing.ch;
 
+import com.carrotsearch.hppc.IntIndexedContainer;
 import com.graphhopper.routing.*;
 import com.graphhopper.routing.ch.PrepareContractionHierarchies.Shortcut;
 import com.graphhopper.routing.util.BikeFlagEncoder;
@@ -28,7 +29,6 @@ import com.graphhopper.routing.weighting.ShortestWeighting;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.*;
 import com.graphhopper.util.*;
-import gnu.trove.list.TIntList;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -635,7 +635,7 @@ public class PrepareContractionHierarchiesTest {
         checkPath(ghStorage, bikeWeighting, 9, 5, Helper.createTList(3, 10, 14, 16, 13, 12));
     }
 
-    void checkPath(GraphHopperStorage ghStorage, Weighting w, int expShortcuts, double expDistance, TIntList expNodes) {
+    void checkPath(GraphHopperStorage ghStorage, Weighting w, int expShortcuts, double expDistance, IntIndexedContainer expNodes) {
         CHGraph lg = ghStorage.getGraph(CHGraph.class, w);
         PrepareContractionHierarchies prepare = new PrepareContractionHierarchies(dir, ghStorage, lg, w, tMode);
         prepare.doWork();

--- a/core/src/test/java/com/graphhopper/routing/subnetwork/PrepareRoutingSubnetworksTest.java
+++ b/core/src/test/java/com/graphhopper/routing/subnetwork/PrepareRoutingSubnetworksTest.java
@@ -17,6 +17,7 @@
  */
 package com.graphhopper.routing.subnetwork;
 
+import com.carrotsearch.hppc.IntArrayList;
 import com.graphhopper.coll.GHBitSetImpl;
 import com.graphhopper.routing.subnetwork.PrepareRoutingSubnetworks.PrepEdgeFilter;
 import com.graphhopper.routing.util.*;
@@ -26,7 +27,6 @@ import com.graphhopper.util.EdgeExplorer;
 import com.graphhopper.util.EdgeIteratorState;
 import com.graphhopper.util.GHUtility;
 import com.graphhopper.util.Helper;
-import gnu.trove.list.array.TIntArrayList;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -98,7 +98,7 @@ public class PrepareRoutingSubnetworksTest {
         GraphHopperStorage g = createSubnetworkTestStorage();
         PrepEdgeFilter filter = new PrepEdgeFilter(carFlagEncoder);
         PrepareRoutingSubnetworks instance = new PrepareRoutingSubnetworks(g, Collections.singletonList(carFlagEncoder));
-        List<TIntArrayList> components = instance.findSubnetworks(filter);
+        List<IntArrayList> components = instance.findSubnetworks(filter);
 
         assertEquals(3, components.size());
 
@@ -114,7 +114,7 @@ public class PrepareRoutingSubnetworksTest {
         GraphHopperStorage g = createSubnetworkTestStorage();
         PrepEdgeFilter filter = new PrepEdgeFilter(carFlagEncoder);
         PrepareRoutingSubnetworks instance = new PrepareRoutingSubnetworks(g, Collections.singletonList(carFlagEncoder));
-        List<TIntArrayList> components = instance.findSubnetworks(filter);
+        List<IntArrayList> components = instance.findSubnetworks(filter);
         assertEquals(3, components.size());
         int removedEdges = instance.keepLargeNetworks(filter, components);
         assertEquals(8, removedEdges);
@@ -268,13 +268,13 @@ public class PrepareRoutingSubnetworksTest {
         TarjansSCCAlgorithm tarjan
                 = new TarjansSCCAlgorithm(g, new GHBitSetImpl(), filter);
 
-        List<TIntArrayList> components = tarjan.findComponents();
+        List<IntArrayList> components = tarjan.findComponents();
 
         assertEquals(4, components.size());
-        assertEquals(new TIntArrayList(new int[]{13, 5, 3, 7, 0}), components.get(0));
-        assertEquals(new TIntArrayList(new int[]{2, 4, 12, 11, 8, 1}), components.get(1));
-        assertEquals(new TIntArrayList(new int[]{10, 14, 6}), components.get(2));
-        assertEquals(new TIntArrayList(new int[]{15, 9}), components.get(3));
+        assertEquals(IntArrayList.from(13, 5, 3, 7, 0), components.get(0));
+        assertEquals(IntArrayList.from(2, 4, 12, 11, 8, 1), components.get(1));
+        assertEquals(IntArrayList.from(10, 14, 6), components.get(2));
+        assertEquals(IntArrayList.from(15, 9), components.get(3));
     }
 
     // Previous two-pass implementation failed on 1 -> 2 -> 0
@@ -314,7 +314,7 @@ public class PrepareRoutingSubnetworksTest {
         instance.doWork();
 
         // only one remaining network
-        List<TIntArrayList> components = instance.findSubnetworks(new PrepEdgeFilter(carFlagEncoder));
+        List<IntArrayList> components = instance.findSubnetworks(new PrepEdgeFilter(carFlagEncoder));
         assertEquals(1, components.size());
     }
 }

--- a/core/src/test/java/com/graphhopper/storage/index/LocationIndexTreeCHTest.java
+++ b/core/src/test/java/com/graphhopper/storage/index/LocationIndexTreeCHTest.java
@@ -17,22 +17,20 @@
  */
 package com.graphhopper.storage.index;
 
+import com.carrotsearch.hppc.IntSet;
+import com.graphhopper.coll.GHIntHashSet;
 import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.routing.weighting.FastestWeighting;
 import com.graphhopper.storage.*;
 import com.graphhopper.util.CHEdgeIteratorState;
 import com.graphhopper.util.EdgeIteratorState;
-import com.graphhopper.util.Helper;
-import gnu.trove.list.TIntList;
-import gnu.trove.set.TIntSet;
-import gnu.trove.set.hash.TIntHashSet;
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
@@ -108,19 +106,16 @@ public class LocationIndexTreeCHTest extends LocationIndexTreeTest {
         lg.setLevel(1, 10);
         lg.setLevel(2, 30);
         lg.setLevel(3, 20);
-        TIntList tlist = Helper.createTList(1, 2, 3);
 
         // nodes with high level should come first to be covered by lower level nodes
-        ArrayList<Integer> list = Helper.tIntListToArrayList(tlist);
+        List<Integer> list = Arrays.asList(1, 2, 3);
         Collections.sort(list, new Comparator<Integer>() {
             @Override
             public int compare(Integer o1, Integer o2) {
                 return lg.getLevel(o2) - lg.getLevel(o1);
             }
         });
-        tlist.clear();
-        tlist.addAll(list);
-        assertEquals(Helper.createTList(2, 3, 1), tlist);
+        assertEquals("[2, 3, 1]", list.toString());
     }
 
     @Test
@@ -155,10 +150,10 @@ public class LocationIndexTreeCHTest extends LocationIndexTreeTest {
         LocationIndexTree index = createIndex(g, 100000);
 
         // very close to 2, but should match the edge 0--1
-        TIntHashSet set = new TIntHashSet();
+        GHIntHashSet set = new GHIntHashSet();
         index.findNetworkEntries(0.51, 0.2, set, 0);
         index.findNetworkEntries(0.51, 0.2, set, 1);
-        TIntSet expectedSet = new TIntHashSet();
+        IntSet expectedSet = new GHIntHashSet();
         expectedSet.add(0);
         expectedSet.add(2);
         assertEquals(expectedSet, set);

--- a/core/src/test/java/com/graphhopper/storage/index/LocationIndexTreeTest.java
+++ b/core/src/test/java/com/graphhopper/storage/index/LocationIndexTreeTest.java
@@ -17,6 +17,7 @@
  */
 package com.graphhopper.storage.index;
 
+import com.graphhopper.coll.GHIntHashSet;
 import com.graphhopper.routing.util.*;
 import com.graphhopper.storage.Directory;
 import com.graphhopper.storage.Graph;
@@ -24,7 +25,6 @@ import com.graphhopper.storage.NodeAccess;
 import com.graphhopper.storage.RAMDirectory;
 import com.graphhopper.util.*;
 import com.graphhopper.util.shapes.GHPoint;
-import gnu.trove.set.hash.TIntHashSet;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -118,10 +118,10 @@ public class LocationIndexTreeTest extends AbstractLocationIndexTester {
         // [LEAF 0 {2} {},    LEAF 2 {1} {},    LEAF 1 {2} {}, LEAF 3 {1} {}, LEAF 8 {0} {}, LEAF 10 {0} {}, LEAF 9 {0} {}, LEAF 4 {2} {}, LEAF 6 {0, 3} {},       LEAF 5 {0, 2, 3} {}, LEAF 7 {1, 2, 3} {}, LEAF 13 {1} {}]
         // System.out.println(inMemIndex.getLayer(2));
 
-        TIntHashSet set = new TIntHashSet();
+        GHIntHashSet set = new GHIntHashSet();
         set.add(0);
 
-        TIntHashSet foundIds = new TIntHashSet();
+        GHIntHashSet foundIds = new GHIntHashSet();
         index.findNetworkEntries(0.5, -0.5, foundIds, 0);
         assertEquals(set, foundIds);
 
@@ -178,10 +178,10 @@ public class LocationIndexTreeTest extends AbstractLocationIndexTester {
         // get only 0 or any node in the lefter greater subgraph.
         // The other subnetwork is already perfect {26}.
         // For compaction see: https://github.com/graphhopper/graphhopper/blob/5594f7f9d98d932f365557dc37b4b2d3b7abf698/core/src/main/java/com/graphhopper/storage/index/Location2NodesNtree.java#L277
-        TIntHashSet set = new TIntHashSet();
-        set.addAll(Arrays.asList(28, 27, 26, 24, 23, 21, 19, 18, 16, 14, 6, 5, 4, 3, 2, 1, 0));
+        GHIntHashSet set = new GHIntHashSet();
+        set.addAll(28, 27, 26, 24, 23, 21, 19, 18, 16, 14, 6, 5, 4, 3, 2, 1, 0);
 
-        TIntHashSet foundIds = new TIntHashSet();
+        GHIntHashSet foundIds = new GHIntHashSet();
         index.findNetworkEntries(49.950, 11.5732, foundIds, 0);
         assertEquals(set, foundIds);
     }
@@ -412,7 +412,7 @@ public class LocationIndexTreeTest extends AbstractLocationIndexTester {
 
         assertTrue((rmin2 - check2) < 0.0001);
 
-        TIntHashSet points = new TIntHashSet();
+        GHIntHashSet points = new GHIntHashSet();
         assertEquals(Double.MAX_VALUE, index.calcMinDistance(0.05, -0.3, points), 1e-1);
 
         points.add(0);

--- a/core/src/test/java/com/graphhopper/util/BreadthFirstSearchTest.java
+++ b/core/src/test/java/com/graphhopper/util/BreadthFirstSearchTest.java
@@ -17,12 +17,11 @@
  */
 package com.graphhopper.util;
 
+import com.carrotsearch.hppc.IntArrayList;
+import com.graphhopper.coll.GHIntHashSet;
 import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.storage.Graph;
 import com.graphhopper.storage.GraphBuilder;
-import gnu.trove.list.TIntList;
-import gnu.trove.list.array.TIntArrayList;
-import gnu.trove.set.hash.TIntHashSet;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -34,8 +33,8 @@ import static org.junit.Assert.assertTrue;
  */
 public class BreadthFirstSearchTest {
     int counter;
-    TIntHashSet set = new TIntHashSet();
-    TIntList list = new TIntArrayList();
+    GHIntHashSet set = new GHIntHashSet();
+    IntArrayList list = new IntArrayList();
 
     @Before
     public void setup() {
@@ -73,7 +72,7 @@ public class BreadthFirstSearchTest {
 
         assertTrue(counter > 0);
         assertEquals(g.getNodes(), counter);
-        assertEquals("{0, 5, 3, 2, 1, 10, 8, 7, 6, 9, 4}", list.toString());
+        assertEquals("[0, 5, 3, 2, 1, 10, 8, 7, 6, 9, 4]", list.toString());
     }
 
     @Test
@@ -100,7 +99,7 @@ public class BreadthFirstSearchTest {
         bfs.start(g.createEdgeExplorer(), 1);
 
         assertTrue(counter > 0);
-        assertEquals("{1, 5, 2, 6, 3, 4}", list.toString());
+        assertEquals("[1, 5, 2, 6, 3, 4]", list.toString());
     }
 
 }

--- a/core/src/test/java/com/graphhopper/util/DepthFirstSearchTest.java
+++ b/core/src/test/java/com/graphhopper/util/DepthFirstSearchTest.java
@@ -17,14 +17,13 @@
  */
 package com.graphhopper.util;
 
+import com.carrotsearch.hppc.IntArrayList;
+import com.graphhopper.coll.GHIntHashSet;
 import com.graphhopper.routing.util.DefaultEdgeFilter;
 import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.storage.Graph;
 import com.graphhopper.storage.GraphBuilder;
-import gnu.trove.list.TIntList;
-import gnu.trove.list.array.TIntArrayList;
-import gnu.trove.set.hash.TIntHashSet;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -37,8 +36,8 @@ import static org.junit.Assert.assertTrue;
 public class DepthFirstSearchTest {
 
     int counter;
-    TIntHashSet set = new TIntHashSet();
-    TIntList list = new TIntArrayList();
+    GHIntHashSet set = new GHIntHashSet();
+    IntArrayList list = new IntArrayList();
 
     @Before
     public void setup() {
@@ -72,7 +71,7 @@ public class DepthFirstSearchTest {
         dfs.start(g.createEdgeExplorer(new DefaultEdgeFilter(fe, false, true)), 1);
 
         assertTrue(counter > 0);
-        assertEquals("{1, 2, 3, 4, 5, 6}", list.toString());
+        assertEquals("[1, 2, 3, 4, 5, 6]", list.toString());
     }
 
     @Test
@@ -100,7 +99,7 @@ public class DepthFirstSearchTest {
         dfs.start(g.createEdgeExplorer(new DefaultEdgeFilter(fe, false, true)), 1);
 
         assertTrue(counter > 0);
-        assertEquals("{1, 2, 3, 4}", list.toString());
+        assertEquals("[1, 2, 3, 4]", list.toString());
     }
 
 }

--- a/core/src/test/java/com/graphhopper/util/GHUtilityTest.java
+++ b/core/src/test/java/com/graphhopper/util/GHUtilityTest.java
@@ -205,10 +205,4 @@ public class GHUtilityTest {
 //        assertEquals(1, map2.get(2));
 //        assertEquals(-1, map2.get(3));
     }
-
-    @Test
-    public void testLongArrayListCopy() {
-        LongArrayList arr = LongArrayList.from(1, 2, 3, 4, 5, 6, 7);
-        assertEquals(LongArrayList.from(2, 3, 4, 5, 6), GHUtility.copy(arr, 1, 5));
-    }
 }

--- a/core/src/test/java/com/graphhopper/util/GHUtilityTest.java
+++ b/core/src/test/java/com/graphhopper/util/GHUtilityTest.java
@@ -17,11 +17,17 @@
  */
 package com.graphhopper.util;
 
+import com.carrotsearch.hppc.IntArrayList;
+import com.carrotsearch.hppc.IntIntHashMap;
+import com.carrotsearch.hppc.LongArrayList;
+import com.graphhopper.coll.GHIntHashSet;
+import com.graphhopper.coll.GHIntObjectHashMap;
 import com.graphhopper.routing.util.CarFlagEncoder;
 import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.routing.weighting.FastestWeighting;
 import com.graphhopper.storage.*;
+import java.util.Random;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -106,7 +112,7 @@ public class GHUtilityTest {
     @Test
     public void testCopyWithSelfRef() {
         Graph g = initUnsorted(createGraph());
-        EdgeIteratorState eb = g.edge(0, 0, 11, true);
+        g.edge(0, 0, 11, true);
 
         CHGraph lg = new GraphBuilder(encodingManager).chGraphCreate(new FastestWeighting(carEncoder));
         GHUtility.copyTo(g, lg);
@@ -170,5 +176,54 @@ public class GHUtilityTest {
         assertTrue(GHUtility.isSameEdgeKeys(GHUtility.createEdgeKey(1, 2, 4, false), GHUtility.createEdgeKey(1, 2, 4, false)));
         assertTrue(GHUtility.isSameEdgeKeys(GHUtility.createEdgeKey(2, 1, 4, false), GHUtility.createEdgeKey(1, 2, 4, false)));
         assertFalse(GHUtility.isSameEdgeKeys(GHUtility.createEdgeKey(1, 2, 4, false), GHUtility.createEdgeKey(1, 2, 5, false)));
+    }
+
+    @Test
+    public void testReverse() {
+        assertEquals(IntArrayList.from(4, 3, 2, 1), GHUtility.reverse(IntArrayList.from(1, 2, 3, 4)));
+        assertEquals(IntArrayList.from(5, 4, 3, 2, 1), GHUtility.reverse(IntArrayList.from(1, 2, 3, 4, 5)));
+    }
+
+    @Test
+    public void testShuffle() {
+        assertEquals(IntArrayList.from(4, 1, 3, 2), GHUtility.shuffle(IntArrayList.from(1, 2, 3, 4), new Random(0)));
+        assertEquals(IntArrayList.from(4, 3, 2, 1, 5), GHUtility.shuffle(IntArrayList.from(1, 2, 3, 4, 5), new Random(1)));
+    }
+
+    @Test
+    public void testFill() {
+        assertEquals(IntArrayList.from(-1, -1, -1, -1), GHUtility.fill(new IntArrayList(4), 4, -1));
+    }
+
+    @Test
+    public void testZeroValue() {
+        GHIntObjectHashMap map = new GHIntObjectHashMap<>();
+        map.put(0, null);
+        assertEquals(null, map.get(0));
+        assertEquals(null, map.get(1));
+
+        GHIntHashSet set = new GHIntHashSet();
+        assertFalse(set.contains(0));
+        set.add(0);
+        set.add(1);
+        assertTrue(set.contains(0));
+        assertTrue(set.contains(1));
+        assertFalse(set.contains(2));
+
+        IntIntHashMap map2 = new IntIntHashMap();
+        assertEquals(0, map2.get(0));
+        map2.put(1, 0);
+        map2.put(2, 1);
+
+        assertEquals(0, map2.get(1));
+        assertEquals(1, map2.get(2));
+        // wrong due to 0 is empty
+        assertEquals(0, map2.get(0));
+    }
+
+    @Test
+    public void testLongArrayListCopy() {
+        LongArrayList arr = LongArrayList.from(1, 2, 3, 4, 5, 6, 7);
+        assertEquals(LongArrayList.from(2, 3, 4, 5, 6), GHUtility.copy(arr, 1, 5));
     }
 }

--- a/core/src/test/java/com/graphhopper/util/GHUtilityTest.java
+++ b/core/src/test/java/com/graphhopper/util/GHUtilityTest.java
@@ -17,17 +17,13 @@
  */
 package com.graphhopper.util;
 
-import com.carrotsearch.hppc.IntArrayList;
-import com.carrotsearch.hppc.IntIntHashMap;
 import com.carrotsearch.hppc.LongArrayList;
-import com.graphhopper.coll.GHIntHashSet;
-import com.graphhopper.coll.GHIntObjectHashMap;
+import com.graphhopper.coll.GHIntLongHashMap;
 import com.graphhopper.routing.util.CarFlagEncoder;
 import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.routing.weighting.FastestWeighting;
 import com.graphhopper.storage.*;
-import java.util.Random;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -179,46 +175,35 @@ public class GHUtilityTest {
     }
 
     @Test
-    public void testReverse() {
-        assertEquals(IntArrayList.from(4, 3, 2, 1), GHUtility.reverse(IntArrayList.from(1, 2, 3, 4)));
-        assertEquals(IntArrayList.from(5, 4, 3, 2, 1), GHUtility.reverse(IntArrayList.from(1, 2, 3, 4, 5)));
-    }
-
-    @Test
-    public void testShuffle() {
-        assertEquals(IntArrayList.from(4, 1, 3, 2), GHUtility.shuffle(IntArrayList.from(1, 2, 3, 4), new Random(0)));
-        assertEquals(IntArrayList.from(4, 3, 2, 1, 5), GHUtility.shuffle(IntArrayList.from(1, 2, 3, 4, 5), new Random(1)));
-    }
-
-    @Test
-    public void testFill() {
-        assertEquals(IntArrayList.from(-1, -1, -1, -1), GHUtility.fill(new IntArrayList(4), 4, -1));
-    }
-
-    @Test
     public void testZeroValue() {
-        GHIntObjectHashMap map = new GHIntObjectHashMap<>();
-        map.put(0, null);
-        assertEquals(null, map.get(0));
-        assertEquals(null, map.get(1));
+        GHIntLongHashMap map1 = new GHIntLongHashMap();
+        assertFalse(map1.containsKey(0));
+        // assertFalse(map1.containsValue(0));
+        map1.put(0, 3);
+        map1.put(1, 0);
+        map1.put(2, 1);
 
-        GHIntHashSet set = new GHIntHashSet();
-        assertFalse(set.contains(0));
-        set.add(0);
-        set.add(1);
-        assertTrue(set.contains(0));
-        assertTrue(set.contains(1));
-        assertFalse(set.contains(2));
+        // assertTrue(map1.containsValue(0));
+        assertEquals(3, map1.get(0));
+        assertEquals(0, map1.get(1));
+        assertEquals(1, map1.get(2));
 
-        IntIntHashMap map2 = new IntIntHashMap();
-        assertEquals(0, map2.get(0));
-        map2.put(1, 0);
-        map2.put(2, 1);
+        // instead of assertEquals(-1, map1.get(3)); with hppc we have to check before:
+        assertTrue(map1.containsKey(0));
 
-        assertEquals(0, map2.get(1));
-        assertEquals(1, map2.get(2));
-        // wrong due to 0 is empty
-        assertEquals(0, map2.get(0));
+        // trove4j behaviour was to return -1 if non existing:
+//        TIntLongHashMap map2 = new TIntLongHashMap(100, 0.7f, -1, -1);
+//        assertFalse(map2.containsKey(0));
+//        assertFalse(map2.containsValue(0));
+//        map2.put(0, 3);
+//        map2.put(1, 0);
+//        map2.put(2, 1);
+//        assertTrue(map2.containsKey(0));
+//        assertTrue(map2.containsValue(0));
+//        assertEquals(3, map2.get(0));
+//        assertEquals(0, map2.get(1));
+//        assertEquals(1, map2.get(2));
+//        assertEquals(-1, map2.get(3));
     }
 
     @Test

--- a/docs/android/index.md
+++ b/docs/android/index.md
@@ -82,27 +82,28 @@ The [GraphHopper Directions API Java client](https://github.com/graphhopper/dire
 ## Problems
 
 If you encounter problems like 'trouble writing output: Too many methods: 72332; max is 65536.' or you 
-want to reduce the size of the jar/apk size you can try to apply autojar on trove4j:
+want to reduce the size of the jar/apk size you can try to apply autojar on hppc:
 
 ```bash
-java -jar autojar-2.1/autojar.jar -o trove4j-stripped.jar -c $TROVE_SRC/target/classes @trove-class.list
+java -jar autojar-2.1/autojar.jar -o trove4j-stripped.jar -c $TROVE_SRC/target/classes @class.list
 ```
 
-where trove-class.list is a file with the required classes for GraphHopper as content:
+where class.list is a file with the required classes for GraphHopper as content:
 
 ```text
-gnu.trove.list.TDoubleList.class
-gnu.trove.list.TIntList.class
-gnu.trove.list.array.TDoubleArrayList.class
-gnu.trove.list.array.TIntArrayList.class
-gnu.trove.map.TIntObjectMap.class
-gnu.trove.map.hash.TIntObjectHashMap.class
-gnu.trove.map.hash.TIntIntHashMap.class
-gnu.trove.set.hash.TIntHashSet.class
-gnu.trove.iterator.TIntIterator.class
-gnu.trove.procedure.TIntProcedure.class
-gnu.trove.procedure.TObjectProcedure.class
-gnu.trove.stack.array.TIntArrayStack.class
+com.carrotsearch.hppc.IntArrayList
+com.carrotsearch.hppc.IntObjectHashMap.class
+com.carrotsearch.hppc.IntHashSet
+com.carrotsearch.hppc.IntLongHashMap
+com.carrotsearch.hppc.IntContainer
+com.carrotsearch.hppc.LongHashSet
+com.carrotsearch.hppc.LongObjectHashMap
+com.carrotsearch.hppc.ObjectIntAssociativeContainer
+com.carrotsearch.hppc.ObjectIntHashMap
+com.carrotsearch.hppc.HashOrderMixing
+com.carrotsearch.hppc.HashOrderMixingStrategy
+com.carrotsearch.hppc.cursors.IntCursor
+...
 ```
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -142,21 +142,6 @@
             </plugin>
             -->
 
-            <!-- create html output for findbugs -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-site-plugin</artifactId>
-                <version>3.5.1</version>
-                <configuration>
-                    <reportPlugins>
-                        <plugin>
-                            <groupId>org.codehaus.mojo</groupId>
-                            <artifactId>findbugs-maven-plugin</artifactId>
-                        </plugin>
-                    </reportPlugins>
-                </configuration>
-            </plugin>
-
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>findbugs-maven-plugin</artifactId>

--- a/reader-osm/src/main/java/com/graphhopper/reader/osm/OSMReader.java
+++ b/reader-osm/src/main/java/com/graphhopper/reader/osm/OSMReader.java
@@ -224,7 +224,7 @@ public class OSMReader implements DataReader {
     private IntLongMap getEdgeIdToOsmWayIdMap() {
         if (edgeIdToOsmWayIdMap == null)
             edgeIdToOsmWayIdMap = new GHIntLongHashMap(getOsmWayIdSet().size(), 0.5f);
-        
+
         return edgeIdToOsmWayIdMap;
     }
 
@@ -377,9 +377,9 @@ public class OSMReader implements DataReader {
                             lastBarrier = 0;
 
                         // add way up to barrier shadow node                        
-                        int lastIndex = i - lastBarrier;
-                        LongIndexedContainer partNodeIds = GHUtility.copy(osmNodeIds, lastBarrier, lastIndex + 1);
-                        partNodeIds.set(lastIndex, newNodeId);
+                        int length = i - lastBarrier + 1;
+                        LongIndexedContainer partNodeIds = GHUtility.copy(osmNodeIds, lastBarrier, length);
+                        partNodeIds.set(length - 1, newNodeId);
                         createdEdges.addAll(addOSMWay(partNodeIds, wayFlags, wayOsmId));
 
                         // create zero length edge for barrier

--- a/reader-osm/src/main/java/com/graphhopper/reader/osm/OSMReader.java
+++ b/reader-osm/src/main/java/com/graphhopper/reader/osm/OSMReader.java
@@ -378,7 +378,8 @@ public class OSMReader implements DataReader {
 
                         // add way up to barrier shadow node                        
                         int length = i - lastBarrier + 1;
-                        LongIndexedContainer partNodeIds = GHUtility.copy(osmNodeIds, lastBarrier, length);
+                        LongArrayList partNodeIds = new LongArrayList();
+                        partNodeIds.add(osmNodeIds.buffer, lastBarrier, length);
                         partNodeIds.set(length - 1, newNodeId);
                         createdEdges.addAll(addOSMWay(partNodeIds, wayFlags, wayOsmId));
 
@@ -400,7 +401,8 @@ public class OSMReader implements DataReader {
         // just add remainder of way to graph if barrier was not the last node
         if (lastBarrier >= 0) {
             if (lastBarrier < size - 1) {
-                LongIndexedContainer partNodeIds = GHUtility.copy(osmNodeIds, lastBarrier, size - lastBarrier);
+                LongArrayList partNodeIds = new LongArrayList();
+                partNodeIds.add(osmNodeIds.buffer, lastBarrier, size - lastBarrier);
                 createdEdges.addAll(addOSMWay(partNodeIds, wayFlags, wayOsmId));
             }
         } else {

--- a/reader-osm/src/main/java/com/graphhopper/reader/osm/OSMReader.java
+++ b/reader-osm/src/main/java/com/graphhopper/reader/osm/OSMReader.java
@@ -26,7 +26,6 @@ import com.graphhopper.coll.GHIntLongHashMap;
 import com.graphhopper.coll.GHLongHashSet;
 import com.graphhopper.coll.GHLongIntBTree;
 import com.graphhopper.coll.GHLongLongHashMap;
-import com.graphhopper.coll.GHLongObjectHashMap;
 import com.graphhopper.coll.LongIntMap;
 import com.graphhopper.reader.*;
 import com.graphhopper.reader.dem.ElevationProvider;
@@ -73,7 +72,7 @@ import static com.graphhopper.util.Helper.nf;
  * @author Peter Karich
  */
 public class OSMReader implements DataReader {
-    protected static final int EMPTY = -1;
+    protected static final int EMPTY_NODE = -1;
     // pillar node is >= 3
     protected static final int PILLAR_NODE = 1;
     // tower node is <= -3
@@ -225,7 +224,7 @@ public class OSMReader implements DataReader {
     private IntLongMap getEdgeIdToOsmWayIdMap() {
         if (edgeIdToOsmWayIdMap == null)
             edgeIdToOsmWayIdMap = new GHIntLongHashMap(getOsmWayIdSet().size(), 0.5f);
-
+        
         return edgeIdToOsmWayIdMap;
     }
 
@@ -478,12 +477,12 @@ public class OSMReader implements DataReader {
         if (id < TOWER_NODE)
             return -id - 3;
 
-        return EMPTY;
+        return EMPTY_NODE;
     }
 
     // TODO remove this ugly stuff via better preparsing phase! E.g. putting every tags etc into a helper file!
     double getTmpLatitude(int id) {
-        if (id == EMPTY)
+        if (id == EMPTY_NODE)
             return Double.NaN;
         if (id < TOWER_NODE) {
             // tower node
@@ -499,7 +498,7 @@ public class OSMReader implements DataReader {
     }
 
     double getTmpLongitude(int id) {
-        if (id == EMPTY)
+        if (id == EMPTY_NODE)
             return Double.NaN;
         if (id < TOWER_NODE) {
             // tower node
@@ -533,7 +532,7 @@ public class OSMReader implements DataReader {
 
     boolean addNode(ReaderNode node) {
         int nodeType = getNodeMap().get(node.getId());
-        if (nodeType == EMPTY)
+        if (nodeType == EMPTY_NODE)
             return false;
 
         double lat = node.getLat();
@@ -575,11 +574,11 @@ public class OSMReader implements DataReader {
     }
 
     void prepareHighwayNode(long osmId) {
-        int tmpIndex = getNodeMap().get(osmId);
-        if (tmpIndex == EMPTY) {
+        int tmpGHNodeId = getNodeMap().get(osmId);
+        if (tmpGHNodeId == EMPTY_NODE) {
             // osmId is used exactly once
             getNodeMap().put(osmId, PILLAR_NODE);
-        } else if (tmpIndex > EMPTY) {
+        } else if (tmpGHNodeId > EMPTY_NODE) {
             // mark node as tower node as it occured at least twice times
             getNodeMap().put(osmId, TOWER_NODE);
         } else {
@@ -612,7 +611,7 @@ public class OSMReader implements DataReader {
             for (int i = 0; i < osmNodeIds.size(); i++) {
                 long osmId = osmNodeIds.get(i);
                 int tmpNode = getNodeMap().get(osmId);
-                if (tmpNode == EMPTY)
+                if (tmpNode == EMPTY_NODE)
                     continue;
 
                 // skip osmIds with no associated pillar or tower id (e.g. !OSMReader.isBounds)

--- a/reader-osm/src/main/java/com/graphhopper/reader/osm/OSMTurnRelation.java
+++ b/reader-osm/src/main/java/com/graphhopper/reader/osm/OSMTurnRelation.java
@@ -64,7 +64,7 @@ public class OSMTurnRelation {
 
         try {
             // street with restriction was not included (access or tag limits etc)
-            if (nodeVia == OSMReader.EMPTY)
+            if (nodeVia == OSMReader.EMPTY_NODE)
                 return Collections.emptyList();
 
             int edgeIdFrom = EdgeIterator.NO_EDGE;

--- a/reader-osm/src/main/java/com/graphhopper/reader/osm/pbf/PbfBlobDecoder.java
+++ b/reader-osm/src/main/java/com/graphhopper/reader/osm/pbf/PbfBlobDecoder.java
@@ -1,6 +1,7 @@
 // This software is released into the Public Domain.  See copying.txt for details.
 package com.graphhopper.reader.osm.pbf;
 
+import com.carrotsearch.hppc.LongIndexedContainer;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.graphhopper.reader.ReaderElement;
 import com.graphhopper.reader.ReaderNode;
@@ -8,7 +9,6 @@ import com.graphhopper.reader.ReaderRelation;
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.reader.osm.OSMFileHeader;
 import com.graphhopper.util.Helper;
-import gnu.trove.list.TLongList;
 import org.openstreetmap.osmosis.osmbinary.Fileformat;
 import org.openstreetmap.osmosis.osmbinary.Osmformat;
 import org.slf4j.Logger;
@@ -253,7 +253,7 @@ public class PbfBlobDecoder implements Runnable {
             // delta encoded meaning that each id is stored as a delta against
             // the previous one.
             long nodeId = 0;
-            TLongList wayNodes = osmWay.getNodes();
+            LongIndexedContainer wayNodes = osmWay.getNodes();
             for (long nodeIdOffset : way.getRefsList()) {
                 nodeId += nodeIdOffset;
                 wayNodes.add(nodeId);

--- a/reader-osm/src/test/java/com/graphhopper/GraphHopperIT.java
+++ b/reader-osm/src/test/java/com/graphhopper/GraphHopperIT.java
@@ -40,7 +40,7 @@ import static org.junit.Assert.*;
  * @author Peter Karich
  */
 public class GraphHopperIT {
-    private static final double PRECISION = 0.01;
+    
     public static final String DIR = "../core/files";
     private static final String graphFileFoot = "target/graphhopperIT-foot";
     private static final String osmFile = DIR + "/monaco.osm.gz";
@@ -89,7 +89,7 @@ public class GraphHopperIT {
         assertEquals(698, rsp.getHints().getLong("visited_nodes.sum", 0));
 
         PathWrapper arsp = rsp.getBest();
-        assertEquals(3437.58, arsp.getDistance(), PRECISION);
+        assertEquals(3437.6, arsp.getDistance(), .1);
         assertEquals(89, arsp.getPoints().getSize());
 
         assertEquals(43.7276852, arsp.getWaypoints().getLat(0), 1e-7);
@@ -197,7 +197,7 @@ public class GraphHopperIT {
                 setEncodingManager(new EncodingManager("car"));
         tmpHopper.importOrLoad();
 
-        GHRequest req = new GHRequest(49.46553,11.154669, 49.465244,11.152577).
+        GHRequest req = new GHRequest(49.46553, 11.154669, 49.465244, 11.152577).
                 setVehicle("car").setWeighting("fastest");
 
         req.setPointHints(new ArrayList<>(Arrays.asList("Laufamholzstraße, 90482, Nürnberg, Deutschland", "")));
@@ -232,7 +232,7 @@ public class GraphHopperIT {
                 setAlgorithm(ASTAR).setVehicle(vehicle).setWeighting(weightCalcStr));
 
         PathWrapper arsp = rsp.getBest();
-        assertEquals(6875.17, arsp.getDistance(), PRECISION);
+        assertEquals(6875.2, arsp.getDistance(), .1);
         assertEquals(179, arsp.getPoints().getSize());
 
         InstructionList il = arsp.getInstructions();
@@ -274,8 +274,8 @@ public class GraphHopperIT {
                 setAlgorithm(ASTAR).setVehicle(vehicle).setWeighting(weightCalcStr));
 
         arsp = rsp.getBest();
-        assertEquals(0, arsp.getDistance(), PRECISION);
-        assertEquals(0, arsp.getRouteWeight(), PRECISION);
+        assertEquals(0, arsp.getDistance(), .1);
+        assertEquals(0, arsp.getRouteWeight(), .1);
         assertEquals(1, arsp.getPoints().getSize());
         assertEquals(1, arsp.getInstructions().size());
         assertEquals("Finish!", arsp.getInstructions().createJson().get(0).get("text"));
@@ -288,8 +288,8 @@ public class GraphHopperIT {
                 setAlgorithm(ASTAR).setVehicle(vehicle).setWeighting(weightCalcStr));
 
         arsp = rsp.getBest();
-        assertEquals(0, arsp.getDistance(), PRECISION);
-        assertEquals(0, arsp.getRouteWeight(), PRECISION);
+        assertEquals(0, arsp.getDistance(), .1);
+        assertEquals(0, arsp.getRouteWeight(), .1);
         assertEquals(2, arsp.getPoints().getSize());
         assertEquals(2, arsp.getInstructions().size());
         assertEquals(Instruction.REACHED_VIA, arsp.getInstructions().createJson().get(0).get("sign"));
@@ -423,7 +423,7 @@ public class GraphHopperIT {
                 setAlgorithm(ASTAR).setVehicle(vehicle).setWeighting(weightCalcStr));
 
         PathWrapper arsp = rsp.getBest();
-        assertEquals(1626.81, arsp.getDistance(), PRECISION);
+        assertEquals(1626.8, arsp.getDistance(), .1);
         assertEquals(60, arsp.getPoints().getSize());
         assertTrue(arsp.getPoints().is3D());
 
@@ -464,56 +464,54 @@ public class GraphHopperIT {
     @Test
     public void testSRTMWithoutTunnelInterpolation() throws Exception {
         GraphHopper tmpHopper = new GraphHopperOSM().setOSMFile(osmFile).setStoreOnFlush(true)
-                        .setCHEnabled(false).setGraphHopperLocation(tmpGraphFile)
-                        .setEncodingManager(new EncodingManager(importVehicles, 8));
+                .setCHEnabled(false).setGraphHopperLocation(tmpGraphFile)
+                .setEncodingManager(new EncodingManager(importVehicles, 8));
 
         tmpHopper.setElevationProvider(new SRTMProvider().setCacheDir(new File(DIR)));
         tmpHopper.importOrLoad();
 
         GHResponse rsp = tmpHopper.route(new GHRequest(43.74056471749763, 7.4299266210693755,
-                        43.73790260334179, 7.427984089259056).setAlgorithm(ASTAR)
-                                        .setVehicle(vehicle).setWeighting(weightCalcStr));
+                43.73790260334179, 7.427984089259056).setAlgorithm(ASTAR)
+                .setVehicle(vehicle).setWeighting(weightCalcStr));
         PathWrapper arsp = rsp.getBest();
-        assertEquals(356.79, arsp.getDistance(), PRECISION);
+        assertEquals(356.5, arsp.getDistance(), .1);
         PointList pointList = arsp.getPoints();
         assertEquals(6, pointList.getSize());
         assertTrue(pointList.is3D());
 
-        assertEquals(17.0, pointList.getEle(0), PRECISION);
-        assertEquals(23.0, pointList.getEle(1), PRECISION);
-        assertEquals(23.0, pointList.getEle(2), PRECISION);
-        assertEquals(41.0, pointList.getEle(3), PRECISION);
-        assertEquals(19.0, pointList.getEle(4), PRECISION);
-        assertEquals(26.5, pointList.getEle(5), PRECISION);
+        assertEquals(20.0, pointList.getEle(0), .1);
+        assertEquals(23.0, pointList.getEle(1), .1);
+        assertEquals(23.0, pointList.getEle(2), .1);
+        assertEquals(41.0, pointList.getEle(3), .1);
+        assertEquals(19.0, pointList.getEle(4), .1);
+        assertEquals(26.5, pointList.getEle(5), .1);
     }
 
     @Test
     public void testSRTMWithTunnelInterpolation() throws Exception {
         GraphHopper tmpHopper = new GraphHopperOSM().setOSMFile(osmFile).setStoreOnFlush(true)
-                        .setCHEnabled(false).setGraphHopperLocation(tmpGraphFile)
-                        .setEncodingManager(new EncodingManager(genericImportVehicles, 8));
+                .setCHEnabled(false).setGraphHopperLocation(tmpGraphFile)
+                .setEncodingManager(new EncodingManager(genericImportVehicles, 8));
 
         tmpHopper.setElevationProvider(new SRTMProvider().setCacheDir(new File(DIR)));
         tmpHopper.importOrLoad();
 
         GHResponse rsp = tmpHopper.route(new GHRequest(43.74056471749763, 7.4299266210693755,
-                        43.73790260334179, 7.427984089259056).setAlgorithm(ASTAR)
-                                        .setVehicle(vehicle).setWeighting(weightCalcStr));
+                43.73790260334179, 7.427984089259056).setAlgorithm(ASTAR)
+                .setVehicle(vehicle).setWeighting(weightCalcStr));
         PathWrapper arsp = rsp.getBest();
-        // Without
-        // interpolation:
-        // 356.79372559007476
-        assertEquals(351.39, arsp.getDistance(), PRECISION);
+        // Without interpolation: 356.5
+        assertEquals(351.4, arsp.getDistance(), .1);
         PointList pointList = arsp.getPoints();
         assertEquals(6, pointList.getSize());
         assertTrue(pointList.is3D());
 
-        assertEquals(17, pointList.getEle(0), PRECISION);
-        assertEquals(19.04, pointList.getEle(1), PRECISION);
-        assertEquals(21.67, pointList.getEle(2), PRECISION);
-        assertEquals(25.03, pointList.getEle(3), PRECISION);
-        assertEquals(28.65, pointList.getEle(4), PRECISION);
-        assertEquals(31.32, pointList.getEle(5), PRECISION);
+        assertEquals(17, pointList.getEle(0), .1);
+        assertEquals(19.04, pointList.getEle(1), .1);
+        assertEquals(21.67, pointList.getEle(2), .1);
+        assertEquals(25.03, pointList.getEle(3), .1);
+        assertEquals(28.65, pointList.getEle(4), .1);
+        assertEquals(31.32, pointList.getEle(5), .1);
     }
 
     @Test
@@ -535,7 +533,7 @@ public class GraphHopperIT {
                 setAlgorithm(ASTAR).setVehicle(tmpVehicle).setWeighting(tmpWeightCalcStr));
 
         PathWrapper arsp = rsp.getBest();
-        assertEquals(6932.24, arsp.getDistance(), PRECISION);
+        assertEquals(6932.2, arsp.getDistance(), .1);
         assertEquals(110, arsp.getPoints().getSize());
 
         InstructionList il = arsp.getInstructions();
@@ -686,7 +684,7 @@ public class GraphHopperIT {
         long sum = rsp.getHints().getLong("visited_nodes.sum", 0);
         assertNotEquals(sum, 0);
         assertTrue("Too many nodes visited " + sum, sum < 120);
-        assertEquals(3437.59, bestPath.getDistance(), PRECISION);
+        assertEquals(3437.6, bestPath.getDistance(), .1);
         assertEquals(89, bestPath.getPoints().getSize());
 
         tmpHopper.close();
@@ -706,7 +704,7 @@ public class GraphHopperIT {
 
         assertEquals(1, rsp.getAll().size());
         PathWrapper pw = rsp.getBest();
-        assertEquals(1.45, rsp.getBest().getDistance() / 1000f, PRECISION);
+        assertEquals(1.45, rsp.getBest().getDistance() / 1000f, .01);
         assertEquals(17, rsp.getBest().getTime() / 1000f / 60, 1);
         assertEquals(65, pw.getPoints().size());
     }

--- a/reader-osm/src/test/java/com/graphhopper/reader/osm/GraphHopperOSMTest.java
+++ b/reader-osm/src/test/java/com/graphhopper/reader/osm/GraphHopperOSMTest.java
@@ -17,6 +17,7 @@
  */
 package com.graphhopper.reader.osm;
 
+import com.carrotsearch.hppc.IntArrayList;
 import com.graphhopper.GHRequest;
 import com.graphhopper.GHResponse;
 import com.graphhopper.GraphHopper;
@@ -616,7 +617,7 @@ public class GraphHopperOSMTest {
         GHResponse response = new GHResponse();
         List<Path> paths = instance.calcPaths(req, response);
         assertFalse(response.hasErrors());
-        assertArrayEquals(new int[]{10, 5, 6, 7, 11}, paths.get(0).calcNodes().toArray());
+        assertEquals(IntArrayList.from(9, 5, 6, 7, 11), paths.get(0).calcNodes());
     }
 
     @Test
@@ -636,8 +637,8 @@ public class GraphHopperOSMTest {
         List<Path> paths = instance.calcPaths(req, response);
         assertFalse(response.hasErrors());
         assertEquals(1, response.getAll().size());
-        assertArrayEquals(new int[]{10, 4, 3, 11}, paths.get(0).calcNodes().toArray());
-        assertArrayEquals(new int[]{11, 8, 1, 2, 9}, paths.get(1).calcNodes().toArray());
+        assertEquals(IntArrayList.from(9, 4, 3, 10), paths.get(0).calcNodes());
+        assertEquals(IntArrayList.from(10, 8, 1, 2, 11), paths.get(1).calcNodes());
     }
 
     @Test
@@ -656,8 +657,8 @@ public class GraphHopperOSMTest {
         GHResponse response = new GHResponse();
         List<Path> paths = instance.calcPaths(req, response);
         assertFalse(response.hasErrors());
-        assertArrayEquals(new int[]{10, 4, 3, 8, 7, 9}, paths.get(0).calcNodes().toArray());
-        assertArrayEquals(new int[]{9, 6, 5, 10, 4, 3, 11}, paths.get(1).calcNodes().toArray());
+        assertEquals(IntArrayList.from(9, 4, 3, 8, 7, 11), paths.get(0).calcNodes());
+        assertEquals(IntArrayList.from(11, 6, 5, 9, 4, 3, 10), paths.get(1).calcNodes());
     }
 
     @Test

--- a/reader-osm/src/test/java/com/graphhopper/reader/osm/OSMReaderTest.java
+++ b/reader-osm/src/test/java/com/graphhopper/reader/osm/OSMReaderTest.java
@@ -17,6 +17,7 @@
  */
 package com.graphhopper.reader.osm;
 
+import com.carrotsearch.hppc.LongIndexedContainer;
 import com.graphhopper.GHRequest;
 import com.graphhopper.GHResponse;
 import com.graphhopper.GraphHopper;
@@ -33,7 +34,6 @@ import com.graphhopper.storage.index.LocationIndex;
 import com.graphhopper.storage.index.QueryResult;
 import com.graphhopper.util.*;
 import com.graphhopper.util.shapes.GHPoint;
-import gnu.trove.list.TLongList;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -553,7 +553,7 @@ public class OSMReaderTest {
             }
 
             @Override
-            Collection<EdgeIteratorState> addOSMWay(TLongList osmNodeIds, long wayFlags, long osmId) {
+            Collection<EdgeIteratorState> addOSMWay(LongIndexedContainer osmNodeIds, long wayFlags, long osmId) {
                 return Collections.emptyList();
             }
         };

--- a/reader-shp/src/main/java/com/graphhopper/reader/shp/OSMShapeFileReader.java
+++ b/reader-shp/src/main/java/com/graphhopper/reader/shp/OSMShapeFileReader.java
@@ -17,18 +17,7 @@
  */
 package com.graphhopper.reader.shp;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-
-import org.geotools.data.DataStore;
-import org.geotools.feature.FeatureIterator;
-import org.opengis.feature.simple.SimpleFeature;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
+import com.graphhopper.coll.GHObjectIntHashMap;
 import com.graphhopper.reader.DataReader;
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.reader.dem.ElevationProvider;
@@ -41,9 +30,17 @@ import com.graphhopper.util.shapes.GHPoint;
 import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.LineString;
 import com.vividsolutions.jts.geom.MultiLineString;
+import org.geotools.data.DataStore;
+import org.geotools.feature.FeatureIterator;
+import org.opengis.feature.simple.SimpleFeature;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import gnu.trove.impl.Constants;
-import gnu.trove.map.hash.TObjectIntHashMap;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
 
 /**
  * OSMShapeFileReader for files present at : http://download.geofabrik.de/ It
@@ -53,13 +50,12 @@ import gnu.trove.map.hash.TObjectIntHashMap;
  * @author Philip Welch
  */
 public class OSMShapeFileReader extends ShapeFileReader {
-    private static final int COORD_STATE_UNKNOWN = -1;
+    private static final int COORD_STATE_UNKNOWN = 0;
     private static final int COORD_STATE_PILLAR = -2;
     private static final int FIRST_NODE_ID = 1;
     private static final String[] DIRECT_COPY_TAGS = new String[]{"name"};
     private File roadsFile;
-    private final TObjectIntHashMap<Coordinate> coordState = new TObjectIntHashMap<>(
-            Constants.DEFAULT_CAPACITY, Constants.DEFAULT_LOAD_FACTOR, COORD_STATE_UNKNOWN);
+    private final GHObjectIntHashMap<Coordinate> coordState = new GHObjectIntHashMap<>(1000, 0.7f);
     private final DistanceCalc distCalc = Helper.DIST_EARTH;
     private static final Logger LOGGER = LoggerFactory.getLogger(OSMShapeFileReader.class);
     private final HashSet<EdgeAddedListener> edgeAddedListeners = new HashSet<>();

--- a/tools/src/main/java/com/graphhopper/ui/MiniGraphUI.java
+++ b/tools/src/main/java/com/graphhopper/ui/MiniGraphUI.java
@@ -17,6 +17,7 @@
  */
 package com.graphhopper.ui;
 
+import com.carrotsearch.hppc.IntIndexedContainer;
 import com.graphhopper.GraphHopper;
 import com.graphhopper.coll.GHBitSet;
 import com.graphhopper.coll.GHTBitSet;
@@ -32,7 +33,6 @@ import com.graphhopper.storage.index.QueryResult;
 import com.graphhopper.util.*;
 import com.graphhopper.util.Parameters.Algorithms;
 import com.graphhopper.util.shapes.BBox;
-import gnu.trove.list.TIntList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -314,7 +314,7 @@ public class MiniGraphUI {
         double prevLat = Double.NaN;
         double prevLon = Double.NaN;
         boolean plotNodes = false;
-        TIntList nodes = tmpPath.calcNodes();
+        IntIndexedContainer nodes = tmpPath.calcNodes();
         if (plotNodes) {
             for (int i = 0; i < nodes.size(); i++) {
                 plotNodeName(g2, nodes.get(i));


### PR DESCRIPTION
This fixes an early issue #34 and improves #562 

The advantages:

 * core no longer relies on any LGPL dependency, which makes using the library a no-brainer then on Android & iOS (license-wise one could have argumented that e.g. dalvik merges trove with our core and 'infects' it and for iOS it could be even worse)
 * hppc is a smaller library (<2MB instead of >3MB)
 * seems to work very similar fast now these days

Disadvantages

 * took a bit time to make it working, see [here](https://groups.google.com/forum/#!topic/java-high-performance-primitive-collections/KvqyWiMTX8g) for the detailed issues
 * some unknown bugs or performance changes?

Not yet done:

 - [x] hppc has only 0 for default value but -1 was required in constructor -> GHTBitSet (TIntHashSet); OSMShapeReader -> TObjectIntHashMap; OSMReader -> edgeIdToOsmWayIdMap (GHIntLongHashMap);
 - [x] fix some license headers (GHIntHashSet.java)
 - [x] review by community
 - [x] deployed and tested to staging server world wide
 - [x] deploy to production (also ww)
 - [x] is hashmixing only important for mixing two hashes or also when resizing a hash? Or other way around if trove4j also this problem we can probably ignore it for now but must be aware of it e.g. if there are performance problems.
 - [x] fix android docs about trove (docs/android/index.md#Problems)
 - [ ] fix iOS with @clns its help