### PR TITLE
Updated SpatialRuleLookup initialization

### DIFF
--- a/config-example.properties
+++ b/config-example.properties
@@ -123,8 +123,7 @@ graph.dataaccess=RAM_STORE
 
 # Spatial Rules require some configuration and only work with the DataFlagEncoder.
 # Below line shows how to define the DataFlagEncoder, you need to define the number of spatial rules (X).
-# You have to add one SpatialRule to the absolute number of SpatialRules due to the Empty rule
-# graph.flag_encoders=generic|spatial_rules=X+1
+# graph.flag_encoders=generic|spatial_rules=X
 
 # Spatial Rules require you to provide Polygons in which the rules are enforced
 # Below line contains the default location for these rules

--- a/config-example.properties
+++ b/config-example.properties
@@ -119,11 +119,7 @@ graph.dataaccess=RAM_STORE
 
 
 ##### Spatial Rules #####
-
-
 # Spatial Rules require some configuration and only work with the DataFlagEncoder.
-# Below line shows how to define the DataFlagEncoder, you need to define the number of spatial rules (X).
-# graph.flag_encoders=generic|spatial_rules=X
 
 # Spatial Rules require you to provide Polygons in which the rules are enforced
 # Below line contains the default location for these rules

--- a/config-example.properties
+++ b/config-example.properties
@@ -61,6 +61,7 @@ prepare.min_network_size=200
 prepare.min_one_way_network_size=200
 
 
+
 ##### Routing #####
 
 
@@ -92,7 +93,9 @@ routing.non_ch.max_waypoint_distance = 1000000
 # block_area=lat1,lon1,lat2,lon2
 
 
+
 ##### Web #####
+
 
 # if you want to support jsonp response type you need to add it explicitely here. By default it is disabled for stronger security.
 # web.jsonp_allowed=true
@@ -113,16 +116,21 @@ graph.dataaccess=RAM_STORE
 # Sort the graph after import to make requests roughly ~10% faster. Note that this requires significantly more RAM on import.
 # graph.do_sort=true
 
+
+
 ##### Spatial Rules #####
 
+
 # Spatial Rules require some configuration and only work with the DataFlagEncoder.
-# Below line shows how to define the DataFlagEncoder, you need to define the number of spatial rules.
-# graph.flag_encoders=generic|spatial_rules=X
+# Below line shows how to define the DataFlagEncoder, you need to define the number of spatial rules (X).
+# You have to add one SpatialRule to the absolute number of SpatialRules due to the Empty rule
+# graph.flag_encoders=generic|spatial_rules=X+1
 
 # Spatial Rules require you to provide Polygons in which the rules are enforced
 # Below line contains the default location for these rules
 # spatial_rules.location=web/src/main/resources/com/graphhopper/http/countries.geo.json
 
-# You have to define the BBox for which spatial rules are loaded, usually a subset of your covered area
-# Below line contains the world-wide bounding box
-# spatial_rules.bbox=-180,180,-90,90
+# You have to define the the class names of the SpatialRules you want to enforce.
+# If you use classes defined in com.graphhopper.routing.util.spatialrules.countries, you can omit the package name
+# otherwise you have to provide the fully qualified name (fqn).
+# spatial_rules.fqn=GermanySpatialRule,AustriaSpatialRule

--- a/config-example.properties
+++ b/config-example.properties
@@ -6,7 +6,7 @@
 graph.flag_encoders=car
 
 
-# Enable turn restrictions for car or motorcycle. 
+# Enable turn restrictions for car or motorcycle.
 # Currently you need to additionally set prepare.ch.weightings=no before using this (see below and #270)
 # graph.flag_encoders=car|turn_costs=true
 
@@ -112,3 +112,17 @@ graph.dataaccess=RAM_STORE
 
 # Sort the graph after import to make requests roughly ~10% faster. Note that this requires significantly more RAM on import.
 # graph.do_sort=true
+
+##### Spatial Rules #####
+
+# Spatial Rules require some configuration and only work with the DataFlagEncoder.
+# Below line shows how to define the DataFlagEncoder, you need to define the number of spatial rules.
+# graph.flag_encoders=generic|spatial_rules=X
+
+# Spatial Rules require you to provide Polygons in which the rules are enforced
+# Below line contains the default location for these rules
+# spatial_rules.location=web/src/main/resources/com/graphhopper/http/countries.geo.json
+
+# You have to define the BBox for which spatial rules are loaded, usually a subset of your covered area
+# Below line contains the world-wide bounding box
+# spatial_rules.bbox=-180,180,-90,90

--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -497,6 +497,10 @@ public class GraphHopper implements GraphHopperAPI {
         return this;
     }
 
