### PR TITLE
fix NullPointerException during Import using the BikeCommonFlagEncoder

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
@@ -195,6 +195,8 @@ public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
         setCyclingNetworkPreference("deprecated", AVOID_AT_ALL_COSTS.getValue());
 
         setAvoidSpeedLimit(71);
+        
+        init();
     }
 
     @Override


### PR DESCRIPTION
As it is stated in the AbstractFlagEncoder, the protected method init() should be called as the last action in the constructor.

I was getting NullPointerExceptions on line 278 in the BikeCommonFlagEncoder resulting in "Problem while parsing file"-Exceptions.
The NPE was caused by the "getConditionalTagInspector" returning null.

Calling the init()-Method at the end of the constructor initializes the ConditionalTagInspector. Now I can import again :-)

Hope this helps :-)

Feedback very welcome!

Grüße aus Stuttgart/München :-)