### PR TITLE
Add .jitpack.yml

### DIFF
--- a/.jitpack.yml
+++ b/.jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - oraclejdk8


### PR DESCRIPTION
JitPack, which is super-useful, [tries to](https://jitpack.io/#graphhopper/graphhopper) build GraphHopper with Java 7, because it guesses that from our parent-pom. It doesn't realise that the web submodule needs Java 8.

Let's help it by adding a ``.jitpack.yml``. Then it works.