### PR TITLE
fixes decimal format in createGPX for locales with comma as separator

### DIFF
--- a/core/src/main/java/com/graphhopper/util/InstructionList.java
+++ b/core/src/main/java/com/graphhopper/util/InstructionList.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 import java.text.DateFormat;
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.util.*;
 
 /**
@@ -181,6 +182,7 @@ public class InstructionList extends AbstractList<Instruction> {
         decimalFormat.setMinimumFractionDigits(1);
         decimalFormat.setMaximumFractionDigits(6);
         decimalFormat.setMinimumIntegerDigits(1);
+        decimalFormat.setDecimalFormatSymbols(DecimalFormatSymbols.getInstance(Locale.US));
 
         String header = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\" ?>"
                 + "<gpx xmlns=\"http://www.topografix.com/GPX/1/1\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\""


### PR DESCRIPTION
When I try to build the current master on a system with German locale, I get the following test failures:

  InstructionListTest.testCreateGPX:483->verifyGPX:517 Runtime org.xml.sax.SAXPa...
  InstructionListTest.testCreateGPXIncludesRoundaboutExitNumber:409->verifyGPX:517 Runtime
  InstructionListTest.testCreateGPXWithEle:443->verifyGPX:517 Runtime org.xml.sa...
  InstructionListTest.testInstructionsWithTimeAndPlace:319->verifyGPX:517 Runtime

They are caused by this exception:

```
java.lang.RuntimeException: org.xml.sax.SAXParseException; lineNumber: 4; columnNumber: 30; cvc-datatype-valid.1.2.1: '12,0' ist kein gültiger Wert für 'decimal'.
	at com.graphhopper.util.InstructionListTest.verifyGPX(InstructionListTest.java:517)
	at com.graphhopper.util.InstructionListTest.testCreateGPXWithEle(InstructionListTest.java:443)
Caused by: org.xml.sax.SAXParseException: cvc-datatype-valid.1.2.1: '12,0' ist kein gültiger Wert für 'decimal'.
	at com.graphhopper.util.InstructionListTest.verifyGPX(InstructionListTest.java:515)
	at com.graphhopper.util.InstructionListTest.testCreateGPXWithEle(InstructionListTest.java:443)
```

..., which is thrown because the generated gpx contains attributes like this:
\<rtept lat="**0,000852**" lon="**0,000852**">

This PR fixes the problem by setting the decimal symbols used by the NumberFormat to Locale.US.