### PR TITLE
Allow to block area per request

### DIFF
--- a/config-example.properties
+++ b/config-example.properties
@@ -57,6 +57,8 @@ prepare.min_one_way_network_size=200
 # the given distance in meter. Default is set to 1000km.
 routing.non_ch.max_waypoint_distance = 1000000
 
+# You can block certain areas from routing
+# e.g. you can block a BBox using this snippet blocked_rectangular_areas=8.6153,48.1875,9.8692,48.7242
 
 ##### Web #####
 

--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -44,6 +44,7 @@ import com.graphhopper.util.Parameters.Routing;
 import com.graphhopper.util.exceptions.PointDistanceExceededException;
 import com.graphhopper.util.exceptions.PointOutOfBoundsException;
 import com.graphhopper.util.shapes.BBox;
+import com.graphhopper.util.shapes.Circle;
 import com.graphhopper.util.shapes.GHPoint;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -972,12 +973,12 @@ public class GraphHopper implements GraphHopperAPI {
             }
         }
 
-        // Add Blocked Areas
-        String blockedAreasStr = hints.get(Parameters.NON_CH.BLOCKED_AREAS, "");
+        // Add Blocked Rectangular Areas
+        String blockedAreasStr = hints.get(Parameters.NON_CH.BLOCKED_RECTANGULAR_AREAS, "");
         if (!blockedAreasStr.isEmpty()) {
             String[] blockedAreasArr = blockedAreasStr.split(",");
             if (blockedAreasArr.length % 4 != 0) {
-                throw new IllegalArgumentException(Parameters.NON_CH.BLOCKED_AREAS + " need to be defined as left,bottom,right,top");
+                throw new IllegalArgumentException(Parameters.NON_CH.BLOCKED_RECTANGULAR_AREAS + " need to be defined as left,bottom,right,top");
             }
 
             double left;
@@ -991,7 +992,29 @@ public class GraphHopper implements GraphHopperAPI {
                 top = Double.parseDouble(blockedAreasArr[4 * i + 3]);
 
                 final BBox bbox = new BBox(left, right, bottom, top);
-                browser.findEdgesInBBox(blockedEdges, bbox, filter);
+                browser.findEdgesInShape(blockedEdges, bbox, filter);
+            }
+
+        }
+
+        // Add Blocked Circular Areas
+        String blockedCircularAreasStr = hints.get(Parameters.NON_CH.BLOCKED_CIRCULAR_AREAS, "");
+        if (!blockedCircularAreasStr.isEmpty()) {
+            String[] blockedCircularAreasArr = blockedCircularAreasStr.split(",");
+            if (blockedCircularAreasArr.length % 3 != 0) {
+                //TODO: Do we ant radius or diameter?
+                throw new IllegalArgumentException(Parameters.NON_CH.BLOCKED_CIRCULAR_AREAS + " need to be defined as lat,lng,radius");
+            }
+
+            double lat;
+            double lng;
+            int radius;
+            for (int i = 0; i < blockedCircularAreasArr.length / 3; i++) {
+                lat= Double.parseDouble(blockedCircularAreasArr[3 * i]);
+                lng = Double.parseDouble(blockedCircularAreasArr[3 * i + 1]);
+                radius = Integer.parseInt(blockedCircularAreasArr[3 * i + 2]);
+                Circle circle = new Circle(lat, lng, radius);
+                browser.findEdgesInShape(blockedEdges, circle, filter);
             }
 
         }