+    public FlagEncoderFactory getFlagEncoderFactory() {
+        return this.flagEncoderFactory;
+    }
+
     /**
      * Reads configuration from a CmdArgs object. Which can be manually filled, or via main(String[]
      * args) ala CmdArgs.read(args) or via configuration file ala

--- a/core/src/main/java/com/graphhopper/routing/util/DataFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/DataFlagEncoder.java
@@ -829,6 +829,10 @@ public class DataFlagEncoder extends AbstractFlagEncoder {
 
 
     public DataFlagEncoder setSpatialRules(int rules) {
+        if(rules > 0){
+            // Add +1 for the Empty rule
+            rules++;
+        }
         this.spatialRules = rules;
         return this;
     }

--- a/core/src/main/java/com/graphhopper/routing/util/DataFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/DataFlagEncoder.java
@@ -427,7 +427,7 @@ public class DataFlagEncoder extends AbstractFlagEncoder {
         }
     }
 
-    private boolean spatialRuleLookupEnabled(){
+    public boolean spatialRuleLookupEnabled(){
         if (spatialRules > 0) {
             if (spatialRuleLookup == null)
                 throw new IllegalStateException("This encoder was asked to store spatial IDs for every edge, " +

--- a/core/src/main/java/com/graphhopper/routing/util/spatialrules/SpatialRuleLookupBuilder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/spatialrules/SpatialRuleLookupBuilder.java
@@ -44,43 +44,13 @@ public class SpatialRuleLookupBuilder {
     }
 
     public static class SpatialRuleListFactory implements SpatialRuleFactory {
-        private final Logger logger = LoggerFactory.getLogger(getClass());
-        private final Map<String, SpatialRule> ruleMap;
+        protected final Logger logger = LoggerFactory.getLogger(getClass());
+        protected Map<String, SpatialRule> ruleMap;
 
         public SpatialRuleListFactory(SpatialRule... rules) {
             this(Arrays.asList(rules));
         }
 
-        public SpatialRuleListFactory(String rules) {
-            this(rules.split(","));
-        }
-
-        public SpatialRuleListFactory(String... rules) {
-            if (rules.length == 0) {
-                throw new IllegalStateException("You have to pass at least one rule");
-            }
-            ruleMap = new HashMap<>(rules.length);
-            for (String rule : rules) {
-                try {
-                    // Makes it easy to define a rule as CountrySpatialRule and skip the fqn
-                    if (!rule.contains(".")) {
-                        rule = "com.graphhopper.routing.util.spatialrules.countries." + rule;
-                    }
-                    Object o = Class.forName(rule).newInstance();
-                    if (SpatialRule.class.isAssignableFrom(o.getClass())) {
-                        ruleMap.put(((SpatialRule) o).getId(), (SpatialRule) o);
-                    } else {
-                        String ex = "Cannot find SpatialRule for rule " + rule + " but found " + o.getClass();
-                        logger.error(ex);
-                        throw new IllegalArgumentException(ex);
-                    }
-                } catch (ReflectiveOperationException e) {
-                    String ex = "Cannot find SpatialRule for rule " + rule;
-                    logger.error(ex);
-                    throw new IllegalArgumentException(ex, e);
-                }
-            }
-        }
 
         public SpatialRuleListFactory(List<SpatialRule> rules) {
             ruleMap = new HashMap<>(rules.size());
@@ -115,9 +85,9 @@ public class SpatialRuleLookupBuilder {
         }
     }
 
-    public SpatialRuleLookup build(String rulesFQN, JsonFeatureCollection jsonFeatureCollection, BBox bounds,
+    public SpatialRuleLookup build(SpatialRuleFactory ruleFactory, JsonFeatureCollection jsonFeatureCollection, BBox bounds,
                                    double resolution, boolean exact) {
-        return build("ISO_A3", new SpatialRuleListFactory(rulesFQN), jsonFeatureCollection, bounds, resolution, exact);
+        return build("ISO_A3", ruleFactory, jsonFeatureCollection, bounds, resolution, exact);
     }
 
     /**

--- a/core/src/main/java/com/graphhopper/util/shapes/BBox.java
+++ b/core/src/main/java/com/graphhopper/util/shapes/BBox.java
@@ -308,4 +308,23 @@ public class BBox implements Shape, Cloneable {
 
         return new BBox(minLon, maxLon, minLat, maxLat);
     }
+
+    /**
+     * This method creates a BBox out of a string in format lon1,lon2,lat1,lat2
+     */
+    public static BBox parseBBoxString(String objectAsString) {
+        String[] splittedObject = objectAsString.split(",");
+
+        if (splittedObject.length != 4)
+            throw new IllegalArgumentException("BBox should have 4 parts but was " + objectAsString);
+
+        double minLon = Double.parseDouble(splittedObject[0]);
+        double maxLon = Double.parseDouble(splittedObject[1]);
+
+        double minLat = Double.parseDouble(splittedObject[2]);
+        double maxLat = Double.parseDouble(splittedObject[3]);
+
+        return new BBox(minLon, maxLon, minLat, maxLat);
+    }
+
 }

