### PR TITLE
Fixed Exponential Notation for GPX export

### DIFF
--- a/core/src/main/java/com/graphhopper/util/Helper.java
+++ b/core/src/main/java/com/graphhopper/util/Helper.java
@@ -63,7 +63,6 @@ public class Helper {
     private static final float DEGREE_FACTOR = Integer.MAX_VALUE / 400f;
     // milli meter is a bit extreme but we have integers
     private static final float ELE_FACTOR = 1000f;
-    private static final DecimalFormat DECIMAL_FORMAT = new DecimalFormat("#");
 
     private Helper() {
     }
@@ -483,13 +482,6 @@ public class Helper {
 
     public static final double round6(double value) {
         return Math.round(value * 1e6) / 1e6;
-    }
-
-    public static final String print6(double value) {
-        DECIMAL_FORMAT.setMinimumFractionDigits(1);
-        DECIMAL_FORMAT.setMaximumFractionDigits(6);
-        DECIMAL_FORMAT.setMinimumIntegerDigits(1);
-        return DECIMAL_FORMAT.format(value);
     }
 
     public static final double round4(double value) {

--- a/core/src/main/java/com/graphhopper/util/Helper.java
+++ b/core/src/main/java/com/graphhopper/util/Helper.java
@@ -37,6 +37,7 @@ import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.text.DateFormat;
+import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.text.SimpleDateFormat;
 import java.util.*;
@@ -62,6 +63,7 @@ public class Helper {
     private static final float DEGREE_FACTOR = Integer.MAX_VALUE / 400f;
     // milli meter is a bit extreme but we have integers
     private static final float ELE_FACTOR = 1000f;
+    private static final DecimalFormat DECIMAL_FORMAT = new DecimalFormat("#");
 
     private Helper() {
     }
@@ -481,6 +483,13 @@ public class Helper {
 
     public static final double round6(double value) {
         return Math.round(value * 1e6) / 1e6;
+    }
+
+    public static final String print6(double value) {
+        DECIMAL_FORMAT.setMinimumFractionDigits(1);
+        DECIMAL_FORMAT.setMaximumFractionDigits(6);
+        DECIMAL_FORMAT.setMinimumIntegerDigits(1);
+        return DECIMAL_FORMAT.format(value);
     }
 
     public static final double round4(double value) {

--- a/core/src/main/java/com/graphhopper/util/InstructionList.java
+++ b/core/src/main/java/com/graphhopper/util/InstructionList.java
@@ -161,8 +161,8 @@ public class InstructionList extends AbstractList<Instruction> {
 
     private void createWayPointBlock(StringBuilder output, Instruction instruction) {
         output.append("\n<wpt ");
-        output.append("lat=\"").append(Helper.round6(instruction.getFirstLat()));
-        output.append("\" lon=\"").append(Helper.round6(instruction.getFirstLon())).append("\">");
+        output.append("lat=\"").append(Helper.print6(instruction.getFirstLat()));
+        output.append("\" lon=\"").append(Helper.print6(instruction.getFirstLon())).append("\">");
         String name;
         if (instruction.getName().isEmpty())
             name = instruction.getTurnDescription(tr);
@@ -219,8 +219,8 @@ public class InstructionList extends AbstractList<Instruction> {
 
             gpxOutput.append("<trkseg>");
             for (GPXEntry entry : createGPXList()) {
-                gpxOutput.append("\n<trkpt lat=\"").append(Helper.round6(entry.getLat()));
-                gpxOutput.append("\" lon=\"").append(Helper.round6(entry.getLon())).append("\">");
+                gpxOutput.append("\n<trkpt lat=\"").append(Helper.print6(entry.getLat()));
+                gpxOutput.append("\" lon=\"").append(Helper.print6(entry.getLon())).append("\">");
                 if (includeElevation)
                     gpxOutput.append("<ele>").append(Helper.round2(entry.getEle())).append("</ele>");
                 gpxOutput.append("<time>").append(formatter.format(startTimeMillis + entry.getTime())).append("</time>");
@@ -236,8 +236,8 @@ public class InstructionList extends AbstractList<Instruction> {
     }
 
     public void createRteptBlock(StringBuilder output, Instruction instruction, Instruction nextI) {
-        output.append("\n<rtept lat=\"").append(Helper.round6(instruction.getFirstLat())).
-                append("\" lon=\"").append(Helper.round6(instruction.getFirstLon())).append("\">");
+        output.append("\n<rtept lat=\"").append(Helper.print6(instruction.getFirstLat())).
+                append("\" lon=\"").append(Helper.print6(instruction.getFirstLon())).append("\">");
 
         if (!instruction.getName().isEmpty())
             output.append("<desc>").append(simpleXMLEscape(instruction.getTurnDescription(tr))).append("</desc>");

--- a/core/src/test/java/com/graphhopper/util/InstructionListTest.java
+++ b/core/src/test/java/com/graphhopper/util/InstructionListTest.java
@@ -410,6 +410,25 @@ public class InstructionListTest {
     }
 
     @Test
+    public void testCreateGPXCorrectFormattingSmallNumbers() {
+        InstructionList instructions = new InstructionList(usTR);
+
+        PointList pl = new PointList();
+        pl.add(0.000001, 0.000001);
+        pl.add(-0.000123, -0.000125);
+        Instruction instruction = new Instruction(0, "do it", null, pl);
+        instructions.add(instruction);
+        instructions.add(new FinishInstruction(0.000852, 0.000852, 0));
+
+        String gpxStr = instructions.createGPX("test", 0, true, true, true, true);
+
+        assertFalse(gpxStr, gpxStr.contains("E-"));
+        assertTrue(gpxStr, gpxStr.contains("0.000001"));
+        assertTrue(gpxStr, gpxStr.contains("-0.000125"));
+        verifyGPX(gpxStr);
+    }
+
+    @Test
     public void testCreateGPXWithEle() {
         final List<GPXEntry> fakeList = new ArrayList<GPXEntry>();
         fakeList.add(new GPXEntry(12, 13, 0));


### PR DESCRIPTION
[Kurviger](https://kurviger.de/en) received a [bug report](https://groups.google.com/d/msg/kurviger/b4TdQQSzkT8/nTGrpmTwAQAJ) that there can be an issue with the GPX export if coordinates are close to 0. The default formatting of Java for values like `0.000123` is `1.23E-4` which makes sense for readability, but some programs like Garmin Basecamp have issues importing these numbers.

This PR fixes this issue. I tried to stay as close to the current behaviour of GH as possible, but removing the exponential notation. For coordinates like 15.0 it prints 15.0 but not just 15 or 15.000000. Also values like 0.1 are printed as 0.1. 