### PR TITLE
Fix PathDetails exception for empty EdgeIdDs list

### DIFF
--- a/core/src/main/java/com/graphhopper/PathWrapper.java
+++ b/core/src/main/java/com/graphhopper/PathWrapper.java
@@ -254,9 +254,6 @@ public class PathWrapper {
             throw new IllegalStateException("Details have to be the same size");
         }
         for (Map.Entry<String, List<PathDetail>> detailEntry : details.entrySet()) {
-            if (detailEntry.getValue().isEmpty())
-                throw new IllegalStateException("PathDetails " + detailEntry.getKey() + " must not be empty");
-
             if (this.pathDetails.containsKey(detailEntry.getKey())) {
                 List<PathDetail> pd = this.pathDetails.get(detailEntry.getKey());
                 PathMerger.merge(pd, detailEntry.getValue());

--- a/core/src/main/java/com/graphhopper/util/PathSimplification.java
+++ b/core/src/main/java/com/graphhopper/util/PathSimplification.java
@@ -1,14 +1,14 @@
 /*
  *  Licensed to GraphHopper GmbH under one or more contributor
- *  license agreements. See the NOTICE file distributed with this work for
+ *  license agreements. See the NOTICE file distributed with this work for 
  *  additional information regarding copyright ownership.
- *
- *  GraphHopper GmbH licenses this file to you under the Apache License,
- *  Version 2.0 (the "License"); you may not use this file except in
+ * 
+ *  GraphHopper GmbH licenses this file to you under the Apache License, 
+ *  Version 2.0 (the "License"); you may not use this file except in 
  *  compliance with the License. You may obtain a copy of the License at
- *
+ * 
  *       http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/core/src/main/java/com/graphhopper/util/PathSimplification.java
+++ b/core/src/main/java/com/graphhopper/util/PathSimplification.java
@@ -59,7 +59,7 @@ public class PathSimplification {
     }
 
     public PointList simplify() {
-        if (listsToSimplify.isEmpty() || pointList.isEmpty() || pointList.size() <= 2)
+        if (listsToSimplify.isEmpty() || pointList.size() <= 2)
             return pointList;
 
         // The offset of already included points

--- a/core/src/main/java/com/graphhopper/util/PathSimplification.java
+++ b/core/src/main/java/com/graphhopper/util/PathSimplification.java
@@ -1,14 +1,14 @@
 /*
  *  Licensed to GraphHopper GmbH under one or more contributor
- *  license agreements. See the NOTICE file distributed with this work for 
+ *  license agreements. See the NOTICE file distributed with this work for
  *  additional information regarding copyright ownership.
- * 
- *  GraphHopper GmbH licenses this file to you under the Apache License, 
- *  Version 2.0 (the "License"); you may not use this file except in 
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
  *  compliance with the License. You may obtain a copy of the License at
- * 
+ *
  *       http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -49,7 +49,8 @@ public class PathSimplification {
         this.pathDetails = pathWrapper.getPathDetails();
         for (String name : pathDetails.keySet()) {
             List<PathDetail> pathDetailList = pathDetails.get(name);
-            if (pathDetailList.isEmpty())
+            // If the pointList only contains one point, PathDetails have to be empty because 1 point => 0 edges
+            if (pathDetailList.isEmpty() && pointList.size() > 1)
                 throw new IllegalStateException("PathDetails " + name + " must not be empty");
 
             listsToSimplify.add(pathDetailList);
@@ -58,7 +59,7 @@ public class PathSimplification {
     }
 
     public PointList simplify() {
-        if (listsToSimplify.isEmpty() || pointList.isEmpty())
+        if (listsToSimplify.isEmpty() || pointList.isEmpty() || pointList.size() <= 2)
             return pointList;
 
         // The offset of already included points

--- a/reader-osm/src/test/java/com/graphhopper/GraphHopperIT.java
+++ b/reader-osm/src/test/java/com/graphhopper/GraphHopperIT.java
@@ -1,14 +1,14 @@
 /*
  *  Licensed to GraphHopper GmbH under one or more contributor
- *  license agreements. See the NOTICE file distributed with this work for 
+ *  license agreements. See the NOTICE file distributed with this work for
  *  additional information regarding copyright ownership.
- * 
- *  GraphHopper GmbH licenses this file to you under the Apache License, 
- *  Version 2.0 (the "License"); you may not use this file except in 
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
  *  compliance with the License. You may obtain a copy of the License at
- * 
+ *
  *       http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -730,7 +730,7 @@ public class GraphHopperIT {
 
         assertEquals(2, tmpHopper.getCHFactoryDecorator().getPreparations().size());
 
-        GHResponse rsp = tmpHopper.route(new GHRequest(52.513505,13.350443, 52.513505,13.350245)
+        GHResponse rsp = tmpHopper.route(new GHRequest(52.513505, 13.350443, 52.513505, 13.350245)
                 .setVehicle(tmpVehicle).setWeighting(tmpWeightCalcStr));
 
         Instruction instr = rsp.getBest().getInstructions().get(1);
@@ -864,6 +864,26 @@ public class GraphHopperIT {
                         addPoint(new GHPoint(49.9847, 11.499612)).
                         setVehicle("car").setWeighting("fastest").
                         setPathDetails(Arrays.asList(Parameters.DETAILS.AVERAGE_SPEED));
+
+        GHResponse rsp = tmpHopper.route(req);
+
+        assertFalse(rsp.hasErrors());
+    }
+
+    @Test
+    public void testPathDetailsSamePoint() {
+        GraphHopper tmpHopper = new GraphHopperOSM().
+                setOSMFile(DIR + "/north-bayreuth.osm.gz").
+                setCHEnabled(false).
+                setGraphHopperLocation(tmpGraphFile).
+                setEncodingManager(new EncodingManager("car"));
+        tmpHopper.importOrLoad();
+
+        GHRequest req = new GHRequest().
+                addPoint(new GHPoint(49.984352, 11.498802)).
+                addPoint(new GHPoint(49.984352, 11.498802)).
+                setVehicle("car").setWeighting("fastest").
+                setPathDetails(Arrays.asList(Parameters.DETAILS.AVERAGE_SPEED));
 
         GHResponse rsp = tmpHopper.route(req);
 

--- a/reader-osm/src/test/java/com/graphhopper/GraphHopperIT.java
+++ b/reader-osm/src/test/java/com/graphhopper/GraphHopperIT.java
@@ -1,14 +1,14 @@
 /*
  *  Licensed to GraphHopper GmbH under one or more contributor
- *  license agreements. See the NOTICE file distributed with this work for
+ *  license agreements. See the NOTICE file distributed with this work for 
  *  additional information regarding copyright ownership.
- *
- *  GraphHopper GmbH licenses this file to you under the Apache License,
- *  Version 2.0 (the "License"); you may not use this file except in
+ * 
+ *  GraphHopper GmbH licenses this file to you under the Apache License, 
+ *  Version 2.0 (the "License"); you may not use this file except in 
  *  compliance with the License. You may obtain a copy of the License at
- *
+ * 
  *       http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/web/src/test/java/com/graphhopper/http/GraphHopperServletIT.java
+++ b/web/src/test/java/com/graphhopper/http/GraphHopperServletIT.java
@@ -180,6 +180,17 @@ public class GraphHopperServletIT extends BaseServletTester {
     }
 
     @Test
+    public void testPathDetailsSamePoint() throws Exception {
+        GraphHopperAPI hopper = new com.graphhopper.api.GraphHopperWeb();
+        assertTrue(hopper.load(getTestRouteAPIUrl()));
+        GHRequest request = new GHRequest(42.554851, 1.536198, 42.554851, 1.536198);
+        request.setPathDetails(Arrays.asList("average_speed", "edge_id", "time"));
+        GHResponse rsp = hopper.route(request);
+        assertFalse(rsp.getErrors().toString(), rsp.hasErrors());
+        assertTrue(rsp.getErrors().toString(), rsp.getErrors().isEmpty());
+    }
+
+    @Test
     public void testPathDetailsNoConnection() throws Exception {
         GraphHopperAPI hopper = new com.graphhopper.api.GraphHopperWeb();
         assertTrue(hopper.load(getTestRouteAPIUrl()));


### PR DESCRIPTION
If you request a route with two points, with start and end being the same snapped_point, the resulting path has only one point and no edges.

This resulted in an exception:
```
java.lang.IllegalStateException: PathDetails time must not be empty
at com.graphhopper.PathWrapper.addPathDetails(PathWrapper.java:258)
```

This PR proposes a possible solution for this by allowing to set empty PathDetails in the PathWrapper.

Due to this change the resulting PathDetails will be empty:
```
details: {
average_speed: [ ]
},
```