### PR TITLE
(WIP) Isochrone documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -62,7 +62,9 @@ Various topics are explained in more detail separately:
  * [Create new FlagEncoder](./core/create-new-flagencoder.md): Documentation to create new routing profiles to influence which ways to favor and how the track-time is calculated.
  * [Spatial Rules](./core/spatial-rules.md): Instruction on how to use and create new SpatialRules. SpatialRules are used to enforce country-specific routing rules.
  * [Turn Restrictions](./core/turn-restrictions.md): Details on how to enable and use turn restrictions.
+ * [Isochrone generation in Java](../isochrone/java.md): Instruction on how to create isochrones using the low-level Java API.
  * [Postgis query script](../core/files/postgis)
+
 
 #### Other links
 

--- a/docs/isochrone/java.md
+++ b/docs/isochrone/java.md
@@ -7,19 +7,6 @@ To create an isochrone in Java code:
 
 You'll first need to build off an existing Graphhopper instance for [routing](/../core/routing.md).
 
-```java
-// create one GraphHopper instance
-GraphHopper hopper = new GraphHopperOSM().forServer();
-hopper.setDataReaderFile(osmFile);
-// where to store graphhopper files?
-hopper.setGraphHopperLocation(graphFolder);
-hopper.setEncodingManager(new EncodingManager("car"));
-
-// now this can take minutes if it imports or a few seconds for loading
-// of course this is dependent on the area you import
-hopper.importOrLoad();
-```
-
 Next, compute the isochrone itself.
 ```java
 

--- a/docs/isochrone/java.md
+++ b/docs/isochrone/java.md
@@ -20,115 +20,29 @@ hopper.setEncodingManager(new EncodingManager("car"));
 hopper.importOrLoad();
 ```
 
-Next, you'll need to set a range of variable options for isochrone generation.
-```java
-String vehicle = "car";
-int buckets = 1L;
-boolean reverseFlow = false;
-String queryStr = "point";
-String resultStr = "polygon";
-double distanceInMeter = 10000;
-long timeLimitInSeconds = 600L;
-// bigger raster distance => bigger raster => less points => stranger buffer results, but faster
-double rasterDistance = 0.75;
-// bigger buffer distance => less holes, lower means less points!
-double bufferDistance = 0.003;
-// precision of the 'circles'
-int quadrantSegments = 3;
-
-```
-
 Next, compute the isochrone itself.
 ```java
-// parse the query point and get an encoder
 
-GHPoint query = GHPoint.parse(queryStr);
-
+// get encoder from GraphHopper instance
 EncodingManager encodingManager = hopper.getEncodingManager();
-if (!encodingManager.supports(vehicle)) {
-    throw new IllegalArgumentException("vehicle not supported:" + vehicle);
-}
+FlagEncoder encoder = encodingManager.getEncoder("car");
 
-FlagEncoder encoder = encodingManager.getEncoder(vehicle);
-EdgeFilter edgeFilter = new DefaultEdgeFilter(encoder);
-
-// pick the closest point on the graph to the query point
-QueryResult qr = hopper.getLocationIndex().findClosest(query.lat, query.lon, edgeFilter);
-if (!qr.isValid()) {
-    throw new IllegalArgumentException("Point not found:" + query);
-}
+// pick the closest point on the graph to the query point and generate a query graph
+QueryResult qr = hopper.getLocationIndex().findClosest(lat, lon, DefaultEdgeFilter.allEdges(encoder));
 
 Graph graph = hopper.getGraphHopperStorage();
 QueryGraph queryGraph = new QueryGraph(graph);
 queryGraph.lookup(Collections.singletonList(qr));
 
-HintsMap hintsMap = new HintsMap();
-initHints(hintsMap, hReq.getParameterMap());
-Weighting weighting = hopper.createWeighting(hintsMap, encoder, graph);
-Isochrone isochrone = new Isochrone(queryGraph, weighting, reverseFlow);
-if (distanceInMeter > 0) {
-    double maxMeter = 50 * 1000;
-    if (distanceInMeter > maxMeter)
-        throw new IllegalArgumentException("Specify a limit of less than " + maxMeter / 1000f + "km");
-    if (buckets > (distanceInMeter / 500))
-        throw new IllegalArgumentException("Specify buckets less than the number of explored kilometers");
-    isochrone.setDistanceLimit(distanceInMeter);
-} else {
-    long maxSeconds = 80 * 60;
-    if (timeLimitInSeconds > maxSeconds)
-        throw new IllegalArgumentException("Specify a limit of less than " + maxSeconds + " seconds");
-    if (buckets > (timeLimitInSeconds / 60))
-        throw new IllegalArgumentException("Specify buckets less than the number of explored minutes");
+// calculate isochrone from query graph
+PMap pMap = new PMap();
+Isochrone isochrone = new Isochrone(queryGraph, new FastestWeighting(carEncoder, pmap), false);
+isochrone.setTimeLimit(60);
 
-    isochrone.setTimeLimit(timeLimitInSeconds);
-}
-
-List<List<Double[]>> list = isochrone.searchGPS(qr.getClosestNode(), buckets);
-if (isochrone.getVisitedNodes() > hopper.getMaxVisitedNodes() / 5) {
-    throw new IllegalArgumentException("Reset: too many junction nodes would have to explored (" + isochrone.getVisitedNodes() + "). You may need to increase this value.");
-}
-
-int counter = 0;
-for (List<Double[]> tmp : list) {
-    if (tmp.size() < 2) {
-        throw new IllegalArgumentException("Too few points found for bucket " + counter + ". "
-                + "Please try a different point, a smaller buckets count, or a larger time limit.. ");
-    }
-    counter++;
-}
+List<List<Double[]>> res = isochrone.searchGPS(qr.getClosestNode(), 1L);
 ```
 
