### PR TITLE
Don't merge: How to store a custom attribute, read/write

### DIFF
--- a/core/src/main/java/com/michaz/OriginalDirectionFlagEncoder.java
+++ b/core/src/main/java/com/michaz/OriginalDirectionFlagEncoder.java
@@ -1,0 +1,77 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.michaz;
+
+import com.graphhopper.reader.ReaderRelation;
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.util.AbstractFlagEncoder;
+
+public class OriginalDirectionFlagEncoder extends AbstractFlagEncoder {
+
+
+    private long originalDirectionBitmask;
+
+    public OriginalDirectionFlagEncoder() {
+        super(0, 0, 0);
+    }
+
+    @Override
+    public int defineWayBits(int index, int shift) {
+        shift = super.defineWayBits(index, shift);
+        this.originalDirectionBitmask = 1L << shift;
+        return shift + 1;
+    }
+
+    @Override
+    public long handleRelationTags(ReaderRelation readerRelation, long l) {
+        return l;
+    }
+
+    @Override
+    public long acceptWay(ReaderWay readerWay) {
+        return 0;
+    }
+
+    @Override
+    public long handleWayTags(ReaderWay readerWay, long l, long l1) {
+        return 0;
+    }
+
+    @Override
+    public int getVersion() {
+        return 0;
+    }
+
+    public long reverseFlags(long flags) {
+        return super.reverseFlags(flags) ^ this.originalDirectionBitmask;
+    }
+
+    public boolean isOriginalDirection(long flags) {
+        return (flags & this.originalDirectionBitmask) != 0L;
+    }
+
+    public long setOriginalDirection(long flags, boolean originalDirection) {
+        return originalDirection ? flags | originalDirectionBitmask : flags & ~originalDirectionBitmask;
+    }
+
+    public String toString() {
+        return "original-direction";
+    }
+
+}

--- a/web/src/main/java/com/graphhopper/http/GraphHopperManaged.java
+++ b/web/src/main/java/com/graphhopper/http/GraphHopperManaged.java
@@ -20,15 +20,26 @@ package com.graphhopper.http;
 
 import com.graphhopper.GraphHopper;
 import com.graphhopper.reader.osm.GraphHopperOSM;
+import com.graphhopper.routing.util.DefaultFlagEncoderFactory;
+import com.graphhopper.routing.util.FlagEncoder;
+import com.graphhopper.routing.util.FlagEncoderFactory;
+import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.spatialrules.SpatialRuleLookupHelper;
 import com.graphhopper.util.CmdArgs;
+import com.graphhopper.util.EdgeIteratorState;
+import com.graphhopper.util.PMap;
 import com.graphhopper.util.Parameters;
+import com.graphhopper.util.details.AbstractPathDetailsBuilder;
+import com.graphhopper.util.details.PathDetailsBuilder;
+import com.graphhopper.util.details.PathDetailsBuilderFactory;
 import io.dropwizard.lifecycle.Managed;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import com.michaz.OriginalDirectionFlagEncoder;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import java.util.List;
 
 @Singleton
 public class GraphHopperManaged implements Managed {
@@ -41,8 +52,44 @@ public class GraphHopperManaged implements Managed {
         graphHopper = new GraphHopperOSM(
                 SpatialRuleLookupHelper.createLandmarkSplittingFeatureCollection(configuration.get(Parameters.Landmark.PREPARE + "split_area_location", ""))
         ).forServer();
+        graphHopper.setFlagEncoderFactory(new FlagEncoderFactory() {
+            private FlagEncoderFactory delegate = new DefaultFlagEncoderFactory();
+            @Override
+            public FlagEncoder createFlagEncoder(String name, PMap configuration) {
+                if (name.equals("original-direction")) {
+                    return new OriginalDirectionFlagEncoder();
+                }
+                return delegate.createFlagEncoder(name, configuration);
+            }
+        });
         SpatialRuleLookupHelper.buildAndInjectSpatialRuleIntoGH(graphHopper, configuration);
         graphHopper.init(configuration);
+        graphHopper.setPathDetailsBuilderFactory(new PathDetailsBuilderFactory() {
+            @Override
+            public List<PathDetailsBuilder> createPathDetailsBuilders(List<String> requestedPathDetails, FlagEncoder encoder, Weighting weighting) {
+                // request-scoped
+                OriginalDirectionFlagEncoder originalDirectionFlagEncoder = (OriginalDirectionFlagEncoder) graphHopper.getGraphHopperStorage().getEncodingManager().getEncoder("original-direction");
+                List<PathDetailsBuilder> pathDetailsBuilders = super.createPathDetailsBuilders(requestedPathDetails, encoder, weighting);
+                pathDetailsBuilders.add(new AbstractPathDetailsBuilder("r5_edge_id") {
+                    private int edgeId = -1;
+
+                    @Override
+                    public boolean isEdgeDifferentToLastEdge(EdgeIteratorState edge) {
+                        if (edge.getEdge() != edgeId) {
+                            edgeId = edge.getEdge() * 2 + (originalDirectionFlagEncoder.isOriginalDirection(edge.getFlags()) ? 0 : 1);
+                            return true;
+                        }
+                        return false;
+                    }
+
+                    @Override
+                    public Object getCurrentValue() {
+                        return this.edgeId;
+                    }
+                });
+                return pathDetailsBuilders;
+            }
+        });
     }
 
     @Override


### PR DESCRIPTION
This is just a request for review of a use case. I want to store a custom edge attribute in the ``Graph``, and I want to use that attribute in a ``PathDetailsBuilder``. Am I doing it right?

What I particularly would like to know:

- Do I need a whole ``FlagEncoder`` to store one attribute? I am asking because the idea behind ``FlagEncoder`` really seems to be specifically **vehicle type** or **mode of transport**. (How do I know this? Because a broken vehicle icon appears in the web client.) Is there a different public API for what I am trying to do?

Things I do not require feedback about:

- that the ``FlagEncoder`` and the ``PathDetailsBuilder`` are hacked into ``GraphHopperManaged``
- that you are not seeing where I actually set the attribute -- just assume my setter on my custom ``FlagEncoder`` is used at some point during preprocessing