### PR TITLE
merge PMap and ConfigMap

### DIFF
--- a/core/src/main/java/com/graphhopper/GHResponse.java
+++ b/core/src/main/java/com/graphhopper/GHResponse.java
@@ -17,7 +17,7 @@
  */
 package com.graphhopper;
 
-import com.graphhopper.util.PMap;
+import com.graphhopper.util.StringConfigMap;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -30,7 +30,7 @@ import java.util.List;
  */
 public class GHResponse {
     private final List<Throwable> errors = new ArrayList<Throwable>(4);
-    private final PMap hintsMap = new PMap();
+    private final StringConfigMap hintsMap = new StringConfigMap();
     private final List<PathWrapper> pathWrappers = new ArrayList<PathWrapper>(5);
     private String debugInfo = "";
 
@@ -140,7 +140,7 @@ public class GHResponse {
         return str;
     }
 
-    public PMap getHints() {
+    public StringConfigMap getHints() {
         return hintsMap;
     }
 }

--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -878,7 +878,7 @@ public class GraphHopper implements GraphHopperAPI {
      * you use the web module.
      *
      * @param hintsMap all parameters influencing the weighting. E.g. parameters coming via
-     *                 GHRequest.getHints or directly via "&amp;api.xy=" from the URL of the web UI
+     *                 GHRequest.getConfigMap or directly via "&amp;api.xy=" from the URL of the web UI
      * @param encoder  the required vehicle
      * @param graph    The Graph enables the Weighting for NodeAccess and more
      * @return the weighting to be used for route calculation

--- a/core/src/main/java/com/graphhopper/routing/AlgorithmOptions.java
+++ b/core/src/main/java/com/graphhopper/routing/AlgorithmOptions.java
@@ -19,7 +19,8 @@ package com.graphhopper.routing;
 
 import com.graphhopper.routing.util.TraversalMode;
 import com.graphhopper.routing.weighting.Weighting;
-import com.graphhopper.util.PMap;
+import com.graphhopper.util.ConfigMap;
+import com.graphhopper.util.StringConfigMap;
 import com.graphhopper.util.Parameters;
 
 /**
@@ -35,7 +36,7 @@ import com.graphhopper.util.Parameters;
  * @author Peter Karich
  */
 public class AlgorithmOptions {
-    private final PMap hints = new PMap(5);
+    private final StringConfigMap hints = new StringConfigMap(5);
     private String algorithm = Parameters.Algorithms.DIJKSTRA_BI;
     private Weighting weighting;
     private TraversalMode traversalMode = TraversalMode.NODE_BASED;
@@ -110,7 +111,7 @@ public class AlgorithmOptions {
         return maxVisitedNodes;
     }
 
-    public PMap getHints() {
+    public ConfigMap getConfigMap() {
         return hints;
     }
 
@@ -154,7 +155,7 @@ public class AlgorithmOptions {
             return this;
         }
 
-        public Builder hints(PMap hints) {
+        public Builder hints(StringConfigMap hints) {
             this.opts.hints.put(hints);
             return this;
         }

--- a/core/src/main/java/com/graphhopper/routing/RoutingAlgorithmFactorySimple.java
+++ b/core/src/main/java/com/graphhopper/routing/RoutingAlgorithmFactorySimple.java
@@ -58,11 +58,11 @@ public class RoutingAlgorithmFactorySimple implements RoutingAlgorithmFactory {
 
         } else if (ALT_ROUTE.equalsIgnoreCase(algoStr)) {
             AlternativeRoute altRouteAlgo = new AlternativeRoute(g, opts.getWeighting(), opts.getTraversalMode());
-            altRouteAlgo.setMaxPaths(opts.getHints().getInt(MAX_PATHS, 2));
-            altRouteAlgo.setMaxWeightFactor(opts.getHints().getDouble(MAX_WEIGHT, 1.4));
-            altRouteAlgo.setMaxShareFactor(opts.getHints().getDouble(MAX_SHARE, 0.6));
-            altRouteAlgo.setMinPlateauFactor(opts.getHints().getDouble("alternative_route.min_plateau_factor", 0.2));
-            altRouteAlgo.setMaxExplorationFactor(opts.getHints().getDouble("alternative_route.max_exploration_factor", 1));
+            altRouteAlgo.setMaxPaths(opts.getConfigMap().getInt(MAX_PATHS, 2));
+            altRouteAlgo.setMaxWeightFactor(opts.getConfigMap().getDouble(MAX_WEIGHT, 1.4));
+            altRouteAlgo.setMaxShareFactor(opts.getConfigMap().getDouble(MAX_SHARE, 0.6));
+            altRouteAlgo.setMinPlateauFactor(opts.getConfigMap().getDouble("alternative_route.min_plateau_factor", 0.2));
+            altRouteAlgo.setMaxExplorationFactor(opts.getConfigMap().getDouble("alternative_route.max_exploration_factor", 1));
             ra = altRouteAlgo;
 
         } else {
@@ -74,8 +74,8 @@ public class RoutingAlgorithmFactorySimple implements RoutingAlgorithmFactory {
     }
 
     public static WeightApproximator getApproximation(String prop, AlgorithmOptions opts, NodeAccess na) {
-        String approxAsStr = opts.getHints().get(prop + ".approximation", "BeelineSimplification");
-        double epsilon = opts.getHints().getDouble(prop + ".epsilon", 1);
+        String approxAsStr = opts.getConfigMap().get(prop + ".approximation", "BeelineSimplification");
+        double epsilon = opts.getConfigMap().getDouble(prop + ".epsilon", 1);
 
         BeelineWeightApproximator approx = new BeelineWeightApproximator(na, opts.getWeighting());
         approx.setEpsilon(epsilon);

--- a/core/src/main/java/com/graphhopper/routing/ch/CHAlgoFactoryDecorator.java
+++ b/core/src/main/java/com/graphhopper/routing/ch/CHAlgoFactoryDecorator.java
@@ -222,7 +222,7 @@ public class CHAlgoFactoryDecorator implements RoutingAlgorithmFactoryDecorator 
      */
     public CHAlgoFactoryDecorator setWeightingsAsStrings(List<String> weightingList) {
         if (weightingList.isEmpty())
-            throw new IllegalArgumentException("It is not allowed to pass an emtpy weightingList");
+            throw new IllegalArgumentException("It is not allowed to pass an empty weightingList");
 
         weightingsAsStrings.clear();
         for (String strWeighting : weightingList) {

--- a/core/src/main/java/com/graphhopper/routing/lm/LMAlgoFactoryDecorator.java
+++ b/core/src/main/java/com/graphhopper/routing/lm/LMAlgoFactoryDecorator.java
@@ -33,7 +33,7 @@ import com.graphhopper.storage.StorableProperties;
 import com.graphhopper.storage.index.LocationIndex;
 import com.graphhopper.util.CmdArgs;
 import com.graphhopper.util.Helper;
-import com.graphhopper.util.PMap;
+import com.graphhopper.util.StringConfigMap;
 import com.graphhopper.util.Parameters;
 import com.graphhopper.util.Parameters.Landmark;
 import org.slf4j.Logger;
@@ -166,7 +166,7 @@ public class LMAlgoFactoryDecorator implements RoutingAlgorithmFactoryDecorator 
         String str[] = weighting.split("\\|");
         double value = -1;
         if (str.length > 1) {
-            PMap map = new PMap(weighting);
+            StringConfigMap map = StringConfigMap.create(weighting);
             value = map.getDouble("maximum", -1);
         }
 

--- a/core/src/main/java/com/graphhopper/routing/lm/PrepareLandmarks.java
+++ b/core/src/main/java/com/graphhopper/routing/lm/PrepareLandmarks.java
@@ -20,7 +20,6 @@ package com.graphhopper.routing.lm;
 import com.graphhopper.routing.*;
 import com.graphhopper.routing.util.AbstractAlgoPreparation;
 import com.graphhopper.routing.util.TraversalMode;
-import com.graphhopper.routing.util.spatialrules.Polygon;
 import com.graphhopper.routing.util.spatialrules.SpatialRuleLookup;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.Directory;
@@ -34,7 +33,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
-import java.util.Map;
 
 /**
  * This class does the preprocessing for the ALT algorithm (A* , landmark, triangle inequality).
@@ -141,12 +139,12 @@ public class PrepareLandmarks extends AbstractAlgoPreparation {
     }
 
     public RoutingAlgorithm getDecoratedAlgorithm(Graph qGraph, RoutingAlgorithm algo, AlgorithmOptions opts) {
-        int activeLM = Math.max(1, opts.getHints().getInt(Landmark.ACTIVE_COUNT, defaultActiveLandmarks));
+        int activeLM = Math.max(1, opts.getConfigMap().getInt(Landmark.ACTIVE_COUNT, defaultActiveLandmarks));
         if (algo instanceof AStar) {
             if (!lms.isInitialized())
                 throw new IllegalStateException("Initalize landmark storage before creating algorithms");
 
-            double epsilon = opts.getHints().getDouble(Parameters.Algorithms.ASTAR + ".epsilon", 1);
+            double epsilon = opts.getConfigMap().getDouble(Parameters.Algorithms.ASTAR + ".epsilon", 1);
             AStar astar = (AStar) algo;
             astar.setApproximation(new LMApproximator(qGraph, this.graph.getNodes(), lms, activeLM, lms.getFactor(), false).
                     setEpsilon(epsilon));
@@ -155,7 +153,7 @@ public class PrepareLandmarks extends AbstractAlgoPreparation {
             if (!lms.isInitialized())
                 throw new IllegalStateException("Initalize landmark storage before creating algorithms");
 
-            double epsilon = opts.getHints().getDouble(Parameters.Algorithms.ASTAR_BI + ".epsilon", 1);
+            double epsilon = opts.getConfigMap().getDouble(Parameters.Algorithms.ASTAR_BI + ".epsilon", 1);
             AStarBidirection astarbi = (AStarBidirection) algo;
             astarbi.setApproximation(new LMApproximator(qGraph, this.graph.getNodes(), lms, activeLM, lms.getFactor(), false).
                     setEpsilon(epsilon));
@@ -164,7 +162,7 @@ public class PrepareLandmarks extends AbstractAlgoPreparation {
             if (!lms.isInitialized())
                 throw new IllegalStateException("Initalize landmark storage before creating algorithms");
 
-            double epsilon = opts.getHints().getDouble(Parameters.Algorithms.ASTAR_BI + ".epsilon", 1);
+            double epsilon = opts.getConfigMap().getDouble(Parameters.Algorithms.ASTAR_BI + ".epsilon", 1);
             AlternativeRoute altRoute = (AlternativeRoute) algo;
             altRoute.setApproximation(new LMApproximator(qGraph, this.graph.getNodes(), lms, activeLM, lms.getFactor(), false).
                     setEpsilon(epsilon));

--- a/core/src/main/java/com/graphhopper/routing/template/RoundTripRoutingTemplate.java
+++ b/core/src/main/java/com/graphhopper/routing/template/RoundTripRoutingTemplate.java
@@ -113,7 +113,7 @@ public class RoundTripRoutingTemplate extends AbstractRoutingTemplate implements
         algoOpts = AlgorithmOptions.start(algoOpts).
                 algorithm(Parameters.Algorithms.ASTAR_BI).
                 weighting(avoidPathWeighting).build();
-        algoOpts.getHints().put(Algorithms.ASTAR_BI + ".epsilon", 2);
+        algoOpts.getConfigMap().put(Algorithms.ASTAR_BI + ".epsilon", 2);
 
         long visitedNodesSum = 0L;
         QueryResult start = queryResults.get(0);

--- a/core/src/main/java/com/graphhopper/routing/util/AbstractFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/AbstractFlagEncoder.java
@@ -66,7 +66,7 @@ public abstract class AbstractFlagEncoder implements FlagEncoder, TurnCostEncode
     // bit to signal that way is accepted
     protected long acceptBit;
     protected long ferryBit;
-    protected PMap properties;
+    protected StringConfigMap properties;
     // This value determines the maximal possible speed of any road regardless the maxspeed value
     // lower values allow more compact representation of the routing graph
     protected int maxPossibleSpeed;
@@ -85,12 +85,12 @@ public abstract class AbstractFlagEncoder implements FlagEncoder, TurnCostEncode
 
     private ConditionalTagInspector conditionalTagInspector;
 
-    public AbstractFlagEncoder(PMap properties) {
+    public AbstractFlagEncoder(StringConfigMap properties) {
         throw new RuntimeException("This method must be overridden in derived classes");
     }
 
     public AbstractFlagEncoder(String propertiesStr) {
-        this(new PMap(propertiesStr));
+        this(StringConfigMap.create(propertiesStr));
     }
 
     /**

--- a/core/src/main/java/com/graphhopper/routing/util/Bike2WeightFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/Bike2WeightFlagEncoder.java
@@ -19,8 +19,8 @@ package com.graphhopper.routing.util;
 
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.util.BitUtil;
+import com.graphhopper.util.StringConfigMap;
 import com.graphhopper.util.EdgeIteratorState;
-import com.graphhopper.util.PMap;
 import com.graphhopper.util.PointList;
 
 import static com.graphhopper.util.Helper.keepIn;
@@ -39,10 +39,10 @@ public class Bike2WeightFlagEncoder extends BikeFlagEncoder {
     }
 
     public Bike2WeightFlagEncoder(String propertiesStr) {
-        super(new PMap(propertiesStr));
+        super(StringConfigMap.create(propertiesStr));
     }
 
-    public Bike2WeightFlagEncoder(PMap properties) {
+    public Bike2WeightFlagEncoder(StringConfigMap properties) {
         super(properties);
     }
 

--- a/core/src/main/java/com/graphhopper/routing/util/BikeFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/BikeFlagEncoder.java
@@ -18,7 +18,7 @@
 package com.graphhopper.routing.util;
 
 import com.graphhopper.reader.ReaderWay;
-import com.graphhopper.util.PMap;
+import com.graphhopper.util.StringConfigMap;
 
 /**
  * Specifies the settings for cycletouring/trekking
@@ -33,10 +33,10 @@ public class BikeFlagEncoder extends BikeCommonFlagEncoder {
     }
 
     public BikeFlagEncoder(String propertiesString) {
-        this(new PMap(propertiesString));
+        this(StringConfigMap.create(propertiesString));
     }
 
-    public BikeFlagEncoder(PMap properties) {
+    public BikeFlagEncoder(StringConfigMap properties) {
         this((int) properties.getLong("speed_bits", 4),
                 properties.getLong("speed_factor", 2),
                 properties.getBool("turn_costs", false) ? 1 : 0);

--- a/core/src/main/java/com/graphhopper/routing/util/Car4WDFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/Car4WDFlagEncoder.java
@@ -18,7 +18,7 @@
 package com.graphhopper.routing.util;
 
 import com.graphhopper.reader.ReaderWay;
-import com.graphhopper.util.PMap;
+import com.graphhopper.util.StringConfigMap;
 
 /**
  * Defines bit layout for cars with four wheel drive
@@ -31,12 +31,12 @@ public class Car4WDFlagEncoder extends CarFlagEncoder {
         this(5, 5, 0);
     }
 
-    public Car4WDFlagEncoder(PMap properties) {
+    public Car4WDFlagEncoder(StringConfigMap properties) {
         super(properties);
     }
 
     public Car4WDFlagEncoder(String propertiesStr) {
-        this(new PMap(propertiesStr));
+        this(StringConfigMap.create(propertiesStr));
     }
 
     public Car4WDFlagEncoder(int speedBits, double speedFactor, int maxTurnCosts) {

--- a/core/src/main/java/com/graphhopper/routing/util/CarFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/CarFlagEncoder.java
@@ -20,7 +20,7 @@ package com.graphhopper.routing.util;
 import com.graphhopper.reader.ReaderRelation;
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.util.Helper;
-import com.graphhopper.util.PMap;
+import com.graphhopper.util.StringConfigMap;
 
 import java.util.*;
 
@@ -51,7 +51,7 @@ public class CarFlagEncoder extends AbstractFlagEncoder {
         this(5, 5, 0);
     }
 
-    public CarFlagEncoder(PMap properties) {
+    public CarFlagEncoder(StringConfigMap properties) {
         this((int) properties.getLong("speed_bits", 5),
                 properties.getDouble("speed_factor", 5),
                 properties.getBool("turn_costs", false) ? 1 : 0);
@@ -61,7 +61,7 @@ public class CarFlagEncoder extends AbstractFlagEncoder {
     }
 
     public CarFlagEncoder(String propertiesStr) {
-        this(new PMap(propertiesStr));
+        this(StringConfigMap.create(propertiesStr));
     }
 
     public CarFlagEncoder(int speedBits, double speedFactor, int maxTurnCosts) {

--- a/core/src/main/java/com/graphhopper/routing/util/DataFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/DataFlagEncoder.java
@@ -92,7 +92,7 @@ public class DataFlagEncoder extends AbstractFlagEncoder {
         this(5, 5, 0);
     }
 
-    public DataFlagEncoder(PMap properties) {
+    public DataFlagEncoder(StringConfigMap properties) {
         this((int) properties.getLong("speed_bits", 5),
                 properties.getDouble("speed_factor", 5),
                 properties.getBool("turn_costs", false) ? 1 : 0);
@@ -844,10 +844,10 @@ public class DataFlagEncoder extends AbstractFlagEncoder {
     }
 
     /**
-     * This method creates a Config map out of the PMap. Later on this conversion should not be
+     * This method creates a Config map out of the StringConfigMap. Later on this conversion should not be
      * necessary when we read JSON.
      */
-    public ConfigMap readStringMap(PMap weightingMap) {
+    public ConfigMap readStringMap(StringConfigMap weightingMap) {
         Map<String, Double> map = new HashMap<>();
         for (Entry<String, Double> e : DEFAULT_SPEEDS.entrySet()) {
             map.put(e.getKey(), weightingMap.getDouble("highways." + e.getKey(), e.getValue()));
@@ -863,7 +863,7 @@ public class DataFlagEncoder extends AbstractFlagEncoder {
         return cMap;
     }
 
-    private void cloneDoubleAttribute(PMap weightingMap, ConfigMap cMap, String key, double _default) {
+    private void cloneDoubleAttribute(StringConfigMap weightingMap, ConfigMap cMap, String key, double _default) {
         if (weightingMap.has(key))
             cMap.put(key, weightingMap.getDouble(key, _default));
     }

--- a/core/src/main/java/com/graphhopper/routing/util/DefaultFlagEncoderFactory.java
+++ b/core/src/main/java/com/graphhopper/routing/util/DefaultFlagEncoderFactory.java
@@ -17,7 +17,7 @@
  */
 package com.graphhopper.routing.util;
 
-import com.graphhopper.util.PMap;
+import com.graphhopper.util.StringConfigMap;
 
 /**
  * This class creates FlagEncoders that are already included in the GraphHopper distribution.
@@ -26,7 +26,7 @@ import com.graphhopper.util.PMap;
  */
 public class DefaultFlagEncoderFactory implements FlagEncoderFactory {
     @Override
-    public FlagEncoder createFlagEncoder(String name, PMap configuration) {
+    public FlagEncoder createFlagEncoder(String name, StringConfigMap configuration) {
         if (name.equals(GENERIC))
             return new DataFlagEncoder(configuration);
 

--- a/core/src/main/java/com/graphhopper/routing/util/EncodingManager.java
+++ b/core/src/main/java/com/graphhopper/routing/util/EncodingManager.java
@@ -25,7 +25,7 @@ import com.graphhopper.storage.Directory;
 import com.graphhopper.storage.RAMDirectory;
 import com.graphhopper.storage.StorableProperties;
 import com.graphhopper.util.EdgeIteratorState;
-import com.graphhopper.util.PMap;
+import com.graphhopper.util.StringConfigMap;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -124,7 +124,7 @@ public class EncodingManager {
                 entryVal = entry;
                 entry = entry.split("\\|")[0];
             }
-            PMap configuration = new PMap(entryVal);
+            StringConfigMap configuration = StringConfigMap.create(entryVal);
 
             FlagEncoder fe = factory.createFlagEncoder(entry, configuration);
 

--- a/core/src/main/java/com/graphhopper/routing/util/FlagEncoderFactory.java
+++ b/core/src/main/java/com/graphhopper/routing/util/FlagEncoderFactory.java
@@ -17,7 +17,7 @@
  */
 package com.graphhopper.routing.util;
 
-import com.graphhopper.util.PMap;
+import com.graphhopper.util.StringConfigMap;
 
 /**
  * @author Peter Karich
@@ -35,5 +35,5 @@ public interface FlagEncoderFactory {
     final String GENERIC = "generic";
     final FlagEncoderFactory DEFAULT = new DefaultFlagEncoderFactory();
 
-    FlagEncoder createFlagEncoder(String name, PMap configuration);
+    FlagEncoder createFlagEncoder(String name, StringConfigMap configuration);
 }

--- a/core/src/main/java/com/graphhopper/routing/util/FootFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/FootFlagEncoder.java
@@ -20,7 +20,7 @@ package com.graphhopper.routing.util;
 import com.graphhopper.reader.ReaderRelation;
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.weighting.PriorityWeighting;
-import com.graphhopper.util.PMap;
+import com.graphhopper.util.StringConfigMap;
 
 import java.util.*;
 
@@ -57,7 +57,7 @@ public class FootFlagEncoder extends AbstractFlagEncoder {
         this(4, 1);
     }
 
-    public FootFlagEncoder(PMap properties) {
+    public FootFlagEncoder(StringConfigMap properties) {
         this((int) properties.getLong("speedBits", 4),
                 properties.getDouble("speedFactor", 1));
         this.properties = properties;
@@ -65,7 +65,7 @@ public class FootFlagEncoder extends AbstractFlagEncoder {
     }
 
     public FootFlagEncoder(String propertiesStr) {
-        this(new PMap(propertiesStr));
+        this(StringConfigMap.create(propertiesStr));
     }
 
     public FootFlagEncoder(int speedBits, double speedFactor) {

--- a/core/src/main/java/com/graphhopper/routing/util/HikeFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/HikeFlagEncoder.java
@@ -19,7 +19,7 @@ package com.graphhopper.routing.util;
 
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.weighting.PriorityWeighting;
-import com.graphhopper.util.PMap;
+import com.graphhopper.util.StringConfigMap;
 
 import java.util.TreeMap;
 
@@ -38,7 +38,7 @@ public class HikeFlagEncoder extends FootFlagEncoder {
         this(4, 1);
     }
 
-    public HikeFlagEncoder(PMap properties) {
+    public HikeFlagEncoder(StringConfigMap properties) {
         this((int) properties.getLong("speedBits", 4),
                 properties.getDouble("speedFactor", 1));
         this.properties = properties;
@@ -46,7 +46,7 @@ public class HikeFlagEncoder extends FootFlagEncoder {
     }
 
     public HikeFlagEncoder(String propertiesStr) {
-        this(new PMap(propertiesStr));
+        this(StringConfigMap.create(propertiesStr));
     }
 
     public HikeFlagEncoder(int speedBits, double speedFactor) {

--- a/core/src/main/java/com/graphhopper/routing/util/HintsMap.java
+++ b/core/src/main/java/com/graphhopper/routing/util/HintsMap.java
@@ -17,12 +17,12 @@
  */
 package com.graphhopper.routing.util;
 
-import com.graphhopper.util.PMap;
+import com.graphhopper.util.StringConfigMap;
 
 /**
  * @author Peter Karich
  */
-public class HintsMap extends PMap {
+public class HintsMap extends StringConfigMap {
     public HintsMap() {
     }
 
@@ -34,7 +34,7 @@ public class HintsMap extends PMap {
         setWeighting(weighting);
     }
 
-    public HintsMap(PMap map) {
+    public HintsMap(StringConfigMap map) {
         super(map);
     }
 

--- a/core/src/main/java/com/graphhopper/routing/util/MotorcycleFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/MotorcycleFlagEncoder.java
@@ -21,8 +21,8 @@ import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.weighting.CurvatureWeighting;
 import com.graphhopper.routing.weighting.PriorityWeighting;
 import com.graphhopper.util.BitUtil;
+import com.graphhopper.util.StringConfigMap;
 import com.graphhopper.util.EdgeIteratorState;
-import com.graphhopper.util.PMap;
 
 import java.util.HashSet;
 
@@ -47,7 +47,7 @@ public class MotorcycleFlagEncoder extends CarFlagEncoder {
         this(5, 5, 0);
     }
 
-    public MotorcycleFlagEncoder(PMap properties) {
+    public MotorcycleFlagEncoder(StringConfigMap properties) {
         this(
                 (int) properties.getLong("speed_bits", 5),
                 properties.getDouble("speed_factor", 5),
@@ -58,7 +58,7 @@ public class MotorcycleFlagEncoder extends CarFlagEncoder {
     }
 
     public MotorcycleFlagEncoder(String propertiesStr) {
-        this(new PMap(propertiesStr));
+        this(StringConfigMap.create(propertiesStr));
     }
 
     public MotorcycleFlagEncoder(int speedBits, double speedFactor, int maxTurnCosts) {

--- a/core/src/main/java/com/graphhopper/routing/util/MountainBikeFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/MountainBikeFlagEncoder.java
@@ -19,7 +19,7 @@ package com.graphhopper.routing.util;
 
 import com.graphhopper.reader.ReaderRelation;
 import com.graphhopper.reader.ReaderWay;
-import com.graphhopper.util.PMap;
+import com.graphhopper.util.StringConfigMap;
 
 import java.util.TreeMap;
 
@@ -37,7 +37,7 @@ public class MountainBikeFlagEncoder extends BikeCommonFlagEncoder {
         this(4, 2, 0);
     }
 
-    public MountainBikeFlagEncoder(PMap properties) {
+    public MountainBikeFlagEncoder(StringConfigMap properties) {
         this(
                 (int) properties.getLong("speed_bits", 4),
                 properties.getDouble("speed_factor", 2),
@@ -48,7 +48,7 @@ public class MountainBikeFlagEncoder extends BikeCommonFlagEncoder {
     }
 
     public MountainBikeFlagEncoder(String propertiesStr) {
-        this(new PMap(propertiesStr));
+        this(StringConfigMap.create(propertiesStr));
     }
 
     public MountainBikeFlagEncoder(int speedBits, double speedFactor, int maxTurnCosts) {

--- a/core/src/main/java/com/graphhopper/routing/util/RacingBikeFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/RacingBikeFlagEncoder.java
@@ -18,7 +18,7 @@
 package com.graphhopper.routing.util;
 
 import com.graphhopper.reader.ReaderWay;
-import com.graphhopper.util.PMap;
+import com.graphhopper.util.StringConfigMap;
 
 import java.util.TreeMap;
 
@@ -36,7 +36,7 @@ public class RacingBikeFlagEncoder extends BikeCommonFlagEncoder {
         this(4, 2, 0);
     }
 
-    public RacingBikeFlagEncoder(PMap properties) {
+    public RacingBikeFlagEncoder(StringConfigMap properties) {
         this(
                 (int) properties.getLong("speed_bits", 4),
                 properties.getDouble("speed_factor", 2),
@@ -47,7 +47,7 @@ public class RacingBikeFlagEncoder extends BikeCommonFlagEncoder {
     }
 
     public RacingBikeFlagEncoder(String propertiesStr) {
-        this(new PMap(propertiesStr));
+        this(StringConfigMap.create(propertiesStr));
     }
 
     public RacingBikeFlagEncoder(int speedBits, double speedFactor, int maxTurnCosts) {

--- a/core/src/main/java/com/graphhopper/routing/util/TestAlgoCollector.java
+++ b/core/src/main/java/com/graphhopper/routing/util/TestAlgoCollector.java
@@ -57,7 +57,9 @@ public class TestAlgoCollector {
                 errors.add("Cannot use TurnWeighting with a node based traversal");
                 return this;
             }
-            algoEntry.setAlgorithmOptions(AlgorithmOptions.start(opts).weighting(new TurnWeighting(opts.getWeighting(), (TurnCostExtension) queryGraph.getExtension())).build());
+            algoEntry.setAlgorithmOptions(AlgorithmOptions.start(opts).
+                    weighting(new TurnWeighting(opts.getWeighting(), (TurnCostExtension) queryGraph.getExtension())).
+                    build());
         }
 
         RoutingAlgorithmFactory factory = algoEntry.createRoutingFactory();

--- a/core/src/main/java/com/graphhopper/routing/weighting/CurvatureWeighting.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/CurvatureWeighting.java
@@ -20,7 +20,7 @@ package com.graphhopper.routing.weighting;
 import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.routing.util.MotorcycleFlagEncoder;
 import com.graphhopper.util.EdgeIteratorState;
-import com.graphhopper.util.PMap;
+import com.graphhopper.util.StringConfigMap;
 
 /**
  * This Class uses bendiness parameter to prefer curvy routes.
@@ -28,7 +28,7 @@ import com.graphhopper.util.PMap;
 public class CurvatureWeighting extends PriorityWeighting {
     private final double minFactor;
 
-    public CurvatureWeighting(FlagEncoder flagEncoder, PMap pMap) {
+    public CurvatureWeighting(FlagEncoder flagEncoder, StringConfigMap pMap) {
         super(flagEncoder, pMap);
 
         double minBendiness = 1; // see correctErrors

--- a/core/src/main/java/com/graphhopper/routing/weighting/FastestWeighting.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/FastestWeighting.java
@@ -18,8 +18,8 @@
 package com.graphhopper.routing.weighting;
 
 import com.graphhopper.routing.util.FlagEncoder;
+import com.graphhopper.util.StringConfigMap;
 import com.graphhopper.util.EdgeIteratorState;
-import com.graphhopper.util.PMap;
 import com.graphhopper.util.Parameters.Routing;
 
 /**
@@ -39,7 +39,7 @@ public class FastestWeighting extends AbstractWeighting {
     private final long headingPenaltyMillis;
     private final double maxSpeed;
 
-    public FastestWeighting(FlagEncoder encoder, PMap pMap) {
+    public FastestWeighting(FlagEncoder encoder, StringConfigMap pMap) {
         super(encoder);
         headingPenalty = pMap.getDouble(Routing.HEADING_PENALTY, Routing.DEFAULT_HEADING_PENALTY);
         headingPenaltyMillis = Math.round(headingPenalty * 1000);
@@ -47,7 +47,7 @@ public class FastestWeighting extends AbstractWeighting {
     }
 
     public FastestWeighting(FlagEncoder encoder) {
-        this(encoder, new PMap(0));
+        this(encoder, new StringConfigMap(0));
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/weighting/PriorityWeighting.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/PriorityWeighting.java
@@ -19,7 +19,7 @@ package com.graphhopper.routing.weighting;
 
 import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.util.EdgeIteratorState;
-import com.graphhopper.util.PMap;
+import com.graphhopper.util.StringConfigMap;
 
 /**
  * Special weighting for (motor)bike
@@ -35,10 +35,10 @@ public class PriorityWeighting extends FastestWeighting {
     private final double minFactor;
 
     public PriorityWeighting(FlagEncoder encoder) {
-        this(encoder, new PMap(0));
+        this(encoder, new StringConfigMap(0));
     }
 
-    public PriorityWeighting(FlagEncoder encoder, PMap pMap) {
+    public PriorityWeighting(FlagEncoder encoder, StringConfigMap pMap) {
         super(encoder, pMap);
         double maxPriority = 1; // BEST / BEST
         minFactor = 1 / (0.5 + maxPriority);

--- a/core/src/main/java/com/graphhopper/routing/weighting/ShortFastestWeighting.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/ShortFastestWeighting.java
@@ -19,7 +19,7 @@ package com.graphhopper.routing.weighting;
 
 import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.util.EdgeIteratorState;
-import com.graphhopper.util.PMap;
+import com.graphhopper.util.StringConfigMap;
 
 /**
  * Calculates the fastest route with distance influence controlled by a new parameter.
@@ -35,7 +35,7 @@ public class ShortFastestWeighting extends FastestWeighting {
     private final double distanceFactor;
     private final double timeFactor;
 
-    public ShortFastestWeighting(FlagEncoder encoder, PMap pMap) {
+    public ShortFastestWeighting(FlagEncoder encoder, StringConfigMap pMap) {
         super(encoder);
         timeFactor = checkBounds(TIME_FACTOR, pMap.getDouble(TIME_FACTOR, 1));
 

--- a/core/src/main/java/com/graphhopper/routing/weighting/Weighting.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/Weighting.java
@@ -20,7 +20,6 @@ package com.graphhopper.routing.weighting;
 import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.routing.util.HintsMap;
 import com.graphhopper.util.EdgeIteratorState;
-import com.graphhopper.util.PMap;
 
 /**
  * Specifies how the best route is calculated. E.g. the fastest or shortest route.

--- a/core/src/main/java/com/graphhopper/util/CmdArgs.java
+++ b/core/src/main/java/com/graphhopper/util/CmdArgs.java
@@ -32,7 +32,7 @@ import java.util.Properties;
  *
  * @author Peter Karich
  */
-public class CmdArgs extends PMap {
+public class CmdArgs extends StringConfigMap {
 
     public CmdArgs() {
     }
@@ -57,7 +57,7 @@ public class CmdArgs extends PMap {
         Helper.loadProperties(map, new InputStreamReader(new FileInputStream(
                 new File(configLocation).getAbsoluteFile()), Helper.UTF_CS));
         CmdArgs args = new CmdArgs();
-        args.merge(map);
+        args.putAll(map);
 
         // overwrite with system settings
         Properties props = System.getProperties();

--- a/core/src/main/java/com/graphhopper/util/ConfigMap.java
+++ b/core/src/main/java/com/graphhopper/util/ConfigMap.java
@@ -22,14 +22,13 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * A properties map (String to Object) with convenient accessors
- * <p>
+ * A properties map (String to Object) with convenient accessors.
  *
  * @author Peter Karich
- * @see PMap
+ * @see StringConfigMap
  */
 public class ConfigMap {
-    private final Map<String, Object> map;
+    final Map<String, Object> map;
 
     public ConfigMap() {
         this(5);
@@ -40,7 +39,11 @@ public class ConfigMap {
     }
 
     public ConfigMap(Map<String, Object> map) {
-        this.map = map;
+        this.map = new HashMap<>(map);
+    }
+
+    public ConfigMap(ConfigMap map) {
+        this.map = new HashMap<>(map.map);
     }
 
     public ConfigMap put(ConfigMap map) {
@@ -120,6 +123,10 @@ public class ConfigMap {
 
     public <T> List<T> getList(String key, Class<T> embed) {
         return (List<T>) map.get(checkKey(key));
+    }
+
+    public boolean isEmpty() {
+        return map.isEmpty();
     }
 
     @Override

--- a/core/src/test/java/com/graphhopper/routing/PathTest.java
+++ b/core/src/test/java/com/graphhopper/routing/PathTest.java
@@ -533,7 +533,7 @@ public class PathTest {
         g.edge(2, 4, 5, true).setFlags(dataFlagEncoder.handleWayTags(w,1,0));
         g.edge(2, 3, 5, true).setFlags(dataFlagEncoder.handleWayTags(w,1,0));
 
-        ConfigMap cMap = dataFlagEncoder.readStringMap(new PMap());
+        ConfigMap cMap = dataFlagEncoder.readStringMap(new StringConfigMap());
         Path p = new Dijkstra(g, new GenericWeighting(dataFlagEncoder, cMap), TraversalMode.NODE_BASED).calcPath(1, 3);
         assertTrue(p.isFound());
         InstructionList wayList = p.calcInstructions(tr);

--- a/core/src/test/java/com/graphhopper/routing/RoutingAlgorithmIT.java
+++ b/core/src/test/java/com/graphhopper/routing/RoutingAlgorithmIT.java
@@ -72,7 +72,7 @@ public class RoutingAlgorithmIT {
         prepare.add(new AlgoHelperEntry(ghStorage, AlgorithmOptions.start(defaultOpts).algorithm(DIJKSTRA).build(), idx, "dijkstra|" + addStr + weighting));
 
         AlgorithmOptions astarbiOpts = AlgorithmOptions.start(defaultOpts).algorithm(ASTAR_BI).build();
-        astarbiOpts.getHints().put(ASTAR_BI + ".approximation", "BeelineSimplification");
+        astarbiOpts.getConfigMap().put(ASTAR_BI + ".approximation", "BeelineSimplification");
         AlgorithmOptions dijkstrabiOpts = AlgorithmOptions.start(defaultOpts).algorithm(DIJKSTRA_BI).build();
         prepare.add(new AlgoHelperEntry(ghStorage, astarbiOpts, idx, "astarbi|beeline|" + addStr + weighting));
         prepare.add(new AlgoHelperEntry(ghStorage, dijkstrabiOpts, idx, "dijkstrabi|" + addStr + weighting));

--- a/core/src/test/java/com/graphhopper/routing/lm/PrepareLandmarksTest.java
+++ b/core/src/test/java/com/graphhopper/routing/lm/PrepareLandmarksTest.java
@@ -143,7 +143,7 @@ public class PrepareLandmarksTest
         assertEquals(expectedAlgo.getVisitedNodes(), oneDirAlgoWithLandmarks.getVisitedNodes() + 142);
 
         // landmarks with bidir A*
-        opts.getHints().put("lm.recalc_count", 50);
+        opts.getConfigMap().put("lm.recalc_count", 50);
         RoutingAlgorithm biDirAlgoWithLandmarks = prepare.getDecoratedAlgorithm(graph,
                 new AStarBidirection(graph, weighting, tm), opts);
         path = biDirAlgoWithLandmarks.calcPath(41, 183);

--- a/core/src/test/java/com/graphhopper/routing/util/DataFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/DataFlagEncoderTest.java
@@ -4,7 +4,7 @@ import java.util.*;
 
 import com.graphhopper.routing.AbstractRoutingAlgorithmTester;
 import com.graphhopper.routing.util.spatialrules.countries.GermanySpatialRule;
-import com.graphhopper.util.PMap;
+import com.graphhopper.util.StringConfigMap;
 import com.graphhopper.routing.util.spatialrules.*;
 import com.graphhopper.util.*;
 import com.graphhopper.util.shapes.BBox;
@@ -21,7 +21,7 @@ import static org.junit.Assert.*;
  * @author Peter Karich
  */
 public class DataFlagEncoderTest {
-    private final PMap properties;
+    private final StringConfigMap properties;
     private final DataFlagEncoder encoder;
     private final EncodingManager encodingManager;
     private final int motorVehicleInt;
@@ -29,7 +29,7 @@ public class DataFlagEncoderTest {
     private final double DELTA = 0.1;
 
     public DataFlagEncoderTest() {
-        properties = new PMap();
+        properties = new StringConfigMap();
         properties.put("store_height", true);
         properties.put("store_weight", true);
         properties.put("store_width", true);
@@ -363,7 +363,7 @@ public class DataFlagEncoderTest {
             }
         };
 
-        DataFlagEncoder encoder = new DataFlagEncoder(new PMap());
+        DataFlagEncoder encoder = new DataFlagEncoder(new StringConfigMap());
         encoder.setSpatialRuleLookup(index);
         EncodingManager em = new EncodingManager(encoder);
 

--- a/core/src/test/java/com/graphhopper/routing/weighting/FastestWeightingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/FastestWeightingTest.java
@@ -23,12 +23,8 @@ import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.storage.GraphBuilder;
 import com.graphhopper.storage.GraphHopperStorage;
-import com.graphhopper.util.EdgeIterator;
-import com.graphhopper.util.EdgeIteratorState;
-import com.graphhopper.util.GHUtility;
-import com.graphhopper.util.Helper;
-import com.graphhopper.util.PMap;
-import com.graphhopper.util.Parameters;
+import com.graphhopper.util.*;
+import com.graphhopper.util.StringConfigMap;
 import com.graphhopper.util.Parameters.Routing;
 import org.junit.Test;
 
@@ -50,7 +46,7 @@ public class FastestWeightingTest {
 
     @Test
     public void testWeightWrongHeading() {
-        Weighting instance = new FastestWeighting(encoder, new PMap().
+        Weighting instance = new FastestWeighting(encoder, new StringConfigMap().
                 put(Parameters.Routing.HEADING_PENALTY, "100"));
         VirtualEdgeIteratorState virtEdge = new VirtualEdgeIteratorState(0, 1, 1, 2, 10,
                 encoder.setProperties(10, true, true), "test", Helper.createPointList(51, 0, 51, 1));

--- a/core/src/test/java/com/graphhopper/routing/weighting/GenericWeightingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/GenericWeightingTest.java
@@ -40,7 +40,7 @@ import static org.junit.Assert.assertEquals;
  * @author Peter Karich
  */
 public class GenericWeightingTest {
-    private final PMap properties;
+    private final StringConfigMap properties;
     private final DataFlagEncoder encoder;
     private final EncodingManager em;
     private Graph graph;
@@ -48,7 +48,7 @@ public class GenericWeightingTest {
     private final double edgeWeight = 566111;
 
     public GenericWeightingTest() {
-        properties = new PMap();
+        properties = new StringConfigMap();
         properties.put("store_height", true);
         properties.put("store_weight", true);
         properties.put("store_width", true);
@@ -74,7 +74,7 @@ public class GenericWeightingTest {
     @Test
     public void testBlockedById() {
         EdgeIteratorState edge = graph.getEdgeIteratorState(0, 1);
-        ConfigMap cMap = encoder.readStringMap(new PMap());
+        ConfigMap cMap = encoder.readStringMap(new StringConfigMap());
         Weighting instance = new GenericWeighting(encoder, cMap);
         assertEquals(edgeWeight, instance.calcWeight(edge, false, EdgeIterator.NO_EDGE), 1e-8);
 
@@ -88,7 +88,7 @@ public class GenericWeightingTest {
     @Test
     public void testBlockedByShape() {
         EdgeIteratorState edge = graph.getEdgeIteratorState(0, 1);
-        ConfigMap cMap = encoder.readStringMap(new PMap());
+        ConfigMap cMap = encoder.readStringMap(new StringConfigMap());
         GenericWeighting instance = new GenericWeighting(encoder, cMap);
         assertEquals(edgeWeight, instance.calcWeight(edge, false, EdgeIterator.NO_EDGE), 1e-8);
 
@@ -110,7 +110,7 @@ public class GenericWeightingTest {
 
     @Test
     public void testCalcTime() {
-        ConfigMap cMap = encoder.readStringMap(new PMap());
+        ConfigMap cMap = encoder.readStringMap(new StringConfigMap());
         GenericWeighting weighting = new GenericWeighting(encoder, cMap);
         EdgeIteratorState edge = graph.getEdgeIteratorState(0, 1);
         assertEquals(edgeWeight, weighting.calcMillis(edge, false, EdgeIterator.NO_EDGE), .1);
@@ -118,7 +118,7 @@ public class GenericWeightingTest {
 
     @Test
     public void testNullGraph() {
-        ConfigMap cMap = encoder.readStringMap(new PMap());
+        ConfigMap cMap = encoder.readStringMap(new StringConfigMap());
         GenericWeighting weighting = new GenericWeighting(encoder, cMap);
         weighting.setGraph(null);
     }
@@ -126,7 +126,7 @@ public class GenericWeightingTest {
     @Test
     public void testRoadAttributeRestriction() {
         EdgeIteratorState edge = graph.getEdgeIteratorState(0, 1);
-        ConfigMap cMap = encoder.readStringMap(new PMap());
+        ConfigMap cMap = encoder.readStringMap(new StringConfigMap());
         cMap.put(GenericWeighting.HEIGHT_LIMIT, 4.0);
         Weighting instance = new GenericWeighting(encoder, cMap);
         assertEquals(edgeWeight, instance.calcWeight(edge, false, EdgeIterator.NO_EDGE), 1e-8);
@@ -154,7 +154,7 @@ public class GenericWeightingTest {
         simpleGraph.getEdgeIteratorState(0, 1).setFlags(simpleEncoder.handleWayTags(way, 1, 0));
 
         EdgeIteratorState edge = simpleGraph.getEdgeIteratorState(0, 1);
-        ConfigMap cMap = simpleEncoder.readStringMap(new PMap());
+        ConfigMap cMap = simpleEncoder.readStringMap(new StringConfigMap());
         cMap.put(GenericWeighting.HEIGHT_LIMIT, 5.0);
         Weighting instance = new GenericWeighting(simpleEncoder, cMap);
 

--- a/core/src/test/java/com/graphhopper/routing/weighting/ShortFastestWeightingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/ShortFastestWeightingTest.java
@@ -19,10 +19,10 @@ package com.graphhopper.routing.weighting;
 
 import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.routing.util.FlagEncoder;
+import com.graphhopper.util.StringConfigMap;
 import com.graphhopper.util.EdgeIterator;
 import com.graphhopper.util.EdgeIteratorState;
 import com.graphhopper.util.GHUtility;
-import com.graphhopper.util.PMap;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -48,7 +48,7 @@ public class ShortFastestWeightingTest {
     @Test
     public void testTooSmall() {
         try {
-            new ShortFastestWeighting(encoder, new PMap("short_fastest.distance_factor=0|short_fastest.time_factor=0"));
+            new ShortFastestWeighting(encoder, StringConfigMap.create("short_fastest.distance_factor=0|short_fastest.time_factor=0"));
             assertTrue(false);
         } catch (Exception ex) {
         }

--- a/core/src/test/java/com/graphhopper/storage/GraphHopperStorageForDataFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/storage/GraphHopperStorageForDataFlagEncoderTest.java
@@ -6,8 +6,8 @@ import com.graphhopper.routing.AbstractRoutingAlgorithmTester;
 import com.graphhopper.routing.util.DataFlagEncoder;
 import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.routing.util.FlagEncoder;
+import com.graphhopper.util.StringConfigMap;
 import com.graphhopper.util.Helper;
-import com.graphhopper.util.PMap;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -27,12 +27,12 @@ public class GraphHopperStorageForDataFlagEncoderTest {
     private String defaultGraphLoc = "./target/graphstorage/default";
     private GraphHopperStorage graph;
 
-    private final PMap properties;
+    private final StringConfigMap properties;
     private final DataFlagEncoder encoder;
     private final EncodingManager encodingManager;
 
     public GraphHopperStorageForDataFlagEncoderTest() {
-        properties = new PMap();
+        properties = new StringConfigMap();
         properties.put("store_height", true);
         properties.put("store_weight", true);
         properties.put("store_width", false);

--- a/core/src/test/java/com/graphhopper/util/StringConfigMapTest.java
+++ b/core/src/test/java/com/graphhopper/util/StringConfigMapTest.java
@@ -22,18 +22,18 @@ import org.junit.Test;
 
 import static org.junit.Assert.*;
 
-public class PMapTest {
+public class StringConfigMapTest {
 
     @Test
     public void singleStringPropertyCanBeRetrieved() {
-        PMap subject = new PMap("foo=bar");
+        StringConfigMap subject = StringConfigMap.create("foo=bar");
 
         Assert.assertEquals("bar", subject.get("foo"));
     }
 
     @Test
     public void propertyFromStringWithMultiplePropertiesCanBeRetrieved() {
-        PMap subject = new PMap("foo=valueA|bar=valueB");
+        StringConfigMap subject = StringConfigMap.create("foo=valueA|bar=valueB");
 
         Assert.assertEquals("valueA", subject.get("foo", ""));
         Assert.assertEquals("valueB", subject.get("bar", ""));
@@ -41,7 +41,7 @@ public class PMapTest {
 
     @Test
     public void keyCannotHaveAnyCasing() {
-        PMap subject = new PMap("foo=valueA|bar=valueB");
+        StringConfigMap subject = StringConfigMap.create("foo=valueA|bar=valueB");
 
         assertEquals("valueA", subject.get("foo", ""));
         assertEquals("", subject.get("Foo", ""));
@@ -49,25 +49,39 @@ public class PMapTest {
 
     @Test
     public void numericPropertyCanBeRetrievedAsLong() {
-        PMap subject = new PMap("foo=1234|bar=5678");
+        StringConfigMap subject = StringConfigMap.create("foo=1234|bar=5678");
 
         assertEquals(1234L, subject.getLong("foo", 0));
     }
 
     @Test
     public void numericPropertyCanBeRetrievedAsDouble() {
-        PMap subject = new PMap("foo=123.45|bar=56.78");
+        StringConfigMap subject = StringConfigMap.create("foo=123.45|bar=56.78");
 
         assertEquals(123.45, subject.getDouble("foo", 0), 1e-4);
     }
 
     @Test
     public void hasReturnsCorrectResult() {
-        PMap subject = new PMap("foo=123.45|bar=56.78");
+        StringConfigMap subject = StringConfigMap.create("foo=123.45|bar=56.78");
 
         assertTrue(subject.has("foo"));
         assertTrue(subject.has("bar"));
         assertFalse(subject.has("baz"));
     }
 
+    @Test
+    public void putAll() {
+        StringConfigMap map1 = StringConfigMap.create("foo=bar");
+        StringConfigMap map2 = new StringConfigMap(map1);
+
+        Assert.assertEquals("bar", map2.get("foo"));
+    }
+
+    @Test
+    public void toMap() {
+        StringConfigMap map1 = StringConfigMap.create("foo=bar");
+
+        Assert.assertEquals("{foo=bar}", map1.toMap().toString());
+    }
 }

--- a/reader-osm/src/test/java/com/graphhopper/reader/osm/GraphHopperOSMTest.java
+++ b/reader-osm/src/test/java/com/graphhopper/reader/osm/GraphHopperOSMTest.java
@@ -26,7 +26,6 @@ import com.graphhopper.reader.DataReader;
 import com.graphhopper.routing.*;
 import com.graphhopper.routing.ch.CHAlgoFactoryDecorator;
 import com.graphhopper.routing.ch.PrepareContractionHierarchies;
-import com.graphhopper.routing.lm.LandmarkStorage;
 import com.graphhopper.routing.lm.PrepareLandmarks;
 import com.graphhopper.routing.util.*;
 import com.graphhopper.routing.weighting.AbstractWeighting;
@@ -771,7 +770,7 @@ public class GraphHopperOSMTest {
                     @Override
                     public RoutingAlgorithm createAlgo(Graph g, AlgorithmOptions opts) {
                         cnt.addAndGet(1);
-                        assertFalse(opts.getHints().getBool("test", true));
+                        assertFalse(opts.getConfigMap().getBool("test", true));
                         return super.createAlgo(g, opts);
                     }
                 };

--- a/reader-osm/src/test/java/com/graphhopper/routing/RoutingAlgorithmWithOSMIT.java
+++ b/reader-osm/src/test/java/com/graphhopper/routing/RoutingAlgorithmWithOSMIT.java
@@ -495,7 +495,7 @@ public class RoutingAlgorithmWithOSMIT {
                   boolean withCH, String vehicle, String weightStr, boolean is3D) {
 
         // for different weightings we need a different storage, otherwise we would need to remove the graph folder
-        // everytime we come with a different weighting
+        // every time we come with a different weighting
         // graphFile += weightStr;
 
         AlgoHelperEntry algoEntry = null;

--- a/web/src/main/java/com/graphhopper/http/GraphHopperModule.java
+++ b/web/src/main/java/com/graphhopper/http/GraphHopperModule.java
@@ -40,7 +40,7 @@ import com.graphhopper.routing.util.spatialrules.SpatialRuleLookup;
 import com.graphhopper.storage.GraphHopperStorage;
 import com.graphhopper.storage.index.LocationIndex;
 import com.graphhopper.util.CmdArgs;
-import com.graphhopper.util.PMap;
+import com.graphhopper.util.StringConfigMap;
 import com.graphhopper.util.Parameters;
 import com.graphhopper.util.TranslationMap;
 import com.graphhopper.util.shapes.BBox;
@@ -120,7 +120,7 @@ public class GraphHopperModule extends AbstractModule {
                 final FlagEncoderFactory oldFEF = graphHopper.getFlagEncoderFactory();
                 graphHopper.setFlagEncoderFactory(new FlagEncoderFactory() {
                     @Override
-                    public FlagEncoder createFlagEncoder(String name, PMap configuration) {
+                    public FlagEncoder createFlagEncoder(String name, StringConfigMap configuration) {
                         if (name.equals(GENERIC)) {
                             return new DataFlagEncoder(configuration).setSpatialRuleLookup(index);
                         }

--- a/web/src/main/java/com/graphhopper/http/GraphHopperWeb.java
+++ b/web/src/main/java/com/graphhopper/http/GraphHopperWeb.java
@@ -49,7 +49,7 @@ public class GraphHopperWeb implements GraphHopperAPI {
     private boolean elevation = false;
 
     public GraphHopperWeb() {
-        // some parameters are supported directly via Java API so ignore them when writing the getHints map
+        // some parameters are supported directly via Java API so ignore them when writing the getConfigMap map
         ignoreSet = new HashSet<>();
         ignoreSet.add("calc_points");
         ignoreSet.add("calcpoints");


### PR DESCRIPTION
The only major change is that [PMap now extends ConfigMap](https://github.com/graphhopper/graphhopper/pull/1066/files#diff-2089a5d49b9bef4726a1a85bb1e12c7dL30), which makes it compatible and less annoying to handle this. This is an improvement regarding #940 and also PMap was renamed to StringConfigMap.

TODOs:

 - [ ] cleanup GraphHopper.createWeighting

Normally I would say we should disregard the `Map<String,String>` (StringConfigMap) and always prefer the ConfigMap but the problem for a further cleanup is that e.g. GHRequest uses String values and e.g. the weighting is later converted in the GraphHopper class into the `Weighting`-**Object** which is then put into the AlgorithmOptions. So we use the string as a key for a "`Weighting`"-factory (similar for the vehicle and even a bit trickier for the `algorithm`-String) and this conversion is part of the `core`-module and e.g. not separated out into the web as e.g. it should be easy to use via Android too. We'll have to think further about this.