### PR TITLE
Added rounding for Encoded Value

### DIFF
--- a/core/files/changelog.txt
+++ b/core/files/changelog.txt
@@ -1,5 +1,6 @@
 0.9
-    EncodedDoubleValue requires maxValue/factor to be a natural number #954
+    EncodedValue uses Math.round(value/factor). This can change the retrieved values for EncodedValues #954
+    EncodedDoubleValue and EncodedValue requires maxValue/factor to be a natural number #954
     default base algorithm for all modes is bidirectional A* (except speed mode)
     introduced landmarks based hybrid mode, #780
     moving all prepare.xy configs to prepare.ch.xy and e.g. disallow the old

--- a/core/src/main/java/com/graphhopper/routing/util/Bike2WeightFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/Bike2WeightFlagEncoder.java
@@ -52,7 +52,7 @@ public class Bike2WeightFlagEncoder extends BikeFlagEncoder {
 
     @Override
     public int getVersion() {
-        return 1;
+        return 2;
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
@@ -199,7 +199,7 @@ public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
 
     @Override
     public int getVersion() {
-        return 1;
+        return 2;
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/util/BikeFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/BikeFlagEncoder.java
@@ -73,7 +73,7 @@ public class BikeFlagEncoder extends BikeCommonFlagEncoder {
 
     @Override
     public int getVersion() {
-        return 1;
+        return 2;
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/util/DataFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/DataFlagEncoder.java
@@ -853,7 +853,7 @@ public class DataFlagEncoder extends AbstractFlagEncoder {
 
     @Override
     public int getVersion() {
-        return 2;
+        return 3;
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/util/EncodedDoubleValue.java
+++ b/core/src/main/java/com/graphhopper/routing/util/EncodedDoubleValue.java
@@ -31,10 +31,6 @@ public class EncodedDoubleValue extends EncodedValue {
 
     public EncodedDoubleValue(String name, int shift, int bits, double factor, long defaultValue, int maxValue, boolean allowZero) {
         super(name, shift, bits, factor, defaultValue, maxValue, allowZero);
-        double factorDivision = maxValue / factor;
-        if (factorDivision != (int) factorDivision) {
-            throw new IllegalStateException("MaxValue needs to be divisible by factor without remainder");
-        }
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/util/EncodedValue.java
+++ b/core/src/main/java/com/graphhopper/routing/util/EncodedValue.java
@@ -73,9 +73,9 @@ public class EncodedValue {
     }
 
     public long setValue(long flags, long value) {
-        checkValue(value);
         // scale value
-        value /= factor;
+        value = Math.round(value / factor);
+        checkValue((long) (value * factor));
         value <<= shift;
 
         // clear value bits

--- a/core/src/main/java/com/graphhopper/routing/util/EncodedValue.java
+++ b/core/src/main/java/com/graphhopper/routing/util/EncodedValue.java
@@ -59,6 +59,11 @@ public class EncodedValue {
         if (maxValue > this.maxValue)
             throw new IllegalStateException(name + " -> maxValue " + maxValue + " is too large for " + bits + " bits");
 
+        double factorDivision = maxValue / factor;
+        if (factorDivision != (int) factorDivision) {
+            throw new IllegalStateException("MaxValue needs to be divisible by factor without remainder");
+        }
+
         mask = tmpMask << shift;
         this.allowZero = allowZero;
     }

--- a/core/src/main/java/com/graphhopper/routing/util/FootFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/FootFlagEncoder.java
@@ -135,7 +135,7 @@ public class FootFlagEncoder extends AbstractFlagEncoder {
 
     @Override
     public int getVersion() {
-        return 2;
+        return 3;
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/util/HikeFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/HikeFlagEncoder.java
@@ -62,7 +62,7 @@ public class HikeFlagEncoder extends FootFlagEncoder {
 
     @Override
     public int getVersion() {
-        return 1;
+        return 2;
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/util/MotorcycleFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/MotorcycleFlagEncoder.java
@@ -121,7 +121,7 @@ public class MotorcycleFlagEncoder extends CarFlagEncoder {
 
     @Override
     public int getVersion() {
-        return 1;
+        return 2;
     }
 
     /**

--- a/core/src/main/java/com/graphhopper/routing/util/MountainBikeFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/MountainBikeFlagEncoder.java
@@ -140,7 +140,7 @@ public class MountainBikeFlagEncoder extends BikeCommonFlagEncoder {
 
     @Override
     public int getVersion() {
-        return 1;
+        return 2;
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/util/RacingBikeFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/RacingBikeFlagEncoder.java
@@ -132,7 +132,7 @@ public class RacingBikeFlagEncoder extends BikeCommonFlagEncoder {
 
     @Override
     public int getVersion() {
-        return 1;
+        return 2;
     }
 
     @Override


### PR DESCRIPTION
As discussed in #947 this PR tries to implement the same behavior for EncodedValue and EncodedDoubleValue. The results of the division will be rounded. Additionally, I used the checkValue the same way we use it in the EncodedDoubleValue, after multiplying it with the factor again.

As this might change the values retrieved from an EncodedValue, I increased the version of all Encoders using it (I hope I haven't missed one) and added a notice in the changelog.

I moved the maxValue/factor == Integer check to the super constructor in the EncodedValue, I think this makes sense for the EncodedValue as well, right?