### PR TITLE
Force min speed value for short ferries

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/AbstractFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/AbstractFlagEncoder.java
@@ -453,10 +453,10 @@ public abstract class AbstractFlagEncoder implements FlagEncoder, TurnCostEncode
         }
         // seconds to hours
         double durationInHours = duration / 60d / 60d;
+        // Check if our graphhopper specific artificially created estimated_distance way tag is present
+        Number estimatedLength = way.getTag("estimated_distance", null);
         if (durationInHours > 0)
             try {
-                // Check if our graphhopper specific artificially created estimated_distance way tag is present
-                Number estimatedLength = way.getTag("estimated_distance", null);
                 if (estimatedLength != null) {
                     double estimatedLengthInKm = estimatedLength.doubleValue() / 1000;
                     // If duration AND distance is available we can calculate the speed more precisely
@@ -487,6 +487,8 @@ public abstract class AbstractFlagEncoder implements FlagEncoder, TurnCostEncode
             }
 
         if (durationInHours == 0) {
+            if(estimatedLength != null && estimatedLength.doubleValue() <= 300)
+                return speedEncoder.factor / 2;
             // unknown speed -> put penalty on ferry transport
             return UNKNOWN_DURATION_FERRY_SPEED;
         } else if (durationInHours > 1) {

--- a/core/src/test/java/com/graphhopper/routing/util/CarFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/CarFlagEncoderTest.java
@@ -447,7 +447,7 @@ public class CarFlagEncoderTest {
         // accept
         assertTrue(encoder.acceptWay(way) > 0);
         // We have ignored the unrealisitc long duration and take the unknown speed
-        assertEquals(5, encoder.getFerrySpeed(way), 1e-1);
+        assertEquals(2.5, encoder.getFerrySpeed(way), 1e-1);
     }
 
     @Test
@@ -618,5 +618,17 @@ public class CarFlagEncoderTest {
         way.setTag("surface", "unpaved");
         assertEquals(30, encoder.applyBadSurfaceSpeed(way, 90), 1e-1);
 
+    }
+
+    @Test
+    public void testIssue_1256() {
+        ReaderWay way = new ReaderWay(1);
+        way.setTag("route", "ferry");
+        way.setTag("estimated_distance", 257);
+
+        CarFlagEncoder lowFactorCar = new CarFlagEncoder(10, 1, 0);
+        lowFactorCar.defineWayBits(0,0);
+        assertEquals(2.5, encoder.getFerrySpeed(way), .1);
+        assertEquals(.5, lowFactorCar.getFerrySpeed(way), .1);
     }
 }


### PR DESCRIPTION
Fixes #1256.

For cars, this feature makes only sense if a speed factor < 5 is used, so I am not sure if it makes sense? See my comment in #1256.