### PR TITLE
CH-Preparation of Generic Vehicle

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/weighting/GenericWeighting.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/GenericWeighting.java
@@ -162,6 +162,8 @@ public class GenericWeighting extends AbstractWeighting {
      * Use this method to associate a graph with this weighting to calculate e.g. node locations too.
      */
     public void setGraph(Graph graph) {
+        if(graph == null)
+            return;
         this.na = graph.getNodeAccess();
     }
 }

--- a/core/src/test/java/com/graphhopper/routing/weighting/GenericWeightingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/GenericWeightingTest.java
@@ -106,4 +106,11 @@ public class GenericWeightingTest {
         EdgeIteratorState edge = graph.getEdgeIteratorState(0, 1);
         assertEquals(edgeWeight, weighting.calcMillis(edge, false, EdgeIterator.NO_EDGE), .1);
     }
+
+    @Test
+    public void testNullGraph() {
+        ConfigMap cMap = encoder.readStringMap(new PMap());
+        GenericWeighting weighting = new GenericWeighting(encoder, cMap);
+        weighting.setGraph(null);
+    }
 }


### PR DESCRIPTION
We introduced a small bug with the Generic weighting. When we pass a null Graph on initialization, we try to get the NodeAccess, which results in a null-pointer exception.