### PR TITLE
Bug when loading prepared graph with LM

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/lm/LMAlgoFactoryDecorator.java
+++ b/core/src/main/java/com/graphhopper/routing/lm/LMAlgoFactoryDecorator.java
@@ -266,6 +266,7 @@ public class LMAlgoFactoryDecorator implements RoutingAlgorithmFactoryDecorator 
     public boolean loadOrDoWork(final StorableProperties properties) {
         ExecutorCompletionService completionService = new ExecutorCompletionService<>(threadPool);
         int counter = 0;
+        int submittedPreparations = 0;
         boolean prepared = false;
         for (final PrepareLandmarks plm : preparations) {
             counter++;
@@ -291,11 +292,12 @@ public class LMAlgoFactoryDecorator implements RoutingAlgorithmFactoryDecorator 
                     }
                 }
             }, name);
+            submittedPreparations++;
         }
 
         threadPool.shutdown();
         try {
-            for(int i = 0; i < getPreparations().size(); i++){
+            for (int i = 0; i < submittedPreparations; i++) {
                 completionService.take().get();
             }
         } catch (Exception e) {


### PR DESCRIPTION
Important Bugfix, when loading an already prepared graph with LM, the server blocked at: completionService.take(), as no thread is created if LM is already prepared.

I introduced this bug with #995. The problem is that when loading a graph with prepared Landmarks that we don't spawn a thread if they are already prepared. With CH we create a new thread.

A test for this scenario would be nice as well, but I wasn't sure where to add something like this?

BTW: This is #1000 🎉🎉🎉