### PR TITLE
Adapt graphhopper script for dropwizard branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ TODO.txt
 *.osm
 nbactions*.xml
 config.properties
+config.yml
 build.xml
 queries.sh
 maven/

--- a/config-example.yml
+++ b/config-example.yml
@@ -135,8 +135,11 @@ server:
   applicationConnectors:
   - type: http
     port: 8989
+    # for security reasons bind to localhost
+    bindHost: localhost
   requestLog:
       appenders: []
-  # For backward compatibility we remove the admin connectors that would be otherwise unprotected (IPFilter only works for server)
-  # To still enable admin connector remove the following:
-  adminConnectors: []
+  adminConnectors:
+  - type: http
+    port: 8990
+    bindHost: localhost

--- a/config-example.yml
+++ b/config-example.yml
@@ -1,7 +1,7 @@
 graphhopper:
 
   # OpenStreetMap input file
-  datareader.file: core/files/monaco.osm.gz
+  # datareader.file: some.pbf
 
   ##### Vehicles #####
 
@@ -137,3 +137,6 @@ server:
     port: 8989
   requestLog:
       appenders: []
+  # For backward compatibility we remove the admin connectors that would be otherwise unprotected (IPFilter only works for server)
+  # To still enable admin connector remove the following:
+  adminConnectors: []

--- a/graphhopper.sh
+++ b/graphhopper.sh
@@ -225,10 +225,13 @@ echo "## now $ACTION. JAVA_OPTS=$JAVA_OPTS"
 if [ "$ACTION" = "web" ]; then
   export MAVEN_OPTS="$MAVEN_OPTS $JAVA_OPTS"
 
-  RC_BASE=./web/src/main/webapp
+  if [ $JETTY_PORT != "" ]; then
+    GH_WEB_OPTS="$GH_WEB_OPTS -Ddw.server.applicationConnectors[0].port=$JETTY_PORT"
+  fi
+
   if [ "$RUN_BACKGROUND" = "true" ]; then
     exec "$JAVA" $JAVA_OPTS -Dgraphhopper.datareader.file="$OSM_FILE" -Dgraphhopper.graph.location="$GRAPH" \
-         -Dgraphhopper.jetty.resourcebase="$RC_BASE" -Dgraphhopper.jetty.port=$JETTY_PORT -Dgraphhopper.jetty.host=$JETTY_HOST \
+         -Dgraphhopper.jetty.resourcebase="$RC_BASE" -Dgraphhopper.jetty.host=$JETTY_HOST \
          $GH_WEB_OPTS \
          -jar "$JAR" server $CONFIG <&- &
     
@@ -239,7 +242,7 @@ if [ "$ACTION" = "web" ]; then
   else
     # TODO how to avoid duplicative command for foreground and background?
     exec "$JAVA" $JAVA_OPTS -Dgraphhopper.datareader.file="$OSM_FILE" -Dgraphhopper.graph.location="$GRAPH" \
-         -Dgraphhopper.jetty.resourcebase="$RC_BASE" -Dgraphhopper.jetty.port=$JETTY_PORT -Dgraphhopper.jetty.host=$JETTY_HOST \
+         -Dgraphhopper.jetty.resourcebase="$RC_BASE" -Dgraphhopper.jetty.host=$JETTY_HOST \
          $GH_WEB_OPTS \
          -jar "$JAR" server $CONFIG
     # foreground => we never reach this here

--- a/graphhopper.sh
+++ b/graphhopper.sh
@@ -233,7 +233,6 @@ echo "## now $ACTION. JAVA_OPTS=$JAVA_OPTS"
 if [[ "$ACTION" = "web" ]]; then
   export MAVEN_OPTS="$MAVEN_OPTS $JAVA_OPTS"
 
- echo $GH_WEB_OPTS
   if [[ "$RUN_BACKGROUND" == "true" ]]; then
     exec "$JAVA" $JAVA_OPTS -Dgraphhopper.datareader.file="$OSM_FILE" -Dgraphhopper.graph.location="$GRAPH" \
                  $GH_WEB_OPTS -jar "$JAR" server $CONFIG <&- &

