### PR TITLE
Remove duplicated points at ViaPoints and add getLength to Instructions

### DIFF
--- a/core/src/main/java/com/graphhopper/util/FinishInstruction.java
+++ b/core/src/main/java/com/graphhopper/util/FinishInstruction.java
@@ -48,6 +48,11 @@ public class FinishInstruction extends Instruction {
     }
 
     @Override
+    public int getLength() {
+        return 0;
+    }
+
+    @Override
     public String getTurnDescription(Translation tr) {
         if (rawName)
             return getName();

--- a/core/src/main/java/com/graphhopper/util/Instruction.java
+++ b/core/src/main/java/com/graphhopper/util/Instruction.java
@@ -238,6 +238,20 @@ public class Instruction {
             throw new IllegalStateException("Instruction must contain at least one point " + toString());
     }
 
+    /**
+     * This method returns the length of an Instruction. The length of an instruction is defined by [the
+     * index of the first point of the next instruction] - [the index of the first point of this instruction].
+     * <p>
+     * In general this will just resolve to the size of the PointList, except for {@link ViaInstruction} and
+     * {@link FinishInstruction}, which are only virtual instructions, in a sense that they don't provide
+     * a turn instruction, but only an info ("reached via point or destination").
+     * <p>
+     * See #1216 and #1138
+     */
+    public int getLength() {
+        return points.getSize();
+    }
+
     public String getTurnDescription(Translation tr) {
         if (rawName)
             return getName();

--- a/core/src/main/java/com/graphhopper/util/InstructionList.java
+++ b/core/src/main/java/com/graphhopper/util/InstructionList.java
@@ -80,7 +80,8 @@ public class InstructionList extends AbstractList<Instruction> {
         instructions.set(instructions.size() - 1, instr);
     }
 
-    @JsonValue public List<Map<String, Object>> createJson() {
+    @JsonValue
+    public List<Map<String, Object>> createJson() {
         List<Map<String, Object>> instrList = new ArrayList<>(instructions.size());
         int pointsIndex = 0;
         int counter = 0;
@@ -104,11 +105,7 @@ public class InstructionList extends AbstractList<Instruction> {
             instrJson.put("sign", instruction.getSign());
             instrJson.putAll(instruction.getExtraInfoJSON());
 
-            int tmpIndex = pointsIndex + instruction.getPoints().size();
-            // the last instruction should not point to the next instruction
-            if (counter + 1 == instructions.size())
-                tmpIndex--;
-
+            int tmpIndex = pointsIndex + instruction.getLength();
             instrJson.put("interval", Arrays.asList(pointsIndex, tmpIndex));
             pointsIndex = tmpIndex;
 
@@ -120,7 +117,6 @@ public class InstructionList extends AbstractList<Instruction> {
     /**
      * @return This method returns a list of gpx entries where the time (in millis) is relative to
      * the first which is 0.
-     * <p>
      */
     public List<GPXEntry> createGPXList() {
         if (isEmpty())

--- a/core/src/main/java/com/graphhopper/util/PathMerger.java
+++ b/core/src/main/java/com/graphhopper/util/PathMerger.java
@@ -111,9 +111,14 @@ public class PathMerger {
                 if (fullPoints.isEmpty())
                     fullPoints = new PointList(tmpPoints.size(), tmpPoints.is3D());
 
+                // Remove duplicated points, see #1138
+                if (pathIndex + 1 < paths.size()) {
+                    tmpPoints.removeLastPoint();
+                }
+
                 fullPoints.add(tmpPoints);
                 altRsp.addPathDetails(path.calcDetails(requestedPathDetails, pathBuilderFactory, origPoints));
-                origPoints += tmpPoints.size();
+                origPoints = fullPoints.size();
             }
 
             allFound = allFound && path.isFound();

--- a/core/src/main/java/com/graphhopper/util/PathSimplification.java
+++ b/core/src/main/java/com/graphhopper/util/PathSimplification.java
@@ -146,12 +146,7 @@ public class PathSimplification {
 
     private int getLength(Object o, int index) {
         if (o instanceof InstructionList) {
-            // we do not store the last point of an instruction
-            int size = ((InstructionList) o).get(index).getPoints().size();
-            if (size == 0)
-                throw new IllegalStateException("PointList of instruction should not be empty " + o);
-            // the last point of instruction (i.e. first point of next instruction) is not included
-            return size;
+            return ((InstructionList) o).get(index).getLength();
         }
         if (o instanceof List) {
             return ((List<PathDetail>) o).get(index).getLength();

--- a/core/src/main/java/com/graphhopper/util/PointList.java
+++ b/core/src/main/java/com/graphhopper/util/PointList.java
@@ -45,6 +45,11 @@ public class PointList implements Iterable<GHPoint3D>, PointAccess {
         }
 
         @Override
+        public void removeLastPoint() {
+            throw new RuntimeException("cannot change EMPTY PointList");
+        }
+
+        @Override
         public double getLatitude(int index) {
             throw new RuntimeException("cannot access EMPTY PointList");
         }
@@ -258,6 +263,10 @@ public class PointList implements Iterable<GHPoint3D>, PointAccess {
                 elevations[tmp] = points.getElevation(i);
         }
         size = newSize;
+    }
+
+    public void removeLastPoint(){
+        size--;
     }
 
     public int size() {

--- a/core/src/main/java/com/graphhopper/util/ShallowImmutablePointList.java
+++ b/core/src/main/java/com/graphhopper/util/ShallowImmutablePointList.java
@@ -139,6 +139,11 @@ public final class ShallowImmutablePointList extends PointList {
     }
 
     @Override
+    public void removeLastPoint() {
+        throw new UnsupportedOperationException(IMMUTABLE_ERR);
+    }
+
+    @Override
     public void reverse() {
         throw new UnsupportedOperationException(IMMUTABLE_ERR);
     }

--- a/core/src/main/java/com/graphhopper/util/ViaInstruction.java
+++ b/core/src/main/java/com/graphhopper/util/ViaInstruction.java
@@ -33,6 +33,11 @@ public class ViaInstruction extends Instruction {
         setTime(instr.getTime());
     }
 
+    @Override
+    public int getLength() {
+        return 0;
+    }
+
     public int getViaCount() {
         if (viaPosition < 0)
             throw new IllegalStateException("Uninitialized via count in instruction " + getName());

--- a/core/src/test/java/com/graphhopper/util/PointListTest.java
+++ b/core/src/test/java/com/graphhopper/util/PointListTest.java
@@ -101,6 +101,19 @@ public class PointListTest {
     }
 
     @Test
+    public void testRemoveLast() {
+        PointList list = new PointList(20, false);
+        for (int i = 0; i < 10; i++) {
+            list.add(1, i);
+        }
+        assertEquals(10, list.getSize());
+        assertEquals(9, list.getLon(list.getSize()-1), .1);
+        list.removeLastPoint();
+        assertEquals(9, list.getSize());
+        assertEquals(8, list.getLon(list.getSize()-1), .1);
+    }
+
+    @Test
     public void testCopy_issue1166() {
         PointList list = new PointList(20, false);
         for (int i = 0; i < 10; i++) {

--- a/reader-osm/src/test/java/com/graphhopper/GraphHopperIT.java
+++ b/reader-osm/src/test/java/com/graphhopper/GraphHopperIT.java
@@ -327,7 +327,7 @@ public class GraphHopperIT {
 
         PathWrapper arsp = rsp.getBest();
         assertEquals(6875.2, arsp.getDistance(), .1);
-        assertEquals(174, arsp.getPoints().getSize());
+        assertEquals(173, arsp.getPoints().getSize());
 
         InstructionList il = arsp.getInstructions();
         assertEquals(38, il.size());
@@ -384,7 +384,7 @@ public class GraphHopperIT {
         arsp = rsp.getBest();
         assertEquals(0, arsp.getDistance(), .1);
         assertEquals(0, arsp.getRouteWeight(), .1);
-        assertEquals(2, arsp.getPoints().getSize());
+        assertEquals(1, arsp.getPoints().getSize());
         assertEquals(2, arsp.getInstructions().size());
         assertEquals(Instruction.REACHED_VIA, arsp.getInstructions().createJson().get(0).get("sign"));
         assertEquals(Instruction.FINISH, arsp.getInstructions().createJson().get(1).get("sign"));
@@ -509,7 +509,7 @@ public class GraphHopperIT {
 
         PathWrapper arsp = rsp.getBest();
         assertEquals(297, arsp.getDistance(), 5.);
-        assertEquals(24, arsp.getPoints().getSize());
+        assertEquals(23, arsp.getPoints().getSize());
 
         // test if start and first point are identical leading to an empty path, #788
         rq = new GHRequest().
@@ -845,7 +845,29 @@ public class GraphHopperIT {
         PathWrapper pw = rsp.getBest();
         assertEquals(1.45, rsp.getBest().getDistance() / 1000f, .01);
         assertEquals(17, rsp.getBest().getTime() / 1000f / 60, 1);
-        assertEquals(64, pw.getPoints().size());
+        assertEquals(63, pw.getPoints().size());
+    }
+
+    @Test
+    public void testPathDetails1216() {
+        GraphHopper tmpHopper = new GraphHopperOSM().
+                setOSMFile(DIR + "/north-bayreuth.osm.gz").
+                setCHEnabled(false).
+                setGraphHopperLocation(tmpGraphFile).
+                setEncodingManager(new EncodingManager("car"));
+        tmpHopper.importOrLoad();
+
+        GHRequest req = new GHRequest().
+                addPoint(new GHPoint(49.984352, 11.498802)).
+                // This is exactly between two edges with different speed values
+                        addPoint(new GHPoint(49.984565, 11.499188)).
+                        addPoint(new GHPoint(49.9847, 11.499612)).
+                        setVehicle("car").setWeighting("fastest").
+                        setPathDetails(Arrays.asList(Parameters.DETAILS.AVERAGE_SPEED));
+
+        GHResponse rsp = tmpHopper.route(req);
+
+        assertFalse(rsp.hasErrors());
     }
 
     @Test

--- a/reader-osm/src/test/java/com/graphhopper/reader/osm/GraphHopperOSMTest.java
+++ b/reader-osm/src/test/java/com/graphhopper/reader/osm/GraphHopperOSMTest.java
@@ -558,7 +558,7 @@ public class GraphHopperOSMTest {
         assertFalse("should find 1->2->3", grsp.hasErrors());
         PathWrapper rsp = grsp.getBest();
         assertEquals(rsp12.getBest().getDistance() + rsp23.getBest().getDistance(), rsp.getDistance(), 1e-6);
-        assertEquals(5, rsp.getPoints().getSize());
+        assertEquals(4, rsp.getPoints().getSize());
         assertEquals(5, rsp.getInstructions().size());
         assertEquals(Instruction.REACHED_VIA, rsp.getInstructions().get(1).getSign());
     }

--- a/reader-osm/src/test/java/com/graphhopper/routing/RoutingAlgorithmWithOSMIT.java
+++ b/reader-osm/src/test/java/com/graphhopper/routing/RoutingAlgorithmWithOSMIT.java
@@ -309,7 +309,7 @@ public class RoutingAlgorithmWithOSMIT {
         OneRun run = new OneRun();
         run.add(50.016923, 11.514187, 0, 0);
         run.add(50.019129, 11.500325, 0, 0);
-        run.add(50.023623, 11.56929, 7069, 180);
+        run.add(50.023623, 11.56929, 7069, 178);
         list.add(run);
 
         runAlgo(testCollector, DIR + "/north-bayreuth.osm.gz", "target/north-bayreuth-gh",


### PR DESCRIPTION
This PR fixes #1216 and also addresses parts of #1138.

This PR removes the duplicated point at ViaInstructions. Due to that we could also improve the Instructions and added the `getLength` method to the Instruction, which makes the code easier to read and is a step towards making instructions more similar to PathDetails.