### PR TITLE
Build GraphHopper without unit tests and without API key

### DIFF
--- a/graphhopper.sh
+++ b/graphhopper.sh
@@ -166,7 +166,7 @@ function packageJar {
   if [ ! -f "$JAR" ]; then
     echo "## building graphhopper jar: $JAR"
     echo "## using maven at $MAVEN_HOME"
-    execMvn --projects web -am -DskipTests=true package
+    execMvn --projects web -P include-client-hc -am -DskipTests=true package
   else
     echo "## existing jar found $JAR"
   fi


### PR DESCRIPTION
Fixes bug introduced by commit efc336e. Based on comment by karussell
https://github.com/graphhopper/graphhopper/issues/1373#issuecomment-389425697

Running `./graphhopper.sh --action build` would fail with

```
[ERROR] Failed to execute goal on project graphhopper-web: Could not resolve dependencies for project com.graphhopper:graphhopper-web:jar:0.11-SNAPSHOT: Could not find artifact com.graphhopper:directions-api-client-hc:jar:0.11-SNAPSHOT -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/DependencyResolutionException
[ERROR] 
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <goals> -rf :graphhopper-web
```