### PR TITLE
Avoid copying graph, switch to CH routing via request parameter

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/ch/CHAlgoFactoryDecorator.java
+++ b/core/src/main/java/com/graphhopper/routing/ch/CHAlgoFactoryDecorator.java
@@ -31,10 +31,7 @@ import com.graphhopper.util.Parameters.CH;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.List;
+import java.util.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
@@ -52,7 +49,7 @@ public class CHAlgoFactoryDecorator implements RoutingAlgorithmFactoryDecorator 
     // we need to decouple weighting objects from the weighting list of strings 
     // as we need the strings to create the GraphHopperStorage and the GraphHopperStorage to create the preparations from the Weighting objects currently requiring the encoders
     private final List<Weighting> weightings = new ArrayList<>();
-    private final List<String> weightingsAsStrings = new ArrayList<>();
+    private final Set<String> weightingsAsStrings = new LinkedHashSet<>();
     private boolean disablingAllowed = false;
     // for backward compatibility enable CH by default.
     private boolean enabled = true;
@@ -215,7 +212,7 @@ public class CHAlgoFactoryDecorator implements RoutingAlgorithmFactoryDecorator 
         if (this.weightingsAsStrings.isEmpty())
             throw new IllegalStateException("Potential bug: chWeightingList is empty");
 
