### PR TITLE
Added Extent and OsmKey to Geocoding

### DIFF
--- a/client-hc/src/main/java/com/graphhopper/api/model/GHGeocodingEntry.java
+++ b/client-hc/src/main/java/com/graphhopper/api/model/GHGeocodingEntry.java
@@ -20,6 +20,7 @@ package com.graphhopper.api.model;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.graphhopper.util.shapes.BBox;
 
 /**
  * Contains the results of a geocoding request.
@@ -44,9 +45,12 @@ public class GHGeocodingEntry {
     private String street;
     private String houseNumber;
     private String postcode;
+    private String osmKey;
     private String osmValue;
 
-    public GHGeocodingEntry(Long osmId, String type, double lat, double lng, String name, String osmValue, String country, String city, String state, String street, String houseNumber, String postcode) {
+    private BBox extent;
+
+    public GHGeocodingEntry(Long osmId, String type, double lat, double lng, String name, String osmKey, String osmValue, String country, String city, String state, String street, String houseNumber, String postcode, BBox extent) {
         this.osmId = osmId;
         this.osmType = type;
         this.point = new Point(lat, lng);
@@ -57,7 +61,9 @@ public class GHGeocodingEntry {
         this.street = street;
         this.houseNumber = houseNumber;
         this.postcode = postcode;
+        this.osmKey = osmKey;
         this.osmValue = osmValue;
+        this.extent = extent;
     }
 
     public GHGeocodingEntry() {
@@ -163,6 +169,16 @@ public class GHGeocodingEntry {
         this.postcode = postcode;
     }
 
+    @JsonProperty("osm_key")
+    public String getOsmKey() {
+        return this.osmKey;
+    }
+
+    @JsonProperty("osm_key")
+    public void setOsmKey(String osmKey) {
+        this.osmKey = osmKey;
+    }
+
     @JsonProperty("osm_value")
     public String getOsmValue() {
         return osmValue;
@@ -171,6 +187,32 @@ public class GHGeocodingEntry {
     @JsonProperty("osm_value")
     public void setOsmValue(String osmValue) {
         this.osmValue = osmValue;
+    }
+
+    @JsonProperty
+    public Double[] getExtent() {
+        if (this.extent == null) {
+            // TODO should we return null instead?
+            return new Double[0];
+        }
+        return this.extent.toGeoJson().toArray(new Double[4]);
+    }
+
+    public BBox getExtendBBox(){
+        return this.extent;
+    }
+
+    @JsonProperty
+    public void setExtent(Double[] extent) {
+        if (extent == null || extent.length == 0) {
+            return;
+        }
+        if (extent.length == 4) {
+            // Extend is in Left, Top, Right, Bottom; which is very uncommon, Photon uses the same
+            this.extent = new BBox(extent[0], extent[2], extent[3], extent[1]);
+        } else {
+            throw new RuntimeException("Extent had an unexpected length: " + extent.length);
+        }
     }
 
     public class Point {

--- a/client-hc/src/test/java/com/graphhopper/api/GraphHopperGeocodingIT.java
+++ b/client-hc/src/test/java/com/graphhopper/api/GraphHopperGeocodingIT.java
@@ -1,7 +1,9 @@
 package com.graphhopper.api;
 
+import com.graphhopper.api.model.GHGeocodingEntry;
 import com.graphhopper.api.model.GHGeocodingRequest;
 import com.graphhopper.api.model.GHGeocodingResponse;
+import com.graphhopper.util.shapes.BBox;
 import com.graphhopper.util.shapes.GHPoint;
 import org.junit.Before;
 import org.junit.Test;
@@ -32,6 +34,17 @@ public class GraphHopperGeocodingIT {
     }
 
     @Test
+    public void testExtent() {
+        GHGeocodingResponse response = geocoding.geocode(new GHGeocodingRequest("new york", "en", 7));
+        BBox extent = response.getHits().get(0).getExtendBBox();
+        assertTrue(extent.isValid());
+        assertTrue(extent.minLon < -79);
+        assertTrue(extent.maxLon > -72);
+        assertTrue(extent.minLat < 40.5);
+        assertTrue(extent.maxLat > 45);
+    }
+
+    @Test
     public void testForwardGeocodingNominatim() {
         GHGeocodingResponse response = geocoding.geocode(new GHGeocodingRequest(false, null, "Berlin", "en", 5, "nominatim", 5000));
         assertEquals(5, response.getHits().size());
@@ -42,7 +55,11 @@ public class GraphHopperGeocodingIT {
     public void testReverseGeocoding() {
         GHGeocodingResponse response = geocoding.geocode(new GHGeocodingRequest(52.5170365, 13.3888599, "en", 5));
         assertEquals(5, response.getHits().size());
-        assertTrue(response.getHits().get(0).getName().contains("Berlin"));
+        GHGeocodingEntry entry = response.getHits().get(0);
+        assertTrue(entry.getName().contains("Berlin"));
+        assertEquals("place", entry.getOsmKey());
+        assertEquals(0, entry.getExtent().length);
+
     }
 
     @Test


### PR DESCRIPTION
As mentioned by @devemux86 in #1221 the geocoding of the client-hc misses the osm key. While inspecting the Geocoding result I also saw that the extent was also missing, so I added that as well.

BTW: The extent is not documented in the API and I think the format is a bit weird (similar to Photon though). Should we add documentation about this feature in the API doc?