--- a/graphhopper.sh
+++ b/graphhopper.sh
@@ -17,25 +17,24 @@ echo "## using java $vers from $JAVA_HOME"
 
 function printBashUsage {
   echo "Usage:"
-  echo "-h | --help:    display this message"
-  echo "-v | --version: print version"
-  echo "-c | --config:  the application configuration"
-  echo "-a | --action: must be one the following actions:"
+  echo "-a | --action <action>    must be one the following actions:"
   echo "     --action import      creates the graph cache only, used for later faster starts"
   echo "     --action web         starts a local server for user access at localhost:8989 and API access at localhost:8989/route"
   echo "     --action build       creates the graphhopper web JAR"
   echo "     --action clean       removes all JARs, necessary if you need to use the latest source (e.g. after switching the branch etc)"
   echo "     --action measurement does performance analysis of the current source version via random routes (Measurement class)"
   echo "     --action torture     can be used to test real world routes via feeding graphhopper logs into a GraphHopper system (Torture class)"
-  echo "-i | --input:       path to the input map file or name of the file to download"
-  echo "-ig| --gtfs:        path to the input file for public transit routing (GTFS format)"
-  echo "-o | --graph-cache: directory for graph cache output"
-  echo "-v | --profiles:    a comma separated list of vehicle profiles"
-  echo "--host:             specify to which host the service should be bound"
-  echo "--port:             start web server at specific port"
-  echo "--jar:              specify the jar file (useful if you want to reuse this script for custom builds)"
-  echo "-fd| --force-download: force the download of the OSM data file if needed"
-  echo "-d | --run-background: run the application in background (detach)"
+  echo "-c | --config <config>    specify the application configuration"
+  echo "-d | --run-background     run the application in background (detach)"
+  echo "-fd| --force-download     force the download of the OSM data file if needed"
+  echo "-h | --help               display this message"
+  echo "--host <host>             specify to which host the service should be bound"
+  echo "-i | --input <file>       path to the input map file or name of the file to download"
+  echo "--jar <file>              specify the jar file (useful if you want to reuse this script for custom builds)"
+  echo "-o | --graph-cache <dir>  directory for graph cache output"
+  echo "-p | --profiles <string>  comma separated list of vehicle profiles"
+  echo "--port <port>             start web server at specific port"
+  echo "-v | --version            print version"
 }
 
 VERSION=$(grep '<revision' pom.xml | cut -d'>' -f2 | cut -d'<' -f1)
@@ -43,19 +42,18 @@ VERSION=$(grep '<revision' pom.xml | cut -d'>' -f2 | cut -d'<' -f1)
 # one or two character parameters have one minus character'-' all longer parameters have two minus characters '--'
 while [ ! -z $1 ]; do
   case $1 in
-    -h|--help) printBashUsage
-      exit 0;;
-    -fd|--force-download) FORCE_DWN=1; shift 1;;
-    -clean|clean) ACTION=clean; shift 1;;
     -a|--action) ACTION=$2; shift 2;;
-    -i|--input) FILE="$2"; shift 2;;
-    -p|--profiles) GH_WEB_OPTS="$GH_WEB_OPTS -Dgraphhopper.graph.flag_encoders=$2"; shift 2;;
-    --port) GH_WEB_OPTS="$GH_WEB_OPTS -Ddw.server.applicationConnectors[0].port=$2"; shift 2;;
-    --host) GH_WEB_OPTS="$GH_WEB_OPTS -Ddw.server.applicationConnectors[0].bindHost=$2"; shift 2;;
-    --jar) JAR="$2"; shift 2;;
     -c|--config) CONFIG="$2"; shift 2;;
     -d|--run-background) RUN_BACKGROUND=true; shift 1;;
+    -fd|--force-download) FORCE_DWN=1; shift 1;;
+    -h|--help) printBashUsage
+      exit 0;;
+    --host) GH_WEB_OPTS="$GH_WEB_OPTS -Ddw.server.applicationConnectors[0].bindHost=$2"; shift 2;;
+    -i|--input) FILE="$2"; shift 2;;
+    --jar) JAR="$2"; shift 2;;
     -o|--graph-cache) GRAPH="$2"; shift 2;;
+    -p|--profiles) GH_WEB_OPTS="$GH_WEB_OPTS -Dgraphhopper.graph.flag_encoders=$2"; shift 2;;
+    --port) GH_WEB_OPTS="$GH_WEB_OPTS -Ddw.server.applicationConnectors[0].port=$2"; shift 2;;
     -v|--version) echo $VERSION
     	exit 2;;
     # forward parameter via replacing first two characters of the key with -Dgraphhopper.

