### PR TITLE
Checkstyle and Findbugs setup.

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -6,7 +6,7 @@
 <module name="Checker">
     <module name="TreeWalker">
         <module name="LineLength">
-            <property name="max" value="120"/>
+            <property name="max" value="500"/>
         </module>
     </module>
 </module>

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+        "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="LineLength">
+            <property name="max" value="120"/>
+        </module>
+    </module>
+</module>

--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>
+    <!-- ignore some bug type for demonstration only -->
+    <Match>
+        <Bug pattern="RV_RETURN_VALUE_IGNORED"/>
+    </Match>
+    <!-- bugs can also be excluded on the package/file/class/method level
+         see here: http://findbugs.sourceforge.net/manual/filter.html
+         for example this is how we can exclude a bug in some class: -->
+    <Match>
+        <Class name="com.graphhopper.storage.EdgeAccess"/>
+        <Bug pattern="INT_BAD_COMPARISON_WITH_NONNEGATIVE_VALUE"/>
+    </Match>
+</FindBugsFilter>

--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -1,14 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <FindBugsFilter>
-    <!-- ignore some bug type for demonstration only -->
-    <Match>
-        <Bug pattern="RV_RETURN_VALUE_IGNORED"/>
-    </Match>
-    <!-- bugs can also be excluded on the package/file/class/method level
-         see here: http://findbugs.sourceforge.net/manual/filter.html
-         for example this is how we can exclude a bug in some class: -->
-    <Match>
-        <Class name="com.graphhopper.storage.EdgeAccess"/>
-        <Bug pattern="INT_BAD_COMPARISON_WITH_NONNEGATIVE_VALUE"/>
-    </Match>
+    <!-- documentation about findbug's rule match clauses can be found here:
+         http://findbugs.sourceforge.net/manual/filter.html -->
 </FindBugsFilter>

--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <maxRank>7</maxRank>
+                    <maxRank>4</maxRank>
                     <failOnError>true</failOnError>
                     <excludeFilterFile>findbugs-exclude.xml</excludeFilterFile>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -136,21 +136,43 @@
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>3.0.2</version>
             </plugin>
-            <!-- example https://github.com/tananaev/traccar/blob/master/checkstyle.xml
+            <!-- example https://github.com/tananaev/traccar/blob/master/checkstyle.xml -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>2.17</version>
+                <executions>
+                    <execution>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
                 <configuration>
                     <configLocation>checkstyle.xml</configLocation>
+                    <failsOnError>true</failsOnError>
+                    <consoleOutput>true</consoleOutput>
                 </configuration>
             </plugin>
-            -->
 
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>findbugs-maven-plugin</artifactId>
-                <version>3.0.4</version>
+                <version>3.0.5</version>
+                <executions>
+                    <execution>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <maxRank>7</maxRank>
+                    <failOnError>true</failOnError>
+                    <excludeFilterFile>findbugs-exclude.xml</excludeFilterFile>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Related issues: #1109, #694
This PR adds some basic checkstyle and findbugs setup so that the code analysis runs during the integration-test phase. Right now only a line limit of 500 chars is checked and findbugs scans for bugs of the 'scariest' category (rank <=4).
