### PR TITLE
Allow Foot, Hike, and Bike to enter Piers.

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
@@ -242,6 +242,9 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
             if (way.hasTag("railway", "platform"))
                 return acceptBit;
 
+            if (way.hasTag("man_made", "pier"))
+                return acceptBit;
+
             return 0;
         }
 

--- a/core/src/main/java/com/graphhopper/routing/util/FootFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/FootFlagEncoder.java
@@ -210,6 +210,9 @@ public class FootFlagEncoder extends AbstractFlagEncoder {
             if (way.hasTag("railway", "platform"))
                 return acceptBit;
 
+            if (way.hasTag("man_made", "pier"))
+                return acceptBit;
+
             return 0;
         }
 
@@ -224,7 +227,7 @@ public class FootFlagEncoder extends AbstractFlagEncoder {
         // no need to evaluate ferries or fords - already included here
         if (way.hasTag("foot", intendedValues))
             return acceptBit;
-        
+
         // check access restrictions
         if (way.hasTag(restrictions, restrictedValues) && !getConditionalTagInspector().isRestrictedWayConditionallyPermitted(way))
             return 0;

--- a/core/src/main/java/com/graphhopper/routing/util/HikeFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/HikeFlagEncoder.java
@@ -79,6 +79,9 @@ public class HikeFlagEncoder extends FootFlagEncoder {
             if (way.hasTag("railway", "platform"))
                 return acceptBit;
 
+            if (way.hasTag("man_made", "pier"))
+                return acceptBit;
+
             return 0;
         }
 

--- a/core/src/test/java/com/graphhopper/routing/util/FootFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/FootFlagEncoderTest.java
@@ -202,6 +202,14 @@ public class FootFlagEncoderTest {
     }
 
     @Test
+    public void testPier() {
+        ReaderWay way = new ReaderWay(1);
+        way.setTag("man_made", "pier");
+        long flags = footEncoder.handleWayTags(way, footEncoder.acceptWay(way), 0);
+        assertNotEquals(0, flags);
+    }
+
+    @Test
     public void testMixSpeedAndSafe() {
         ReaderWay way = new ReaderWay(1);
         way.setTag("highway", "motorway");

--- a/reader-osm/src/test/java/com/graphhopper/GraphHopperIT.java
+++ b/reader-osm/src/test/java/com/graphhopper/GraphHopperIT.java
@@ -87,7 +87,7 @@ public class GraphHopperIT {
                 setAlgorithm(ASTAR).setVehicle(vehicle).setWeighting(weightCalcStr));
 
         // identify the number of counts to compare with CH foot route
-        assertEquals(698, rsp.getHints().getLong("visited_nodes.sum", 0));
+        assertEquals(699, rsp.getHints().getLong("visited_nodes.sum", 0));
 
         PathWrapper arsp = rsp.getBest();
         assertEquals(3437.6, arsp.getDistance(), .1);

--- a/reader-osm/src/test/java/com/graphhopper/routing/RoutingAlgorithmWithOSMIT.java
+++ b/reader-osm/src/test/java/com/graphhopper/routing/RoutingAlgorithmWithOSMIT.java
@@ -242,12 +242,12 @@ public class RoutingAlgorithmWithOSMIT {
         assertEquals(testCollector.toString(), 0, testCollector.errors.size());
 
         // see testMonaco for a similar ID test
-        assertEquals(GHUtility.asSet(2, 908, 570), GHUtility.getNeighbors(g.createEdgeExplorer().setBaseNode(10)));
-        assertEquals(GHUtility.asSet(443, 954, 739), GHUtility.getNeighbors(g.createEdgeExplorer().setBaseNode(440)));
-        assertEquals(GHUtility.asSet(910, 403, 122, 913), GHUtility.getNeighbors(g.createEdgeExplorer().setBaseNode(911)));
+        assertEquals(GHUtility.asSet(2, 909, 571), GHUtility.getNeighbors(g.createEdgeExplorer().setBaseNode(10)));
+        assertEquals(GHUtility.asSet(444, 956, 740), GHUtility.getNeighbors(g.createEdgeExplorer().setBaseNode(441)));
+        assertEquals(GHUtility.asSet(911, 404, 122, 914), GHUtility.getNeighbors(g.createEdgeExplorer().setBaseNode(912)));
 
         assertEquals(43.743705, g.getNodeAccess().getLat(100), 1e-6);
-        assertEquals(7.426362, g.getNodeAccess().getLon(701), 1e-6);
+        assertEquals(7.426362, g.getNodeAccess().getLon(702), 1e-6);
     }
 
     @Test


### PR DESCRIPTION
As discussed in the [forum](https://discuss.graphhopper.com/t/adding-a-new-way-type-to-foot/2223), GraphHopper does not use piers for foot routing.

Piers are important to consider, for example to access ferries. Usually ferries also allow transportation of bikes, so I allowed piers also for bicycles.