--- a/graphhopper.sh
+++ b/graphhopper.sh
@@ -17,7 +17,9 @@ echo "## using java $vers from $JAVA_HOME"
 
 function printBashUsage {
   echo "Usage:"
-  echo "-h | --help:   display this message"
+  echo "-h | --help:    display this message"
+  echo "-v | --version: print version"
+  echo "-c | --config:  the application configuration"
   echo "-a | --action: must be one the following actions:"
   echo "     --action import      creates the graph cache only, used for later faster starts"
   echo "     --action web         starts a local server for user access at localhost:8989 and API access at localhost:8989/route"
@@ -29,13 +31,11 @@ function printBashUsage {
   echo "-ig| --gtfs:        path to the input file for public transit routing (GTFS format)"
   echo "-o | --graph-cache: directory for graph cache output"
   echo "-v | --profiles:    a comma separated list of vehicle profiles"
-  echo "-c | --config:      the application configuration"
-  echo "--host:        specify to which host the service should be bound"
-  echo "--port:        start web server at specific port"
+  echo "--host:             specify to which host the service should be bound"
+  echo "--port:             start web server at specific port"
+  echo "--jar:              specify the jar file (useful if you want to reuse this script for custom builds)"
   echo "-fd| --force-download: force the download of the OSM data file if needed"
-  echo "-d | --run-background: run the application in background"
-  echo "-v | --version: print version"
-  echo "-jar:               specify the jar file (useful if you want to reuse this script for custom builds)"
+  echo "-d | --run-background: run the application in background (detach)"
 }
 
 VERSION=$(grep '<revision' pom.xml | cut -d'>' -f2 | cut -d'<' -f1)
@@ -52,10 +52,10 @@ while [ ! -z $1 ]; do
     -p|--profiles) GH_WEB_OPTS="$GH_WEB_OPTS -Dgraphhopper.graph.flag_encoders=$2"; shift 2;;
     --port) GH_WEB_OPTS="$GH_WEB_OPTS -Ddw.server.applicationConnectors[0].port=$2"; shift 2;;
     --host) GH_WEB_OPTS="$GH_WEB_OPTS -Ddw.server.applicationConnectors[0].bindHost=$2"; shift 2;;
+    --jar) JAR="$2"; shift 2;;
     -c|--config) CONFIG="$2"; shift 2;;
     -d|--run-background) RUN_BACKGROUND=true; shift 1;;
     -o|--graph-cache) GRAPH="$2"; shift 2;;
-    --jar) JAR="$2"; shift 2;;
     -v|--version) echo $VERSION
     	exit 2;;
     # forward parameter via replacing first two characters of the key with -Dgraphhopper.

--- a/graphhopper.sh
+++ b/graphhopper.sh
@@ -17,9 +17,9 @@ echo "## using java $vers from $JAVA_HOME"
 
 function printBashUsage {
   echo "Usage:"
-  echo "-h | --help: display this message"
+  echo "-h | --help:   display this message"
   echo "-a | --action: must be one the following actions:"
-  echo "     --action import      creates the graph cache used for later faster starts"
+  echo "     --action import      creates the graph cache only, used for later faster starts"
   echo "     --action web         starts a local server for user access at localhost:8989 and API access at localhost:8989/route"
   echo "     --action build       creates the graphhopper web JAR"
   echo "     --action clean       removes all JARs, necessary if you need to use the latest source (e.g. after switching the branch etc)"
@@ -28,13 +28,13 @@ function printBashUsage {
   echo "-i | --input:       path to the input map file or name of the file to download"
   echo "-ig| --gtfs:        path to the input file for public transit routing (GTFS format)"
   echo "-o | --graph-cache: directory for graph cache output"
-  echo "-p | --profiles:    specify comma separated list of vehicle profiles"
+  echo "-p | --profiles:    specify a comma separated list of vehicle profiles"
   echo "-c | --config:      specify the application configuration"
-  echo "-host:              to which host the service should be bound"
+  echo "-host:              specify to which host the service should be bound"
   echo "-port:              start web server at specific port"
-  echo "-jar:               changes the jar file"
-  echo "-fd| --force-download: force the download of the data file if needed"
-  echo "-d | --run-background: run application in background"
+  echo "-jar:               specify the jar file (useful if you want to reuse this script for custom builds)"
+  echo "-fd| --force-download: force the download of the OSM data file if needed"
+  echo "-d | --run-background: run the application in background"
 }
 
 while [ ! -z $1 ]; do
@@ -42,7 +42,7 @@ while [ ! -z $1 ]; do
     -h|--help) printBashUsage
       exit 0;;
     -fd|--force-download) FORCE_DWN=1; shift 1;;
