### PR TITLE
Add a force flag to download a file without any user input

### DIFF
--- a/graphhopper.sh
+++ b/graphhopper.sh
@@ -21,6 +21,17 @@ if [ ! -f "config.properties" ]; then
   cp config-example.properties $CONFIG
 fi
 
+FORCE_DWN='false'
+while getopts f flag; do
+    case $flag in
+      f)    FORCE_DWN='true';;
+      ?)   printf "Usage: %s: [-f] args\n" $0
+            exit 2;;
+    esac
+done
+shift $(($OPTIND - 1))
+printf "Remaining arguments are: %s\n" "$*"
+
 ACTION=$1
 FILE=$2
 
@@ -52,9 +63,11 @@ function ensureOsm {
     # skip
     return
   elif [ ! -s "$OSM_FILE" ]; then
-    echo "File not found '$OSM_FILE'. Press ENTER to get it from: $LINK"
-    echo "Press CTRL+C if you do not have enough disc space or you don't want to download several MB."
-    read -e
+    if [ $FORCE_DWN = 'false' ]; then
+      echo "File not found '$OSM_FILE'. Press ENTER to get it from: $LINK"
+      echo "Press CTRL+C if you do not have enough disc space or you don't want to download several MB."
+      read -e
+    fi
       
     echo "## now downloading OSM file from $LINK and extracting to $OSM_FILE"
     

--- a/graphhopper.sh
+++ b/graphhopper.sh
@@ -25,9 +25,9 @@ while [ ! -z $1 ]; do
   case $1 in
     -h|--help) printBashUsage
       exit 0;;
-    -f|--force-download) FORCE_DWN=1; shift 1;;
+    -fd|--force-download) FORCE_DWN=1; shift 1;;
     -a|--action) ACTION=$2; shift 2;;
-    -d|--datareader.file) FILE=$2; shift 2;;
+    -f|--datareader.file) FILE=$2; shift 2;;
 
     -*|--*) echo "Option unknown: $1 \n"
       echo
@@ -45,8 +45,6 @@ if [ -z $ACTION ] || [ -z $FILE ]; then
   ACTION=${REMAINING_ARGS[0]}
   FILE=${REMAINING_ARGS[1]}
 fi
-echo "ACTION: $ACTION"
-echo "FILE: $FILE"
 
 GH_CLASS=com.graphhopper.tools.Import
 GH_HOME=$(dirname "$0")


### PR DESCRIPTION
I have added a -f flag in the graphhopper.sh script to be able to run it correctly in a docker. The goal is to remove any input of the user, especially when trying to download a new file.
We can now run `./graphhopper.sh -f import europe_germany_berlin.pbf` without having:
```bash
File not found 'europe_germany_berlin.pbf'. Press ENTER to get it from: http://download.geofabrik.de/europe/germany/berlin-latest.osm.pbf
Press CTRL+C if you do not have enough disc space or you don't want to download several MB.
```