### PR TITLE
Added a simple codeclimate.yml

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -12,4 +12,5 @@ ratings:
   paths:
   - "**.java"
 exclude_paths:
-- web/src/main/webapp/
+- "web/src/main/webapp/"
+- "**.js"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -12,4 +12,4 @@ ratings:
   paths:
   - "**.java"
 exclude_paths:
-- web/src/main/webapp/*
+- web/src/main/webapp/

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -11,3 +11,5 @@ engines:
 ratings:
   paths:
   - "**.java"
+exclude_paths:
+- web/src/main/webapp/*

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,10 +1,11 @@
 engines:
   checkstyle:
     enabled: true
-  duplicateion:
+  duplication:
     enabled: true
     config:
       languages:
+      # it's not yet available for Java :)
       - java
   pmd:
     enabled: true

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,13 @@
+engines:
+  checkstyle:
+    enabled: true
+  duplicateion:
+    enabled: true
+    config:
+      languages:
+      - java
+  pmd:
+    enabled: true
+ratings:
+  paths:
+  - "**.java"


### PR DESCRIPTION
Ok, CodeClimate is weird. I think we have to merge the `.codeclimate.yml` into the master. Before that we cannot look at the [issues](https://codeclimate.com/github/graphhopper/graphhopper/issues), as the issue view is not PR related. Since this PR changes a lot, I think it's not possible to see the detailed code quality change. I tried to make sure that js files get excluded by excluding their directory + all .js files.

So I would propose to merge this PR and see what changes in the issue view and if this is useful or not.

BTW: Java is [new](https://codeclimate.com/changelog/59cd14d00893fb028f00173b) in code climate, so I am not sure how well it is already integrated into the platform.