### PR TITLE
Fixed Exception for requesting a point=undefined with heading

### DIFF
--- a/web/src/main/java/com/graphhopper/http/GraphHopperServlet.java
+++ b/web/src/main/java/com/graphhopper/http/GraphHopperServlet.java
@@ -85,6 +85,9 @@ public class GraphHopperServlet extends GHBaseServlet {
 
         if (!ghRsp.hasErrors()) {
             try {
+                if(requestPoints.isEmpty()){
+                    throw new IllegalArgumentException("You have to pass at least one point");
+                }
                 List<Double> favoredHeadings = Collections.EMPTY_LIST;
                 try {
                     favoredHeadings = getDoubleParamList(httpReq, "heading");

--- a/web/src/test/java/com/graphhopper/http/GraphHopperServletIT.java
+++ b/web/src/test/java/com/graphhopper/http/GraphHopperServletIT.java
@@ -216,4 +216,12 @@ public class GraphHopperServletIT extends BaseServletTester {
         assertTrue("Expected error but was: " + str, str.contains("<message>At least 2 points have to be specified, but was:1</message>"));
         assertTrue("Expected error but was: " + str, str.contains("<hints><error details=\"java"));
     }
+
+    @Test
+    public void testUndefinedPointHeading() throws Exception {
+        JSONObject json = query("point=undefined&heading=0", 400);
+        assertEquals("You have to pass at least one point", json.get("message"));
+        json = query("point=42.554851,1.536198&point=undefined&heading=0&heading=0", 400);
+        assertEquals("The number of 'heading' parameters must be <= 1 or equal to the number of points (1)", json.get("message"));
+    }
 }


### PR DESCRIPTION
Currently, there is a bug, when you don't specify a point in the request, but specify a heading. This PR fixes this bug, by assuming that a request that does not contain any points is not a valid request at all. I think this is a valid assumption?