### PR TITLE
Extracted blocking edges/areas from GenericWeighting into BlockedWeighting

### DIFF
--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -898,8 +898,9 @@ public class GraphHopper implements GraphHopperAPI {
 
             cMap = new GraphEdgeIdFinder(graph, locationIndex).parseStringHints(cMap, hintsMap, new DefaultEdgeFilter(encoder));
             GenericWeighting genericWeighting = new GenericWeighting(dataEncoder, cMap);
-            genericWeighting.setGraph(graph);
-            return genericWeighting;
+            BlockedWeighting blockedWeighting = new BlockedWeighting(genericWeighting, cMap);
+            blockedWeighting.setGraph(graph);
+            return blockedWeighting;
         } else if ("shortest".equalsIgnoreCase(weighting)) {
             return new ShortestWeighting(encoder);
         } else if ("fastest".equalsIgnoreCase(weighting) || weighting.isEmpty()) {

--- a/core/src/main/java/com/graphhopper/routing/ch/CHAlgoFactoryDecorator.java
+++ b/core/src/main/java/com/graphhopper/routing/ch/CHAlgoFactoryDecorator.java
@@ -22,7 +22,7 @@ import com.graphhopper.routing.RoutingAlgorithmFactoryDecorator;
 import com.graphhopper.routing.util.HintsMap;
 import com.graphhopper.routing.util.TraversalMode;
 import com.graphhopper.routing.weighting.AbstractWeighting;
-import com.graphhopper.routing.weighting.GenericWeighting;
+import com.graphhopper.routing.weighting.BlockedWeighting;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.*;
 import com.graphhopper.util.CmdArgs;
@@ -325,8 +325,8 @@ public class CHAlgoFactoryDecorator implements RoutingAlgorithmFactoryDecorator 
         traversalMode = getNodeBase();
 
         for (Weighting weighting : getWeightings()) {
-            if (weighting instanceof GenericWeighting) {
-                ((GenericWeighting) weighting).setGraph(ghStorage);
+            if (weighting instanceof BlockedWeighting) {
+                ((BlockedWeighting) weighting).setGraph(ghStorage);
             }
             PrepareContractionHierarchies tmpPrepareCH = new PrepareContractionHierarchies(
                     new GHDirectory("", DAType.RAM_INT), ghStorage, ghStorage.getGraph(CHGraph.class, weighting),

--- a/core/src/main/java/com/graphhopper/routing/weighting/BlockedWeighting.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/BlockedWeighting.java
@@ -1,0 +1,81 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.routing.weighting;
+
+import com.graphhopper.coll.GHIntHashSet;
+import com.graphhopper.storage.Graph;
+import com.graphhopper.storage.GraphEdgeIdFinder;
+import com.graphhopper.storage.NodeAccess;
+import com.graphhopper.util.ConfigMap;
+import com.graphhopper.util.EdgeIteratorState;
+import com.graphhopper.util.shapes.Shape;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Sets weights of blocked edges to infinity.
+ *
+ * @author Fedor Ermishin
+ */
+public class BlockedWeighting extends AbstractAdjustedWeighting {
+    private final GHIntHashSet blockedEdges;
+    private final List<Shape> blockedShapes;
+    private NodeAccess na;
+
+    public BlockedWeighting(Weighting superWeighting, ConfigMap cMap) {
+        super(superWeighting);
+        blockedEdges = cMap.get(GraphEdgeIdFinder.BLOCKED_EDGES, new GHIntHashSet(0));
+        blockedShapes = cMap.get(GraphEdgeIdFinder.BLOCKED_SHAPES, Collections.EMPTY_LIST);
+    }
+
+    @Override
+    public double getMinWeight(double distance) {
+        return superWeighting.getMinWeight(distance);
+    }
+
+    @Override
+    public double calcWeight(EdgeIteratorState edgeState, boolean reverse, int prevOrNextEdgeId) {
+        if (!blockedEdges.isEmpty() && blockedEdges.contains(edgeState.getEdge())) {
+            return Double.POSITIVE_INFINITY;
+        }
+
+        if (!blockedShapes.isEmpty() && na != null) {
+            for (Shape shape : blockedShapes) {
+                if (shape.contains(na.getLatitude(edgeState.getAdjNode()), na.getLongitude(edgeState.getAdjNode()))) {
+                    return Double.POSITIVE_INFINITY;
+                }
+            }
+        }
+
+        return superWeighting.calcWeight(edgeState, reverse, prevOrNextEdgeId);
+    }
+
+    @Override
+    public String getName() {
+        return "blocked";
+    }
+
+    /**
+     * Use this method to associate a graph with this weighting to calculate e.g. node locations too.
+     */
+    public void setGraph(Graph graph) {
+        if (graph != null)
+            this.na = graph.getNodeAccess();
+    }
+}

--- a/core/src/test/java/com/graphhopper/routing/weighting/BlockedWeightingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/BlockedWeightingTest.java
@@ -1,0 +1,129 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.routing.weighting;
+
+import com.graphhopper.coll.GHIntHashSet;
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.AbstractRoutingAlgorithmTester;
+import com.graphhopper.routing.util.DataFlagEncoder;
+import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.storage.Graph;
+import com.graphhopper.storage.GraphBuilder;
+import com.graphhopper.util.ConfigMap;
+import com.graphhopper.util.EdgeIterator;
+import com.graphhopper.util.EdgeIteratorState;
+import com.graphhopper.util.PMap;
+import com.graphhopper.util.shapes.Circle;
+import com.graphhopper.util.shapes.Shape;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static com.graphhopper.storage.GraphEdgeIdFinder.BLOCKED_EDGES;
+import static com.graphhopper.storage.GraphEdgeIdFinder.BLOCKED_SHAPES;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Fedor Ermishin
+ */
+public class BlockedWeightingTest {
+    private final DataFlagEncoder encoder;
+    private final EncodingManager em;
+    private Graph graph;
+
+    private double edgeDistance;
+
+    public BlockedWeightingTest() {
+        PMap properties = new PMap();
+        properties.put("store_height", true);
+        properties.put("store_weight", true);
+        properties.put("store_width", true);
+        encoder = new DataFlagEncoder(properties);
+        em = new EncodingManager(Arrays.asList(encoder), 8);
+    }
+
+    @Before
+    public void setUp() {
+        ReaderWay way = new ReaderWay(27L);
+        way.setTag("highway", "primary");
+        way.setTag("maxspeed", "10");
+        way.setTag("maxheight", "4.4");
+
+        graph = new GraphBuilder(em).create();
+        // 0-1
+        graph.edge(0, 1, 1, true);
+        AbstractRoutingAlgorithmTester.updateDistancesFor(graph, 0, 0.00, 0.00);
+        AbstractRoutingAlgorithmTester.updateDistancesFor(graph, 1, 0.01, 0.01);
+        graph.getEdgeIteratorState(0, 1).setFlags(encoder.handleWayTags(way, 1, 0));
+
+        edgeDistance = graph.getEdgeIteratorState(0, 1).getDistance();
+    }
+
+    @Test
+    public void testBlockedById() {
+        EdgeIteratorState edge = graph.getEdgeIteratorState(0, 1);
+        ConfigMap cMap = encoder.readStringMap(new PMap());
+        Weighting baseWeighting = new ShortestWeighting(encoder);
+        Weighting instance = new BlockedWeighting(baseWeighting, cMap);
+        assertEquals(edgeDistance, instance.calcWeight(edge, false, EdgeIterator.NO_EDGE), 1e-8);
+
+        GHIntHashSet blockedEdges = new GHIntHashSet(1);
+        cMap.put(BLOCKED_EDGES, blockedEdges);
+        blockedEdges.add(0);
+        baseWeighting = new ShortestWeighting(encoder);
+        instance = new BlockedWeighting(baseWeighting, cMap);
+        assertEquals(Double.POSITIVE_INFINITY, instance.calcWeight(edge, false, EdgeIterator.NO_EDGE), 1e-8);
+    }
+
+    @Test
+    public void testBlockedByShape() {
+        EdgeIteratorState edge = graph.getEdgeIteratorState(0, 1);
+        ConfigMap cMap = encoder.readStringMap(new PMap());
+        Weighting baseWeighting = new ShortestWeighting(encoder);
+        BlockedWeighting instance = new BlockedWeighting(baseWeighting, cMap);
+        assertEquals(edgeDistance, instance.calcWeight(edge, false, EdgeIterator.NO_EDGE), 1e-8);
+
+        List<Shape> shapes = new ArrayList<>(1);
+        shapes.add(new Circle(0.01, 0.01, 100));
+        cMap.put(BLOCKED_SHAPES, shapes);
+        baseWeighting = new ShortestWeighting(encoder);
+        instance = new BlockedWeighting(baseWeighting, cMap);
+        instance.setGraph(graph);
+        assertEquals(Double.POSITIVE_INFINITY, instance.calcWeight(edge, false, EdgeIterator.NO_EDGE), 1e-8);
+
+        shapes.clear();
+        // Do not match 1,1 of edge
+        shapes.add(new Circle(0.1, 0.1, 100));
+        cMap.put(BLOCKED_SHAPES, shapes);
+        baseWeighting = new ShortestWeighting(encoder);
+        instance = new BlockedWeighting(baseWeighting, cMap);
+        instance.setGraph(graph);
+        assertEquals(edgeDistance, instance.calcWeight(edge, false, EdgeIterator.NO_EDGE), 1e-8);
+    }
+
+    @Test
+    public void testNullGraph() {
+        ConfigMap cMap = encoder.readStringMap(new PMap());
+        Weighting baseWeighting = new ShortestWeighting(encoder);
+        BlockedWeighting weighting = new BlockedWeighting(baseWeighting, cMap);
+        weighting.setGraph(null);
+    }
+}

--- a/core/src/test/java/com/graphhopper/routing/weighting/GenericWeightingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/GenericWeightingTest.java
@@ -17,22 +17,20 @@
  */
 package com.graphhopper.routing.weighting;
 
-import com.graphhopper.coll.GHIntHashSet;
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.AbstractRoutingAlgorithmTester;
-import com.graphhopper.routing.util.*;
-import com.graphhopper.storage.*;
-
-import static com.graphhopper.storage.GraphEdgeIdFinder.BLOCKED_EDGES;
-import static com.graphhopper.storage.GraphEdgeIdFinder.BLOCKED_SHAPES;
-
-import com.graphhopper.util.*;
-import com.graphhopper.util.shapes.Circle;
-import com.graphhopper.util.shapes.Shape;
+import com.graphhopper.routing.util.DataFlagEncoder;
+import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.storage.Graph;
+import com.graphhopper.storage.GraphBuilder;
+import com.graphhopper.util.ConfigMap;
+import com.graphhopper.util.EdgeIterator;
+import com.graphhopper.util.EdgeIteratorState;
+import com.graphhopper.util.PMap;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.*;
+import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
 
@@ -40,7 +38,6 @@ import static org.junit.Assert.assertEquals;
  * @author Peter Karich
  */
 public class GenericWeightingTest {
-    private final PMap properties;
     private final DataFlagEncoder encoder;
     private final EncodingManager em;
     private Graph graph;
@@ -48,7 +45,7 @@ public class GenericWeightingTest {
     private final double edgeWeight = 566111;
 
     public GenericWeightingTest() {
-        properties = new PMap();
+        PMap properties = new PMap();
         properties.put("store_height", true);
         properties.put("store_weight", true);
         properties.put("store_width", true);
@@ -58,7 +55,7 @@ public class GenericWeightingTest {
 
     @Before
     public void setUp() {
-        ReaderWay way = new ReaderWay(27l);
+        ReaderWay way = new ReaderWay(27L);
         way.setTag("highway", "primary");
         way.setTag("maxspeed", "10");
         way.setTag("maxheight", "4.4");
@@ -72,55 +69,11 @@ public class GenericWeightingTest {
     }
 
     @Test
-    public void testBlockedById() {
-        EdgeIteratorState edge = graph.getEdgeIteratorState(0, 1);
-        ConfigMap cMap = encoder.readStringMap(new PMap());
-        Weighting instance = new GenericWeighting(encoder, cMap);
-        assertEquals(edgeWeight, instance.calcWeight(edge, false, EdgeIterator.NO_EDGE), 1e-8);
-
-        GHIntHashSet blockedEdges = new GHIntHashSet(1);
-        cMap.put(BLOCKED_EDGES, blockedEdges);
-        blockedEdges.add(0);
-        instance = new GenericWeighting(encoder, cMap);
-        assertEquals(Double.POSITIVE_INFINITY, instance.calcWeight(edge, false, EdgeIterator.NO_EDGE), 1e-8);
-    }
-
-    @Test
-    public void testBlockedByShape() {
-        EdgeIteratorState edge = graph.getEdgeIteratorState(0, 1);
-        ConfigMap cMap = encoder.readStringMap(new PMap());
-        GenericWeighting instance = new GenericWeighting(encoder, cMap);
-        assertEquals(edgeWeight, instance.calcWeight(edge, false, EdgeIterator.NO_EDGE), 1e-8);
-
-        List<Shape> shapes = new ArrayList<>(1);
-        shapes.add(new Circle(0.01, 0.01, 100));
-        cMap.put(BLOCKED_SHAPES, shapes);
-        instance = new GenericWeighting(encoder, cMap);
-        instance.setGraph(graph);
-        assertEquals(Double.POSITIVE_INFINITY, instance.calcWeight(edge, false, EdgeIterator.NO_EDGE), 1e-8);
-
-        shapes.clear();
-        // Do not match 1,1 of edge
-        shapes.add(new Circle(0.1, 0.1, 100));
-        cMap.put(BLOCKED_SHAPES, shapes);
-        instance = new GenericWeighting(encoder, cMap);
-        instance.setGraph(graph);
-        assertEquals(edgeWeight, instance.calcWeight(edge, false, EdgeIterator.NO_EDGE), 1e-8);
-    }
-
-    @Test
     public void testCalcTime() {
         ConfigMap cMap = encoder.readStringMap(new PMap());
         GenericWeighting weighting = new GenericWeighting(encoder, cMap);
         EdgeIteratorState edge = graph.getEdgeIteratorState(0, 1);
         assertEquals(edgeWeight, weighting.calcMillis(edge, false, EdgeIterator.NO_EDGE), .1);
-    }
-
-    @Test
-    public void testNullGraph() {
-        ConfigMap cMap = encoder.readStringMap(new PMap());
-        GenericWeighting weighting = new GenericWeighting(encoder, cMap);
-        weighting.setGraph(null);
     }
 
     @Test
@@ -142,7 +95,7 @@ public class GenericWeightingTest {
         EncodingManager simpleEncodingManager = new EncodingManager(simpleEncoder);
         Graph simpleGraph = new GraphBuilder(simpleEncodingManager).create();
 
-        ReaderWay way = new ReaderWay(27l);
+        ReaderWay way = new ReaderWay(27L);
         way.setTag("highway", "primary");
         way.setTag("maxspeed", "10");
         way.setTag("maxheight", "4.4");


### PR DESCRIPTION
Related issue:  #958
I'm not sure about one thing: is it OK to change order of checks in GenericWeighting.calcWeight? When using GenericWeighting with BlockedWeighting now it is firstly checked that edge is not blocked and then other checks from GenericWeighting go. Can it affect performance in any way?