### PR TITLE
moved LocationIndexMatch.findNClosest from map-matching to LocationIndexTree

### DIFF
--- a/core/src/main/java/com/graphhopper/storage/index/LocationIndexTree.java
+++ b/core/src/main/java/com/graphhopper/storage/index/LocationIndexTree.java
@@ -578,8 +578,7 @@ public class LocationIndexTree implements LocationIndex {
      * @param queryLat latitude to search from
      * @param queryLon longitude to search from
      * @param edgeFilter only include edges from edgeFilter
-     * @param radius include all results within this radius (in meters) - assuming it's not
-     *        bounded by maxIterations.
+     * @param radius include all results within this radius (in meters)
      * @param maxIterations if not null, search only a square of (2 * maxIterations - 1) tiles
      *        wide/high (with center tile containing (queryLat, queryLon)). Note that it is
      *        possible that the search radius exceeds this square - in this case, an exception

--- a/core/src/test/java/com/graphhopper/storage/index/LocationIndexTreeTest.java
+++ b/core/src/test/java/com/graphhopper/storage/index/LocationIndexTreeTest.java
@@ -27,7 +27,10 @@ import com.graphhopper.util.*;
 import com.graphhopper.util.shapes.GHPoint;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -515,4 +518,63 @@ public class LocationIndexTreeTest extends AbstractLocationIndexTester {
             assertEquals(i, qr.getClosestNode());
         }
     }
+
+    // 0---1---2
+    // |   |   |
+    // |10 |   |
+    // | | |   |
+    // 3-9-4---5
+    // |   |   |
+    // 6---7---8
+    @Test
+    public void testFindNClosest() {
+        Graph graph = createGHStorage(new RAMDirectory(), encodingManager, false);
+        NodeAccess na = graph.getNodeAccess();
+        na.setNode(0, 0.0010, 0.0000);
+        na.setNode(1, 0.0010, 0.0005);
+        na.setNode(2, 0.0010, 0.0010);
+        na.setNode(3, 0.0005, 0.0000);
+        na.setNode(4, 0.0005, 0.0005);
+        na.setNode(5, 0.0005, 0.0010);
+        na.setNode(6, 0.0000, 0.0000);
+        na.setNode(7, 0.0000, 0.0005);
+        na.setNode(8, 0.0000, 0.0010);
+        na.setNode(9, 0.0005, 0.0002);
+        na.setNode(10, 0.0007, 0.0002);
+        graph.edge(0, 1);
+        graph.edge(1, 2);
+        graph.edge(0, 3);
+        graph.edge(1, 4);
+        graph.edge(2, 5);
+        graph.edge(3, 9);
+        graph.edge(9, 4);
+        EdgeIteratorState edge4_5 = graph.edge(4, 5);
+        graph.edge(10, 9);
+        graph.edge(3, 6);
+        EdgeIteratorState edge4_7 = graph.edge(4, 7);
+        graph.edge(5, 8);
+        graph.edge(6, 7);
+        graph.edge(7, 8);
+
+        LocationIndexTree index = createIndexNoPrepare(graph, 500);
+        index.prepareIndex();
+
+        // query node 4 => get at least 4-5, 4-7
+        List<QueryResult> result = index.findWithinRadius(0.0004, 0.0006, EdgeFilter.ALL_EDGES, 15, 2);
+        List<Integer> ids = new ArrayList<Integer>();
+        for (QueryResult qr : result) {
+            ids.add(qr.getClosestEdge().getEdge());
+        }
+        Collections.sort(ids);
+        assertEquals("edge ids do not match",
+                Arrays.asList(edge4_5.getEdge(), edge4_7.getEdge()), ids);
+        
+        // check fails if maxIterations bounds radius:
+        try {
+            index.findWithinRadius(0.0004, 0.0006, EdgeFilter.ALL_EDGES, 2000, 2);
+        } catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().indexOf("maxIterations") >= 0);
+        }
+    }
+
 }

--- a/core/src/test/java/com/graphhopper/storage/index/LocationIndexTreeTest.java
+++ b/core/src/test/java/com/graphhopper/storage/index/LocationIndexTreeTest.java
@@ -560,7 +560,7 @@ public class LocationIndexTreeTest extends AbstractLocationIndexTester {
         index.prepareIndex();
 
         // query node 4 => get at least 4-5, 4-7
-        List<QueryResult> result = index.findWithinRadius(0.0004, 0.0006, EdgeFilter.ALL_EDGES, 15, 2);
+        List<QueryResult> result = index.findNClosest(0.0004, 0.0006, EdgeFilter.ALL_EDGES, 15);
         List<Integer> ids = new ArrayList<Integer>();
         for (QueryResult qr : result) {
             ids.add(qr.getClosestEdge().getEdge());
@@ -568,13 +568,6 @@ public class LocationIndexTreeTest extends AbstractLocationIndexTester {
         Collections.sort(ids);
         assertEquals("edge ids do not match",
                 Arrays.asList(edge4_5.getEdge(), edge4_7.getEdge()), ids);
-        
-        // check fails if maxIterations bounds radius:
-        try {
-            index.findWithinRadius(0.0004, 0.0006, EdgeFilter.ALL_EDGES, 2000, 2);
-        } catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().indexOf("maxIterations") >= 0);
-        }
     }
 
 }


### PR DESCRIPTION
This is for #993 ~and [map-matching 65](https://github.com/graphhopper/map-matching/issues/65). Comments:~

- ~no real logic changed excepted made maxIterations configurable (from hardcoded value of 2 in map-matching) and throws an error if maxIterations 'truncates' the radius (as discussed in map-matching 65).~ I've added some comments for tidy-ups (that can be made later).
- ~renamed to `findWithinRadius` to better reflect the method (as opposed to the somewhat misleading `findNClosest`).~
- copied tests over from map-matching ~and added one to check the error is thrown for maxIterations truncation.~
- #971 was (I think) prompted by map-matching requirements for XFirstSearchCheck. This is no longer the case, so I'm not sure if we can close #971?
- required by [map-matching 87](https://github.com/graphhopper/map-matching/pull/87)