--- a/core/src/main/java/com/graphhopper/coll/GHBitSetImpl.java
+++ b/core/src/main/java/com/graphhopper/coll/GHBitSetImpl.java
@@ -24,6 +24,7 @@ import java.util.BitSet;
  */
 public class GHBitSetImpl extends BitSet implements GHBitSet {
     public GHBitSetImpl() {
+        super();
     }
 
     public GHBitSetImpl(int nbits) {

--- a/core/src/main/java/com/graphhopper/routing/ch/CHAlgoFactoryDecorator.java
+++ b/core/src/main/java/com/graphhopper/routing/ch/CHAlgoFactoryDecorator.java
@@ -22,6 +22,7 @@ import com.graphhopper.routing.RoutingAlgorithmFactoryDecorator;
 import com.graphhopper.routing.util.HintsMap;
 import com.graphhopper.routing.util.TraversalMode;
 import com.graphhopper.routing.weighting.AbstractWeighting;
+import com.graphhopper.routing.weighting.GenericWeighting;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.*;
 import com.graphhopper.util.CmdArgs;
@@ -322,6 +323,9 @@ public class CHAlgoFactoryDecorator implements RoutingAlgorithmFactoryDecorator 
         traversalMode = getNodeBase();
 
         for (Weighting weighting : getWeightings()) {
+            if(weighting instanceof GenericWeighting){
+                ((GenericWeighting) weighting).setGraph(ghStorage);
+            }
             PrepareContractionHierarchies tmpPrepareCH = new PrepareContractionHierarchies(
                     new GHDirectory("", DAType.RAM_INT), ghStorage, ghStorage.getGraph(CHGraph.class, weighting),
                     weighting, traversalMode);

--- a/core/src/main/java/com/graphhopper/routing/weighting/GenericWeighting.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/GenericWeighting.java
@@ -20,15 +20,11 @@ package com.graphhopper.routing.weighting;
 import com.graphhopper.coll.GHIntHashSet;
 import com.graphhopper.routing.util.DataFlagEncoder;
 import com.graphhopper.storage.Graph;
-import com.graphhopper.storage.NodeAccess;
 import com.graphhopper.util.ConfigMap;
 import com.graphhopper.util.EdgeIteratorState;
-import com.graphhopper.util.Parameters;
 import com.graphhopper.util.Parameters.Routing;
-import com.graphhopper.util.shapes.Circle;
 import com.graphhopper.util.shapes.Shape;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -53,7 +49,7 @@ public class GenericWeighting extends AbstractWeighting {
     private final int eventuallAccessiblePenalty = 10;
 
     private final GHIntHashSet blockedEdges;
-    private List<Shape> blockedShapes;
+    private final List<Shape> blockedShapes;
     private Graph graph;
 
     public GenericWeighting(DataFlagEncoder encoder, ConfigMap cMap) {
@@ -73,16 +69,8 @@ public class GenericWeighting extends AbstractWeighting {
 
         maxSpeed = tmpSpeed / SPEED_CONV;
         accessType = gEncoder.getAccessType("motor_vehicle");
-        blockedEdges = cMap.get(Parameters.NON_CH.BLOCKED_EDGES, new GHIntHashSet(0));
-        blockedShapes = cMap.get(Parameters.NON_CH.BLOCKED_SHAPES, Collections.EMPTY_LIST);
-        // TODO Uncomment this, if you want to use Blocked Shapes with CH
-        /*
-        if(blockedShapes.isEmpty()){
-            // TODO add final Again
-            blockedShapes = new ArrayList<>();
-            blockedShapes.add(new Circle(48.491127,9.28894, 70000));
-        }
-        */
+        blockedEdges = cMap.get(Routing.BLOCKED_EDGES, new GHIntHashSet(0));
+        blockedShapes = cMap.get(Routing.BLOCKED_SHAPES, Collections.EMPTY_LIST);
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/weighting/GenericWeighting.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/GenericWeighting.java
@@ -17,9 +17,11 @@
  */
 package com.graphhopper.routing.weighting;
 
+import com.graphhopper.coll.GHIntHashSet;
 import com.graphhopper.routing.util.DataFlagEncoder;
 import com.graphhopper.util.ConfigMap;
 import com.graphhopper.util.EdgeIteratorState;
+import com.graphhopper.util.Parameters;
 import com.graphhopper.util.Parameters.Routing;
 
 /**
@@ -42,6 +44,8 @@ public class GenericWeighting extends AbstractWeighting {
     private final int accessType;
     private final int eventuallAccessiblePenalty = 10;
 
+    private final GHIntHashSet blockedEdges;
+
 
     public GenericWeighting(DataFlagEncoder encoder, ConfigMap cMap) {
         super(encoder);
@@ -60,6 +64,7 @@ public class GenericWeighting extends AbstractWeighting {
 
         maxSpeed = tmpSpeed / SPEED_CONV;
         accessType = gEncoder.getAccessType("motor_vehicle");
+        blockedEdges = cMap.get(Parameters.NON_CH.BLOCKED_EDGES, new GHIntHashSet(0));
     }
 
     @Override
@@ -85,6 +90,10 @@ public class GenericWeighting extends AbstractWeighting {
                 return Double.POSITIVE_INFINITY;
             case EVENTUALLY_ACCESSIBLE:
                 time = time * eventuallAccessiblePenalty;
+        }
+
+        if(!blockedEdges.isEmpty() && blockedEdges.contains(edgeState.getEdge())){
+            return Double.POSITIVE_INFINITY;
         }
 
         return time;

--- a/core/src/main/java/com/graphhopper/storage/GraphBrowser.java
+++ b/core/src/main/java/com/graphhopper/storage/GraphBrowser.java
@@ -1,0 +1,84 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.graphhopper.storage;
+
+import com.graphhopper.coll.GHIntHashSet;
+import com.graphhopper.routing.util.EdgeFilter;
+import com.graphhopper.storage.index.LocationIndex;
+import com.graphhopper.storage.index.QueryResult;
+import com.graphhopper.util.BreadthFirstSearch;
+import com.graphhopper.util.EdgeIteratorState;
+import com.graphhopper.util.shapes.BBox;
+import com.graphhopper.util.shapes.GHPoint;
+
+/**
+ * This Class allows to easily Browse the Graph for Edges with Certain Properties
+ *
+ * @author Robin Boldt
+ */
+public class GraphBrowser {
+
+    private final Graph graph;
+    private final LocationIndex locationIndex;
+
+    public GraphBrowser(Graph graph, LocationIndex locationIndex) {
+        this.graph = graph;
+        this.locationIndex = locationIndex;
+    }
+
+    public void findClosestEdgeToPoint(GHIntHashSet edgeIds, GHPoint point, EdgeFilter filter) {
+        findClosestEdge(edgeIds, point.getLat(), point.getLon(), filter);
+    }
+
+    public void findClosestEdge(GHIntHashSet edgeIds, double lat, double lon, EdgeFilter filter) {
+        QueryResult qr = locationIndex.findClosest(lat, lon, filter);
+        if (qr.isValid())
+            edgeIds.add(qr.getClosestEdge().getEdge());
+    }
+
+    public void findEdgesInBBox(final GHIntHashSet edgeIds, final BBox bbox, EdgeFilter filter) {
+        // Issue with this is approach is, if there is no street close by, it won't work as qr is not valid
+        QueryResult qr = locationIndex.findClosest((bbox.maxLat + bbox.minLat) / 2, (bbox.maxLon + bbox.minLon) / 2, filter);
+
+        // We should throw an Exception here, or add an Error somehow. Otherwise the user will not understand what is happening
+        // It might happen that a BBox center does not match an underlying street
+        if (!qr.isValid())
+            return;
+
+        BreadthFirstSearch bfs = new BreadthFirstSearch() {
+            final NodeAccess na = graph.getNodeAccess();
+            final BBox localBBox = bbox;
+
+            @Override
+            protected boolean goFurther(int nodeId) {
+                return localBBox.contains(na.getLatitude(nodeId), na.getLongitude(nodeId));
+            }
+
+            @Override
+            protected boolean checkAdjacent(EdgeIteratorState edge) {
+                if (localBBox.contains(na.getLatitude(edge.getAdjNode()), na.getLongitude(edge.getAdjNode()))) {
+                    edgeIds.add(edge.getEdge());
+                    return true;
+                }
+                return false;
+            }
+        };
+        bfs.start(graph.createEdgeExplorer(filter), qr.getClosestNode());
+    }
+}

--- a/core/src/main/java/com/graphhopper/util/Parameters.java
+++ b/core/src/main/java/com/graphhopper/util/Parameters.java
@@ -142,10 +142,10 @@ public class Parameters {
          */
         public static final String MAX_NON_CH_POINT_DISTANCE = ROUTING_INIT_PREFIX + NON_CH_PREFIX + "max_waypoint_distance";
 
-        public static final String BLOCKED_EDGES = ROUTING_INIT_PREFIX + NON_CH_PREFIX + "blocked_edges";
+        public static final String BLOCKED_EDGES = NON_CH_PREFIX + "blocked_edges";
 
-        public static final String BLOCKED_POINTS = ROUTING_INIT_PREFIX + NON_CH_PREFIX + "blocked_points";
+        public static final String BLOCKED_POINTS = NON_CH_PREFIX + "blocked_points";
 
-        public static final String BLOCKED_AREAS = ROUTING_INIT_PREFIX + NON_CH_PREFIX + "blocked_areas";
+        public static final String BLOCKED_AREAS = NON_CH_PREFIX + "blocked_areas";
     }
 }

--- a/core/src/main/java/com/graphhopper/util/Parameters.java
+++ b/core/src/main/java/com/graphhopper/util/Parameters.java
@@ -141,5 +141,11 @@ public class Parameters {
          * Describes the max allowed distance between two consecutive waypoints of a non ch request. Distance is in Meter
          */
         public static final String MAX_NON_CH_POINT_DISTANCE = ROUTING_INIT_PREFIX + NON_CH_PREFIX + "max_waypoint_distance";
+
+        public static final String BLOCKED_EDGES = ROUTING_INIT_PREFIX + NON_CH_PREFIX + "blocked_edges";
+
+        public static final String BLOCKED_POINTS = ROUTING_INIT_PREFIX + NON_CH_PREFIX + "blocked_points";
+
+        public static final String BLOCKED_AREAS = ROUTING_INIT_PREFIX + NON_CH_PREFIX + "blocked_areas";
     }
 }

--- a/core/src/main/java/com/graphhopper/util/Parameters.java
+++ b/core/src/main/java/com/graphhopper/util/Parameters.java
@@ -146,6 +146,8 @@ public class Parameters {
 
         public static final String BLOCKED_POINTS = NON_CH_PREFIX + "blocked_points";
 
-        public static final String BLOCKED_AREAS = NON_CH_PREFIX + "blocked_areas";
+        public static final String BLOCKED_RECTANGULAR_AREAS = NON_CH_PREFIX + "blocked_rectangular_areas";
+
+        public static final String BLOCKED_CIRCULAR_AREAS = NON_CH_PREFIX + "blocked_circular_areas";
     }
 }

--- a/core/src/main/java/com/graphhopper/util/Parameters.java
+++ b/core/src/main/java/com/graphhopper/util/Parameters.java
@@ -149,5 +149,9 @@ public class Parameters {
         public static final String BLOCKED_RECTANGULAR_AREAS = NON_CH_PREFIX + "blocked_rectangular_areas";
 
         public static final String BLOCKED_CIRCULAR_AREAS = NON_CH_PREFIX + "blocked_circular_areas";
+
+        public static final String BLOCK_BY_SHAPE = NON_CH_PREFIX + "block_by_shape";
+
+        public static final String BLOCKED_SHAPES = NON_CH_PREFIX + "blocked_shapes";
     }
 }

--- a/core/src/main/java/com/graphhopper/util/Parameters.java
+++ b/core/src/main/java/com/graphhopper/util/Parameters.java
@@ -109,6 +109,15 @@ public class Parameters {
          */
         public static final double DEFAULT_HEADING_PENALTY = 300;
         public static final String HEADING_PENALTY = "heading_penalty";
+        /**
+         * Blocking Settings
+         */
+        public static final String BLOCKED_EDGES = "blocked_edges";
+        public static final String BLOCKED_POINTS = "blocked_points";
+        public static final String BLOCKED_RECTANGULAR_AREAS = "blocked_rectangular_areas";
+        public static final String BLOCKED_CIRCULAR_AREAS = "blocked_circular_areas";
+        public static final String BLOCK_BY_SHAPE = "block_by_shape";
+        public static final String BLOCKED_SHAPES = "blocked_shapes";
     }
 
     /**
@@ -142,16 +151,5 @@ public class Parameters {
          */
         public static final String MAX_NON_CH_POINT_DISTANCE = ROUTING_INIT_PREFIX + NON_CH_PREFIX + "max_waypoint_distance";
 
-        public static final String BLOCKED_EDGES = NON_CH_PREFIX + "blocked_edges";
-
-        public static final String BLOCKED_POINTS = NON_CH_PREFIX + "blocked_points";
-
-        public static final String BLOCKED_RECTANGULAR_AREAS = NON_CH_PREFIX + "blocked_rectangular_areas";
-
-        public static final String BLOCKED_CIRCULAR_AREAS = NON_CH_PREFIX + "blocked_circular_areas";
-
-        public static final String BLOCK_BY_SHAPE = NON_CH_PREFIX + "block_by_shape";
-
-        public static final String BLOCKED_SHAPES = NON_CH_PREFIX + "blocked_shapes";
     }
 }

