### PR TITLE
Documentation improvement to explain the Encoding does not match: error

### DIFF
--- a/docs/web/quickstart.md
+++ b/docs/web/quickstart.md
@@ -16,4 +16,5 @@ See [here](./../core/elevation.md) how to easily enable elevation data. To see h
  * Regarding step 2:
     * The folder where you execute the java command should contain the following files: berlin-latest.osm.pbf, config-example.properties and `graphhopper-web-[version].jar`
     * The first time you execute this it'll take ~30 seconds (for Berlin), further starts will only load the graph and should be nearly instantaneous. You should see log statements but no exceptions and the last entry should be something like: Started server at HTTP 8989
+    * If you make changes to the config file, you may need to delete the generated .osm-gh folder to avoid the `Encoding does not match:` error.
  * Or [contact us](../index.md#contact)


### PR DESCRIPTION
I ran the quickstart with all of the default settings, then changed graph.flag_encoders settings and started the server again, resulting in the following error. I got confused and thought it was the config text-encoding (utf8/ascii stuff), until I figured it out. Hopefully this documentation improvement will help someone else. You may want to improve the error message as well, or maybe handle this automatically by clearing out the graph `cache`?

The problem was of-course solved by deleting the .osm-gh folder. Error message:
```
Exception in thread "main" java.lang.IllegalStateException: Encoding does not match:
Graphhopper config: car|speed_factor=5.0|speed_bits=5|turn_costs=false|version=1,foot|speed_factor=1.0|speed_bits=4|turn_costs=false|version=3,bike|speed_factor=2.0|speed_bits=4|turn_costs=false|version=2
Graph: car|speed_factor=5.0|speed_bits=5|turn_costs=false|version=1, dir:norway-latest.osm-gh/
	at com.graphhopper.storage.GraphHopperStorage.loadExisting(GraphHopperStorage.java:235)
	at com.graphhopper.GraphHopper.load(GraphHopper.java:760)
	at com.graphhopper.GraphHopper.importOrLoad(GraphHopper.java:617)
	at com.graphhopper.http.GraphHopperModule$3.start(GraphHopperModule.java:182)
	at com.graphhopper.http.GHServer.start(GHServer.java:118)
	at com.graphhopper.http.GHServer.start(GHServer.java:62)
	at com.graphhopper.http.GHServer.main(GHServer.java:57)
```