### PR TITLE
allow "false" in addition to "no", fixes #1337

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/ch/CHAlgoFactoryDecorator.java
+++ b/core/src/main/java/com/graphhopper/routing/ch/CHAlgoFactoryDecorator.java
@@ -80,7 +80,7 @@ public class CHAlgoFactoryDecorator implements RoutingAlgorithmFactoryDecorator 
         // default is enabled & fastest
         String chWeightingsStr = args.get(CH.PREPARE + "weightings", "");
 
-        if ("no".equals(chWeightingsStr)) {
+        if ("no".equals(chWeightingsStr) || "false".equals(chWeightingsStr)) {
             // default is fastest and we need to clear this explicitely
             weightingsAsStrings.clear();
         } else if (!chWeightingsStr.isEmpty()) {


### PR DESCRIPTION
- ``no`` is a reserved word in YAML, like ``false`` in JSON
- YAML allows string values without quotes, except for reserved words
- the schema for our ``graphhopper`` configuration block is ``Map<String,String>``, we have no typesafe config yet
- so ``no`` is parsed to ``false: Boolean``, and then stringified to ``"false": String``

Solution: Just interpret ``"false"`` the same way as ``"no"``. No need to do anything more general about this IMO, since the general thing we should do is move to a typed config.

Alternative: Not do this and tell users to write ``"no"`` or to not use YAML. But I think allowing a second reserved string ourselves doesn't hurt.