### PR TITLE
Improve cleaning of memory mapped ByteBuffers for JDK9 EA and Android

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ before_install:
 install: true
 
 script:
-  - mvn -DfailIfNoTests=false clean test verify -B
+  - mvn clean test verify -B
 
 after_success:
   # deploy snapshot artifacts to maven central

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ matrix:
       sudo: required
       dist: trusty
       group: edge
+  allow_failures:
+    - jdk: oraclejdk9
 
 env:
   global:

--- a/core/src/main/java/com/graphhopper/util/Helper.java
+++ b/core/src/main/java/com/graphhopper/util/Helper.java
@@ -395,7 +395,6 @@ public class Helper {
                             // now call sun.misc.Cleaner.clean
                             cleanMethod.invoke(cleaner);
                         }
-                        System.out.println("JDK8 " + Constants.JAVA_VERSION + " " + cleaner);
                     } catch (NoSuchMethodException ex2) {
                         // ignore if method cleaner or clean is not available
 

--- a/core/src/main/java/com/graphhopper/util/Helper.java
+++ b/core/src/main/java/com/graphhopper/util/Helper.java
@@ -391,14 +391,6 @@ public class Helper {
                     final Class<?> directByteBufferClass = buffer.getClass().getSimpleName().equals("MappedByteBufferAdapter") ?
                             Class.forName("java.nio.MappedByteBufferAdapter") : Class.forName("java.nio.DirectByteBuffer");
 
-                    if (Constants.ANDROID) {
-                        final Method dbbFreeMethod = directByteBufferClass.getMethod("free");
-                        dbbFreeMethod.setAccessible(true);
-                        // call DirectByteBuffer.free(buffer)
-                        dbbFreeMethod.invoke(buffer);
-                        return null;
-                    }
-
                     // <=JDK8 class DirectByteBuffer { sun.misc.Cleaner cleaner(Buffer buf) }
                     //        then call sun.misc.Cleaner.clean
                     try {
@@ -415,13 +407,13 @@ public class Helper {
                         }
                     } catch (NoSuchMethodException ex2) {
                         // ignore if method cleaner or clean is not available
-
+                        LOGGER.warn("NoSuchMethodException | " + directByteBufferClass.getName() + " | " + Constants.JAVA_VERSION, ex2);
                     }
                     return null;
                 }
             });
         } catch (PrivilegedActionException e) {
-            throw new RuntimeException("unable to unmap the mapped buffer", e);
+            throw new RuntimeException("Unable to unmap the mapped buffer", e);
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -291,7 +291,7 @@
             <id>jdk9</id>
             <activation>
                 <activeByDefault>false</activeByDefault>                                
-                <jdk>9</jdk>
+                <jdk>9-ea</jdk>
             </activation>
             <properties />           
             <build>


### PR DESCRIPTION
This should pass the JDK9 travis tests once we have JDK9-ea-152 there, see #701.

And regarding the Android part, see #933