-    clean) ACTION=clean; shift 1;;
+    -clean|clean) ACTION=clean; shift 1;;
     -a|--action) ACTION=$2; shift 2;;
     -i|--input) FILE="$2"; shift 2;;
     -ig|--gtfs-input) GH_WEB_OPTS="$GH_WEB_OPTS -Dgraphhopper.gtfs.file=$2"; shift 2;;

--- a/graphhopper.sh
+++ b/graphhopper.sh
@@ -50,7 +50,7 @@ while [ ! -z $1 ]; do
     -port) GH_WEB_OPTS="$GH_WEB_OPTS -Ddw.server.applicationConnectors[0].port=$2"; shift 2;;
     -host) GH_WEB_OPTS="$GH_WEB_OPTS -Ddw.server.applicationConnectors[0].bindHost=$2"; shift 2;;
     -c|--config) CONFIG="$2"; shift 2;;
-    -d|--run-background) RUN_BACKGROUND=$2; shift 2;;
+    -d|--run-background) RUN_BACKGROUND=true; shift 1;;
     -o|--graph-cache) GRAPH="$2"; shift 2;;
     -jar) JAR="$2"; shift 2;;
     -*|--*) echo "Option unknown: $1"

--- a/graphhopper.sh
+++ b/graphhopper.sh
@@ -2,49 +2,76 @@
 (set -o igncr) 2>/dev/null && set -o igncr; # this comment is required for handling Windows cr/lf 
 # See StackOverflow answer http://stackoverflow.com/a/14607651
 
-GH_CLASS=com.graphhopper.tools.Import
 GH_HOME=$(dirname "$0")
 JAVA=$JAVA_HOME/bin/java
 if [ "$JAVA_HOME" = "" ]; then
  JAVA=java
 fi
 
-vers=$($JAVA -version 2>&1 | grep "java version" | awk '{print $3}' | tr -d \")
+vers=$($JAVA -version 2>&1 | grep "version" | awk '{print $3}' | tr -d \")
 bit64=$($JAVA -version 2>&1 | grep "64-Bit")
 if [ "$bit64" != "" ]; then
   vers="$vers (64bit)"
 fi
 echo "## using java $vers from $JAVA_HOME"
 
-CONFIG=config.properties
-if [ ! -f "config.properties" ]; then
-  cp config-example.properties $CONFIG
-fi
-
-ACTION=$1
-FILE=$2
-
-function printUsage {
- echo
- echo "./graphhopper.sh import|web <some-map-file>"
- echo "./graphhopper.sh clean|build|buildweb|help"
- echo
- echo "  help        this message"
- echo "  import      creates the graphhopper files used for later (faster) starts"
- echo "  web         starts a local server for user access at localhost:8989 and API access at localhost:8989/route"
- echo "  build       creates the graphhopper JAR (without the web module)"
- echo "  buildweb    creates the graphhopper JAR (with the web module)"
- echo "  clean       removes all JARs, necessary if you need to use the latest source (e.g. after switching the branch etc)"
- echo "  measurement does performance analysis of the current source version via random routes (Measurement class)"
- echo "  torture     can be used to test real world routes via feeding graphhopper logs into a GraphHopper system (Torture class)"
- echo "  miniui      is a simple Java/Swing visualization application used for debugging purposes (MiniGraphUI class)"
- echo "  extract     calls the overpass API to grab any area as .osm file"
- echo "  android     builds, deploys and starts the Android demo for your connected device"
+function printBashUsage {
+  echo "Usage:"
+  echo "-h | --help: display this message"
+  echo "-a | --action: must be one the following actions:"
+  echo "     --action import      creates the graph cache used for later faster starts"
+  echo "     --action web         starts a local server for user access at localhost:8989 and API access at localhost:8989/route"
+  echo "     --action build       creates the graphhopper web JAR"
+  echo "     --action clean       removes all JARs, necessary if you need to use the latest source (e.g. after switching the branch etc)"
+  echo "     --action measurement does performance analysis of the current source version via random routes (Measurement class)"
+  echo "     --action torture     can be used to test real world routes via feeding graphhopper logs into a GraphHopper system (Torture class)"
+  echo "-d | --datareader.file: path to the map file or name of the file to download"
+  echo "-o | -gc | --graph-cache: directory for graph cache output"
+  echo "-c | --config: app configuration"
+  echo "-fd| --force-download: force the download of the data file if needed"
+  echo "-rb| --run-background: run app in background"
+  echo "-jar: changes the jar file"
 }
 
+while [ ! -z $1 ]; do
+  case $1 in
+    -h|--help) printBashUsage
+      exit 0;;
+    -fd|--force-download) FORCE_DWN=1; shift 1;;
+    clean) ACTION=clean; shift 1;;
+    -a|--action) ACTION=$2; shift 2;;
+    -f|--datareader.file) FILE="$2"; shift 2;;
+    -c|--config) CONFIG="$2"; shift 2;;
+    -rb|--run-background) RUN_BACKGROUND=$2; shift 2;;
+    -o|-gc|--graph-cache) GRAPH="$2"; shift 2;;
+    -jar) JAR="$2"; shift 2;;
+    -*|--*) echo "Option unknown: $1"
+        echo
+        printBashUsage
+	exit 2;;
+    # backward compatibility
+    *) REMAINING_ARGS+=($1); shift 1;;
+  esac
+done
+
+if [ ! -z $REMAINING_ARGS ]; then
+  echo "Remaining arguments: ${REMAINING_ARGS[@]}"
+fi
+
+if [ -z $ACTION ] || [ -z $FILE ]; then
+  ACTION=${REMAINING_ARGS[0]}
+  FILE=${REMAINING_ARGS[1]}
+fi
+
 if [ "$ACTION" = "" ]; then
