### PR TITLE
Improve release management

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,9 +42,10 @@ after_success:
   # deploy snapshot artifacts to sonatype and if tagged deploy the release to maven central
   - if [ "$TRAVIS_JDK_VERSION" == "oraclejdk8" ] &&
        [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
-        mvn deploy --settings core/files/settings.xml -DskipTests=true -B;
+        travis_wait mvn deploy --settings core/files/settings.xml -DskipTests=true -B;
     elif [ "$TRAVIS_JDK_VERSION" == "oraclejdk8" ]; then
-        mvn -P release --settings core/files/settings.xml -DskipTests=true -Drevision=0.10.alpha$TRAVIS_BUILD_NUMBER -B deploy;
+        echo "release to maven central";
+        travis_wait mvn -P release --settings core/files/settings.xml -DskipTests=true -Drevision=0.10.alpha$TRAVIS_BUILD_NUMBER -B deploy;
     else
         echo "Not deploying artifacts for $TRAVIS_BRANCH";
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 
 env:
   global:
-    - GH_VERSION=0.9.$TRAVIS_BUILD_NUMBER
     - GPG_EXECUTABLE=gpg
     # TODO move this into the travis settings
     - secure: "j6a61/qnfFcSjx5XxmxO2hqBOwtVx5HWrD1+4Atl7WG/pRKz9+jSga1Y7oDAFb2SIl8S65kDmPQB/vC8aHxUDj/Wizjxnxn1FhPqoe9yO6Ztft+984FKFyvj7s6tsBJKcehGec+chTOwZQpH4oI4rU6IlepDHnGLHiOd0Iviryg="

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ after_success:
   - if [ "$TRAVIS_JDK_VERSION" == "oraclejdk8" ] &&
        [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
         mvn deploy --settings core/files/settings.xml -DskipTests=true -B;
-    elif [ "$TRAVIS_JDK_VERSION" == "oraclejdk8" ] && [ "$TRAVIS_TAG" != "" ] ; then
+    elif [ "$TRAVIS_JDK_VERSION" == "oraclejdk8" ]; then
         mvn -P release --settings core/files/settings.xml -DskipTests=true -Drevision=$TRAVIS_TAG -B deploy;
     else
         echo "Not deploying artifacts for $TRAVIS_BRANCH";

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,12 +39,11 @@ script:
 
 after_success:
   # deploy snapshot artifacts to sonatype and if tagged deploy the release to maven central
-  - if [ "$TRAVIS_JDK_VERSION" == "openjdk8" ] &&
-       [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+  - if [ "$TRAVIS_JDK_VERSION" == "openjdk8" ] && [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
         travis_wait mvn deploy --settings core/files/settings.xml -DskipTests=true -B;
-    elif [ "$TRAVIS_JDK_VERSION" == "openjdk8" ]; then
+    elif [ "$TRAVIS_JDK_VERSION" == "openjdk8" ] && [ "$TRAVIS_TAG" != "" ]; then
         echo "release to maven central";
-        mvn -P release --settings core/files/settings.xml -DskipTests=true -Drevision=0.10.alpha$TRAVIS_BUILD_NUMBER -B deploy;
+        mvn -P release --settings core/files/settings.xml -DskipTests=true -Drevision=$TRAVIS_TAG -B deploy;
     else
         echo "Not deploying artifacts for $TRAVIS_BRANCH";
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,8 @@ jdk:
 install: true
 
 # store them into travis via https://dracoblue.net/dev/uploading-snapshots-and-releases-to-maven-central-with-travis/
-# gpg -a --export-secret-keys your@email.org | base64 | tr -d '\n'
-# gpg --export-ownertrust | base64 | tr -d '\n'
+# gpg -a --export-secret-keys your@email.org | base64 -w 0
+# gpg --export-ownertrust | base64 -w 0
 before_install:
   - if [ ! -z "$GPG_SECRET_KEYS" ]; then echo $GPG_SECRET_KEYS | base64 --decode | $GPG_EXECUTABLE --import; fi
   - if [ ! -z "$GPG_OWNERTRUST" ]; then echo $GPG_OWNERTRUST | base64 --decode | $GPG_EXECUTABLE --import-ownertrust; fi
@@ -42,10 +42,9 @@ after_success:
   # deploy snapshot artifacts to sonatype and if tagged deploy the release to maven central
   - if [ "$TRAVIS_JDK_VERSION" == "oraclejdk8" ] &&
        [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
-        travis_wait mvn deploy --settings core/files/settings.xml -DskipTests=true -B;
-    elif [ "$TRAVIS_JDK_VERSION" == "oraclejdk8" ]; then
-        echo "Release of $GH_VERSION"
-        travis_wait mvn -P release --settings core/files/settings.xml -DskipTests=true -Drevision=$GH_VERSION -B deploy;
+        mvn deploy --settings core/files/settings.xml -DskipTests=true -B;
+    elif [ "$TRAVIS_JDK_VERSION" == "oraclejdk8" ] && [ "$TRAVIS_TAG" != "" ] ; then
+        mvn -P release --settings core/files/settings.xml -DskipTests=true -Drevision=$TRAVIS_TAG -B deploy;
     else
         echo "Not deploying artifacts for $TRAVIS_BRANCH";
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ cache:
 
 deploy:
   provider: script
-  script: "mvn --settings core/files/settings.xml -DskipTests=true -Drevision=$GH_VERSION -B deploy"
+  script: "mvn -P release --settings core/files/settings.xml -DskipTests=true -Drevision=$GH_VERSION -B deploy"
   skip_cleanup: true
   on:
     all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ group: edge
 
 jdk:
   - oraclejdk8
-  - openjdk9
+  - oraclejdk9
   - openjdk8
 
 # matrix:
@@ -42,11 +42,12 @@ after_success:
   # deploy snapshot artifacts to sonatype and if tagged deploy the release to maven central
   - if [ "$TRAVIS_JDK_VERSION" == "oraclejdk8" ] &&
        [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
-         travis_wait mvn deploy --settings core/files/settings.xml -DskipTests=true -B;
+        travis_wait mvn deploy --settings core/files/settings.xml -DskipTests=true -B;
     elif [ "$TRAVIS_JDK_VERSION" == "oraclejdk8" ]; then
-         travis_wait mvn -P release --settings core/files/settings.xml -DskipTests=true -Drevision=$GH_VERSION -B deploy
+        echo "Release of $GH_VERSION"
+        travis_wait mvn -P release --settings core/files/settings.xml -DskipTests=true -Drevision=$GH_VERSION -B deploy;
     else
-        echo "Not deploying snapshot artifact for $TRAVIS_BRANCH";
+        echo "Not deploying artifacts for $TRAVIS_BRANCH";
     fi
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ group: edge
 
 jdk:
   - oraclejdk8
-  - oraclejdk9
   - openjdk9
   - openjdk8
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ after_success:
        [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
         mvn deploy --settings core/files/settings.xml -DskipTests=true -B;
     elif [ "$TRAVIS_JDK_VERSION" == "oraclejdk8" ]; then
-        mvn -P release --settings core/files/settings.xml -DskipTests=true -Drevision=$TRAVIS_TAG -B deploy;
+        mvn -P release --settings core/files/settings.xml -DskipTests=true -Drevision=0.10.alpha$TRAVIS_BUILD_NUMBER -B deploy;
     else
         echo "Not deploying artifacts for $TRAVIS_BRANCH";
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ script:
 after_success:
   # deploy snapshot artifacts to sonatype and if tagged deploy the release to maven central
   - if [ "$TRAVIS_JDK_VERSION" == "openjdk8" ] && [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
-        travis_wait mvn deploy --settings core/files/settings.xml -DskipTests=true -B;
+        mvn deploy --settings core/files/settings.xml -DskipTests=true -B;
     elif [ "$TRAVIS_JDK_VERSION" == "openjdk8" ] && [ "$TRAVIS_TAG" != "" ]; then
         echo "release to maven central";
         mvn -P release --settings core/files/settings.xml -DskipTests=true -Drevision=$TRAVIS_TAG -B deploy;

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,10 @@ install: true
 before_install:
   - if [ ! -z "$GPG_SECRET_KEYS" ]; then echo $GPG_SECRET_KEYS | base64 --decode | $GPG_EXECUTABLE --import; fi
   - if [ ! -z "$GPG_OWNERTRUST" ]; then echo $GPG_OWNERTRUST | base64 --decode | $GPG_EXECUTABLE --import-ownertrust; fi
+  
+# avoid increase of memory via travis https://github.com/travis-ci/travis-ci/issues/8408
+before_script:
+  - _JAVA_OPTIONS=
 
 script:
   - mvn clean test verify checkstyle:check findbugs:check forbiddenapis:check -B

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ after_success:
   - if [ "$TRAVIS_JDK_VERSION" == "oraclejdk8" ] &&
        [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
          travis_wait mvn deploy --settings core/files/settings.xml -DskipTests=true -B;
-    elif [ "$TRAVIS_JDK_VERSION" == "oraclejdk8" ]
+    elif [ "$TRAVIS_JDK_VERSION" == "oraclejdk8" ]; then
          travis_wait mvn -P release --settings core/files/settings.xml -DskipTests=true -Drevision=$GH_VERSION -B deploy
     else
         echo "Not deploying snapshot artifact for $TRAVIS_BRANCH";

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,9 @@ jdk:
 # avoid default dependency command for maven, 'true' means 'return true' and continue
 install: true
 
+# store them into travis via https://dracoblue.net/dev/uploading-snapshots-and-releases-to-maven-central-with-travis/
+# gpg -a --export-secret-keys your@email.org | base64 | tr -d '\n'
+# gpg --export-ownertrust | base64 | tr -d '\n'
 before_install:
   - if [ ! -z "$GPG_SECRET_KEYS" ]; then echo $GPG_SECRET_KEYS | base64 --decode | $GPG_EXECUTABLE --import; fi
   - if [ ! -z "$GPG_OWNERTRUST" ]; then echo $GPG_OWNERTRUST | base64 --decode | $GPG_EXECUTABLE --import-ownertrust; fi
@@ -58,5 +61,6 @@ deploy:
   script: "mvn --settings core/files/settings.xml -DskipTests=true -Drevision=$GH_VERSION -B deploy"
   skip_cleanup: true
   on:
+    all_branches: true
     # branch: master
     # tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ after_success:
         travis_wait mvn deploy --settings core/files/settings.xml -DskipTests=true -B;
     elif [ "$TRAVIS_JDK_VERSION" == "openjdk8" ]; then
         echo "release to maven central";
-        travis_wait mvn -P release --settings core/files/settings.xml -DskipTests=true -Drevision=0.10.alpha$TRAVIS_BUILD_NUMBER -B deploy;
+        mvn -P release --settings core/files/settings.xml -DskipTests=true -Drevision=0.10.alpha$TRAVIS_BUILD_NUMBER -B deploy;
     else
         echo "Not deploying artifacts for $TRAVIS_BRANCH";
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,49 +1,33 @@
 language: java
 sudo: false
-matrix:
-  fast_finish: true
-  include:
-    - jdk: oraclejdk8
-      # Java 9 needs to be manually installed/upgraded
-      # see: https://github.com/travis-ci/travis-ci/issues/2968#issuecomment-149164058      
-    - jdk: oraclejdk9
-      env: JVM=latest
-      sudo: required
-      dist: trusty
-      group: edge
 
 env:
   global:
-    - BASEURL=https://www-eu.apache.org/dist/maven/maven-3/VERSION/binaries/apache-maven-VERSION-bin.zip
-    - FILE=apache-maven-VERSION-bin.zip
-    - DIR=apache-maven-VERSION
-    - VERSION=3.3.9
+    - GH_VERSION=0.9.$TRAVIS_BUILD_NUMBER
+    - GPG_EXECUTABLE=gpg
+    # TODO move this into the travis settings
     - secure: "j6a61/qnfFcSjx5XxmxO2hqBOwtVx5HWrD1+4Atl7WG/pRKz9+jSga1Y7oDAFb2SIl8S65kDmPQB/vC8aHxUDj/Wizjxnxn1FhPqoe9yO6Ztft+984FKFyvj7s6tsBJKcehGec+chTOwZQpH4oI4rU6IlepDHnGLHiOd0Iviryg="
     - secure: "GiFr+v2lTQk/sTQB7CYjju1/mupS8LSJupmizLqY454utiZkabDMBOZQnF9ukpy7WhveB9hKQyEKf9iP2w7HSYEjgvogT26vZ5f2MeLnR4SWvqEtf/WBvvh+W+k/rb2f6YgitkB4Jlxn2izemBEDuKplGJphzGW41lf8XZ2IxVI="
 
+dist: trusty
+group: edge
+
 jdk:
   - oraclejdk8
+  - oraclejdk9
+  - openjdk9
+  - openjdk8
+
+# matrix:
+#   allow_failures:
+#    - jdk: oraclejdk9
+    
+# avoid default dependency command for maven, 'true' means 'return true' and continue
+install: true
 
 before_install:
-   # update maven
-   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then
-         wget --no-check-certificate $(echo -n $BASEURL | sed -e 's#VERSION#'$VERSION'#g');
-         unzip -qq $(echo -n $FILE | sed -e 's#VERSION#'$VERSION'#');
-         export M2_HOME=$PWD/$(echo -n $DIR | sed -e 's#VERSION#'$VERSION'#');
-         export PATH=$M2_HOME/bin:$PATH;
-     fi
-   # update java 9
-   - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ "$JVM" == "latest" ]; then
-         sudo apt-get update -qq;
-         sudo /bin/echo -e oracle-java9-installer shared/accepted-oracle-license-v1-1 select true | sudo debconf-set-selections;
-         sudo apt-get -o Dpkg::Options::="--force-confnew" install -y oracle-java9-installer oracle-java9-set-default oracle-java9-unlimited-jce-policy;
-         sudo update-java-alternatives -s java-9-oracle;
-     fi
-#   - if [ "$TRAVIS_JDK_VERSION" == oraclejdk9 ]; then
-#         sudo rm /etc/mavenrc;
-#     fi
-
-install: true
+  - if [ ! -z "$GPG_SECRET_KEYS" ]; then echo $GPG_SECRET_KEYS | base64 --decode | $GPG_EXECUTABLE --import; fi
+  - if [ ! -z "$GPG_OWNERTRUST" ]; then echo $GPG_OWNERTRUST | base64 --decode | $GPG_EXECUTABLE --import-ownertrust; fi
 
 script:
   - mvn clean test verify checkstyle:check findbugs:check forbiddenapis:check -B
@@ -65,3 +49,10 @@ cache:
   directories:
   - $HOME/.m2
 
+deploy:
+  provider: script
+  script: "mvn --settings core/files/settings.xml -DskipTests=true -Drevision=$GH_VERSION -B deploy"
+  skip_cleanup: true
+  on:
+    # branch: master
+    # tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,10 +39,12 @@ script:
   - mvn clean test verify checkstyle:check findbugs:check forbiddenapis:check -B
 
 after_success:
-  # deploy snapshot artifacts to maven central
+  # deploy snapshot artifacts to sonatype and if tagged deploy the release to maven central
   - if [ "$TRAVIS_JDK_VERSION" == "oraclejdk8" ] &&
        [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
          travis_wait mvn deploy --settings core/files/settings.xml -DskipTests=true -B;
+    elif [ "$TRAVIS_JDK_VERSION" == "oraclejdk8" ]
+         travis_wait mvn -P release --settings core/files/settings.xml -DskipTests=true -Drevision=$GH_VERSION -B deploy
     else
         echo "Not deploying snapshot artifact for $TRAVIS_BRANCH";
     fi
@@ -54,12 +56,3 @@ notifications:
 cache:
   directories:
   - $HOME/.m2
-
-deploy:
-  provider: script
-  script: "mvn -P release --settings core/files/settings.xml -DskipTests=true -Drevision=$GH_VERSION -B deploy"
-  skip_cleanup: true
-  on:
-    all_branches: true
-    # branch: master
-    # tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,10 +40,10 @@ script:
 
 after_success:
   # deploy snapshot artifacts to sonatype and if tagged deploy the release to maven central
-  - if [ "$TRAVIS_JDK_VERSION" == "oraclejdk8" ] &&
+  - if [ "$TRAVIS_JDK_VERSION" == "openjdk8" ] &&
        [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
         travis_wait mvn deploy --settings core/files/settings.xml -DskipTests=true -B;
-    elif [ "$TRAVIS_JDK_VERSION" == "oraclejdk8" ]; then
+    elif [ "$TRAVIS_JDK_VERSION" == "openjdk8" ]; then
         echo "release to maven central";
         travis_wait mvn -P release --settings core/files/settings.xml -DskipTests=true -Drevision=0.10.alpha$TRAVIS_BUILD_NUMBER -B deploy;
     else

--- a/android/app/pom.xml
+++ b/android/app/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.graphhopper</groupId>
     <artifactId>graphhopper-android</artifactId>
-    <version>0.10-SNAPSHOT</version>
+    <version>${revision}</version>
     <name>GraphHopper Android</name>
     <packaging>apk</packaging>    
     <organization>
@@ -16,7 +16,7 @@
         <relativePath>../..</relativePath>
         <groupId>com.graphhopper</groupId>
         <artifactId>graphhopper-parent</artifactId>    	
-        <version>0.10-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <properties>
         <vtm.version>0.9.2</vtm.version>

--- a/client-hc/pom.xml
+++ b/client-hc/pom.xml
@@ -23,14 +23,14 @@
 
     <groupId>com.graphhopper</groupId>
     <artifactId>directions-api-client-hc</artifactId>
-    <version>0.10-SNAPSHOT</version>
+    <version>${revision}</version>
     <packaging>jar</packaging>
     <name>GraphHopper Directions API hand-crafted Java Client.</name>
      
     <parent>
         <groupId>com.graphhopper</groupId>
         <artifactId>graphhopper-parent</artifactId>
-        <version>0.10-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>  
     
     <properties>

--- a/client-hc/src/test/java/com/graphhopper/api/GraphHopperMatrixGoogleIT.java
+++ b/client-hc/src/test/java/com/graphhopper/api/GraphHopperMatrixGoogleIT.java
@@ -10,12 +10,14 @@ import static org.junit.Assert.assertEquals;
  */
 public class GraphHopperMatrixGoogleIT {
 
+    private static String GOOGK = "AIzaSyD82yk4uSmNcruqtue1lFTyuWAtEiLiJbs";
     protected GraphHopperMatrixWeb ghMatrix;
 
     @Before
     public void setUp() {
-        // skip setKey as it is the graphhopper key
         ghMatrix = createMatrixWeb();
+        String key = System.getProperty("google.key", GOOGK);
+        ghMatrix.setKey(key);
     }
 
     GraphHopperMatrixWeb createMatrixWeb() {

--- a/core/files/settings.xml
+++ b/core/files/settings.xml
@@ -7,4 +7,16 @@
       <password>${env.CI_DEPLOY_PASSWORD}</password>
     </server>
   </servers>
+  <profiles>
+      <profile>
+        <id>ossrh</id>
+        <activation>
+          <activeByDefault>true</activeByDefault>
+        </activation>
+        <properties>
+          <gpg.executable>${env.GPG_EXECUTABLE}</gpg.executable>
+          <gpg.passphrase>${env.GPG_PASSPHRASE}</gpg.passphrase>
+        </properties>
+      </profile>
+    </profiles>
 </settings>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.graphhopper</groupId>
     <artifactId>graphhopper-core</artifactId>
     <name>GraphHopper Core</name>
-    <version>0.10-SNAPSHOT</version>
+    <version>${revision}</version>
     <packaging>jar</packaging>
     <description>
         GraphHopper is a fast and memory efficient Java road routing engine
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.graphhopper</groupId>
         <artifactId>graphhopper-parent</artifactId>
-        <version>0.10-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,9 @@
         <module>reader-json</module>
         <module>tools</module>
         <module>web</module>
+        <!--
         <module>client-hc</module>
+        -->
     </modules>
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -270,6 +270,9 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <version>2.10.4</version>
+                        <configuration>
+                          <quiet>true</quiet>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.graphhopper</groupId>
     <artifactId>graphhopper-parent</artifactId>
     <name>GraphHopper Parent Project</name>
-    <version>0.10-SNAPSHOT</version>
+    <version>${revision}</version>
     <packaging>pom</packaging>
     <url>https://www.graphhopper.com</url>
     <inceptionYear>2012</inceptionYear>
@@ -20,6 +20,7 @@
         <commons-compress.version>1.12</commons-compress.version>
         <jackson.version>2.8.4</jackson.version>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <revision>0.10-SNAPSHOT</revision>
 
         <org-netbeans-modules-editor-indent.CodeStyle.project.indent-shift-width>4</org-netbeans-modules-editor-indent.CodeStyle.project.indent-shift-width>
         <org-netbeans-modules-editor-indent.CodeStyle.project.spaces-per-tab>4</org-netbeans-modules-editor-indent.CodeStyle.project.spaces-per-tab>

--- a/pom.xml
+++ b/pom.xml
@@ -82,9 +82,7 @@
         <module>reader-json</module>
         <module>tools</module>
         <module>web</module>
-        <!--
         <module>client-hc</module>
-        -->
     </modules>
     <build>
         <plugins>

--- a/reader-gtfs/pom.xml
+++ b/reader-gtfs/pom.xml
@@ -5,14 +5,14 @@
 
     <groupId>com.graphhopper</groupId>
     <artifactId>graphhopper-reader-gtfs</artifactId>
-    <version>0.10-SNAPSHOT</version>
+    <version>${revision}</version>
     <packaging>jar</packaging>
     <name>GraphHopper Reader for Gtfs Data</name>
 
     <parent>
         <groupId>com.graphhopper</groupId>
         <artifactId>graphhopper-parent</artifactId>    	
-        <version>0.10-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <dependencies>

--- a/reader-json/pom.xml
+++ b/reader-json/pom.xml
@@ -5,14 +5,14 @@
 
     <groupId>com.graphhopper</groupId>
     <artifactId>graphhopper-reader-json</artifactId>
-    <version>0.10-SNAPSHOT</version>
+    <version>${revision}</version>
     <packaging>jar</packaging>
     <name>GraphHopper Reader JSON</name>
 
     <parent>
         <groupId>com.graphhopper</groupId>
         <artifactId>graphhopper-parent</artifactId>    	
-        <version>0.10-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <dependencies>

--- a/reader-osm/pom.xml
+++ b/reader-osm/pom.xml
@@ -5,14 +5,14 @@
 
     <groupId>com.graphhopper</groupId>
     <artifactId>graphhopper-reader-osm</artifactId>
-    <version>0.10-SNAPSHOT</version>
+    <version>${revision}</version>
     <packaging>jar</packaging>
     <name>GraphHopper Reader for OpenStreetMap Data</name>
 
     <parent>
         <groupId>com.graphhopper</groupId>
         <artifactId>graphhopper-parent</artifactId>    	
-        <version>0.10-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <dependencies>

--- a/reader-shp/pom.xml
+++ b/reader-shp/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.graphhopper</groupId>
     <artifactId>graphhopper-reader-shp</artifactId>
-    <version>0.10-SNAPSHOT</version>
+    <version>${revision}</version>
     <packaging>jar</packaging>
     <name>GraphHopper Reader for Shapefile Data</name>
 	
@@ -16,7 +16,7 @@
     <parent>
         <groupId>com.graphhopper</groupId>
         <artifactId>graphhopper-parent</artifactId>    	
-        <version>0.10-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <dependencies>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -5,14 +5,14 @@
 
     <groupId>com.graphhopper</groupId>
     <artifactId>graphhopper-tools</artifactId>
-    <version>0.10-SNAPSHOT</version>
+    <version>${revision}</version>
     <packaging>jar</packaging>
     <name>GraphHopper Tools</name>
 
     <parent>
         <groupId>com.graphhopper</groupId>
         <artifactId>graphhopper-parent</artifactId>    	
-        <version>0.10-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <dependencies>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -6,14 +6,14 @@
     <groupId>com.graphhopper</groupId>
     <artifactId>graphhopper-web</artifactId>
     <packaging>jar</packaging>
-    <version>0.10-SNAPSHOT</version>
+    <version>${revision}</version>
     <name>GraphHopper Web</name>
     <description>Use the GraphHopper routing engine as a web-service</description>
 
     <parent>
         <groupId>com.graphhopper</groupId>
         <artifactId>graphhopper-parent</artifactId>
-        <version>0.10-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <properties>
         <jetty.version>9.4.2.v20170220</jetty.version>
@@ -96,7 +96,7 @@
         <dependency>
             <groupId>com.graphhopper</groupId>
             <artifactId>directions-api-client-hc</artifactId>
-            <version>0.10-SNAPSHOT</version>
+            <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
This PR automatically creates maven releases if a commit is tagged and fixes #1285 :) ! A first test was already *automatically* released as 0.10.alphaX on maven central.

It also changes a bit our travis handling uses the default way to support jdk9 and removes our old stuff.

Tasks:

 - [x] deploy Android demo too. I'm unsure if we can mix android and java on travis. Not sure if this is a blocker
 - [x] use `-Drevision=$TRAVIS_TAG`