### PR TITLE
Equal Ferry Speeds between Encoders

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/AbstractFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/AbstractFlagEncoder.java
@@ -469,8 +469,8 @@ public abstract class AbstractFlagEncoder implements FlagEncoder, TurnCostEncode
                             return getMaxSpeed();
                         }
                         // If the speed is lower than the speed we can store, we have to set it to the minSpeed, but > 0
-                        if (Math.round(calculatedTripSpeed) < speedEncoder.factor) {
-                            return speedEncoder.factor;
+                        if (Math.round(calculatedTripSpeed) < speedEncoder.factor / 2) {
+                            return speedEncoder.factor / 2;
                         }
 
                         return Math.round(calculatedTripSpeed);

--- a/core/src/main/java/com/graphhopper/routing/util/AbstractFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/AbstractFlagEncoder.java
@@ -83,6 +83,11 @@ public abstract class AbstractFlagEncoder implements FlagEncoder, TurnCostEncode
     private boolean blockFords = true;
     private boolean registered;
 
+    // Speeds from CarFlagEncoder
+    protected static final double UNKNOWN_DURATION_FERRY_SPEED = 5;
+    protected static final double SHORT_TRIP_FERRY_SPEED = 20;
+    protected static final double LONG_TRIP_FERRY_SPEED = 30;
+
     private ConditionalTagInspector conditionalTagInspector;
 
     public AbstractFlagEncoder(PMap properties) {
@@ -438,8 +443,9 @@ public abstract class AbstractFlagEncoder implements FlagEncoder, TurnCostEncode
     /**
      * Special handling for ferry ways.
      */
-    protected double getFerrySpeed(ReaderWay way, double unknownSpeed, double shortTripsSpeed, double longTripsSpeed) {
+    protected double getFerrySpeed(ReaderWay way) {
         long duration = 0;
+
         try {
             // During the reader process we have converted the duration value into a artificial tag called "duration:seconds".
             duration = Long.parseLong(way.getTag("duration:seconds"));
@@ -452,25 +458,22 @@ public abstract class AbstractFlagEncoder implements FlagEncoder, TurnCostEncode
                 // Check if our graphhopper specific artificially created estimated_distance way tag is present
                 Number estimatedLength = way.getTag("estimated_distance", null);
                 if (estimatedLength != null) {
-                    // to km
-                    double val = estimatedLength.doubleValue() / 1000;
+                    double estimatedLengthInKm = estimatedLength.doubleValue() / 1000;
                     // If duration AND distance is available we can calculate the speed more precisely
                     // and set both speed to the same value. Factor 1.4 slower because of waiting time!
-                    double calculatedTripSpeed = val / durationInHours / 1.4;
+                    double calculatedTripSpeed = estimatedLengthInKm / durationInHours / 1.4;
                     // Plausibility check especially for the case of wrongly used PxM format with the intention to
                     // specify the duration in minutes, but actually using months
                     if (calculatedTripSpeed > 0.01d) {
-                        // If we have a very short ferry with an average lower compared to what we can encode 
-                        // then we need to avoid setting it as otherwise the edge would not be found at all any more.
-                        if (Math.round(calculatedTripSpeed) > speedEncoder.factor / 2) {
-                            shortTripsSpeed = Math.round(calculatedTripSpeed);
-                            if (shortTripsSpeed > getMaxSpeed())
-                                shortTripsSpeed = getMaxSpeed();
-                            longTripsSpeed = shortTripsSpeed;
-                        } else {
-                            // Now we set to the lowest possible still accessible speed. 
-                            shortTripsSpeed = speedEncoder.factor / 2;
+                        if (calculatedTripSpeed > getMaxSpeed()) {
+                            return getMaxSpeed();
                         }
+                        // If the speed is lower than the speed we can store, we have to set it to the minSpeed, but > 0
+                        if (Math.round(calculatedTripSpeed) < speedEncoder.factor) {
+                            return speedEncoder.factor;
+                        }
+
+                        return Math.round(calculatedTripSpeed);
                     } else {
                         long lastId = way.getNodes().isEmpty() ? -1 : way.getNodes().get(way.getNodes().size() - 1);
                         long firstId = way.getNodes().isEmpty() ? -1 : way.getNodes().get(0);
@@ -485,12 +488,12 @@ public abstract class AbstractFlagEncoder implements FlagEncoder, TurnCostEncode
 
         if (durationInHours == 0) {
             // unknown speed -> put penalty on ferry transport
-            return unknownSpeed;
+            return UNKNOWN_DURATION_FERRY_SPEED;
         } else if (durationInHours > 1) {
             // lengthy ferries should be faster than short trip ferry
-            return longTripsSpeed;
+            return LONG_TRIP_FERRY_SPEED;
         } else {
-            return shortTripsSpeed;
+            return SHORT_TRIP_FERRY_SPEED;
         }
     }
 

--- a/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
@@ -351,10 +351,7 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
             }
 
         } else {
-            double ferrySpeed = getFerrySpeed(way,
-                    highwaySpeeds.get("living_street"),
-                    highwaySpeeds.get("track"),
-                    highwaySpeeds.get("primary"));
+            double ferrySpeed = getFerrySpeed(way);
             flags = handleSpeed(way, ferrySpeed, flags);
             flags |= directionBitMask;
         }

--- a/core/src/main/java/com/graphhopper/routing/util/CarFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/CarFlagEncoder.java
@@ -264,7 +264,7 @@ public class CarFlagEncoder extends AbstractFlagEncoder {
                 flags |= directionBitMask;
 
         } else {
-            double ferrySpeed = getFerrySpeed(way, defaultSpeedMap.get("living_street"), defaultSpeedMap.get("service"), defaultSpeedMap.get("residential"));
+            double ferrySpeed = getFerrySpeed(way);
             flags = setSpeed(flags, ferrySpeed);
             flags |= directionBitMask;
         }

--- a/core/src/main/java/com/graphhopper/routing/util/FootFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/FootFlagEncoder.java
@@ -39,7 +39,6 @@ import static com.graphhopper.routing.util.PriorityCode.*;
 public class FootFlagEncoder extends AbstractFlagEncoder {
     static final int SLOW_SPEED = 2;
     static final int MEAN_SPEED = 5;
-    static final int FERRY_SPEED = 10;
     final Set<String> safeHighwayTags = new HashSet<String>();
     final Set<String> allowedHighwayTags = new HashSet<String>();
     final Set<String> avoidHighwayTags = new HashSet<String>();
@@ -49,6 +48,8 @@ public class FootFlagEncoder extends AbstractFlagEncoder {
     protected HashSet<String> sidewalksNoValues = new HashSet<String>(5);
     private EncodedValue priorityWayEncoder;
     private EncodedValue relationCodeEncoder;
+
+    private static final int FERRY_SPEED = 15;
 
     /**
      * Should be only instantiated via EncodingManager
@@ -135,7 +136,7 @@ public class FootFlagEncoder extends AbstractFlagEncoder {
 
     @Override
     public int getVersion() {
-        return 3;
+        return 4;
     }
 
     @Override
@@ -367,5 +368,18 @@ public class FootFlagEncoder extends AbstractFlagEncoder {
     @Override
     public String toString() {
         return "foot";
+    }
+
+    /*
+     * This method is a current hack, to allow ferries to be actually faster than our current storable maxSpeed.
+     */
+    @Override
+    public double getSpeed(long flags) {
+        double speed = super.getSpeed(flags);
+        if (speed == getMaxSpeed()) {
+            // We cannot be sure if it was a long or a short trip
+            return SHORT_TRIP_FERRY_SPEED;
+        }
+        return speed;
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/util/FootFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/FootFlagEncoder.java
@@ -39,6 +39,7 @@ import static com.graphhopper.routing.util.PriorityCode.*;
 public class FootFlagEncoder extends AbstractFlagEncoder {
     static final int SLOW_SPEED = 2;
     static final int MEAN_SPEED = 5;
+    static final int FERRY_SPEED = 15;
     final Set<String> safeHighwayTags = new HashSet<String>();
     final Set<String> allowedHighwayTags = new HashSet<String>();
     final Set<String> avoidHighwayTags = new HashSet<String>();
@@ -48,8 +49,6 @@ public class FootFlagEncoder extends AbstractFlagEncoder {
     protected HashSet<String> sidewalksNoValues = new HashSet<String>(5);
     private EncodedValue priorityWayEncoder;
     private EncodedValue relationCodeEncoder;
-
-    private static final int FERRY_SPEED = 15;
 
     /**
      * Should be only instantiated via EncodingManager

--- a/core/src/main/java/com/graphhopper/routing/util/FootFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/FootFlagEncoder.java
@@ -293,7 +293,7 @@ public class FootFlagEncoder extends AbstractFlagEncoder {
                 flags = setBool(flags, K_ROUNDABOUT, true);
 
         } else {
-            double ferrySpeed = getFerrySpeed(way, SLOW_SPEED, MEAN_SPEED, FERRY_SPEED);
+            double ferrySpeed = getFerrySpeed(way);
             flags = setSpeed(flags, ferrySpeed);
             flags |= directionBitMask;
         }

--- a/core/src/main/java/com/graphhopper/routing/util/HikeFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/HikeFlagEncoder.java
@@ -62,7 +62,7 @@ public class HikeFlagEncoder extends FootFlagEncoder {
 
     @Override
     public int getVersion() {
-        return 2;
+        return 3;
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/util/MotorcycleFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/MotorcycleFlagEncoder.java
@@ -227,7 +227,7 @@ public class MotorcycleFlagEncoder extends CarFlagEncoder {
             }
 
         } else {
-            double ferrySpeed = getFerrySpeed(way, defaultSpeedMap.get("living_street"), defaultSpeedMap.get("service"), defaultSpeedMap.get("residential"));
+            double ferrySpeed = getFerrySpeed(way);
             flags = setSpeed(flags, ferrySpeed);
             flags = setReverseSpeed(flags, ferrySpeed);
             flags |= directionBitMask;

--- a/core/src/test/java/com/graphhopper/routing/util/CarFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/CarFlagEncoderTest.java
@@ -414,7 +414,7 @@ public class CarFlagEncoderTest {
         // accept
         assertTrue(encoder.acceptWay(way) > 0);
         // calculate speed from estimated_distance and duration
-        assertEquals(61, encoder.getFerrySpeed(way, 20, 30, 40), 1e-1);
+        assertEquals(61, encoder.getFerrySpeed(way), 1e-1);
 
         //Test for very short and slow 0.5km/h still realisitic ferry
         way = new ReaderWay(1);
@@ -426,7 +426,7 @@ public class CarFlagEncoderTest {
         // accept
         assertTrue(encoder.acceptWay(way) > 0);
         // We can't store 0.5km/h, but we expect the lowest possible speed (5km/h)
-        assertEquals(2.5, encoder.getFerrySpeed(way, 20, 30, 40), 1e-1);
+        assertEquals(2.5, encoder.getFerrySpeed(way), 1e-1);
         assertEquals(5, encoder.getSpeed(encoder.setSpeed(0, 2.5)), 1e-1);
 
         //Test for an unrealisitic long duration
@@ -439,7 +439,7 @@ public class CarFlagEncoderTest {
         // accept
         assertTrue(encoder.acceptWay(way) > 0);
         // We have ignored the unrealisitc long duration and take the unknown speed
-        assertEquals(20, encoder.getFerrySpeed(way, 20, 30, 40), 1e-1);
+        assertEquals(5, encoder.getFerrySpeed(way), 1e-1);
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/routing/util/FootFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/FootFlagEncoderTest.java
@@ -216,7 +216,8 @@ public class FootFlagEncoderTest {
         // a bit longer than an hour
         way.setTag("duration:seconds", "4000");
         long flags = footEncoder.handleWayTags(way, footEncoder.acceptWay(way), 0);
-        assertEquals(10, footEncoder.getSpeed(flags), .1);
+        assertTrue(footEncoder.getSpeed(flags) > footEncoder.getMaxSpeed());
+        assertEquals(20, footEncoder.getSpeed(flags), .1);
     }
 
     @Test


### PR DESCRIPTION
Fixes #1116. 

I removed the parameters with individual ferry speeds for the method getFerrySpeed. The speeds are now stored in the AbstractFlagEncoder.

The FootFlagEncoder, however, does not not allow to store speeds > 10 km/h. So I changed the max speed for the FootFlagEncoder to 15 km/h (still 4 bits). If the stored speed speed equals 15 km/h I return 20 km/h for the speed instead. This is the short_trip_ferry_speed. 

I increased the versions for Foot, as well as HikeEncoder, not for the others, as I didn't change anything with the EncodedValues for the others.