### PR TITLE
Update Osmosis to 0.46 for protobuf 3 support

### DIFF
--- a/reader-osm/pom.xml
+++ b/reader-osm/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>org.openstreetmap.osmosis</groupId>
             <artifactId>osmosis-osm-binary</artifactId>
-            <version>0.45</version>
+            <version>0.46</version>
         </dependency>
         <!-- 
         <dependency>


### PR DESCRIPTION
OpenStreetMap finally updated their osmosis with protobuf 3.4.0 support so we can use new 0.46 version to fix this issue:
https://discuss.graphhopper.com/t/graphopper-reader-and-protobuf-3/2251/11