### PR TITLE
Improve Checkstyle Warnings / Code Climate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -16,6 +16,10 @@ engines:
         enabled: false
       com.puppycrawl.tools.checkstyle.checks.blocks.NeedBracesCheck:
         enabled: false
+      com.puppycrawl.tools.checkstyle.checks.whitespace.OperatorWrapCheck:
+        enabled: false
+      com.puppycrawl.tools.checkstyle.checks.naming.LocalVariableNameCheck:
+        enabled: false
   duplication:
     enabled: true
     config:


### PR DESCRIPTION
I removed two Checkstyle warnings, one for local variables that have to follow a certain naming scheme. This rule was triggered by variables like `g`, or `myURL`. The other rule is about String wrapping, if you do: "a" + var.toString it tells you to wrap the + to a new line, which makes no sense to me.