-Finally, convert the isochrone into a result, for easy return. You can either return a point list or a polygon.
-```java
-Object calcRes;
+The returned list will represent a point list. It can also be converted into a polygon.
 
-// get result as a point list
-if ("pointlist".equalsIgnoreCase(resultStr)) {
-    calcRes = list;
-
-// or get result as a polygon
-} else if ("polygon".equalsIgnoreCase(resultStr)) {
-    list = rasterHullBuilder.calcList(list, list.size() - 1, rasterDistance, bufferDistance, quadrantSegments);
-
-    ArrayList polyList = new ArrayList();
-    int index = 0;
-    for (List<Double[]> polygon : list) {
-        HashMap<String, Object> geoJsonMap = new HashMap<>();
-        HashMap<String, Object> propMap = new HashMap<>();
-        HashMap<String, Object> geometryMap = new HashMap<>();
-        polyList.add(geoJsonMap);
-        geoJsonMap.put("type", "Feature");
-        geoJsonMap.put("properties", propMap);
-        geoJsonMap.put("geometry", geometryMap);
-
-        propMap.put("bucket", index);
-        geometryMap.put("type", "Polygon");
-        // we have no holes => embed in yet another list
-        geometryMap.put("coordinates", Collections.singletonList(polygon));
-        index++;
-    }
-    calcRes = polyList;
-} else {
-    throw new IllegalArgumentException("type not supported:" + resultStr);
-}
-```
+See [GraphHopper's servlet](https://github.com/graphhopper/graphhopper/blob/master/web-bundle/src/main/java/com/graphhopper/resources/IsochroneResource.java)
+for more comprehensive construction of an isochrone.

--- a/docs/isochrone/java.md
+++ b/docs/isochrone/java.md
@@ -1,0 +1,134 @@
+# Isochrone via Java API
+
+To use the following examples you need to specify the dependency in
+your [Maven config](/README.md#maven) correctly.
+
+To create an isochrone in Java code:
+
+You'll first need to build off an existing Graphhopper instance for [routing](/../core/routing.md).
+
+```java
+// create one GraphHopper instance
+GraphHopper hopper = new GraphHopperOSM().forServer();
+hopper.setDataReaderFile(osmFile);
+// where to store graphhopper files?
+hopper.setGraphHopperLocation(graphFolder);
+hopper.setEncodingManager(new EncodingManager("car"));
+
+// now this can take minutes if it imports or a few seconds for loading
+// of course this is dependent on the area you import
+hopper.importOrLoad();
+```
+
+Next, you'll need to set a range of variable options for isochrone generation.
+```java
+String vehicle = "car";
+int buckets = 1L;
+boolean reverseFlow = false;
+String queryStr = "point";
+String resultStr = "polygon";
+double distanceInMeter = 10000;
+long timeLimitInSeconds = 600L;
+// bigger raster distance => bigger raster => less points => stranger buffer results, but faster
+double rasterDistance = 0.75;
+// bigger buffer distance => less holes, lower means less points!
+double bufferDistance = 0.003;
+// precision of the 'circles'
+int quadrantSegments = 3;
+
+```
+
+Next, compute the isochrone itself.
+```java
+// parse the query point and get an encoder
+
+GHPoint query = GHPoint.parse(queryStr);
+
+EncodingManager encodingManager = hopper.getEncodingManager();
+if (!encodingManager.supports(vehicle)) {
+    throw new IllegalArgumentException("vehicle not supported:" + vehicle);
+}
+
+FlagEncoder encoder = encodingManager.getEncoder(vehicle);
+EdgeFilter edgeFilter = new DefaultEdgeFilter(encoder);
+
+// pick the closest point on the graph to the query point
+QueryResult qr = hopper.getLocationIndex().findClosest(query.lat, query.lon, edgeFilter);
+if (!qr.isValid()) {
+    throw new IllegalArgumentException("Point not found:" + query);
+}
+
+Graph graph = hopper.getGraphHopperStorage();
+QueryGraph queryGraph = new QueryGraph(graph);
+queryGraph.lookup(Collections.singletonList(qr));
+
+HintsMap hintsMap = new HintsMap();
+initHints(hintsMap, hReq.getParameterMap());
+Weighting weighting = hopper.createWeighting(hintsMap, encoder, graph);
+Isochrone isochrone = new Isochrone(queryGraph, weighting, reverseFlow);
+if (distanceInMeter > 0) {
+    double maxMeter = 50 * 1000;
+    if (distanceInMeter > maxMeter)
+        throw new IllegalArgumentException("Specify a limit of less than " + maxMeter / 1000f + "km");
+    if (buckets > (distanceInMeter / 500))
+        throw new IllegalArgumentException("Specify buckets less than the number of explored kilometers");
+    isochrone.setDistanceLimit(distanceInMeter);
+} else {
+    long maxSeconds = 80 * 60;
+    if (timeLimitInSeconds > maxSeconds)
+        throw new IllegalArgumentException("Specify a limit of less than " + maxSeconds + " seconds");
+    if (buckets > (timeLimitInSeconds / 60))
+        throw new IllegalArgumentException("Specify buckets less than the number of explored minutes");
+
+    isochrone.setTimeLimit(timeLimitInSeconds);
+}
+
+List<List<Double[]>> list = isochrone.searchGPS(qr.getClosestNode(), buckets);
+if (isochrone.getVisitedNodes() > hopper.getMaxVisitedNodes() / 5) {
+    throw new IllegalArgumentException("Reset: too many junction nodes would have to explored (" + isochrone.getVisitedNodes() + "). You may need to increase this value.");
+}
+
+int counter = 0;
+for (List<Double[]> tmp : list) {
+    if (tmp.size() < 2) {
+        throw new IllegalArgumentException("Too few points found for bucket " + counter + ". "
+                + "Please try a different point, a smaller buckets count, or a larger time limit.. ");
+    }
+    counter++;
+}
+```
+
+Finally, convert the isochrone into a result, for easy return. You can either return a point list or a polygon.
+```java
+Object calcRes;
+
+// get result as a point list
+if ("pointlist".equalsIgnoreCase(resultStr)) {
+    calcRes = list;
+
+// or get result as a polygon
+} else if ("polygon".equalsIgnoreCase(resultStr)) {
+    list = rasterHullBuilder.calcList(list, list.size() - 1, rasterDistance, bufferDistance, quadrantSegments);
+
+    ArrayList polyList = new ArrayList();
+    int index = 0;
+    for (List<Double[]> polygon : list) {
+        HashMap<String, Object> geoJsonMap = new HashMap<>();
+        HashMap<String, Object> propMap = new HashMap<>();
+        HashMap<String, Object> geometryMap = new HashMap<>();
+        polyList.add(geoJsonMap);
+        geoJsonMap.put("type", "Feature");
+        geoJsonMap.put("properties", propMap);
+        geoJsonMap.put("geometry", geometryMap);
+
+        propMap.put("bucket", index);
+        geometryMap.put("type", "Polygon");
+        // we have no holes => embed in yet another list
+        geometryMap.put("coordinates", Collections.singletonList(polygon));
+        index++;
+    }
+    calcRes = polyList;
+} else {
+    throw new IllegalArgumentException("type not supported:" + resultStr);
+}
+```

--- a/docs/web/api-doc.md
+++ b/docs/web/api-doc.md
@@ -6,9 +6,9 @@ server you need to understand how to use it. There is a separate [JavaScript](ht
 ### A simple example
 [http://localhost:8989/route?point=45.752193%2C-0.686646&point=46.229253%2C-0.32959](http://localhost:8989/route?point=45.752193%2C-0.686646&point=46.229253%2C-0.32959)
 
-The end point of the local instance is [http://localhost:8989](http://localhost:8989)
+The URL path of the local instance is [http://localhost:8989](http://localhost:8989)
 
-The URL path to obtain the route is `/route`
+The endpoint to obtain the route is `/route`
 
 ## Parameters
 
@@ -223,7 +223,7 @@ HTTP error code | Reason
 
 ## Isochrone
 
-In addition to routing, the URL path to obtain an isochrone is `/isochrone`.
+In addition to routing, the end point to obtain an isochrone is `/isochrone`.
 
 [http://localhost:8989/isochrone](http://localhost:8989/isochrone)
 
@@ -232,12 +232,9 @@ All parameters are shown in the following table.
 Parameter                   | Default | Description
 :---------------------------|:--------|:-----------
 vehicle                     | car     | The vehicle for which the route should be calculated. Other vehicles are foot, bike, motorcycle, hike, ...
-buckets                     | 1       | For how many sub intervals an additional polygon should be calculated. (optional, default to 1)
+buckets                     | 1       | Number by which to divide the given `time_limit` to create `buckets` nested isochrones of time intervals `time_limit/buckets`, `time_limit/(buckets - 1)`, ... , `time_limit`. Applies analogously to `distance_limit`.
 reverse_flow                | false   | If false the flow goes from point to the polygon, if true the flow goes from the polygon inside to the point. Example usage for false: *How many potential customer can be reached within 30min travel time from your store* vs. true: *How many customers can reach your store within 30min travel time.* (optional, default to false)
-point                       |         | Specify the start coordinate (required)
+point                       |         | Specify the start coordinate (required). A string organized as `latitude,longitude`.
 result                      | polygon | Can be "pointlist" or "polygon".
-distance_limit              | -1      | Specify which distance the vehicle should travel. In meter. (optional, default to -1)
 time_limit                  | 600     | Specify which time the vehicle should travel. In seconds. (optional, default to 600)
-isochrone.raster_distance   | 0.75    | bigger raster distance => bigger raster => less points => stranger buffer results, but faster
-isochrone.buffer_distance   | 0.003   | bigger buffer distance => less holes, lower means less points!
-isochrone.quadrant_segments | 3       | precision of the 'circles'
+distance_limit              | -1      | Specify which distance the vehicle should travel. In meter. (optional, default to -1)

--- a/docs/web/api-doc.md
+++ b/docs/web/api-doc.md
@@ -220,3 +220,24 @@ HTTP error code | Reason
 500             | Internal server error. It is strongly recommended to send us the message and the link to it, as it is very likely a bug in our system.
 501             | Only a special list of vehicles is supported
 400             | Something was wrong in your request
+
+## Isochrone
+
+In addition to routing, the URL path to obtain an isochrone is `/isochrone`.
+
+[http://localhost:8989/isochrone](http://localhost:8989/isochrone)
+
+All parameters are shown in the following table.
+
+Parameter                   | Default | Description
+:---------------------------|:--------|:-----------
+vehicle                     | car     | The vehicle for which the route should be calculated. Other vehicles are foot, bike, motorcycle, hike, ...
+buckets                     | 1       | For how many sub intervals an additional polygon should be calculated. (optional, default to 1)
+reverse_flow                | false   | If false the flow goes from point to the polygon, if true the flow goes from the polygon inside to the point. Example usage for false: *How many potential customer can be reached within 30min travel time from your store* vs. true: *How many customers can reach your store within 30min travel time.* (optional, default to false)
+point                       |         | Specify the start coordinate (required)
+result                      | polygon | Can be "pointlist" or "polygon".
+distance_limit              | -1      | Specify which distance the vehicle should travel. In meter. (optional, default to -1)
+time_limit                  | 600     | Specify which time the vehicle should travel. In seconds. (optional, default to 600)
+isochrone.raster_distance   | 0.75    | bigger raster distance => bigger raster => less points => stranger buffer results, but faster
+isochrone.buffer_distance   | 0.003   | bigger buffer distance => less holes, lower means less points!
+isochrone.quadrant_segments | 3       | precision of the 'circles'


### PR DESCRIPTION
Signed-off-by: Will Cohen <willcohen@users.noreply.github.com>

Re #1237 and a first pass at documentation:
- Adds annotations to the process used in IsochroneServlet to docs/isochrone/java.md, replacing the request parameters with variables at the top. Is this the right approach? It seems like sticking as close as possible to what's actually being used on the backend is important.
- Describes the parameters for /isochrone in docs/web/api-doc.md, based on the [directions API docs](https://github.com/graphhopper/directions-api-java-client/blob/master/client/src/main/java/com/graphhopper/directions/api/client/api/IsochroneApi.java).
- Does not currently have javadocs. The algorithm itself is taken from OTP, and the meat of the isochrone generation itself is spread among the multiple components. Where would you like to see more information?