--- a/core/src/test/java/com/graphhopper/routing/util/DataFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/DataFlagEncoderTest.java
@@ -334,7 +334,7 @@ public class DataFlagEncoderTest {
 
         SpatialRuleLookup index = new SpatialRuleLookupBuilder().build("GermanySpatialRule",
                 jsonFeatures, bbox, 1, false);
-        DataFlagEncoder encoder = new DataFlagEncoder(new PMap().put("spatial_rules", index.size()));
+        DataFlagEncoder encoder = new DataFlagEncoder(new PMap().put("spatial_rules", index.size()-1));
         encoder.setSpatialRuleLookup(index);
         EncodingManager em = new EncodingManager(encoder);
 

--- a/core/src/test/java/com/graphhopper/routing/util/DataFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/DataFlagEncoderTest.java
@@ -332,9 +332,20 @@ public class DataFlagEncoderTest {
             }
         };
 
-        SpatialRuleLookup index = new SpatialRuleLookupBuilder().build("GermanySpatialRule",
+        SpatialRuleLookup index = new SpatialRuleLookupBuilder().build(
+                new SpatialRuleLookupBuilder.SpatialRuleFactory() {
+                    @Override
+                    public SpatialRule createSpatialRule(String id, List<Polygon> polygons) {
+                        if (id.equals("DEU")) {
+                            SpatialRule rule = new GermanySpatialRule();
+                            rule.setBorders(polygons);
+                            return rule;
+                        }
+                        return SpatialRule.EMPTY;
+                    }
+                },
                 jsonFeatures, bbox, 1, false);
-        DataFlagEncoder encoder = new DataFlagEncoder(new PMap().put("spatial_rules", index.size()-1));
+        DataFlagEncoder encoder = new DataFlagEncoder(new PMap().put("spatial_rules", index.size() - 1));
         encoder.setSpatialRuleLookup(index);
         EncodingManager em = new EncodingManager(encoder);
 

--- a/core/src/test/java/com/graphhopper/routing/util/DataFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/DataFlagEncoderTest.java
@@ -332,7 +332,8 @@ public class DataFlagEncoderTest {
             }
         };
 
-        SpatialRuleLookup index = new SpatialRuleLookupBuilder().build(rules, jsonFeatures, bbox, 1, false);
+        SpatialRuleLookup index = new SpatialRuleLookupBuilder().build("GermanySpatialRule",
+                jsonFeatures, bbox, 1, false);
         DataFlagEncoder encoder = new DataFlagEncoder(new PMap().put("spatial_rules", index.size()));
         encoder.setSpatialRuleLookup(index);
         EncodingManager em = new EncodingManager(encoder);

--- a/core/src/test/java/com/graphhopper/util/shapes/BBoxTest.java
+++ b/core/src/test/java/com/graphhopper/util/shapes/BBoxTest.java
@@ -146,4 +146,9 @@ public class BBoxTest {
         // stable parsing, i.e. if first point is in north or south it does not matter:
         assertEquals(new BBox(2, 4, 1, 3), BBox.parseTwoPoints("3,2,1,4"));
     }
+
+    @Test
+    public void testParseBBoxString() {
+        assertEquals(new BBox(2, 4, 1, 3), BBox.parseBBoxString("2,4,1,3"));
+    }
 }

--- a/web/src/main/java/com/graphhopper/http/DefaultModule.java
+++ b/web/src/main/java/com/graphhopper/http/DefaultModule.java
@@ -64,6 +64,7 @@ public class DefaultModule extends AbstractModule {
     }
 
     static SpatialRuleLookup buildIndex(Reader reader, String rules) {
+        // The world-wide BBox will be automatically shrinked to fit the defined rules
         return buildIndex(reader, rules, new BBox(-180, 180, -90, 90));
     }
 

--- a/web/src/main/java/com/graphhopper/http/DefaultModule.java
+++ b/web/src/main/java/com/graphhopper/http/DefaultModule.java
@@ -63,11 +63,14 @@ public class DefaultModule extends AbstractModule {
         return graphHopper;
     }
 
