### PR TITLE
Allow exporting alternative routes

### DIFF
--- a/core/src/main/java/com/graphhopper/util/Parameters.java
+++ b/core/src/main/java/com/graphhopper/util/Parameters.java
@@ -17,8 +17,6 @@
  */
 package com.graphhopper.util;
 
-import static com.graphhopper.util.Parameters.Algorithms.ALT_ROUTE;
-
 /**
  * @author Peter Karich
  */
@@ -172,6 +170,6 @@ public class Parameters {
         //TODO rename to gpx.trackname?
         public static final String TRACK_NAME = "trackname";
 
-        public static final String PATH_INDEX = "gpx."+ALT_ROUTE+".path_index";
+        public static final String PATH_INDEX = "gpx." + Parameters.Algorithms.ALT_ROUTE + ".path_index";
     }
 }

--- a/core/src/main/java/com/graphhopper/util/Parameters.java
+++ b/core/src/main/java/com/graphhopper/util/Parameters.java
@@ -17,6 +17,8 @@
  */
 package com.graphhopper.util;
 
+import static com.graphhopper.util.Parameters.Algorithms.ALT_ROUTE;
+
 /**
  * @author Peter Karich
  */
@@ -94,11 +96,17 @@ public class Parameters {
         public static final String EDGE_BASED = "edge_based";
         public static final String MAX_VISITED_NODES = "max_visited_nodes";
         public static final String INIT_MAX_VISITED_NODES = ROUTING_INIT_PREFIX + "max_visited_nodes";
-        /** if true the response will contain turn instructions */
+        /**
+         * if true the response will contain turn instructions
+         */
         public static final String INSTRUCTIONS = "instructions";
-        /** if true the response will contain a point list */
+        /**
+         * if true the response will contain a point list
+         */
         public static final String CALC_POINTS = "calc_points";
-        /** configure simplification of returned point list */
+        /**
+         * configure simplification of returned point list
+         */
         public static final String WAY_POINT_MAX_DISTANCE = "way_point_max_distance";
         public static final String INIT_WAY_POINT_MAX_DISTANCE = ROUTING_INIT_PREFIX + "way_point_max_distance";
         /**
@@ -151,5 +159,19 @@ public class Parameters {
          */
         public static final String MAX_NON_CH_POINT_DISTANCE = ROUTING_INIT_PREFIX + NON_CH_PREFIX + "max_waypoint_distance";
 
+    }
+
+    /**
+     * Properties for gpx export
+     */
+    public static final class GPX_EXPORT {
+        public static final String ROUTE = "gpx.route";
+        public static final String TRACK = "gpx.track";
+        public static final String WAYPOINTS = "gpx.waypoints";
+
+        //TODO rename to gpx.trackname?
+        public static final String TRACK_NAME = "trackname";
+
+        public static final String PATH_INDEX = "gpx."+ALT_ROUTE+".path_index";
     }
 }

--- a/docs/web/api-doc.md
+++ b/docs/web/api-doc.md
@@ -36,6 +36,8 @@ Parameter     | Default | Description
 gpx.track     |	true    | Include <trk> tag in gpx result. Only applicable if type=gpx is specified.
 gpx.route     | true    | Include <rte> tag in gpx result. Only applicable if type=gpx is specified.
 gpx.waypoints | false   | Include <wpt> tag in gpx result. Only applicable if type=gpx is specified.
+trackname     | GraphHopper Track   | Set the value of the <name> tag in the <trk> segment.
+gpx.alternative_route.path_index | -1      | If `algorithm=alternative_route` this parameter is needed to specify which path should be exported.
 
 ### Flexible
 

--- a/web/src/test/java/com/graphhopper/http/GraphHopperServletIT.java
+++ b/web/src/test/java/com/graphhopper/http/GraphHopperServletIT.java
@@ -176,6 +176,21 @@ public class GraphHopperServletIT extends BaseServletTester {
     }
 
     @Test
+    public void testGPXSelectedPath() throws Exception {
+        //TODO Example Properties does not allow disabling ch, therefore we cannot test alternative routes here
+        //TODO Is it worth the overhead to create a non-ch environment for this small change?
+
+        // No alternative, therefore path_index=1 is out of range
+        queryString("point=42.554851,1.536198&point=42.510071,1.548128&type=gpx&gpx.alternative_route.path_index=1", 400);
+
+        String str = queryString("point=42.554851,1.536198&point=42.510071,1.548128&type=gpx&gpx.alternative_route.path_index=0", 200);
+        // For backward compatibility we currently export route and track.
+        assertTrue(str.contains("<gh:distance>115.1</gh:distance>"));
+        assertFalse(str.contains("<wpt lat=\"42.51003\" lon=\"1.548188\"> <name>Finish!</name></wpt>"));
+        assertTrue(str.contains("<trkpt lat=\"42.554839\" lon=\"1.536374\"><time>"));
+    }
+
+    @Test
     public void testGPXWithExcludedRouteSelection() throws Exception {
         String str = queryString("point=42.554851,1.536198&point=42.510071,1.548128&type=gpx&gpx.route=false&gpx.waypoints=false", 200);
         assertFalse(str.contains("<gh:distance>115.1</gh:distance>"));


### PR DESCRIPTION
As discussed in #649, exporting alternative_routes is not possible yet. Therefore, I added a parameter to allow exporting a single path of the alternative routes.

WDYT?