### PR TITLE
Fix missing vertical bar for elevation

### DIFF
--- a/web/src/main/resources/assets/css/leaflet.elevation-0.0.4.css
+++ b/web/src/main/resources/assets/css/leaflet.elevation-0.0.4.css
@@ -1,11 +1,64 @@
-.lime-theme.leaflet-control.elevation .background{background-color:rgba(156,194,34,.2);-webkit-border-radius:5px;-moz-border-radius:5px;-ms-border-radius:5px;-o-border-radius:5px;border-radius:5px}.lime-theme.leaflet-control.elevation .axis line,.lime-theme.leaflet-control.elevation .axis path{fill:none;stroke:#566b13;stroke-width:2}
-.lime-theme.leaflet-control.elevation .area{fill:#9cc222}.lime-theme.leaflet-control.elevation .mouse-focus-line{pointer-events:none;stroke-width:1;stroke:#101404}.lime-theme.leaflet-control.elevation-collapsed .background{display:none}.lime-theme.leaflet-control.elevation-collapsed .elevation-toggle{display:block}.lime-theme.height-focus{stroke:#9cc222;fill:#9cc222}.lime-theme.height-focus.line{pointer-events:none;stroke-width:2}.steelblue-theme.leaflet-control.elevation .background{background-color:rgba(70,130,180,.2);-webkit-border-radius:5px;-moz-border-radius:5px;-ms-border-radius:5px;-o-border-radius:5px;border-radius:5px}.steelblue-theme.leaflet-control.elevation .axis line,.steelblue-theme.leaflet-control.elevation .axis path{fill:none;stroke:#0d1821;stroke-width:2}.steelblue-theme.leaflet-control.elevation .mouse-drag{fill:rgba(23,74,117,.4)}.steelblue-theme.leaflet-control.elevation .elevation-toggle{cursor:pointer;box-shadow:0 1px 7px rgba(0,0,0,.4);-webkit-border-radius:5px;border-radius:5px;width:36px;height:36px;background-color:#f8f8f9}.steelblue-theme.leaflet-control.elevation .elevation-toggle-icon{background:url(images/elevation-steelblue.png) no-repeat center center}.steelblue-theme.leaflet-control.elevation .area{fill:#4682b4}.steelblue-theme.leaflet-control.elevation .mouse-focus-line{pointer-events:none;stroke-width:1;stroke:#0d1821}.steelblue-theme.leaflet-control.elevation-collapsed .background{display:none}.steelblue-theme.leaflet-control.elevation-collapsed .elevation-toggle{display:block}.steelblue-theme.height-focus{stroke:#4682b4;fill:#4682b4}.steelblue-theme.height-focus.line{pointer-events:none;stroke-width:2}.purple-theme.leaflet-control.elevation .background{background-color:rgba(115,44,123,.2);-webkit-border-radius:5px;-moz-border-radius:5px;-ms-border-radius:5px;-o-border-radius:5px;border-radius:5px}.purple-theme.leaflet-control.elevation .axis line,.purple-theme.leaflet-control.elevation .axis path{fill:none;stroke:#2d1130;stroke-width:2}.purple-theme.leaflet-control.elevation .mouse-drag{fill:rgba(74,14,80,.4)}.purple-theme.leaflet-control.elevation .elevation-toggle{cursor:pointer;box-shadow:0 1px 7px rgba(0,0,0,.4);-webkit-border-radius:5px;border-radius:5px;width:36px;height:36px;background-color:#f8f8f9}.purple-theme.leaflet-control.elevation .elevation-toggle-icon{background:url(images/elevation-purple.png) no-repeat center center}.purple-theme.leaflet-control.elevation .area{fill:#732c7b}.purple-theme.leaflet-control.elevation .mouse-focus-line{pointer-events:none;stroke-width:1;stroke:#000}.purple-theme.leaflet-control.elevation-collapsed .background{display:none}.purple-theme.leaflet-control.elevation-collapsed .elevation-toggle{display:block}.purple-theme.height-focus{stroke:#732c7b;fill:#732c7b}.purple-theme.height-focus.line{pointer-events:none;stroke-width:2}
-.lime-theme.leaflet-control.elevation .mouse-drag{fill:rgba(99,126,11,.4)}.lime-theme.leaflet-control.elevation .elevation-toggle{cursor:pointer;box-shadow:0 1px 7px rgba(0,0,0,.4);-webkit-border-radius:5px;border-radius:5px;width:36px;height:36px;background-color:#f8f8f9}.lime-theme.leaflet-control.elevation .elevation-toggle-icon{background:url(images/elevation-lime.png) no-repeat center center}
-
-.white-theme.leaflet-control.elevation .background{background-color:rgba(250,250,250,.6);-webkit-border-radius:5px;-moz-border-radius:5px;-ms-border-radius:5px;-o-border-radius:5px;border-radius:5px}.white-theme.leaflet-control.elevation .axis path,.white-theme.leaflet-control.elevation .axis line{fill:none;stroke:#0d1821;stroke-width:2}
-.white-theme.leaflet-control.elevation .area{fill:#00cc33; opacity: 0.8}.white-theme.leaflet-control.elevation .mouse-focus-line{pointer-events:none;stroke-width:1;stroke:#0d1821}.white-theme.leaflet-control.elevation .elevation-toggle{cursor:pointer;box-shadow:0 1px 7px rgba(0,0,0,.4);-webkit-border-radius:5px;border-radius:5px;width:36px;height:36px;background:url(images/elevation.png) no-repeat center center #f8f8f9}.white-theme.leaflet-control.elevation-collapsed .background{display:none}.white-theme.leaflet-control.elevation-collapsed .elevation-toggle{display:block}.white-theme.leaflet-overlay-pane .height-focus{stroke:#4682b4;fill:#4682b4}.white-theme.leaflet-overlay-pane .height-focus.line{pointer-events:none;stroke-width:2}
-.white-theme.leaflet-control.elevation .mouse-drag{fill:#00cc33; opacity: 0.2}
-.white-theme.leaflet-control.elevation .axis text{ x: -10; }
-.text {
-    color:#00cc33
+.white-theme.leaflet-control.elevation .background
+{
+  background-color: rgba(250,250,250,.6);
+  -webkit-border-radius: 5px;
+  -moz-border-radius: 5px;
+  -ms-border-radius: 5px;
+  -o-border-radius: 5px;
+  border-radius: 5px;
+}
+.white-theme.leaflet-control.elevation .axis line,
+.white-theme.leaflet-control.elevation .axis path
+{
+  fill: none;
+  stroke: #0d1821;
+  stroke-width: 2;
+}
+.white-theme.leaflet-control.elevation .mouse-drag
+{
+  fill: #00cc33;
+  opacity: 0.2;
+}
+.white-theme.leaflet-control.elevation .elevation-toggle
+{
+  cursor: pointer;
+  box-shadow: 0 1px 7px rgba(0,0,0,.4);
+  -webkit-border-radius: 5px;
+  border-radius: 5px;
+  width: 36px;
+  height: 36px;
+  background-color: #f8f8f9;
+}
+.white-theme.leaflet-control.elevation .elevation-toggle-icon
+{
+  background: url(images/elevation.png) no-repeat center center;
+}
+.white-theme.leaflet-control.elevation .area
+{
+  fill: #00cc33;
+  opacity: 0.8;
+}
+.white-theme.leaflet-control.elevation .mouse-focus-line
+{
+  pointer-events: none;
+  stroke-width: 1;
+  stroke: #0d1821;
+}
+.white-theme.leaflet-control.elevation-collapsed .background
+{
+  display: none;
+}
+.white-theme.leaflet-control.elevation-collapsed .elevation-toggle
+{
+  display: block;
+}
+.white-theme.height-focus
+{
+  stroke: #4682b4;
+  fill: #4682b4;
+}
+.white-theme.height-focus.line
+{
+  pointer-events: none;
+  stroke-width: 2;
 }


### PR DESCRIPTION
It was not showing up and in a wrong color, due to a bad `.leaflet-overlay-pane` selector in CSS, which was removed in https://github.com/MrMufflon/Leaflet.Elevation/commit/94a5d5ee7e0708e1ea2399c1a95c37ab0e18b316.

I delete also here the unused themes, and keep only the white-theme.

<img width="296" alt="screen shot 2018-05-06 at 08 28 56" src="https://user-images.githubusercontent.com/1116761/39670559-b4e2d898-5107-11e8-8930-a33fd57f8f16.png">

Demo currently at: https://gh.bikewm.com/