-    static SpatialRuleLookup buildIndex(Reader reader, BBox graphBBox) {
+    static SpatialRuleLookup buildIndex(Reader reader, String rules) {
+        return buildIndex(reader, rules, new BBox(-180, 180, -90, 90));
+    }
+
+    static SpatialRuleLookup buildIndex(Reader reader, String rules, BBox bbox) {
         GHJson ghJson = new GHJsonBuilder().create();
         JsonFeatureCollection jsonFeatureCollection = ghJson.fromJson(reader, JsonFeatureCollection.class);
-        return new SpatialRuleLookupBuilder().build(Arrays.asList(new GermanySpatialRule(), new AustriaSpatialRule()),
-                jsonFeatureCollection, graphBBox, 1, true);
+        return new SpatialRuleLookupBuilder().build(rules, jsonFeatureCollection, bbox, 1, true);
     }
 
     /**
@@ -106,10 +109,10 @@ public class DefaultModule extends AbstractModule {
                 logger.warn("spatial_rules.location was specified but 'generic' encoder is missing to utilize the index");
             } else
                 try {
-                    BBox spatialRuleBBox = BBox.parseBBoxString(args.get("spatial_rules.bbox", "0,0,0,0"));
-                    SpatialRuleLookup index = buildIndex(new FileReader(spatialRuleLocation), spatialRuleBBox);
+                    String ruleFQN = args.get("spatial_rules.fqn", "");
+                    SpatialRuleLookup index = buildIndex(new FileReader(spatialRuleLocation), ruleFQN);
                     if (index != null) {
-                        logger.info("Set spatial rule lookup with " + index.size() + " rules and a BBox of " + spatialRuleBBox);
+                        logger.info("Set spatial rule lookup with " + index.size() + " rules and the following Rules " + ruleFQN);
                         ((DataFlagEncoder) tmp.getEncodingManager().getEncoder("generic")).setSpatialRuleLookup(index);
                     } else {
                         // Throws an exception if spatialRuleLookup was enabled

--- a/web/src/test/java/com/graphhopper/http/SpatialRuleLookupBuilderTest.java
+++ b/web/src/test/java/com/graphhopper/http/SpatialRuleLookupBuilderTest.java
@@ -33,10 +33,13 @@ import static org.junit.Assert.assertTrue;
  */
 public class SpatialRuleLookupBuilderTest {
 
+    // Test class name only and fqn
+    private final String countries = "GermanySpatialRule,com.graphhopper.routing.util.spatialrules.countries.AustriaSpatialRule";
+
     @Test
     public void testIndex() {
         Reader reader = new InputStreamReader(SpatialRuleLookupBuilderTest.class.getResourceAsStream("countries.geo.json"));
-        SpatialRuleLookup spatialRuleLookup = DefaultModule.buildIndex(reader, new BBox(-180, 180, -90, 90));
+        SpatialRuleLookup spatialRuleLookup = DefaultModule.buildIndex(reader, countries);
 
         // Berlin
         assertEquals(AccessValue.EVENTUALLY_ACCESSIBLE, spatialRuleLookup.lookupRule(52.5243700, 13.4105300).getAccessValue("track", TransportationMode.MOTOR_VEHICLE, AccessValue.ACCESSIBLE));
@@ -55,7 +58,7 @@ public class SpatialRuleLookupBuilderTest {
     @Test
     public void testBounds() {
         Reader reader = new InputStreamReader(SpatialRuleLookupBuilderTest.class.getResourceAsStream("countries.geo.json"));
-        SpatialRuleLookup spatialRuleLookup = DefaultModule.buildIndex(reader, new BBox(-180, 180, -90, 90));
+        SpatialRuleLookup spatialRuleLookup = DefaultModule.buildIndex(reader, countries);
         BBox almostWorldWide = new BBox(-179, 179, -89, 89);
 
         // Might fail if a polygon is defined outside the above coordinates
@@ -69,14 +72,14 @@ public class SpatialRuleLookupBuilderTest {
             So the BBox should not contain a Point lying somewhere close in Germany.
          */
         Reader reader = new InputStreamReader(SpatialRuleLookupBuilderTest.class.getResourceAsStream("countries.geo.json"));
-        SpatialRuleLookup spatialRuleLookup = DefaultModule.buildIndex(reader, new BBox(9, 10, 51, 52));
+        SpatialRuleLookup spatialRuleLookup = DefaultModule.buildIndex(reader, countries, new BBox(9, 10, 51, 52));
         assertFalse("BBox seems to be incorrectly contracted", spatialRuleLookup.getBounds().contains(49.9, 8.9));
     }
 
     @Test
     public void testNoIntersection() {
         Reader reader = new InputStreamReader(SpatialRuleLookupBuilderTest.class.getResourceAsStream("countries.geo.json"));
-        SpatialRuleLookup spatialRuleLookup = DefaultModule.buildIndex(reader, new BBox(-180, -179, -90, -89));
+        SpatialRuleLookup spatialRuleLookup = DefaultModule.buildIndex(reader, countries, new BBox(-180, -179, -90, -89));
         assertNull(spatialRuleLookup);
     }
 }


### PR DESCRIPTION
Fixes #965 

Not entirely happy with the fix. Defining the BBox beforehand is unnecessary tedious. The spatial lookup works now with the provided configuration in the config-examples. 