### PR TITLE
graphhopper.sh: let env decide $CONFIG

### DIFF
--- a/graphhopper.sh
+++ b/graphhopper.sh
@@ -16,8 +16,8 @@ if [ "$bit64" != "" ]; then
 fi
 echo "## using java $vers from $JAVA_HOME"
 
-CONFIG=config.properties
-if [ ! -f "config.properties" ]; then
+CONFIG=${CONFIG:-config.properties}
+if [ ! -f "$CONFIG" ]; then
   cp config-example.properties $CONFIG
 fi
 


### PR DESCRIPTION
If there is concern about a spurious CONFIG in the environment (because the name is so generic)  could look for GH_CONFIG instead:

    CONFIG=${GH_CONFIG:-config.properties}