### PR TITLE
Added lane information based on the osm tag turn:lanes, use

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -85,7 +85,14 @@
             <version>${log4j.version}</version>
             <scope>test</scope>
         </dependency>
-        
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.12.0</version>
+            <scope>test</scope>
+        </dependency>
+
+
     </dependencies>
 
     <build>

--- a/core/src/main/java/com/graphhopper/routing/util/LaneInfoEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/LaneInfoEncoder.java
@@ -1,0 +1,55 @@
+package com.graphhopper.routing.util;
+
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.util.Lane;
+
+import java.util.List;
+
+/**
+ * Encodes and decodes a turn lane information with an integer flag.
+ * This encoder can be enabled setting the flag encoder property <b>lane_info</b> to <code>true</code> in the property
+ * <b>graph.flag_encoders</b>.
+ * The current implementation requires the property <b>graph.bytes_for_flags</b> to be set to 8.
+ */
+public interface LaneInfoEncoder {
+
+    /**
+     * Reads the corresponding OSM tags for <b>turn:lanes</b> and encodes all the lanes into one integer flag.
+     * There is a maximum number of lanes that can be encoded. If the limit is
+     * reached then no information will be saved for the given way.
+     *
+     * @param readerWay the way containing the lane tags.
+     * @return the encoded lane information as integer
+     */
+    long encodeTurnLanes(ReaderWay readerWay);
+
+    /**
+     * Transforms the encoded lane information value to the original string from the <b>turn:lanes</b> tag.
+     * <p/>
+     * Note: the original tag and the decoded value may vary because the encoded tags were simplified.
+     * (e.g. through;slight_right => through;right) the directions are respected.
+     *
+     * @param flags the encoded lane information
+     * @return the tag representation of the lane information
+     */
+    String decodeTurnLanes(long flags);
+
+    /**
+     * Transforms the encoded lane information value to the original string from the <b>turn:lanes</b> tag with codes.
+     * <p/>
+     * Note: the original tag and the decoded value may vary because the encoded tags were simplified.
+     * (e.g. through;slight_right => through;right) the directions are respected.
+     *
+     * @param flags the encoded lane information
+     * @return a list of Lanes that contains the string representation of the tags as well as the codes.
+     * @see Lane
+     */
+    List<Lane> decodeTurnLanesToList(long flags);
+
+    /**
+     * Defines if the lane information is enabled and available to decode or not.
+     *
+     * @return true if the lane information is enabled.
+     */
+    boolean isLaneInfoEnabled();
+}

