### PR TITLE
Don't run findbugs and checkstyle as default during the ITs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ before_install:
 install: true
 
 script:
-  - mvn clean test verify -B
+  - mvn clean test verify checkstyle:checkstyle findbugs:findbugs -B
 
 after_success:
   # deploy snapshot artifacts to maven central

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ before_install:
 install: true
 
 script:
-  - mvn clean test verify checkstyle:checkstyle findbugs:findbugs -B
+  - mvn clean test verify checkstyle:check findbugs:check -B
 
 after_success:
   # deploy snapshot artifacts to maven central

--- a/core/src/main/java/com/graphhopper/util/PointList.java
+++ b/core/src/main/java/com/graphhopper/util/PointList.java
@@ -486,6 +486,25 @@ public class PointList implements Iterable<GHPoint3D>, PointAccess {
         return hash;
     }
 
+    private static Boolean inited = Boolean.FALSE;
+
+    public int hashcode() {
+        synchronized(inited) {
+            if (!inited) {
+                inited = Boolean.TRUE;
+            }
+        }
+        int hash = 5;
+        for (int i = 0; i < getSize(); i++) {
+            hash = 73 * hash + (int) Math.round(getLatitude(i) * 1000000);
+            hash = 73 * hash + (int) Math.round(getLongitude(i) * 1000000);
+        }
+        hash = 73 * hash + this.getSize();
+        return hash;
+    }
+
+
+
     public double calcDistance(DistanceCalc calc) {
         double prevLat = Double.NaN;
         double prevLon = Double.NaN;

--- a/core/src/main/java/com/graphhopper/util/PointList.java
+++ b/core/src/main/java/com/graphhopper/util/PointList.java
@@ -486,25 +486,6 @@ public class PointList implements Iterable<GHPoint3D>, PointAccess {
         return hash;
     }
 
-    private static Boolean inited = Boolean.FALSE;
-
-    public int hashcode() {
-        synchronized(inited) {
-            if (!inited) {
-                inited = Boolean.TRUE;
-            }
-        }
-        int hash = 5;
-        for (int i = 0; i < getSize(); i++) {
-            hash = 73 * hash + (int) Math.round(getLatitude(i) * 1000000);
-            hash = 73 * hash + (int) Math.round(getLongitude(i) * 1000000);
-        }
-        hash = 73 * hash + this.getSize();
-        return hash;
-    }
-
-
-
     public double calcDistance(DistanceCalc calc) {
         double prevLat = Double.NaN;
         double prevLon = Double.NaN;

--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,7 @@
                     <configLocation>checkstyle.xml</configLocation>
                     <failsOnError>true</failsOnError>
                     <consoleOutput>true</consoleOutput>
+                    <linkXRef>false</linkXRef>
                 </configuration>
             </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -141,14 +141,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>2.17</version>
-                <executions>
-                    <execution>
-                        <phase>integration-test</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
                 <configuration>
                     <configLocation>checkstyle.xml</configLocation>
                     <failsOnError>true</failsOnError>
@@ -160,14 +152,6 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>findbugs-maven-plugin</artifactId>
                 <version>3.0.5</version>
-                <executions>
-                    <execution>
-                        <phase>integration-test</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
                 <configuration>
                     <maxRank>4</maxRank>
                     <failOnError>true</failOnError>


### PR DESCRIPTION
As mentioned in #1184 findbugs and checkstyle slow down the test execution. I therefore removed the from the verify maven phase. They are still executed on travis, so if we introduce a massive issue in a PR travis should fail and report about it.

BTW: Findbugs seems to have issues with the Java 9 build.