### PR TITLE
Create hook for importing OSM elements from something else than a File.

### DIFF
--- a/reader-osm/src/main/java/com/graphhopper/reader/osm/OSMInput.java
+++ b/reader-osm/src/main/java/com/graphhopper/reader/osm/OSMInput.java
@@ -1,0 +1,28 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.reader.osm;
+
+import com.graphhopper.reader.ReaderElement;
+
+import javax.xml.stream.XMLStreamException;
+
+public interface OSMInput extends AutoCloseable {
+    ReaderElement getNext() throws XMLStreamException;
+
+    int getUnprocessedElements();
+}

--- a/reader-osm/src/main/java/com/graphhopper/reader/osm/OSMInputFile.java
+++ b/reader-osm/src/main/java/com/graphhopper/reader/osm/OSMInputFile.java
@@ -39,7 +39,7 @@ import java.util.zip.ZipInputStream;
  *
  * @author Nop
  */
-public class OSMInputFile implements Sink, Closeable {
+public class OSMInputFile implements Sink, OSMInput {
     private final InputStream bis;
     private final BlockingQueue<ReaderElement> itemQueue;
     Thread pbfReaderThread;
@@ -156,6 +156,7 @@ public class OSMInputFile implements Sink, Closeable {
         eof = false;
     }
 
+    @Override
     public ReaderElement getNext() throws XMLStreamException {
         if (eof)
             throw new IllegalStateException("EOF reached");

--- a/reader-osm/src/main/java/com/graphhopper/reader/osm/OSMReader.java
+++ b/reader-osm/src/main/java/com/graphhopper/reader/osm/OSMReader.java
@@ -159,10 +159,7 @@ public class OSMReader implements DataReader {
      * compact graph data structure.
      */
     void preProcess(File osmFile) {
-        OSMInputFile in = null;
-        try {
-            in = new OSMInputFile(osmFile).setWorkerThreads(workerThreads).open();
-
+        try (OSMInput in = openOsmInputFile(osmFile)) {
             long tmpWayCounter = 1;
             long tmpRelationCounter = 1;
             ReaderElement item;
@@ -202,8 +199,6 @@ public class OSMReader implements DataReader {
             }
         } catch (Exception ex) {
             throw new RuntimeException("Problem while parsing file", ex);
-        } finally {
-            Helper.close(in);
         }
     }
 
@@ -258,9 +253,7 @@ public class OSMReader implements DataReader {
         long wayStart = -1;
         long relationStart = -1;
         long counter = 1;
-        OSMInputFile in = null;
-        try {
-            in = new OSMInputFile(osmFile).setWorkerThreads(workerThreads).open();
+        try (OSMInput in = openOsmInputFile(osmFile)) {
             LongIntMap nodeFilter = getNodeMap();
 
             ReaderElement item;
@@ -302,13 +295,15 @@ public class OSMReader implements DataReader {
             // logger.info("storage nodes:" + storage.nodes() + " vs. graph nodes:" + storage.getGraph().nodes());
         } catch (Exception ex) {
             throw new RuntimeException("Couldn't process file " + osmFile + ", error: " + ex.getMessage(), ex);
-        } finally {
-            Helper.close(in);
         }
 
         finishedReading();
         if (graph.getNodes() == 0)
             throw new RuntimeException("Graph after reading OSM must not be empty. Read " + counter + " items and " + locations + " locations");
+    }
+
+    protected OSMInput openOsmInputFile(File osmFile) throws XMLStreamException, IOException {
+        return new OSMInputFile(osmFile).setWorkerThreads(workerThreads).open();
     }
 
     /**


### PR DESCRIPTION
On OSM-Saturday at FOSSGIS, I sketched a (GraphHopper-based) routing-plugin for JOSM. Not worth checking out yet, but directly reading the JOSM data model from memory and finding a route from the GUI works like a charm -- in about 120 lines of code.

This is the minimal set of changes I had to make to plug into GraphHopper's OSM-import to have it read the data structures I feed it from JOSM, instead of a file.

(Could be followed up by a refactoring where the PBF and the XML file readers are separated.)