--- a/core/src/main/java/com/graphhopper/util/shapes/BBox.java
+++ b/core/src/main/java/com/graphhopper/util/shapes/BBox.java
@@ -181,6 +181,11 @@ public class BBox implements Shape, Cloneable {
     }
 
     @Override
+    public GHPoint getCenter() {
+        return new GHPoint((maxLat + minLat) / 2, (maxLon + minLon) / 2);
+    }
+
+    @Override
     public boolean equals(Object obj) {
         if (obj == null)
             return false;

--- a/core/src/main/java/com/graphhopper/util/shapes/Circle.java
+++ b/core/src/main/java/com/graphhopper/util/shapes/Circle.java
@@ -24,7 +24,7 @@ import com.graphhopper.util.Helper;
  * @author Peter Karich
  */
 public class Circle implements Shape {
-    private final double radiusInKm;
+    private final double radiusInMeter;
     private final double lat;
     private final double lon;
     private final double normedDist;
@@ -39,7 +39,7 @@ public class Circle implements Shape {
         this.calc = calc;
         this.lat = lat;
         this.lon = lon;
-        this.radiusInKm = radiusInMeter;
+        this.radiusInMeter = radiusInMeter;
         this.normedDist = calc.calcNormalizedDist(radiusInMeter);
         bbox = calc.createBBox(lat, lon, radiusInMeter);
     }
@@ -60,6 +60,11 @@ public class Circle implements Shape {
     @Override
     public BBox getBounds() {
         return bbox;
+    }
+
+    @Override
+    public GHPoint getCenter() {
+        return new GHPoint(lat,lon);
     }
 
     private double normDist(double lat1, double lon1) {
@@ -127,7 +132,7 @@ public class Circle implements Shape {
             return false;
         }
 
-        return normDist(c.lat, c.lon) <= calc.calcNormalizedDist(radiusInKm + c.radiusInKm);
+        return normDist(c.lat, c.lon) <= calc.calcNormalizedDist(radiusInMeter + c.radiusInMeter);
     }
 
     public boolean contains(BBox b) {
@@ -140,7 +145,7 @@ public class Circle implements Shape {
     }
 
     public boolean contains(Circle c) {
-        double res = radiusInKm - c.radiusInKm;
+        double res = radiusInMeter - c.radiusInMeter;
         if (res < 0) {
             return false;
         }
@@ -150,6 +155,6 @@ public class Circle implements Shape {
 
     @Override
     public String toString() {
-        return lat + "," + lon + ", radius:" + radiusInKm;
+        return lat + "," + lon + ", radius:" + radiusInMeter;
     }
 }

--- a/core/src/main/java/com/graphhopper/util/shapes/Shape.java
+++ b/core/src/main/java/com/graphhopper/util/shapes/Shape.java
@@ -44,4 +44,9 @@ public interface Shape {
      * @return the minimal rectangular bounding box of this shape
      */
     BBox getBounds();
+
+    /**
+     * @return The center of the shape, if applicable
+     */
+    GHPoint getCenter();
 }

--- a/core/src/test/java/com/graphhopper/routing/weighting/GenericWeightingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/GenericWeightingTest.java
@@ -19,10 +19,15 @@ package com.graphhopper.routing.weighting;
 
 import com.graphhopper.coll.GHIntHashSet;
 import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.util.AllEdgesIterator;
 import com.graphhopper.routing.util.DataFlagEncoder;
+import com.graphhopper.routing.util.EdgeFilter;
 import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.storage.Graph;
+import com.graphhopper.storage.GraphExtension;
 import com.graphhopper.storage.NodeAccess;
 import com.graphhopper.util.*;
+import com.graphhopper.util.shapes.BBox;
 import com.graphhopper.util.shapes.Circle;
 import com.graphhopper.util.shapes.Shape;
 import org.junit.Test;
@@ -62,22 +67,22 @@ public class GenericWeightingTest {
         way.setTag("maxspeed", "10");
         EdgeIteratorState edge = createEdge(27, 10, encoder.handleWayTags(way, 1, 0));
         ConfigMap cMap = encoder.readStringMap(new PMap());
-        Weighting instance = new GenericWeighting(encoder, cMap);
+        GenericWeighting instance = new GenericWeighting(encoder, cMap);
         assertEquals(3.0, instance.calcWeight(edge, false, EdgeIterator.NO_EDGE), 1e-8);
 
         List<Shape> shapes = new ArrayList<>(1);
         shapes.add(new Circle(1, 1, 1));
         cMap.put(Parameters.NON_CH.BLOCKED_SHAPES, shapes);
-        cMap.put("node_access", getNodeAccess());
         instance = new GenericWeighting(encoder, cMap);
+        instance.setGraph(getGraph());
         assertEquals(Double.POSITIVE_INFINITY, instance.calcWeight(edge, false, EdgeIterator.NO_EDGE), 1e-8);
 
         shapes.clear();
         // Do not match 1,1 of Edge - which is returned by NodeAccess
         shapes.add(new Circle(10, 10, 1));
         cMap.put(Parameters.NON_CH.BLOCKED_SHAPES, shapes);
-        cMap.put("node_access", getNodeAccess());
         instance = new GenericWeighting(encoder, cMap);
+        instance.setGraph(getGraph());
         assertEquals(3.0, instance.calcWeight(edge, false, EdgeIterator.NO_EDGE), 1e-8);
     }
 
@@ -112,72 +117,132 @@ public class GenericWeightingTest {
         };
     }
 
-    NodeAccess getNodeAccess(){
-        // Return 1 for every LatLon
-        return new NodeAccess() {
+    // Fake Graph that returns a Node Acess that returns 1 for for every getLat,getLon Edge
+    Graph getGraph(){
+        return new Graph() {
             @Override
-            public int getAdditionalNodeField(int nodeId) {
+            public Graph getBaseGraph() {
+                return null;
+            }
+
+            @Override
+            public int getNodes() {
                 return 0;
             }
 
             @Override
-            public void setAdditionalNodeField(int nodeId, int additionalValue) {
+            public NodeAccess getNodeAccess() {
+                return new NodeAccess() {
+                    @Override
+                    public int getAdditionalNodeField(int nodeId) {
+                        return 0;
+                    }
 
+                    @Override
+                    public void setAdditionalNodeField(int nodeId, int additionalValue) {
+
+                    }
+
+                    @Override
+                    public boolean is3D() {
+                        return false;
+                    }
+
+                    @Override
+                    public int getDimension() {
+                        return 0;
+                    }
+
+                    @Override
+                    public void ensureNode(int nodeId) {
+
+                    }
+
+                    @Override
+                    public void setNode(int nodeId, double lat, double lon) {
+
+                    }
+
+                    @Override
+                    public void setNode(int nodeId, double lat, double lon, double ele) {
+
+                    }
+
+                    @Override
+                    public double getLatitude(int nodeId) {
+                        return 1;
+                    }
+
+                    @Override
+                    public double getLat(int nodeId) {
+                        return 1;
+                    }
+
+                    @Override
+                    public double getLongitude(int nodeId) {
+                        return 1;
+                    }
+
+                    @Override
+                    public double getLon(int nodeId) {
+                        return 1;
+                    }
+
+                    @Override
+                    public double getElevation(int nodeId) {
+                        return 0;
+                    }
+
+                    @Override
+                    public double getEle(int nodeId) {
+                        return 0;
+                    }
+                };
             }
 
             @Override
-            public boolean is3D() {
-                return false;
+            public BBox getBounds() {
+                return null;
             }
 
             @Override
-            public int getDimension() {
-                return 0;
+            public EdgeIteratorState edge(int a, int b) {
+                return null;
             }
 
             @Override
-            public void ensureNode(int nodeId) {
-
+            public EdgeIteratorState edge(int a, int b, double distance, boolean bothDirections) {
+                return null;
             }
 
             @Override
-            public void setNode(int nodeId, double lat, double lon) {
-
+            public EdgeIteratorState getEdgeIteratorState(int edgeId, int adjNode) {
+                return null;
             }
 
             @Override
-            public void setNode(int nodeId, double lat, double lon, double ele) {
-
+            public AllEdgesIterator getAllEdges() {
+                return null;
             }
 
             @Override
-            public double getLatitude(int nodeId) {
-                return 1;
+            public EdgeExplorer createEdgeExplorer(EdgeFilter filter) {
+                return null;
             }
 
             @Override
-            public double getLat(int nodeId) {
-                return 1;
+            public EdgeExplorer createEdgeExplorer() {
+                return null;
             }
 
             @Override
-            public double getLongitude(int nodeId) {
-                return 1;
+            public Graph copyTo(Graph g) {
+                return null;
             }
 
             @Override
-            public double getLon(int nodeId) {
-                return 1;
-            }
-
-            @Override
-            public double getElevation(int nodeId) {
-                return 0;
-            }
-
-            @Override
-            public double getEle(int nodeId) {
-                return 0;
+            public GraphExtension getExtension() {
+                return null;
             }
         };
     }

--- a/core/src/test/java/com/graphhopper/routing/weighting/GenericWeightingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/GenericWeightingTest.java
@@ -21,8 +21,14 @@ import com.graphhopper.coll.GHIntHashSet;
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.util.DataFlagEncoder;
 import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.storage.NodeAccess;
 import com.graphhopper.util.*;
+import com.graphhopper.util.shapes.Circle;
+import com.graphhopper.util.shapes.Shape;
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
@@ -33,7 +39,7 @@ public class GenericWeightingTest {
     private final DataFlagEncoder encoder = (DataFlagEncoder) new EncodingManager("generic").getEncoder("generic");
 
     @Test
-    public void testBlocked() {
+    public void testBlockedById() {
         ReaderWay way = new ReaderWay(27l);
         way.setTag("highway", "primary");
         way.setTag("maxspeed", "10");
@@ -48,6 +54,33 @@ public class GenericWeightingTest {
         instance = new GenericWeighting(encoder, cMap);
         assertEquals(Double.POSITIVE_INFINITY, instance.calcWeight(edge, false, EdgeIterator.NO_EDGE), 1e-8);
     }
+
+    @Test
+    public void testBlockedByShape() {
+        ReaderWay way = new ReaderWay(27l);
+        way.setTag("highway", "primary");
+        way.setTag("maxspeed", "10");
+        EdgeIteratorState edge = createEdge(27, 10, encoder.handleWayTags(way, 1, 0));
+        ConfigMap cMap = encoder.readStringMap(new PMap());
+        Weighting instance = new GenericWeighting(encoder, cMap);
+        assertEquals(3.0, instance.calcWeight(edge, false, EdgeIterator.NO_EDGE), 1e-8);
+
+        List<Shape> shapes = new ArrayList<>(1);
+        shapes.add(new Circle(1, 1, 1));
+        cMap.put(Parameters.NON_CH.BLOCKED_SHAPES, shapes);
+        cMap.put("node_access", getNodeAccess());
+        instance = new GenericWeighting(encoder, cMap);
+        assertEquals(Double.POSITIVE_INFINITY, instance.calcWeight(edge, false, EdgeIterator.NO_EDGE), 1e-8);
+
+        shapes.clear();
+        // Do not match 1,1 of Edge - which is returned by NodeAccess
+        shapes.add(new Circle(10, 10, 1));
+        cMap.put(Parameters.NON_CH.BLOCKED_SHAPES, shapes);
+        cMap.put("node_access", getNodeAccess());
+        instance = new GenericWeighting(encoder, cMap);
+        assertEquals(3.0, instance.calcWeight(edge, false, EdgeIterator.NO_EDGE), 1e-8);
+    }
+
 
     EdgeIterator createEdge(final int edge, final double distance, final long flags) {
         return new GHUtility.DisabledEdgeIterator() {
@@ -71,6 +104,81 @@ public class GenericWeightingTest {
                 return _default;
             }
 
+            @Override
+            public int getAdjNode() {
+                return 1;
+            }
+
+        };
+    }
+
+    NodeAccess getNodeAccess(){
+        // Return 1 for every LatLon
+        return new NodeAccess() {
+            @Override
+            public int getAdditionalNodeField(int nodeId) {
+                return 0;
+            }
+
+            @Override
+            public void setAdditionalNodeField(int nodeId, int additionalValue) {
+
+            }
+
+            @Override
+            public boolean is3D() {
+                return false;
+            }
+
+            @Override
+            public int getDimension() {
+                return 0;
+            }
+
+            @Override
+            public void ensureNode(int nodeId) {
+
+            }
+
+            @Override
+            public void setNode(int nodeId, double lat, double lon) {
+
+            }
+
+            @Override
+            public void setNode(int nodeId, double lat, double lon, double ele) {
+
+            }
+
+            @Override
+            public double getLatitude(int nodeId) {
+                return 1;
+            }
+
+            @Override
+            public double getLat(int nodeId) {
+                return 1;
+            }
+
+            @Override
+            public double getLongitude(int nodeId) {
+                return 1;
+            }
+
+            @Override
+            public double getLon(int nodeId) {
+                return 1;
+            }
+
+            @Override
+            public double getElevation(int nodeId) {
+                return 0;
+            }
+
+            @Override
+            public double getEle(int nodeId) {
+                return 0;
+            }
         };
     }
 }

--- a/core/src/test/java/com/graphhopper/routing/weighting/GenericWeightingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/GenericWeightingTest.java
@@ -54,7 +54,7 @@ public class GenericWeightingTest {
         assertEquals(3.0, instance.calcWeight(edge, false, EdgeIterator.NO_EDGE), 1e-8);
 
         GHIntHashSet blockedEdges = new GHIntHashSet(1);
-        cMap.put(Parameters.NON_CH.BLOCKED_EDGES, blockedEdges);
+        cMap.put(Parameters.Routing.BLOCKED_EDGES, blockedEdges);
         blockedEdges.add(27);
         instance = new GenericWeighting(encoder, cMap);
         assertEquals(Double.POSITIVE_INFINITY, instance.calcWeight(edge, false, EdgeIterator.NO_EDGE), 1e-8);
@@ -72,7 +72,7 @@ public class GenericWeightingTest {
 
         List<Shape> shapes = new ArrayList<>(1);
         shapes.add(new Circle(1, 1, 1));
-        cMap.put(Parameters.NON_CH.BLOCKED_SHAPES, shapes);
+        cMap.put(Parameters.Routing.BLOCKED_SHAPES, shapes);
         instance = new GenericWeighting(encoder, cMap);
         instance.setGraph(getGraph());
         assertEquals(Double.POSITIVE_INFINITY, instance.calcWeight(edge, false, EdgeIterator.NO_EDGE), 1e-8);
@@ -80,7 +80,7 @@ public class GenericWeightingTest {
         shapes.clear();
         // Do not match 1,1 of Edge - which is returned by NodeAccess
         shapes.add(new Circle(10, 10, 1));
-        cMap.put(Parameters.NON_CH.BLOCKED_SHAPES, shapes);
+        cMap.put(Parameters.Routing.BLOCKED_SHAPES, shapes);
         instance = new GenericWeighting(encoder, cMap);
         instance.setGraph(getGraph());
         assertEquals(3.0, instance.calcWeight(edge, false, EdgeIterator.NO_EDGE), 1e-8);

--- a/core/src/test/java/com/graphhopper/routing/weighting/GenericWeightingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/GenericWeightingTest.java
@@ -1,0 +1,76 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for 
+ *  additional information regarding copyright ownership.
+ * 
+ *  GraphHopper GmbH licenses this file to you under the Apache License, 
+ *  Version 2.0 (the "License"); you may not use this file except in 
+ *  compliance with the License. You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.routing.weighting;
+
+import com.graphhopper.coll.GHIntHashSet;
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.util.DataFlagEncoder;
+import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.util.*;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Peter Karich
+ */
+public class GenericWeightingTest {
+    private final DataFlagEncoder encoder = (DataFlagEncoder) new EncodingManager("generic").getEncoder("generic");
+
+    @Test
+    public void testBlocked() {
+        ReaderWay way = new ReaderWay(27l);
+        way.setTag("highway", "primary");
+        way.setTag("maxspeed", "10");
+        EdgeIteratorState edge = createEdge(27, 10, encoder.handleWayTags(way, 1, 0));
+        ConfigMap cMap = encoder.readStringMap(new PMap());
+        Weighting instance = new GenericWeighting(encoder, cMap);
+        assertEquals(3.0, instance.calcWeight(edge, false, EdgeIterator.NO_EDGE), 1e-8);
+
+        GHIntHashSet blockedEdges = new GHIntHashSet(1);
+        cMap.put(Parameters.NON_CH.BLOCKED_EDGES, blockedEdges);
+        blockedEdges.add(27);
+        instance = new GenericWeighting(encoder, cMap);
+        assertEquals(Double.POSITIVE_INFINITY, instance.calcWeight(edge, false, EdgeIterator.NO_EDGE), 1e-8);
+    }
+
+    EdgeIterator createEdge(final int edge, final double distance, final long flags) {
+        return new GHUtility.DisabledEdgeIterator() {
+            @Override
+            public int getEdge() {
+                return edge;
+            }
+
+            @Override
+            public double getDistance() {
+                return distance;
+            }
+
+            @Override
+            public long getFlags() {
+                return flags;
+            }
+
+            @Override
+            public boolean getBool(int key, boolean _default) {
+                return _default;
+            }
+
+        };
+    }
+}

--- a/core/src/test/java/com/graphhopper/util/shapes/BBoxTest.java
+++ b/core/src/test/java/com/graphhopper/util/shapes/BBoxTest.java
@@ -57,6 +57,14 @@ public class BBoxTest {
     }
 
     @Test
+    public void testGetCenter() {
+        BBox bBox = new BBox(0, 2, 0, 2);
+        GHPoint center = bBox.getCenter();
+        assertEquals(1, center.getLat(), .00001);
+        assertEquals(1, center.getLon(), .00001);
+    }
+
+    @Test
     public void testIntersect() {
         //    ---
         //    | |

--- a/core/src/test/java/com/graphhopper/util/shapes/CircleTest.java
+++ b/core/src/test/java/com/graphhopper/util/shapes/CircleTest.java
@@ -19,6 +19,7 @@ package com.graphhopper.util.shapes;
 
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -47,6 +48,14 @@ public class CircleTest {
         assertTrue(c.contains(new BBox(9, 11, 10, 10.1)));
         assertFalse(c.contains(new BBox(9, 11, 8, 9)));
         assertFalse(c.contains(new BBox(9, 12, 10, 10.1)));
+    }
+
+    @Test
+    public void testGetCenter() {
+        Circle c = new Circle(10, 10, 10);
+        GHPoint center = c.getCenter();
+        assertEquals(10, center.getLat(), .00001);
+        assertEquals(10, center.getLon(), .00001);
     }
 
     @Test

--- a/reader-osm/src/test/java/com/graphhopper/GraphHopperIT.java
+++ b/reader-osm/src/test/java/com/graphhopper/GraphHopperIT.java
@@ -290,6 +290,12 @@ public class GraphHopperIT {
         assertFalse(rsp.getErrors().toString(), rsp.hasErrors());
         assertEquals(16674, rsp.getBest().getDistance(), 1);
 
+        // Block by Shape
+        req.getHints().put(Parameters.NON_CH.BLOCK_BY_SHAPE, "true");
+        rsp = tmpHopper.route(req);
+        assertFalse(rsp.getErrors().toString(), rsp.hasErrors());
+        assertEquals(16674, rsp.getBest().getDistance(), 1);
+
         req = new GHRequest(49.975845,11.522598, 50.026821,11.497364).
                 setVehicle("generic").setWeighting("generic");
 
@@ -301,6 +307,13 @@ public class GraphHopperIT {
         rsp = tmpHopper.route(req);
         assertFalse(rsp.getErrors().toString(), rsp.hasErrors());
         assertEquals(18151, rsp.getBest().getDistance(), 1);
+
+        // Block by Shape
+        req.getHints().put(Parameters.NON_CH.BLOCK_BY_SHAPE, "true");
+        rsp = tmpHopper.route(req);
+        assertFalse(rsp.getErrors().toString(), rsp.hasErrors());
+        assertEquals(18151, rsp.getBest().getDistance(), 1);
+
 
     }
 

--- a/reader-osm/src/test/java/com/graphhopper/GraphHopperIT.java
+++ b/reader-osm/src/test/java/com/graphhopper/GraphHopperIT.java
@@ -278,7 +278,7 @@ public class GraphHopperIT {
         assertEquals(6684, rsp.getBest().getDistance(), 1);
 
         // Block Area 11.472902,49.97986,11.534357,50.003946
-        req.getHints().put(Parameters.NON_CH.BLOCKED_AREAS, "11.472902,49.97986,11.534357,50.003946");
+        req.getHints().put(Parameters.NON_CH.BLOCKED_RECTANGULAR_AREAS, "11.472902,49.97986,11.534357,50.003946");
         rsp = tmpHopper.route(req);
         assertFalse(rsp.getErrors().toString(), rsp.hasErrors());
         assertEquals(12173, rsp.getBest().getDistance(), 1);
@@ -289,6 +289,19 @@ public class GraphHopperIT {
         rsp = tmpHopper.route(req);
         assertFalse(rsp.getErrors().toString(), rsp.hasErrors());
         assertEquals(16674, rsp.getBest().getDistance(), 1);
+
+        req = new GHRequest(49.975845,11.522598, 50.026821,11.497364).
+                setVehicle("generic").setWeighting("generic");
+
+        rsp = tmpHopper.route(req);
+        assertFalse(rsp.getErrors().toString(), rsp.hasErrors());
+        assertEquals(6684, rsp.getBest().getDistance(), 1);
+
+        req.getHints().put(Parameters.NON_CH.BLOCKED_CIRCULAR_AREAS, "50.004871,11.51762,2000");
+        rsp = tmpHopper.route(req);
+        assertFalse(rsp.getErrors().toString(), rsp.hasErrors());
+        assertEquals(18151, rsp.getBest().getDistance(), 1);
+
     }
 
     @Test

--- a/reader-osm/src/test/java/com/graphhopper/GraphHopperIT.java
+++ b/reader-osm/src/test/java/com/graphhopper/GraphHopperIT.java
@@ -224,7 +224,7 @@ public class GraphHopperIT {
     }
 
     @Test
-    public void testFaundauDestination() {
+    public void testNorthBayreuthDestination() {
         GraphHopper tmpHopper = new GraphHopperOSM().
                 setOSMFile(DIR + "/north-bayreuth.osm.gz").
                 setCHEnabled(false).
@@ -245,6 +245,50 @@ public class GraphHopperIT {
         rsp = tmpHopper.route(req);
         assertFalse(rsp.getErrors().toString(), rsp.hasErrors());
         assertEquals(550, rsp.getBest().getDistance(), 1);
+    }
+
+    @Test
+    public void testNorthBayreuthBlockeEdges() {
+        GraphHopper tmpHopper = new GraphHopperOSM().
+                setOSMFile(DIR + "/north-bayreuth.osm.gz").
+                setCHEnabled(false).
+                setGraphHopperLocation(tmpGraphFile).
+                setEncodingManager(new EncodingManager("generic", 4));
+        tmpHopper.importOrLoad();
+
+        GHRequest req = new GHRequest(49.985272,11.506151, 49.986107,11.507202).
+                setVehicle("generic").setWeighting("generic");
+
+        GHResponse rsp = tmpHopper.route(req);
+        assertFalse(rsp.getErrors().toString(), rsp.hasErrors());
+        assertEquals(122, rsp.getBest().getDistance(), 1);
+
+        // Block 49.985759,11.50687
+        req.getHints().put(Parameters.NON_CH.BLOCKED_POINTS, "49.985759,11.50687");
+        rsp = tmpHopper.route(req);
+        assertFalse(rsp.getErrors().toString(), rsp.hasErrors());
+        assertEquals(365, rsp.getBest().getDistance(), 1);
+
+
+        req = new GHRequest(49.975845,11.522598, 50.026821,11.497364).
+                setVehicle("generic").setWeighting("generic");
+
+        rsp = tmpHopper.route(req);
+        assertFalse(rsp.getErrors().toString(), rsp.hasErrors());
+        assertEquals(6684, rsp.getBest().getDistance(), 1);
+
+        // Block Area 11.472902,49.97986,11.534357,50.003946
+        req.getHints().put(Parameters.NON_CH.BLOCKED_AREAS, "11.472902,49.97986,11.534357,50.003946");
+        rsp = tmpHopper.route(req);
+        assertFalse(rsp.getErrors().toString(), rsp.hasErrors());
+        assertEquals(12173, rsp.getBest().getDistance(), 1);
+
+        // Add blocked Point to above area, to increase detour
+        // Block Point 50.017578,11.547527
+        req.getHints().put(Parameters.NON_CH.BLOCKED_POINTS, "50.017578,11.547527");
+        rsp = tmpHopper.route(req);
+        assertFalse(rsp.getErrors().toString(), rsp.hasErrors());
+        assertEquals(16674, rsp.getBest().getDistance(), 1);
     }
 
     @Test

--- a/reader-osm/src/test/java/com/graphhopper/GraphHopperIT.java
+++ b/reader-osm/src/test/java/com/graphhopper/GraphHopperIT.java
@@ -264,7 +264,7 @@ public class GraphHopperIT {
         assertEquals(122, rsp.getBest().getDistance(), 1);
 
         // Block 49.985759,11.50687
-        req.getHints().put(Parameters.NON_CH.BLOCKED_POINTS, "49.985759,11.50687");
+        req.getHints().put(Routing.BLOCKED_POINTS, "49.985759,11.50687");
         rsp = tmpHopper.route(req);
         assertFalse(rsp.getErrors().toString(), rsp.hasErrors());
         assertEquals(365, rsp.getBest().getDistance(), 1);
@@ -278,20 +278,20 @@ public class GraphHopperIT {
         assertEquals(6684, rsp.getBest().getDistance(), 1);
 
         // Block Area 11.472902,49.97986,11.534357,50.003946
-        req.getHints().put(Parameters.NON_CH.BLOCKED_RECTANGULAR_AREAS, "11.472902,49.97986,11.534357,50.003946");
+        req.getHints().put(Routing.BLOCKED_RECTANGULAR_AREAS, "11.472902,49.97986,11.534357,50.003946");
         rsp = tmpHopper.route(req);
         assertFalse(rsp.getErrors().toString(), rsp.hasErrors());
         assertEquals(12173, rsp.getBest().getDistance(), 1);
 
         // Add blocked Point to above area, to increase detour
         // Block Point 50.017578,11.547527
-        req.getHints().put(Parameters.NON_CH.BLOCKED_POINTS, "50.017578,11.547527");
+        req.getHints().put(Routing.BLOCKED_POINTS, "50.017578,11.547527");
         rsp = tmpHopper.route(req);
         assertFalse(rsp.getErrors().toString(), rsp.hasErrors());
         assertEquals(16674, rsp.getBest().getDistance(), 1);
 
         // Block by Shape
-        req.getHints().put(Parameters.NON_CH.BLOCK_BY_SHAPE, "true");
+        req.getHints().put(Routing.BLOCK_BY_SHAPE, "true");
         rsp = tmpHopper.route(req);
         assertFalse(rsp.getErrors().toString(), rsp.hasErrors());
         assertEquals(16674, rsp.getBest().getDistance(), 1);
@@ -303,13 +303,13 @@ public class GraphHopperIT {
         assertFalse(rsp.getErrors().toString(), rsp.hasErrors());
         assertEquals(6684, rsp.getBest().getDistance(), 1);
 
-        req.getHints().put(Parameters.NON_CH.BLOCKED_CIRCULAR_AREAS, "50.004871,11.51762,2000");
+        req.getHints().put(Routing.BLOCKED_CIRCULAR_AREAS, "50.004871,11.51762,2000");
         rsp = tmpHopper.route(req);
         assertFalse(rsp.getErrors().toString(), rsp.hasErrors());
         assertEquals(18151, rsp.getBest().getDistance(), 1);
 
         // Block by Shape
-        req.getHints().put(Parameters.NON_CH.BLOCK_BY_SHAPE, "true");
+        req.getHints().put(Routing.BLOCK_BY_SHAPE, "true");
         rsp = tmpHopper.route(req);
         assertFalse(rsp.getErrors().toString(), rsp.hasErrors());
         assertEquals(18151, rsp.getBest().getDistance(), 1);

--- a/reader-osm/src/test/java/com/graphhopper/routing/RoutingAlgorithmWithOSMIT.java
+++ b/reader-osm/src/test/java/com/graphhopper/routing/RoutingAlgorithmWithOSMIT.java
@@ -157,7 +157,7 @@ public class RoutingAlgorithmWithOSMIT {
         hopper.importOrLoad();
 
         FlagEncoder encoder = hopper.getEncodingManager().getEncoder(vehicle);
-        Weighting weighting = hopper.createWeighting(new HintsMap("shortest"), encoder);
+        Weighting weighting = hopper.createWeighting(new HintsMap("shortest"), encoder, hopper.getGraphHopperStorage());
 
         List<AlgoHelperEntry> prepares = RoutingAlgorithmIT.createAlgos(hopper.getGraphHopperStorage(), hopper.getLocationIndex(),
                 true, TraversalMode.NODE_BASED, weighting, hopper.getEncodingManager());
@@ -547,7 +547,7 @@ public class RoutingAlgorithmWithOSMIT {
             TraversalMode tMode = importVehicles.contains("turn_costs=true")
                     ? TraversalMode.EDGE_BASED_1DIR : TraversalMode.NODE_BASED;
             FlagEncoder encoder = hopper.getEncodingManager().getEncoder(vehicle);
-            Weighting weighting = hopper.createWeighting(new HintsMap(weightStr), encoder);
+            Weighting weighting = hopper.createWeighting(new HintsMap(weightStr), encoder, hopper.getGraphHopperStorage());
 
             Collection<AlgoHelperEntry> prepares = RoutingAlgorithmIT.createAlgos(hopper.getGraphHopperStorage(),
                     hopper.getLocationIndex(), testAlsoCH, tMode, weighting, hopper.getEncodingManager());

--- a/reader-overlay-data/src/main/java/com/graphhopper/reader/overlaydata/FeedOverlayData.java
+++ b/reader-overlay-data/src/main/java/com/graphhopper/reader/overlaydata/FeedOverlayData.java
@@ -124,7 +124,7 @@ public class FeedOverlayData {
         if (jsonFeature.hasGeometry()) {
             fillEdgeIDs(edges, jsonFeature.getGeometry(), filter);
         } else if (jsonFeature.getBBox() != null) {
-            graphBrowser.findEdgesInBBox(edges, jsonFeature.getBBox(), filter);
+            graphBrowser.findEdgesInShape(edges, jsonFeature.getBBox(), filter);
         } else
             throw new IllegalArgumentException("Feature " + jsonFeature.getId() + " has no geometry and no bbox");
 

--- a/reader-overlay-data/src/main/java/com/graphhopper/reader/overlaydata/FeedOverlayData.java
+++ b/reader-overlay-data/src/main/java/com/graphhopper/reader/overlaydata/FeedOverlayData.java
@@ -28,13 +28,10 @@ import com.graphhopper.routing.util.EdgeFilter;
 import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.storage.Graph;
-import com.graphhopper.storage.NodeAccess;
+import com.graphhopper.storage.GraphBrowser;
 import com.graphhopper.storage.index.LocationIndex;
-import com.graphhopper.storage.index.QueryResult;
-import com.graphhopper.util.BreadthFirstSearch;
 import com.graphhopper.util.EdgeIteratorState;
 import com.graphhopper.util.PointList;
-import com.graphhopper.util.shapes.BBox;
 import com.graphhopper.util.shapes.GHPoint;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,6 +50,7 @@ public class FeedOverlayData {
     private final LocationIndex locationIndex;
     private final GHson ghson;
     private final EncodingManager em;
+    private final GraphBrowser graphBrowser;
     private boolean enableLogging = false;
 
     public FeedOverlayData(Graph graph, EncodingManager em, LocationIndex locationIndex, GHson ghson) {
@@ -60,6 +58,7 @@ public class FeedOverlayData {
         this.graph = graph;
         this.em = em;
         this.locationIndex = locationIndex;
+        this.graphBrowser = new GraphBrowser(graph, locationIndex);
     }
 
     public void setLogging(boolean log) {
@@ -125,7 +124,7 @@ public class FeedOverlayData {
         if (jsonFeature.hasGeometry()) {
             fillEdgeIDs(edges, jsonFeature.getGeometry(), filter);
         } else if (jsonFeature.getBBox() != null) {
-            fillEdgeIDs(edges, jsonFeature.getBBox(), filter);
+            graphBrowser.findEdgesInBBox(edges, jsonFeature.getBBox(), filter);
         } else
             throw new IllegalArgumentException("Feature " + jsonFeature.getId() + " has no geometry and no bbox");
 
@@ -160,9 +159,7 @@ public class FeedOverlayData {
     public void fillEdgeIDs(GHIntHashSet edgeIds, Geometry geometry, EdgeFilter filter) {
         if (geometry.isPoint()) {
             GHPoint point = geometry.asPoint();
-            QueryResult qr = locationIndex.findClosest(point.lat, point.lon, filter);
-            if (qr.isValid())
-                edgeIds.add(qr.getClosestEdge().getEdge());
+            graphBrowser.findClosestEdgeToPoint(edgeIds, point, filter);
         } else if (geometry.isPointList()) {
             PointList pl = geometry.asPointList();
             if (geometry.getType().equals("LineString")) {
@@ -171,43 +168,13 @@ public class FeedOverlayData {
                 if (pl.size() >= 2) {
                     double meanLat = (pl.getLatitude(0) + pl.getLatitude(lastIdx)) / 2;
                     double meanLon = (pl.getLongitude(0) + pl.getLongitude(lastIdx)) / 2;
-                    QueryResult qr = locationIndex.findClosest(meanLat, meanLon, filter);
-                    if (qr.isValid())
-                        edgeIds.add(qr.getClosestEdge().getEdge());
+                    graphBrowser.findClosestEdge(edgeIds, meanLat, meanLon, filter);
                 }
             } else {
                 for (int i = 0; i < pl.size(); i++) {
-                    QueryResult qr = locationIndex.findClosest(pl.getLatitude(i), pl.getLongitude(i), filter);
-                    if (qr.isValid())
-                        edgeIds.add(qr.getClosestEdge().getEdge());
+                    graphBrowser.findClosestEdge(edgeIds, pl.getLatitude(i), pl.getLongitude(i), filter);
                 }
             }
         }
-    }
-
-    public void fillEdgeIDs(final GHIntHashSet edgeIds, final BBox bbox, EdgeFilter filter) {
-        QueryResult qr = locationIndex.findClosest((bbox.maxLat + bbox.minLat) / 2, (bbox.maxLon + bbox.minLon) / 2, filter);
-        if (!qr.isValid())
-            return;
-
-        BreadthFirstSearch bfs = new BreadthFirstSearch() {
-            final NodeAccess na = graph.getNodeAccess();
-            final BBox localBBox = bbox;
-
-            @Override
-            protected boolean goFurther(int nodeId) {
-                return localBBox.contains(na.getLatitude(nodeId), na.getLongitude(nodeId));
-            }
-
-            @Override
-            protected boolean checkAdjacent(EdgeIteratorState edge) {
-                if (localBBox.contains(na.getLatitude(edge.getAdjNode()), na.getLongitude(edge.getAdjNode()))) {
-                    edgeIds.add(edge.getEdge());
-                    return true;
-                }
-                return false;
-            }
-        };
-        bfs.start(graph.createEdgeExplorer(filter), qr.getClosestNode());
     }
 }

--- a/tools/src/main/java/com/graphhopper/ui/MiniGraphUI.java
+++ b/tools/src/main/java/com/graphhopper/ui/MiniGraphUI.java
@@ -88,7 +88,7 @@ public class MiniGraphUI {
         // weighting = hopper.getCHFactoryDecorator().getWeightings().get(0);
         // routingGraph = hopper.getGraphHopperStorage().getGraph(CHGraph.class, weighting);
 
-        weighting = hopper.createWeighting(map, encoder);
+        weighting = hopper.createWeighting(map, encoder, this.graph);
         algoFactory = hopper.getAlgorithmFactory(map);
         algoOpts = new AlgorithmOptions(Algorithms.DIJKSTRA_BI, weighting);
 


### PR DESCRIPTION
This PR intents to improve #789. You can either block areas (given as BBox), points (closest edge from Lat,Lng), or by edge_id.

This is currently implemented only for the GenericWeighting, as my Approach is to inject the Weighting and change the weight of certain edges.

Here is an example. This is the unblocked route:
![block_nothing](https://cloud.githubusercontent.com/assets/1553525/20655025/aca2463c-b572-11e6-854b-af483048b919.png)

This is the route with the black area blocked:
![blocked_area](https://cloud.githubusercontent.com/assets/1553525/20655035/c6f89c84-b572-11e6-8f43-62336d8f9435.png)

This is the route with the black area and black point blocked:
![blocked_area_point](https://cloud.githubusercontent.com/assets/1553525/20655034/c36a75f6-b572-11e6-8394-70b48d0b3690.png)

All three cases can be seen in the new Integration test.

Things we might want to add:

- Returned the blocked edge ids, this would allow us to cache the blocked edges for further requests (not sure how much speed this would get us).
- Add the possibility to manage arrays or lists in the HintsMap. Right now a limitation of the current approach is that the parameters are single strings, for example: `routing.non_ch.blocked_points=lat,lon,lat,lon`. This approach works for now, but it would be nice to be able to add every point seperated by &. On the other hand urls might get very long, as the naming is currently rather long.
- Add a (helper)class that searches the Graph for edges that are in a BBox, or maybe circle, or ...

BTW: I added calling super() in GHBitSetImpl(), I figured we might forgot to add it at this position, but I am not sure, so if that was wrong, I can remove it?

BTW2: I did a rough speed comparison on my laptop. I planned a route accross Baden Württemberg, from Lindau to Karlsruhe, so approx. 260km. Without blocking anything the request took about 1s. With blocking a huge area (approx. half Baden Württemberg - BBox: `8.2645,48.1056,9.9124,48.8557` - the blocked edge set **contains 790876 edges**) the request took about 1.5s, which surprised myself, I thought the speed would be massively decreased. 

Unblocked:
![unblocked_bw](https://cloud.githubusercontent.com/assets/1553525/20655449/abb607be-b576-11e6-80d7-a9ab16e94ca3.png)

Blocked:
![blocked_bw](https://cloud.githubusercontent.com/assets/1553525/20655453/b2552f8c-b576-11e6-983c-4c58893a9ba2.png)

