### PR TITLE
Added ascend, descend, weight, and description to the client-hc

### DIFF
--- a/client-hc/src/main/java/com/graphhopper/api/GraphHopperWeb.java
+++ b/client-hc/src/main/java/com/graphhopper/api/GraphHopperWeb.java
@@ -104,9 +104,9 @@ public class GraphHopperWeb implements GraphHopperAPI {
     }
 
     PathWrapper createPathWrapper(JsonNode path,
-                                          boolean tmpCalcPoints, boolean tmpInstructions,
-                                          boolean tmpElevation, boolean turnDescription,
-                                          boolean tmpCalcDetails) {
+                                  boolean tmpCalcPoints, boolean tmpInstructions,
+                                  boolean tmpElevation, boolean turnDescription,
+                                  boolean tmpCalcDetails) {
         PathWrapper pathWrapper = new PathWrapper();
         pathWrapper.addErrors(readErrors(path));
         if (pathWrapper.hasErrors())
@@ -116,6 +116,28 @@ public class GraphHopperWeb implements GraphHopperAPI {
             String snappedPointStr = path.get("snapped_waypoints").asText();
             PointList snappedPoints = WebHelper.decodePolyline(snappedPointStr, 5, tmpElevation);
             pathWrapper.setWaypoints(snappedPoints);
+        }
+
+        if (path.has("ascend")) {
+            pathWrapper.setAscend(path.get("ascend").asDouble());
+        }
+        if (path.has("descend")) {
+            pathWrapper.setDescend(path.get("descend").asDouble());
+        }
+        if (path.has("weight")) {
+            pathWrapper.setRouteWeight(path.get("weight").asDouble());
+        }
+        if (path.has("description")) {
+            JsonNode descriptionNode = path.get("description");
+            if (descriptionNode.isArray()) {
+                List<String> description = new ArrayList<>(descriptionNode.size());
+                for (JsonNode descNode: descriptionNode) {
+                    description.add(descNode.asText());
+                }
+                pathWrapper.setDescription(description);
+            } else {
+                throw new IllegalStateException("Description has to be an array");
+            }
         }
 
         if (tmpCalcPoints) {
@@ -176,8 +198,8 @@ public class GraphHopperWeb implements GraphHopperAPI {
                         instr = new FinishInstruction(text, instPL, 0);
                     } else {
                         instr = new Instruction(sign, text, ia, instPL);
-                        if(sign == Instruction.CONTINUE_ON_STREET){
-                            if(jsonObj.has("heading")){
+                        if (sign == Instruction.CONTINUE_ON_STREET) {
+                            if (jsonObj.has("heading")) {
                                 instr.setExtraInfo("heading", jsonObj.get("heading").asDouble());
                             }
                         }

--- a/client-hc/src/test/java/com/graphhopper/api/GraphHopperWebIT.java
+++ b/client-hc/src/test/java/com/graphhopper/api/GraphHopperWebIT.java
@@ -52,6 +52,9 @@ public class GraphHopperWebIT {
         PathWrapper alt = res.getBest();
         isBetween(200, 250, alt.getPoints().size());
         isBetween(11000, 12000, alt.getDistance());
+        isBetween(310, 320, alt.getAscend());
+        isBetween(235, 245, alt.getDescend());
+
 
         // change vehicle
         res = gh.route(new GHRequest(49.6724, 11.3494, 49.6550, 11.4180).
@@ -59,6 +62,32 @@ public class GraphHopperWebIT {
         alt = res.getBest();
         assertFalse("errors:" + res.getErrors().toString(), res.hasErrors());
         isBetween(9000, 9500, alt.getDistance());
+    }
+
+    @Test
+    public void testAlternativeRoute() {
+        // https://graphhopper.com/maps/?point=52.044124%2C10.378346&point=52.043847%2C10.381994&algorithm=alternative_route&ch.disable=true
+        GHRequest req = new GHRequest().
+                addPoint(new GHPoint(52.044124,10.378346)).
+                addPoint(new GHPoint(52.043847,10.381994));
+        req.setAlgorithm("alternative_route");
+        req.getHints().put("instructions", true);
+        req.getHints().put("calc_points", true);
+        req.getHints().put("ch.disable", true);
+        GHResponse res = gh.route(req);
+        assertFalse("errors:" + res.getErrors().toString(), res.hasErrors());
+        List<PathWrapper> paths = res.getAll();
+        assertEquals(2, paths.size());
+
+        PathWrapper path = paths.get(0);
+        isBetween(5, 20, path.getPoints().size());
+        isBetween(400, 500, path.getDistance());
+        assertEquals("Wiesenstraße", path.getDescription().get(0));
+
+        path = paths.get(1);
+        isBetween(3, 15, path.getPoints().size());
+        isBetween(350, 450, path.getDistance());
+        assertEquals("Schlopweg", path.getDescription().get(0));
     }
 
     @Test

--- a/client-hc/src/test/java/com/graphhopper/api/GraphHopperWebIT.java
+++ b/client-hc/src/test/java/com/graphhopper/api/GraphHopperWebIT.java
@@ -54,6 +54,7 @@ public class GraphHopperWebIT {
         isBetween(11000, 12000, alt.getDistance());
         isBetween(310, 320, alt.getAscend());
         isBetween(235, 245, alt.getDescend());
+        isBetween(1000, 1500, alt.getRouteWeight());
 
 
         // change vehicle


### PR DESCRIPTION
Fixes #1233.

I added ascend, descend, weight, and description to the client-hc.

Because description only appears for alternative_route, I had to write a test for alternative_route as well, with ch.disabled. Not sure if we want this? I tried to create a very short route < 1km.