- echo "## action $ACTION not found. try" 
- printUsage
+ echo "## action $ACTION not found!"
+ printBashUsage
+fi
+
+# default init, https://stackoverflow.com/a/28085062/194609
+: "${CONFIG:=config.yml}"
+if [ ! -f "config.yml" ]; then
+  cp config-example.yml $CONFIG
 fi
 
 function ensureOsm { 
@@ -52,10 +79,12 @@ function ensureOsm {
     # skip
     return
   elif [ ! -s "$OSM_FILE" ]; then
-    echo "File not found '$OSM_FILE'. Press ENTER to get it from: $LINK"
-    echo "Press CTRL+C if you do not have enough disc space or you don't want to download several MB."
-    read -e
-      
+    if [ -z $FORCE_DWN ]; then
+      echo "File not found '$OSM_FILE'. Press ENTER to get it from: $LINK"
+      echo "Press CTRL+C if you do not have enough disc space or you don't want to download several MB."
+      read -e
+    fi
+
     echo "## now downloading OSM file from $LINK and extracting to $OSM_FILE"
     
     if [ ${OSM_FILE: -4} == ".pbf" ]; then
@@ -63,7 +92,7 @@ function ensureOsm {
     elif [ ${OSM_FILE: -4} == ".ghz" ]; then
        wget -S -nv -O "$OSM_FILE" "$LINK"
        cd $DATADIR && unzip "$BASENAME" -d "$NAME-gh"
-    else    
+    else
        # make sure aborting download does not result in loading corrupt osm file
        TMP_OSM=temp.osm
        wget -S -nv -O - "$LINK" | bzip2 -d > $TMP_OSM
@@ -110,7 +139,7 @@ function execMvn {
   fi
 }
 
-function packageCoreJar {
+function packageJar {
   if [ ! -f "$JAR" ]; then
     echo "## building graphhopper jar: $JAR"
     echo "## using maven at $MAVEN_HOME"
@@ -129,33 +158,14 @@ if [ "$ACTION" = "clean" ]; then
  rm -rf ./target
  exit
 
-elif [ "$ACTION" = "eclipse" ]; then
- packageCoreJar
- exit
-
 elif [ "$ACTION" = "build" ]; then
- packageCoreJar
+ packageJar
  exit  
- 
-elif [ "$ACTION" = "buildweb" ]; then
- execMvn --projects web -am -DskipTests=true package
- exit
-
-elif [ "$ACTION" = "extract" ]; then
- echo use "./graphhopper.sh extract \"left,bottom,right,top\""
- URL="http://overpass-api.de/api/map?bbox=$2"
- #echo "$URL"
- wget -O extract.osm "$URL"
- exit
- 
-elif [ "$ACTION" = "android" ]; then
- execMvn -P include-android --projects android/app -am package android:deploy android:run
- exit
 fi
-
+ 
 if [ "$FILE" = "" ]; then
-  echo -e "no file specified? try"
-  printUsage
+  echo -e "no file specified?"
+  printBashUsage
   exit
 fi
 
@@ -187,9 +197,9 @@ else
    OSM_FILE=
 fi
 
-GRAPH=$DATADIR/$NAME-gh
 VERSION=$(grep '<revision' pom.xml | cut -d'>' -f2 | cut -d'<' -f1)
-JAR=tools/target/graphhopper-tools-$VERSION-jar-with-dependencies.jar
+: "${JAR:=web/target/graphhopper-web-$VERSION.jar}"
+: "${GRAPH:=$DATADIR/$NAME-gh}"
 
 LINK=$(echo $NAME | tr '_' '/')
 if [ "$FILE" == "-" ]; then
@@ -205,66 +215,46 @@ else
    LINK="http://download.geofabrik.de/$LINK-latest.osm.pbf"
 fi
 
-if [ "$JAVA_OPTS" = "" ]; then
-  JAVA_OPTS="-Xmx1000m -Xms1000m -server"
-fi
+: "${JAVA_OPTS:=-Xmx1000m -Xms1000m -server}"
 
 ensureOsm
-packageCoreJar
+packageJar
 
 echo "## now $ACTION. JAVA_OPTS=$JAVA_OPTS"
 
-if [ "$ACTION" = "ui" ] || [ "$ACTION" = "web" ]; then
+if [ "$ACTION" = "web" ]; then
   export MAVEN_OPTS="$MAVEN_OPTS $JAVA_OPTS"
-  if [ "$JETTY_PORT" = "" ]; then  
-    JETTY_PORT=8989
-  fi
-  WEB_JAR="$GH_HOME/web/target/graphhopper-web-$VERSION-with-dep.jar"
-  if [ ! -s "$WEB_JAR" ]; then
-    execMvn --projects web -am -DskipTests=true package
-  fi
 
   RC_BASE=./web/src/main/webapp
-
-  if [ "$GH_FOREGROUND" = "" ]; then
-    exec "$JAVA" $JAVA_OPTS -jar "$WEB_JAR" jetty.resourcebase=$RC_BASE \
-	jetty.port=$JETTY_PORT jetty.host=$JETTY_HOST \
-    	config=$CONFIG $GH_WEB_OPTS graph.location="$GRAPH" datareader.file="$OSM_FILE"
-    # foreground => we never reach this here
-  else
-    exec "$JAVA" $JAVA_OPTS -jar "$WEB_JAR" jetty.resourcebase=$RC_BASE \
-    	jetty.port=$JETTY_PORT jetty.host=$JETTY_HOST \
-    	config=$CONFIG $GH_WEB_OPTS graph.location="$GRAPH" datareader.file="$OSM_FILE" <&- &
+  if [ "$RUN_BACKGROUND" = "true" ]; then
+    exec "$JAVA" $JAVA_OPTS -Dgraphhopper.datareader.file="$OSM_FILE" -Dgraphhopper.graph.location="$GRAPH" \
+         -Dgraphhopper.jetty.resourcebase="$RC_BASE" -Dgraphhopper.jetty.port=$JETTY_PORT -Dgraphhopper.jetty.host=$JETTY_HOST \
+         $GH_WEB_OPTS \
+         -jar "$JAR" server $CONFIG <&- &
+    
     if [ "$GH_PID_FILE" != "" ]; then
        echo $! > $GH_PID_FILE
     fi
-    exit $?                    
+    exit $?
+  else
+    # TODO how to avoid duplicative command for foreground and background?
+    exec "$JAVA" $JAVA_OPTS -Dgraphhopper.datareader.file="$OSM_FILE" -Dgraphhopper.graph.location="$GRAPH" \
+         -Dgraphhopper.jetty.resourcebase="$RC_BASE" -Dgraphhopper.jetty.port=$JETTY_PORT -Dgraphhopper.jetty.host=$JETTY_HOST \
+         $GH_WEB_OPTS \
+         -jar "$JAR" server $CONFIG
+    # foreground => we never reach this here
   fi
 
 elif [ "$ACTION" = "import" ]; then
- "$JAVA" $JAVA_OPTS -cp "$JAR" $GH_CLASS config=$CONFIG \
-      $GH_IMPORT_OPTS graph.location="$GRAPH" datareader.file="$OSM_FILE"
-
+ "$JAVA" $JAVA_OPTS -Dgraphhopper.datareader.file="$OSM_FILE" -Dgraphhopper.graph.location="$GRAPH" $GH_IMPORT_OPTS \
+         -jar "$JAR" import $CONFIG
 
 elif [ "$ACTION" = "torture" ]; then
  "$JAVA" $JAVA_OPTS -cp "$JAR" com.graphhopper.tools.QueryTorture $@
 
-
-elif [ "$ACTION" = "miniui" ]; then
- execMvn --projects tools -am -DskipTests clean package
- JAR=tools/target/graphhopper-tools-$VERSION-jar-with-dependencies.jar   
- "$JAVA" $JAVA_OPTS -cp "$JAR" com.graphhopper.ui.MiniGraphUI datareader.file="$OSM_FILE" config=$CONFIG \
-              graph.location="$GRAPH"
-
-
 elif [ "$ACTION" = "measurement" ]; then
- ARGS="config=$CONFIG graph.location=$GRAPH datareader.file=$OSM_FILE prepare.ch.weightings=fastest prepare.lm.weightings=fastest graph.flag_encoders=car prepare.min_network_size=10000 prepare.min_oneway_network_size=10000"
- # echo -e "\ncreate graph via $ARGS, $JAR"
- # START=$(date +%s)
- # avoid islands for measurement at all costs
- # "$JAVA" $JAVA_OPTS -cp "$JAR" $GH_CLASS $ARGS prepare.doPrepare=false prepare.minNetworkSize=10000 prepare.minOnewayNetworkSize=10000
- # END=$(date +%s)
- # IMPORT_TIME=$(($END - $START))
+ ARGS="config=$CONFIG graph.location=$GRAPH datareader.file=$OSM_FILE prepare.ch.weightings=fastest prepare.lm.weightings=fastest graph.flag_encoders=car \
+       prepare.min_network_size=10000 prepare.min_oneway_network_size=10000"
 
  function startMeasurement {
     execMvn --projects tools -am -DskipTests clean package

--- a/graphhopper.sh
+++ b/graphhopper.sh
@@ -222,20 +222,20 @@ packageJar
 
 echo "## now $ACTION. JAVA_OPTS=$JAVA_OPTS"
 
-if [ "$ACTION" = "web" ]; then
+if [[ "$ACTION" = "web" ]]; then
   export MAVEN_OPTS="$MAVEN_OPTS $JAVA_OPTS"
 
-  if [ $JETTY_PORT != "" ]; then
+  if [[ "$JETTY_PORT" != "" ]]; then
     GH_WEB_OPTS="$GH_WEB_OPTS -Ddw.server.applicationConnectors[0].port=$JETTY_PORT"
   fi
 
-  if [ "$RUN_BACKGROUND" = "true" ]; then
+  if [[ "$RUN_BACKGROUND" == "true" ]]; then
     exec "$JAVA" $JAVA_OPTS -Dgraphhopper.datareader.file="$OSM_FILE" -Dgraphhopper.graph.location="$GRAPH" \
          -Dgraphhopper.jetty.resourcebase="$RC_BASE" -Dgraphhopper.jetty.host=$JETTY_HOST \
          $GH_WEB_OPTS \
          -jar "$JAR" server $CONFIG <&- &
     
-    if [ "$GH_PID_FILE" != "" ]; then
+    if [[ "$GH_PID_FILE" != "" ]]; then
        echo $! > $GH_PID_FILE
     fi
     exit $?


### PR DESCRIPTION
And replaces #1244 
 
 - [x] support for gtfs
 - [x] ~~some more short parameters (test measurement and torture)~~ doesn't work at all. we should fix in different PR
 - [x] ~~convert all unknown parameters into `-Dgraphhopper.<unknown>` instead of printing the error?~~ Problem is that this could hide compatibility issues between this and the old arguments. We can do this in one of the next releases as for now other parameters are possible via the old `export GH_WEB_OPTS=xy` approach
 - [x] ~make old approach working: `export JETTY_PORT=8990;./graphhopper.sh web ~/Downloads/berlin-latest.osm.pbf` even when port is removed from config~ use `-port` command line option instead
 - [x]  ~even if not configured the admin stuff is started!~ no problem when we bind to localhost
 - [x] ~test IPFilter~ can be remove since we bind to localhost

Let us also document the old vs. the new way of configuring something:

|old | new
|-----|--------
|export JETTY_PORT=8989| --port 8989
|export GH_FOREGROUND=false| -d