### PR TITLE
GTFS from Switzerland requires larger validityids

### DIFF
--- a/reader-gtfs/src/main/java/com/graphhopper/reader/gtfs/PtFlagEncoder.java
+++ b/reader-gtfs/src/main/java/com/graphhopper/reader/gtfs/PtFlagEncoder.java
@@ -40,7 +40,7 @@ class PtFlagEncoder extends AbstractFlagEncoder {
 		shift += time.getBits();
 		transfers = new EncodedValue("transfers", shift, 1, 1.0, 0, 1);
 		shift += transfers.getBits();
-		validityId = new EncodedValue("validityId", shift, 11, 1.0, 0, 2047);
+		validityId = new EncodedValue("validityId", shift, 20, 1.0, 0, 1048575);
 		shift += validityId.getBits();
 		GtfsStorage.EdgeType[] edgeTypes = GtfsStorage.EdgeType.values();
 		type = new EncodedValue("type", shift, 6, 1.0, GtfsStorage.EdgeType.HIGHWAY.ordinal(), edgeTypes[edgeTypes.length-1].ordinal());


### PR DESCRIPTION
Import of the GTFS for Switzerland works but a few problems occurred:
 
 * https://github.com/conveyal/gtfs-lib/issues/40
 * And the max validityId was too small (What is its purpose?)
 * (query takes long but this is already known)