### PR TITLE
Disable checking for braces

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -14,6 +14,8 @@ engines:
         enabled: false
       com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyLineSeparatorCheck:
         enabled: false
+      com.puppycrawl.tools.checkstyle.checks.blocks.NeedBracesCheck:
+        enabled: false
   duplication:
     enabled: true
     config:


### PR DESCRIPTION
Currently code climate is marking this code
```
if (line == null)
  throw new IllegalStateException("Cannot read line " + lineNo);
```
as checkstyle violation. We use this widely in GH, so I think this check is not for us :).

[Here](http://checkstyle.sourceforge.net/apidocs/com/puppycrawl/tools/checkstyle/checks/blocks/NeedBracesCheck.html) is the JavaDoc for this feature.