--- a/core/src/main/java/com/graphhopper/util/Instruction.java
+++ b/core/src/main/java/com/graphhopper/util/Instruction.java
@@ -17,6 +17,7 @@
  */
 package com.graphhopper.util;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -48,6 +49,7 @@ public class Instruction {
     protected String name;
     protected double distance;
     protected long time;
+    protected List<Lane> lanes = new ArrayList<>();
 
     /**
      * The points, distances and times have exactly the same count. The last point of this
@@ -117,6 +119,14 @@ public class Instruction {
     public Instruction setTime(long time) {
         this.time = time;
         return this;
+    }
+
+    public List<Lane> getLanes() {
+        return lanes;
+    }
+
+    public void setLanes(List<Lane> lanes) {
+        this.lanes = lanes;
     }
 
     /**

--- a/core/src/main/java/com/graphhopper/util/InstructionList.java
+++ b/core/src/main/java/com/graphhopper/util/InstructionList.java
@@ -101,6 +101,9 @@ public class InstructionList extends AbstractList<Instruction> {
             instrJson.put("time", instruction.getTime());
             instrJson.put("distance", Helper.round(instruction.getDistance(), 3));
             instrJson.put("sign", instruction.getSign());
+            if (!instruction.getLanes().isEmpty()) {
+                instrJson.put("lanes", createLanesJson(instruction));
+            }
             instrJson.putAll(instruction.getExtraInfoJSON());
 
             int tmpIndex = pointsIndex + instruction.getPoints().size();
@@ -114,6 +117,17 @@ public class InstructionList extends AbstractList<Instruction> {
             counter++;
         }
         return instrList;
+    }
+
+    private List<Map<String, Object>> createLanesJson(Instruction instruction) {
+        List<Map<String, Object>> instrJson = new ArrayList<>();
+        for(Lane lane : instruction.getLanes()) {
+            Map<String, Object> entry = new HashMap<>();
+            entry.put("direction", lane.getDirection());
+            entry.put("valid", lane.isValid());
+            instrJson.add(entry);
+        }
+        return instrJson;
     }
 
     /**

--- a/core/src/main/java/com/graphhopper/util/Lane.java
+++ b/core/src/main/java/com/graphhopper/util/Lane.java
@@ -1,0 +1,57 @@
+package com.graphhopper.util;
+
+/**
+ * Represents a single lane, used for the instructions.
+ *
+ * @see com.graphhopper.routing.util.CarFlagEncoder
+ */
+public class Lane {
+
+    /**
+     * Direction as string based on the OSM lane tags.
+     */
+    public final String direction;
+
+    /**
+     * Internal code that corresponds to the lane tags.
+     */
+    public final int directionCode;
+
+    /**
+     * Defines if the lane can be used for the next maneuver.
+     */
+    public boolean valid;
+
+    public Lane(String direction, int directionCode) {
+        this.directionCode = directionCode;
+        this.direction = direction;
+    }
+
+    public void setValid(boolean valid) {
+        this.valid = valid;
+    }
+
+    public String getDirection() {
+        return direction;
+    }
+
+    public boolean isValid() {
+        return valid;
+    }
+
+    public int getDirectionCode() {
+        return directionCode;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("direction: ");
+        sb.append(direction).append(", ");
+        sb.append("directionCode: ");
+        sb.append(directionCode).append(", ");
+        sb.append("valid: ");
+        sb.append(valid);
+        return sb.toString();
+    }
+}

--- a/core/src/test/java/com/graphhopper/routing/InstructionsFromEdgesTest.java
+++ b/core/src/test/java/com/graphhopper/routing/InstructionsFromEdgesTest.java
@@ -1,0 +1,142 @@
+package com.graphhopper.routing;
+
+import com.graphhopper.routing.util.CarFlagEncoder;
+import com.graphhopper.routing.util.FlagEncoder;
+import com.graphhopper.storage.Graph;
+import com.graphhopper.storage.NodeAccess;
+import com.graphhopper.util.Instruction;
+import com.graphhopper.util.Lane;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class InstructionsFromEdgesTest {
+
+    @Mock
+    private NodeAccess nodeAccess;
+    @Mock
+    private Graph graph;
+    @Mock
+    private CarFlagEncoder encoder;
+
+    private InstructionsFromEdges instructionsFromEdges;
+
+    private List<Lane> lanes;
+    private long flags = 1;
+
+    @Before
+    public void setup() {
+        lanes = new ArrayList<>();
+        when(encoder.isLaneInfoEnabled()).thenReturn(true);
+        when(encoder.getDouble(anyLong(), anyInt())).thenReturn(1.0);
+        when(encoder.decodeTurnLanesToList(anyLong())).thenReturn(lanes);
+        instructionsFromEdges = new InstructionsFromEdges(0, graph, null, encoder, nodeAccess, null, null);
+    }
+
+    @Test
+    public void getLanesInfoSingleLaneNone() throws Exception {
+        int sign = Instruction.CONTINUE_ON_STREET;
+        lanes.add(new Lane("none", CarFlagEncoder.NONE_LANE_CODE));
+
+        List<Lane> lanesInfo = instructionsFromEdges.getLanesInfo(flags, sign);
+
+        assertNotNull(lanesInfo);
+        assertFalse(lanesInfo.isEmpty());
+        assertEquals("none", lanesInfo.get(0).getDirection());
+        assertTrue(lanesInfo.get(0).isValid());
+    }
+
+    @Test
+    public void getLanesInfoSingleLaneRight() throws Exception {
+        int sign = Instruction.CONTINUE_ON_STREET;
+        lanes.add(new Lane("right", CarFlagEncoder.RIGHT_LANE_CODE));
+
+        List<Lane> lanesInfo = instructionsFromEdges.getLanesInfo(flags, sign);
+
+        assertNotNull(lanesInfo);
+        assertFalse(lanesInfo.isEmpty());
+        assertEquals("right", lanesInfo.get(0).getDirection());
+        assertTrue(lanesInfo.get(0).isValid());
+    }
+
+    @Test
+    public void getLanesInfoMultipleLanesRight() throws Exception {
+        int sign = Instruction.TURN_RIGHT;
+        lanes.add(new Lane("none", CarFlagEncoder.NONE_LANE_CODE));
+        lanes.add(new Lane("right", CarFlagEncoder.RIGHT_LANE_CODE));
+
+        List<Lane> lanesInfo = instructionsFromEdges.getLanesInfo(flags, sign);
+
+        assertNotNull(lanesInfo);
+        assertFalse(lanesInfo.isEmpty());
+        assertEquals("none", lanesInfo.get(0).getDirection());
+        assertFalse(lanesInfo.get(0).isValid());
+        assertEquals("right", lanesInfo.get(1).getDirection());
+        assertTrue(lanesInfo.get(1).isValid());
+    }
+
+    @Test
+    public void getLanesInfoMultipleLanesThrough() throws Exception {
+        int sign = Instruction.CONTINUE_ON_STREET;
+        lanes.add(new Lane("left", CarFlagEncoder.LEFT_LANE_CODE));
+        lanes.add(new Lane("none", CarFlagEncoder.NONE_LANE_CODE));
+        lanes.add(new Lane("none", CarFlagEncoder.NONE_LANE_CODE));
+        lanes.add(new Lane("none", CarFlagEncoder.NONE_LANE_CODE));
+        lanes.add(new Lane("right", CarFlagEncoder.RIGHT_LANE_CODE));
+
+        List<Lane> lanesInfo = instructionsFromEdges.getLanesInfo(flags, sign);
+
+        assertNotNull(lanesInfo);
+        assertFalse(lanesInfo.isEmpty());
+        assertEquals("left", lanesInfo.get(0).getDirection());
+        assertFalse(lanesInfo.get(0).isValid());
+        assertEquals("none", lanesInfo.get(1).getDirection());
+        assertTrue(lanesInfo.get(1).isValid());
+        assertEquals("none", lanesInfo.get(2).getDirection());
+        assertTrue(lanesInfo.get(2).isValid());
+        assertEquals("none", lanesInfo.get(3).getDirection());
+        assertTrue(lanesInfo.get(3).isValid());
+        assertEquals("right", lanesInfo.get(4).getDirection());
+        assertFalse(lanesInfo.get(4).isValid());
+    }
+
+    @Test
+    public void getLanesInfoMultipleDirectionsRight() throws Exception {
+        int sign = Instruction.TURN_RIGHT;
+        lanes.add(new Lane("through;right", 6));
+
+        List<Lane> lanesInfo = instructionsFromEdges.getLanesInfo(flags, sign);
+
+        assertNotNull(lanesInfo);
+        assertFalse(lanesInfo.isEmpty());
+        assertEquals("through;right", lanesInfo.get(0).getDirection());
+        assertTrue(lanesInfo.get(0).isValid());
+    }
+
+    @Test
+    public void getLanesInfoMultipleDirectionsThrough() throws Exception {
+        int sign = Instruction.CONTINUE_ON_STREET;
+        lanes.add(new Lane("left;through;right", 15));
+        lanes.add(new Lane("left", CarFlagEncoder.LEFT_LANE_CODE));
+
+        List<Lane> lanesInfo = instructionsFromEdges.getLanesInfo(flags, sign);
+
+        assertNotNull(lanesInfo);
+        assertFalse(lanesInfo.isEmpty());
+        assertTrue(lanesInfo.get(0).isValid());
+        assertFalse(lanesInfo.get(1).isValid());
+    }
+}


### PR DESCRIPTION
lane_info=true in the encoder string to enable it, it requries 8
bytes_for_flags.
@karussell 
@boldtrn

Issue #1131