### PR TITLE
Store toll information via DataFlagEncoder

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/DataFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/DataFlagEncoder.java
@@ -913,6 +913,10 @@ public class DataFlagEncoder extends AbstractFlagEncoder {
         cloneDoubleAttribute(weightingMap, cMap, GenericWeighting.WEIGHT_LIMIT, 0d);
         cloneDoubleAttribute(weightingMap, cMap, GenericWeighting.WIDTH_LIMIT, 0d);
 
+        if(weightingMap.has(GenericWeighting.AVOID_TOLL)){
+            cMap.put(GenericWeighting.AVOID_TOLL, weightingMap.getBool(GenericWeighting.AVOID_TOLL, false));
+        }
+
         return cMap;
     }
 

--- a/core/src/main/java/com/graphhopper/routing/weighting/GenericWeighting.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/GenericWeighting.java
@@ -40,6 +40,7 @@ public class GenericWeighting extends AbstractWeighting {
     public static final String HEIGHT_LIMIT = "height";
     public static final String WEIGHT_LIMIT = "weight";
     public static final String WIDTH_LIMIT = "width";
+    public static final String AVOID_TOLL = "avoid_toll";
     /**
      * Convert to milliseconds for correct calcMillis.
      */
@@ -55,6 +56,7 @@ public class GenericWeighting extends AbstractWeighting {
     protected final double height;
     protected final double weight;
     protected final double width;
+    protected final boolean avoidtoll;
 
     private final GHIntHashSet blockedEdges;
     private final List<Shape> blockedShapes;
@@ -82,6 +84,7 @@ public class GenericWeighting extends AbstractWeighting {
         height = cMap.getDouble(HEIGHT_LIMIT, 0d);
         weight = cMap.getDouble(WEIGHT_LIMIT, 0d);
         width = cMap.getDouble(WIDTH_LIMIT, 0d);
+        avoidtoll = cMap.getBool(AVOID_TOLL, false);
     }
 
     @Override
@@ -101,6 +104,9 @@ public class GenericWeighting extends AbstractWeighting {
         if ((gEncoder.isStoreHeight() && overLimit(height, gEncoder.getHeight(edgeState))) ||
                 (gEncoder.isStoreWeight() && overLimit(weight, gEncoder.getWeight(edgeState))) ||
                 (gEncoder.isStoreWidth() && overLimit(width, gEncoder.getWidth(edgeState))))
+            return Double.POSITIVE_INFINITY;
+
+        if(avoidtoll && gEncoder.isStoreToll() && gEncoder.isTollRoad(edgeState))
             return Double.POSITIVE_INFINITY;
 
         if (!blockedEdges.isEmpty() && blockedEdges.contains(edgeState.getEdge())) {

--- a/core/src/test/java/com/graphhopper/routing/util/DataFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/DataFlagEncoderTest.java
@@ -36,6 +36,7 @@ public class DataFlagEncoderTest {
         properties.put("store_height", true);
         properties.put("store_weight", true);
         properties.put("store_width", true);
+        properties.put("store_toll", true);
         encoder = new DataFlagEncoder(properties);
         encodingManager = new EncodingManager(Arrays.asList(encoder), 8);
 
@@ -270,6 +271,21 @@ public class DataFlagEncoderTest {
         // important to filter out illegal highways to reduce the number of edges before adding them to the graph
         osmWay.setTag("highway", "building");
         assertTrue(encoder.acceptWay(osmWay) == 0);
+    }
+
+    @Test
+    public void testToll() {
+        ReaderWay osmWay = new ReaderWay(0);
+        osmWay.setTag("highway", "primary");
+        osmWay.setTag("toll", "no");
+        long flags = encoder.handleWayTags(osmWay, 1, 0);
+        EdgeIteratorState edge = GHUtility.createMockedEdgeIteratorState(0, flags);
+        assertFalse(encoder.isTollRoad(edge));
+
+        osmWay.setTag("toll", "yes");
+        flags = encoder.handleWayTags(osmWay, 1, 0);
+        edge = GHUtility.createMockedEdgeIteratorState(0, flags);
+        assertTrue(encoder.isTollRoad(edge));
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/routing/weighting/GenericWeightingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/GenericWeightingTest.java
@@ -52,6 +52,7 @@ public class GenericWeightingTest {
         properties.put("store_height", true);
         properties.put("store_weight", true);
         properties.put("store_width", true);
+        properties.put("store_toll", true);
         encoder = new DataFlagEncoder(properties);
         em = new EncodingManager(Arrays.asList(encoder), 8);
     }
@@ -114,6 +115,25 @@ public class GenericWeightingTest {
         GenericWeighting weighting = new GenericWeighting(encoder, cMap);
         EdgeIteratorState edge = graph.getEdgeIteratorState(0, 1);
         assertEquals(edgeWeight, weighting.calcMillis(edge, false, EdgeIterator.NO_EDGE), .1);
+    }
+
+    @Test
+    public void testToll() {
+        ConfigMap cMap = encoder.readStringMap(new PMap("avoid_toll=true"));
+        GenericWeighting weighting = new GenericWeighting(encoder, cMap);
+
+        ReaderWay way = new ReaderWay(28l);
+        way.setTag("highway", "primary");
+        way.setTag("maxspeed", "10");
+        way.setTag("toll", "yes");
+
+        graph.edge(0, 2, 1, true);
+        AbstractRoutingAlgorithmTester.updateDistancesFor(graph, 0, 0.00, 0.00);
+        AbstractRoutingAlgorithmTester.updateDistancesFor(graph, 2, 0.01, 0.01);
+        graph.getEdgeIteratorState(1, 2).setFlags(encoder.handleWayTags(way, 1, 0));
+
+        EdgeIteratorState edge = graph.getEdgeIteratorState(1, 2);
+        assertEquals(Double.POSITIVE_INFINITY, weighting.calcWeight(edge, false, EdgeIterator.NO_EDGE), .1);
     }
 
     @Test


### PR DESCRIPTION
This PR allows to store toll information in the graph. And avoiding toll roads in the GenericWeighting. It is intended to fix #643.

In this PR I only evaluate ways for the property `toll=yes`. It seems that other also check if there is a `barrier=toll_booth`.

I tried integrating toll booths as well, but I am not sure if the overhead of implementing/maintaining it is worth the benefit? I looked up a couple of toll roads and it seems like all where tagged correct, so toll booth recognition might not be required? I created an overpass-turbo query to find toll_booths that are not on a way with "toll" tagged, but I couldn't find one.

The overpass query looks like this:
```
[bbox:{{bbox}}];
way[!"toll"];node["toll_booth"="yes"](w) -> .booth;
node.booth;
out;
```

BTW: I think the overpass query is correct, I tried it with traffic signals and get results:
```
[bbox:{{bbox}}];
way[!"toll"];node["highway"="traffic_signals"](w) -> .booth;
node.booth;
out;
```

I added the [toll_booth code here](https://github.com/boldtrn/graphhopper/commit/8924dff0e5828e6471a322a94c55b4be13475a97), it's untested, but I assume it could work like that... Testing is not that trivial. I think I would end up extending the test-barriers.xml. Since I couldn't find a live example this might not be worth the effort.