-        return this.weightingsAsStrings;
+        return new ArrayList<>(this.weightingsAsStrings);
     }
 
     /**
@@ -238,7 +235,7 @@ public class CHAlgoFactoryDecorator implements RoutingAlgorithmFactoryDecorator 
     }
 
     private String getDefaultWeighting() {
-        return weightingsAsStrings.isEmpty() ? "fastest" : weightingsAsStrings.get(0);
+        return weightingsAsStrings.isEmpty() ? "fastest" : weightingsAsStrings.iterator().next();
     }
 
     public List<PrepareContractionHierarchies> getPreparations() {
@@ -323,7 +320,7 @@ public class CHAlgoFactoryDecorator implements RoutingAlgorithmFactoryDecorator 
         traversalMode = getNodeBase();
 
         for (Weighting weighting : getWeightings()) {
-            if(weighting instanceof GenericWeighting){
+            if (weighting instanceof GenericWeighting) {
                 ((GenericWeighting) weighting).setGraph(ghStorage);
             }
             PrepareContractionHierarchies tmpPrepareCH = new PrepareContractionHierarchies(

--- a/reader-osm/src/test/java/com/graphhopper/routing/RoutingAlgorithmWithOSMIT.java
+++ b/reader-osm/src/test/java/com/graphhopper/routing/RoutingAlgorithmWithOSMIT.java
@@ -45,6 +45,7 @@ import static com.graphhopper.GraphHopperIT.DIR;
 import static com.graphhopper.util.Parameters.Algorithms.ASTAR;
 import static com.graphhopper.util.Parameters.Algorithms.DIJKSTRA_BI;
 import static org.junit.Assert.assertEquals;
+
 import org.junit.Ignore;
 
 /**
@@ -136,52 +137,6 @@ public class RoutingAlgorithmWithOSMIT {
                 list, "bike2", true, "bike2", "fastest", true);
 
         assertEquals(testCollector.toString(), 0, testCollector.errors.size());
-    }
-
-    @Test
-    public void testMonacoAllAlgorithmsWithBaseGraph() {
-        String vehicle = "car";
-        String graphFile = "target/monaco-gh";
-        String osmFile = DIR + "/monaco.osm.gz";
-        String importVehicles = vehicle;
-
-        Helper.removeDir(new File(graphFile));
-        GraphHopper hopper = new GraphHopperOSM().
-                // avoid that path.getDistance is too different to path.getPoint.calcDistance
-                setWayPointMaxDistance(0).
-                setDataReaderFile(osmFile).
-                setCHEnabled(false).
-                setGraphHopperLocation(graphFile).
-                setEncodingManager(new EncodingManager(importVehicles));
-
-        hopper.importOrLoad();
-
-        FlagEncoder encoder = hopper.getEncodingManager().getEncoder(vehicle);
-        Weighting weighting = hopper.createWeighting(new HintsMap("shortest"), encoder, hopper.getGraphHopperStorage());
-
-        List<AlgoHelperEntry> prepares = RoutingAlgorithmIT.createAlgos(hopper.getGraphHopperStorage(), hopper.getLocationIndex(),
-                true, TraversalMode.NODE_BASED, weighting, hopper.getEncodingManager());
-        AlgoHelperEntry chPrepare = prepares.get(prepares.size() - 1);
-        if (!(chPrepare.getQueryGraph() instanceof CHGraph))
-            throw new IllegalStateException("Last prepared QueryGraph has to be a CHGraph");
-
-        // set all normal algorithms to baseGraph of already prepared to see if all algorithms still work
-        Graph baseGraphOfCHPrepared = chPrepare.getBaseGraph();
-        for (AlgoHelperEntry ahe : prepares) {
-            if (!(ahe.getQueryGraph() instanceof CHGraph)) {
-                ahe.setQueryGraph(baseGraphOfCHPrepared);
-            }
-        }
-
-        List<OneRun> forEveryAlgo = createMonacoCar();
-        EdgeFilter edgeFilter = new DefaultEdgeFilter(encoder);
-        for (AlgoHelperEntry entry : prepares) {
-            LocationIndex idx = entry.getIdx();
-            for (OneRun oneRun : forEveryAlgo) {
-                List<QueryResult> list = oneRun.getList(idx, edgeFilter);
-                testCollector.assertDistance(entry, list, oneRun);
-            }
-        }
     }
 
     @Test
@@ -527,18 +482,27 @@ public class RoutingAlgorithmWithOSMIT {
     Graph runAlgo(TestAlgoCollector testCollector, String osmFile,
                   String graphFile, List<OneRun> forEveryAlgo, String importVehicles,
                   boolean testAlsoCH, String vehicle, String weightStr, boolean is3D) {
+
+        // for different weightings we need a different storage, otherwise we would need to remove the graph folder
+        // everytime we come with a different weighting
+        // graphFile += weightStr;
+
         AlgoHelperEntry algoEntry = null;
         OneRun tmpOneRun = null;
         try {
             Helper.removeDir(new File(graphFile));
             GraphHopper hopper = new GraphHopperOSM().
                     setStoreOnFlush(true).
-                    // avoid that path.getDistance is too different to path.getPoint.calcDistance
-                    setWayPointMaxDistance(0).
+                    setCHEnabled(testAlsoCH).
                     setDataReaderFile(osmFile).
-                    setCHEnabled(false).
                     setGraphHopperLocation(graphFile).
                     setEncodingManager(new EncodingManager(importVehicles));
+
+            // avoid that path.getDistance is too different to path.getPoint.calcDistance
+            hopper.setWayPointMaxDistance(0);
+
+            if (testAlsoCH)
+                hopper.getCHFactoryDecorator().addWeighting(weightStr);
             if (is3D)
                 hopper.setElevationProvider(new SRTMProvider().setCacheDir(new File(DIR)));
 
@@ -550,7 +514,7 @@ public class RoutingAlgorithmWithOSMIT {
             Weighting weighting = hopper.createWeighting(new HintsMap(weightStr), encoder, hopper.getGraphHopperStorage());
 
             Collection<AlgoHelperEntry> prepares = RoutingAlgorithmIT.createAlgos(hopper.getGraphHopperStorage(),
-                    hopper.getLocationIndex(), testAlsoCH, tMode, weighting, hopper.getEncodingManager());
+                    hopper.getLocationIndex(), testAlsoCH, tMode, weighting);
             EdgeFilter edgeFilter = new DefaultEdgeFilter(encoder);
             for (AlgoHelperEntry entry : prepares) {
                 algoEntry = entry;
@@ -603,7 +567,7 @@ public class RoutingAlgorithmWithOSMIT {
         for (int no = 0; no < MAX; no++) {
             for (int instanceNo = 0; instanceNo < instances.size(); instanceNo++) {
                 String[] algos = new String[]{
-                    ASTAR, DIJKSTRA_BI
+                        ASTAR, DIJKSTRA_BI
                 };
                 for (final String algoStr : algos) {
                     // an algorithm is not thread safe! reuse via clear() is ONLY appropriated if used from same thread!


### PR DESCRIPTION
This change avoids copying the graph necessary for #912. Copying the graph changes nodes & edge ids which introduces problems when trying to include turn costs for CH. 

TODOs:
 * Investigate if this is faster (it should)
 * Investigate if ch routing is done