### PR TITLE
Make BikeCommonFlagEncoder abstract

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
@@ -36,7 +36,7 @@ import static com.graphhopper.routing.util.PriorityCode.*;
  * @author Nop
  * @author ratrun
  */
-public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
+abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
     /**
      * Reports whether this edge is unpaved.
      */


### PR DESCRIPTION
Flag-Encoders must call init() as their last action in the constructor. Therefore any FlagEncoder that does not call init() must be abstract.