### PR TITLE
Reduce usages of fwd/bwd flags in DefaultEdgeFilter constructor

### DIFF
--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -932,7 +932,7 @@ public class GraphHopper implements GraphHopperAPI {
         if (hintsMap.has(Routing.BLOCK_AREA)) {
             String blockAreaStr = hintsMap.get(Parameters.Routing.BLOCK_AREA, "");
             GraphEdgeIdFinder.BlockArea blockArea = new GraphEdgeIdFinder(graph, locationIndex).
-                    parseBlockArea(blockAreaStr, new DefaultEdgeFilter(encoder), hintsMap.getDouble("block_area.edge_id_max_area", 1000 * 1000));
+                    parseBlockArea(blockAreaStr, DefaultEdgeFilter.allEdges(encoder), hintsMap.getDouble("block_area.edge_id_max_area", 1000 * 1000));
             return new BlockAreaWeighting(weighting, blockArea);
         }
 

--- a/core/src/main/java/com/graphhopper/routing/AbstractRoutingAlgorithm.java
+++ b/core/src/main/java/com/graphhopper/routing/AbstractRoutingAlgorithm.java
@@ -24,7 +24,6 @@ import com.graphhopper.routing.util.TraversalMode;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.Graph;
 import com.graphhopper.storage.NodeAccess;
-import com.graphhopper.storage.SPTEntry;
 import com.graphhopper.util.EdgeExplorer;
 import com.graphhopper.util.EdgeIteratorState;
 
@@ -57,8 +56,8 @@ public abstract class AbstractRoutingAlgorithm implements RoutingAlgorithm {
         this.traversalMode = traversalMode;
         this.graph = graph;
         this.nodeAccess = graph.getNodeAccess();
-        outEdgeExplorer = graph.createEdgeExplorer(new DefaultEdgeFilter(flagEncoder, false, true));
-        inEdgeExplorer = graph.createEdgeExplorer(new DefaultEdgeFilter(flagEncoder, true, false));
+        outEdgeExplorer = graph.createEdgeExplorer(DefaultEdgeFilter.outEdges(flagEncoder));
+        inEdgeExplorer = graph.createEdgeExplorer(DefaultEdgeFilter.inEdges(flagEncoder));
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/InstructionsFromEdges.java
+++ b/core/src/main/java/com/graphhopper/routing/InstructionsFromEdges.java
@@ -89,7 +89,7 @@ public class InstructionsFromEdges implements Path.EdgeVisitor {
         prevInRoundabout = false;
         prevName = null;
         outEdgeExplorer = graph.createEdgeExplorer(DefaultEdgeFilter.outEdges(encoder));
-        crossingExplorer = graph.createEdgeExplorer(new DefaultEdgeFilter(encoder, true, true));
+        crossingExplorer = graph.createEdgeExplorer(DefaultEdgeFilter.allEdges(encoder));
     }
 
 

--- a/core/src/main/java/com/graphhopper/routing/InstructionsFromEdges.java
+++ b/core/src/main/java/com/graphhopper/routing/InstructionsFromEdges.java
@@ -88,7 +88,7 @@ public class InstructionsFromEdges implements Path.EdgeVisitor {
         prevNode = -1;
         prevInRoundabout = false;
         prevName = null;
-        outEdgeExplorer = graph.createEdgeExplorer(new DefaultEdgeFilter(this.encoder, false, true));
+        outEdgeExplorer = graph.createEdgeExplorer(DefaultEdgeFilter.outEdges(encoder));
         crossingExplorer = graph.createEdgeExplorer(new DefaultEdgeFilter(encoder, true, true));
     }
 

--- a/core/src/main/java/com/graphhopper/routing/ch/NodeContractor.java
+++ b/core/src/main/java/com/graphhopper/routing/ch/NodeContractor.java
@@ -73,8 +73,8 @@ class NodeContractor {
         maxEdgesCount = ghStorage.getAllEdges().length();
         ignoreNodeFilter = new IgnoreNodeFilter(prepareGraph, maxLevel);
         FlagEncoder prepareFlagEncoder = prepareWeighting.getFlagEncoder();
-        vehicleInExplorer = prepareGraph.createEdgeExplorer(new DefaultEdgeFilter(prepareFlagEncoder, true, false));
-        vehicleOutExplorer = prepareGraph.createEdgeExplorer(new DefaultEdgeFilter(prepareFlagEncoder, false, true));
+        vehicleInExplorer = prepareGraph.createEdgeExplorer(DefaultEdgeFilter.inEdges(prepareFlagEncoder));
+        vehicleOutExplorer = prepareGraph.createEdgeExplorer(DefaultEdgeFilter.outEdges(prepareFlagEncoder));
         prepareAlgo = new DijkstraOneToMany(prepareGraph, prepareWeighting, traversalMode);
     }
 

--- a/core/src/main/java/com/graphhopper/routing/ch/PrepareContractionHierarchies.java
+++ b/core/src/main/java/com/graphhopper/routing/ch/PrepareContractionHierarchies.java
@@ -211,7 +211,7 @@ public class PrepareContractionHierarchies extends AbstractAlgoPreparation imple
     private void initFromGraph() {
         ghStorage.freeze();
         FlagEncoder prepareFlagEncoder = prepareWeighting.getFlagEncoder();
-        final EdgeFilter allFilter = new DefaultEdgeFilter(prepareFlagEncoder, true, true);
+        final EdgeFilter allFilter = DefaultEdgeFilter.allEdges(prepareFlagEncoder);
         // filter by vehicle and level number
         final EdgeFilter accessWithLevelFilter = new LevelEdgeFilter(prepareGraph) {
             @Override

--- a/core/src/main/java/com/graphhopper/routing/lm/LandmarkStorage.java
+++ b/core/src/main/java/com/graphhopper/routing/lm/LandmarkStorage.java
@@ -246,7 +246,7 @@ public class LandmarkStorage implements Storable<LandmarkStorage> {
 
         byte[] subnetworks = new byte[graph.getNodes()];
         Arrays.fill(subnetworks, (byte) UNSET_SUBNETWORK);
-        EdgeFilter tarjanFilter = new DefaultEdgeFilter(encoder, false, true);
+        EdgeFilter tarjanFilter = DefaultEdgeFilter.outEdges(encoder);
         IntHashSet blockedEdges = new IntHashSet();
 
         // the ruleLookup splits certain areas from each other but avoids making this a permanent change so that other algorithms still can route through these regions.

--- a/core/src/main/java/com/graphhopper/routing/subnetwork/PrepareRoutingSubnetworks.java
+++ b/core/src/main/java/com/graphhopper/routing/subnetwork/PrepareRoutingSubnetworks.java
@@ -205,7 +205,7 @@ public class PrepareRoutingSubnetworks {
      */
     int removeDeadEndUnvisitedNetworks(final PrepEdgeFilter bothFilter) {
         StopWatch sw = new StopWatch(bothFilter.getEncoder() + " findComponents").start();
-        final EdgeFilter outFilter = new DefaultEdgeFilter(bothFilter.getEncoder(), false, true);
+        final EdgeFilter outFilter = DefaultEdgeFilter.outEdges(bothFilter.getEncoder());
 
         // partition graph into strongly connected components using Tarjan's algorithm        
         TarjansSCCAlgorithm tarjan = new TarjansSCCAlgorithm(ghStorage, outFilter, true);

--- a/core/src/main/java/com/graphhopper/routing/subnetwork/PrepareRoutingSubnetworks.java
+++ b/core/src/main/java/com/graphhopper/routing/subnetwork/PrepareRoutingSubnetworks.java
@@ -288,7 +288,7 @@ public class PrepareRoutingSubnetworks {
         FlagEncoder encoder;
 
         public PrepEdgeFilter(FlagEncoder encoder) {
-            super(encoder);
+            super(encoder, true, true);
             this.encoder = encoder;
         }
 

--- a/core/src/main/java/com/graphhopper/routing/template/RoundTripRoutingTemplate.java
+++ b/core/src/main/java/com/graphhopper/routing/template/RoundTripRoutingTemplate.java
@@ -77,7 +77,7 @@ public class RoundTripRoutingTemplate extends AbstractRoutingTemplate implements
 
         TourStrategy strategy = new MultiPointTour(new Random(seed), distanceInMeter, roundTripPointCount, initialHeading);
         queryResults = new ArrayList<>(2 + strategy.getNumberOfGeneratedPoints());
-        EdgeFilter edgeFilter = new DefaultEdgeFilter(encoder);
+        EdgeFilter edgeFilter = DefaultEdgeFilter.allEdges(encoder);
         QueryResult startQR = locationIndex.findClosest(start.lat, start.lon, edgeFilter);
         if (!startQR.isValid())
             throw new PointNotFoundException("Cannot find point 0: " + start, 0);

--- a/core/src/main/java/com/graphhopper/routing/template/ViaRoutingTemplate.java
+++ b/core/src/main/java/com/graphhopper/routing/template/ViaRoutingTemplate.java
@@ -59,7 +59,7 @@ public class ViaRoutingTemplate extends AbstractRoutingTemplate implements Routi
         if (points.size() < 2)
             throw new IllegalArgumentException("At least 2 points have to be specified, but was:" + points.size());
 
-        EdgeFilter edgeFilter = new DefaultEdgeFilter(encoder);
+        EdgeFilter edgeFilter = DefaultEdgeFilter.allEdges(encoder);
         queryResults = new ArrayList<>(points.size());
         for (int placeIndex = 0; placeIndex < points.size(); placeIndex++) {
             GHPoint point = points.get(placeIndex);

--- a/core/src/main/java/com/graphhopper/routing/util/DefaultEdgeFilter.java
+++ b/core/src/main/java/com/graphhopper/routing/util/DefaultEdgeFilter.java
@@ -27,18 +27,18 @@ public class DefaultEdgeFilter implements EdgeFilter {
     private final boolean fwd;
     private FlagEncoder encoder;
 
-    protected DefaultEdgeFilter(FlagEncoder encoder, boolean bwd, boolean fwd) {
+    protected DefaultEdgeFilter(FlagEncoder encoder, boolean fwd, boolean bwd) {
         this.encoder = encoder;
         this.bwd = bwd;
         this.fwd = fwd;
     }
 
     public static DefaultEdgeFilter outEdges(FlagEncoder flagEncoder) {
-        return new DefaultEdgeFilter(flagEncoder, false, true);
+        return new DefaultEdgeFilter(flagEncoder, true, false);
     }
 
     public static DefaultEdgeFilter inEdges(FlagEncoder flagEncoder) {
-        return new DefaultEdgeFilter(flagEncoder, true, false);
+        return new DefaultEdgeFilter(flagEncoder, false, true);
     }
 
     /**

--- a/core/src/main/java/com/graphhopper/routing/util/DefaultEdgeFilter.java
+++ b/core/src/main/java/com/graphhopper/routing/util/DefaultEdgeFilter.java
@@ -27,14 +27,7 @@ public class DefaultEdgeFilter implements EdgeFilter {
     private final boolean fwd;
     private FlagEncoder encoder;
 
-    /**
-     * Creates an edges filter which accepts both direction of the specified vehicle.
-     */
-    public DefaultEdgeFilter(FlagEncoder encoder) {
-        this(encoder, true, true);
-    }
-
-    public DefaultEdgeFilter(FlagEncoder encoder, boolean bwd, boolean fwd) {
+    protected DefaultEdgeFilter(FlagEncoder encoder, boolean bwd, boolean fwd) {
         this.encoder = encoder;
         this.bwd = bwd;
         this.fwd = fwd;
@@ -48,6 +41,11 @@ public class DefaultEdgeFilter implements EdgeFilter {
         return new DefaultEdgeFilter(flagEncoder, true, false);
     }
 
+    /**
+     * Accepts all edges that are either forward or backward for the given flag encoder.
+     * Edges where neither one of the flags is enabled will still not be accepted. If you need to retrieve all edges
+     * regardless of their encoding use {@link EdgeFilter#ALL_EDGES} instead.
+     */
     public static DefaultEdgeFilter allEdges(FlagEncoder flagEncoder) {
         return new DefaultEdgeFilter(flagEncoder, true, true);
     }

--- a/core/src/main/java/com/graphhopper/routing/util/DefaultEdgeFilter.java
+++ b/core/src/main/java/com/graphhopper/routing/util/DefaultEdgeFilter.java
@@ -40,6 +40,18 @@ public class DefaultEdgeFilter implements EdgeFilter {
         this.fwd = fwd;
     }
 
+    public static DefaultEdgeFilter outEdges(FlagEncoder flagEncoder) {
+        return new DefaultEdgeFilter(flagEncoder, false, true);
+    }
+
+    public static DefaultEdgeFilter inEdges(FlagEncoder flagEncoder) {
+        return new DefaultEdgeFilter(flagEncoder, true, false);
+    }
+
+    public static DefaultEdgeFilter allEdges(FlagEncoder flagEncoder) {
+        return new DefaultEdgeFilter(flagEncoder, true, true);
+    }
+
     @Override
     public final boolean accept(EdgeIteratorState iter) {
         return fwd && iter.isForward(encoder) || bwd && iter.isBackward(encoder);

--- a/core/src/main/java/com/graphhopper/storage/change/ChangeGraphHelper.java
+++ b/core/src/main/java/com/graphhopper/storage/change/ChangeGraphHelper.java
@@ -91,7 +91,7 @@ public class ChangeGraphHelper {
 
     private long applyChange(JsonFeature jsonFeature, FlagEncoder encoder) {
         long updates = 0;
-        EdgeFilter filter = new DefaultEdgeFilter(encoder);
+        EdgeFilter filter = DefaultEdgeFilter.allEdges(encoder);
         GHIntHashSet edges = new GHIntHashSet();
         if (jsonFeature.hasGeometry()) {
             graphBrowser.fillEdgeIDs(edges, jsonFeature.getGeometry(), filter);

--- a/core/src/main/java/com/graphhopper/storage/index/LocationIndex.java
+++ b/core/src/main/java/com/graphhopper/storage/index/LocationIndex.java
@@ -49,7 +49,7 @@ public interface LocationIndex extends Storable<LocationIndex> {
      *
      * @param edgeFilter if a graph supports multiple vehicles we have to make sure that the entry
      *                   node into the graph is accessible from a selected vehicle. E.g. if you have a FOOT-query do:
-     *                   <pre>new DefaultEdgeFilter(footFlagEncoder);</pre>
+     *                   <pre>DefaultEdgeFilter.allEdges(footFlagEncoder);</pre>
      * @return An object containing the closest node and edge for the specified location. The node id
      * has at least one edge which is accepted from the specified edgeFilter. If nothing is found
      * the method QueryResult.isValid will return false.

--- a/core/src/test/java/com/graphhopper/reader/PrincetonReaderTest.java
+++ b/core/src/test/java/com/graphhopper/reader/PrincetonReaderTest.java
@@ -38,7 +38,7 @@ import static org.junit.Assert.assertEquals;
  */
 public class PrincetonReaderTest {
     private EncodingManager encodingManager = new EncodingManager("car");
-    private EdgeFilter carOutEdges = new DefaultEdgeFilter(encodingManager.getEncoder("car"), false, true);
+    private EdgeFilter carOutEdges = DefaultEdgeFilter.outEdges(encodingManager.getEncoder("car"));
 
     @Test
     public void testRead() {

--- a/core/src/test/java/com/graphhopper/routing/PathBidirRefTest.java
+++ b/core/src/test/java/com/graphhopper/routing/PathBidirRefTest.java
@@ -38,7 +38,7 @@ import static org.junit.Assert.assertEquals;
 public class PathBidirRefTest {
     private final EncodingManager encodingManager = new EncodingManager("car");
     private FlagEncoder carEncoder = encodingManager.getEncoder("car");
-    private EdgeFilter carOutEdges = new DefaultEdgeFilter(carEncoder, false, true);
+    private EdgeFilter carOutEdges = DefaultEdgeFilter.outEdges(carEncoder);
 
     Graph createGraph() {
         return new GraphBuilder(encodingManager).create();
@@ -72,7 +72,7 @@ public class PathBidirRefTest {
         pw.sptEntry = new SPTEntry(iter.getEdge(), 2, 10);
         pw.sptEntry.parent = new SPTEntry(EdgeIterator.NO_EDGE, 1, 0);
 
-        explorer = g.createEdgeExplorer(new DefaultEdgeFilter(carEncoder, true, false));
+        explorer = g.createEdgeExplorer(DefaultEdgeFilter.inEdges(carEncoder));
         iter = explorer.setBaseNode(3);
         iter.next();
         pw.edgeTo = new SPTEntry(iter.getEdge(), 2, 20);

--- a/core/src/test/java/com/graphhopper/routing/QueryGraphTest.java
+++ b/core/src/test/java/com/graphhopper/routing/QueryGraphTest.java
@@ -428,8 +428,8 @@ public class QueryGraphTest {
 
     @Test
     public void testIteration_Issue163() {
-        EdgeFilter outEdgeFilter = new DefaultEdgeFilter(encodingManager.getEncoder("car"), false, true);
-        EdgeFilter inEdgeFilter = new DefaultEdgeFilter(encodingManager.getEncoder("car"), true, false);
+        EdgeFilter outEdgeFilter = DefaultEdgeFilter.outEdges(encodingManager.getEncoder("car"));
+        EdgeFilter inEdgeFilter = DefaultEdgeFilter.inEdges(encodingManager.getEncoder("car"));
         EdgeExplorer inExplorer = g.createEdgeExplorer(inEdgeFilter);
         EdgeExplorer outExplorer = g.createEdgeExplorer(outEdgeFilter);
 

--- a/core/src/test/java/com/graphhopper/routing/subnetwork/PrepareRoutingSubnetworksTest.java
+++ b/core/src/test/java/com/graphhopper/routing/subnetwork/PrepareRoutingSubnetworksTest.java
@@ -189,9 +189,9 @@ public class PrepareRoutingSubnetworksTest {
         // remove nothing because of two vehicles with different subnetworks
         assertEquals(9, g.getNodes());
 
-        EdgeExplorer carExplorer = g.createEdgeExplorer(new DefaultEdgeFilter(carEncoder));
+        EdgeExplorer carExplorer = g.createEdgeExplorer(DefaultEdgeFilter.allEdges(carEncoder));
         assertEquals(GHUtility.asSet(7, 2, 1), GHUtility.getNeighbors(carExplorer.setBaseNode(3)));
-        EdgeExplorer bikeExplorer = g.createEdgeExplorer(new DefaultEdgeFilter(bikeEncoder));
+        EdgeExplorer bikeExplorer = g.createEdgeExplorer(DefaultEdgeFilter.allEdges(bikeEncoder));
         assertEquals(GHUtility.asSet(7, 2, 1, 4), GHUtility.getNeighbors(bikeExplorer.setBaseNode(3)));
 
         GHUtility.getEdge(g, 3, 4).setFlags(carEncoder.setProperties(10, false, false) | bikeEncoder.setProperties(5, false, false));

--- a/core/src/test/java/com/graphhopper/routing/subnetwork/PrepareRoutingSubnetworksTest.java
+++ b/core/src/test/java/com/graphhopper/routing/subnetwork/PrepareRoutingSubnetworksTest.java
@@ -283,7 +283,7 @@ public class PrepareRoutingSubnetworksTest {
         GraphHopperStorage g = createSubnetworkTestStorage();
 
         // Requires a single vehicle type, otherwise we throw.
-        final EdgeFilter filter = new DefaultEdgeFilter(carFlagEncoder, false, true);
+        final EdgeFilter filter = DefaultEdgeFilter.outEdges(carFlagEncoder);
         TarjansSCCAlgorithm tarjan = new TarjansSCCAlgorithm(g, filter, false);
 
         List<IntArrayList> components = tarjan.findComponents();

--- a/core/src/test/java/com/graphhopper/routing/util/FootFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/FootFlagEncoderTest.java
@@ -75,7 +75,7 @@ public class FootFlagEncoderTest {
         g.edge(0, 1).setDistance(10).setFlags(footEncoder.setProperties(10, true, true));
         g.edge(0, 2).setDistance(10).setFlags(footEncoder.setProperties(5, true, true));
         g.edge(1, 3).setDistance(10).setFlags(footEncoder.setProperties(10, true, true));
-        EdgeExplorer out = g.createEdgeExplorer(new DefaultEdgeFilter(footEncoder, false, true));
+        EdgeExplorer out = g.createEdgeExplorer(DefaultEdgeFilter.outEdges(footEncoder));
         assertEquals(GHUtility.asSet(1, 2), GHUtility.getNeighbors(out.setBaseNode(0)));
         assertEquals(GHUtility.asSet(0, 3), GHUtility.getNeighbors(out.setBaseNode(1)));
         assertEquals(GHUtility.asSet(0), GHUtility.getNeighbors(out.setBaseNode(2)));

--- a/core/src/test/java/com/graphhopper/routing/util/NameSimilarityEdgeFilterTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/NameSimilarityEdgeFilterTest.java
@@ -32,7 +32,7 @@ public class NameSimilarityEdgeFilterTest {
 
     @Test
     public void testAccept() {
-        EdgeFilter edgeFilter = new NameSimilarityEdgeFilter(new DefaultEdgeFilter(new CarFlagEncoder()), "Laufamholzstraße 154 Nürnberg");
+        EdgeFilter edgeFilter = createNameSimilarityEdgeFilter("Laufamholzstraße 154 Nürnberg");
         EdgeIteratorState edge = createTestEdgeIterator("Laufamholzstraße, ST1333");
         assertTrue(edgeFilter.accept(edge));
 
@@ -48,22 +48,22 @@ public class NameSimilarityEdgeFilterTest {
         edge = createTestEdgeIterator(null);
         assertFalse(edgeFilter.accept(edge));
 
-        edgeFilter = new NameSimilarityEdgeFilter(new DefaultEdgeFilter(new CarFlagEncoder()), null);
+        edgeFilter = createNameSimilarityEdgeFilter(null);
         edge = createTestEdgeIterator("Laufamholzstraße, ST1333");
         assertTrue(edgeFilter.accept(edge));
 
-        edgeFilter = new NameSimilarityEdgeFilter(new DefaultEdgeFilter(new CarFlagEncoder()), "");
+        edgeFilter = createNameSimilarityEdgeFilter("");
         edge = createTestEdgeIterator("Laufamholzstraße, ST1333");
         assertTrue(edgeFilter.accept(edge));
 
-        edgeFilter = new NameSimilarityEdgeFilter(new DefaultEdgeFilter(new CarFlagEncoder()), "Johannesstraße, 99636, Rastenberg, Deutschland");
+        edgeFilter = createNameSimilarityEdgeFilter("Johannesstraße, 99636, Rastenberg, Deutschland");
         edge = createTestEdgeIterator("Laufamholzstraße, ST1333");
         assertFalse(edgeFilter.accept(edge));
 
         edge = createTestEdgeIterator("Johannesstraße");
         assertTrue(edgeFilter.accept(edge));
 
-        edgeFilter = new NameSimilarityEdgeFilter(new DefaultEdgeFilter(new CarFlagEncoder()), "Hauptstraße, 39025, Naturns, Italien");
+        edgeFilter = createNameSimilarityEdgeFilter("Hauptstraße, 39025, Naturns, Italien");
         edge = createTestEdgeIterator("Teststraße");
         assertFalse(edgeFilter.accept(edge));
 
@@ -86,11 +86,11 @@ public class NameSimilarityEdgeFilterTest {
         EdgeFilter edgeFilter;
         EdgeIteratorState edge;
 
-        edgeFilter = new NameSimilarityEdgeFilter(new DefaultEdgeFilter(new CarFlagEncoder()), "Wentworth Street, Caringbah South");
+        edgeFilter = createNameSimilarityEdgeFilter("Wentworth Street, Caringbah South");
         edge = createTestEdgeIterator("Wentworth Street");
         assertTrue(edgeFilter.accept(edge));
 
-        edgeFilter = new NameSimilarityEdgeFilter(new DefaultEdgeFilter(new CarFlagEncoder()), "Zum Toffental, Altdorf bei Nürnnberg");
+        edgeFilter = createNameSimilarityEdgeFilter("Zum Toffental, Altdorf bei Nürnnberg");
         edge = createTestEdgeIterator("Zum Toffental");
         assertTrue(edgeFilter.accept(edge));
     }
@@ -100,21 +100,21 @@ public class NameSimilarityEdgeFilterTest {
         EdgeFilter edgeFilter;
         EdgeIteratorState edge;
 
-        edgeFilter = new NameSimilarityEdgeFilter(new DefaultEdgeFilter(new CarFlagEncoder()), "Rue Notre-Dame O Montréal");
+        edgeFilter = createNameSimilarityEdgeFilter("Rue Notre-Dame O Montréal");
         edge = createTestEdgeIterator("Rue Dupré");
         assertFalse(edgeFilter.accept(edge));
 
         edge = createTestEdgeIterator("Rue Notre-Dame Ouest");
         assertTrue(edgeFilter.accept(edge));
 
-        edgeFilter = new NameSimilarityEdgeFilter(new DefaultEdgeFilter(new CarFlagEncoder()), "227 Rue Saint-Antoine O, Montréal");
+        edgeFilter = createNameSimilarityEdgeFilter("227 Rue Saint-Antoine O, Montréal");
         edge = createTestEdgeIterator("Rue Saint-Antoine O");
         assertTrue(edgeFilter.accept(edge));
 
         edge = createTestEdgeIterator("Rue Saint-Jacques");
         assertFalse(edgeFilter.accept(edge));
 
-        edgeFilter = new NameSimilarityEdgeFilter(new DefaultEdgeFilter(new CarFlagEncoder()), "1025 Rue de Bleury, Montréal, QC H2Z 1M7");
+        edgeFilter = createNameSimilarityEdgeFilter("1025 Rue de Bleury, Montréal, QC H2Z 1M7");
         edge = createTestEdgeIterator("Rue de Bleury");
         assertTrue(edgeFilter.accept(edge));
 
@@ -122,15 +122,15 @@ public class NameSimilarityEdgeFilterTest {
         assertFalse(edgeFilter.accept(edge));
 
         // Modified Test from Below
-        edgeFilter = new NameSimilarityEdgeFilter(new DefaultEdgeFilter(new CarFlagEncoder()), "257 Main Road, Claremont, Cape Town, 7708, Afrique du Sud");
+        edgeFilter = createNameSimilarityEdgeFilter("257 Main Road, Claremont, Cape Town, 7708, Afrique du Sud");
         edge = createTestEdgeIterator("Main Road");
         assertTrue(edgeFilter.accept(edge));
 
-        edgeFilter = new NameSimilarityEdgeFilter(new DefaultEdgeFilter(new CarFlagEncoder()), "Cape Point Rd, Cape Peninsula, Cape Town, 8001, Afrique du Sud");
+        edgeFilter = createNameSimilarityEdgeFilter("Cape Point Rd, Cape Peninsula, Cape Town, 8001, Afrique du Sud");
         edge = createTestEdgeIterator("Cape Point / Cape of Good Hope");
         assertTrue(edgeFilter.accept(edge));
 
-        edgeFilter = new NameSimilarityEdgeFilter(new DefaultEdgeFilter(new CarFlagEncoder()), "Viale Puglie, 26, 20137 Milano, Italy");
+        edgeFilter = createNameSimilarityEdgeFilter("Viale Puglie, 26, 20137 Milano, Italy");
         edge = createTestEdgeIterator("Viale Puglie");
         assertTrue(edgeFilter.accept(edge));
     }
@@ -143,15 +143,15 @@ public class NameSimilarityEdgeFilterTest {
         edge = createTestEdgeIterator("Augustine Street");
 
         // Google Maps
-        edgeFilter = new NameSimilarityEdgeFilter(new DefaultEdgeFilter(new CarFlagEncoder()), "Augustine St, Hunters Hill NSW 2110, Australia");
+        edgeFilter = createNameSimilarityEdgeFilter("Augustine St, Hunters Hill NSW 2110, Australia");
         assertTrue(edgeFilter.accept(edge));
 
         // Opencagedata
-        edgeFilter = new NameSimilarityEdgeFilter(new DefaultEdgeFilter(new CarFlagEncoder()), "Augustine Street, Sydney Neusüdwales 2110, Australien");
+        edgeFilter = createNameSimilarityEdgeFilter("Augustine Street, Sydney Neusüdwales 2110, Australien");
         assertTrue(edgeFilter.accept(edge));
 
         // Nominatim
-        edgeFilter = new NameSimilarityEdgeFilter(new DefaultEdgeFilter(new CarFlagEncoder()), "Augustine Street, Sydney, Municipality of Hunters Hill, Neusüdwales, 2111, Australien");
+        edgeFilter = createNameSimilarityEdgeFilter("Augustine Street, Sydney, Municipality of Hunters Hill, Neusüdwales, 2111, Australien");
         assertTrue(edgeFilter.accept(edge));
 
     }
@@ -162,21 +162,21 @@ public class NameSimilarityEdgeFilterTest {
         EdgeIteratorState edge;
 
         // The Problem is that Rd vs Road is abreviated, if we have Road, it works
-        edgeFilter = new NameSimilarityEdgeFilter(new DefaultEdgeFilter(new CarFlagEncoder()), "257 Main Rd, Claremont, Cape Town, 7708, Afrique du Sud");
+        edgeFilter = createNameSimilarityEdgeFilter("257 Main Rd, Claremont, Cape Town, 7708, Afrique du Sud");
         edge = createTestEdgeIterator("Main Road");
         assertTrue(edgeFilter.accept(edge));
 
         // Just too much difference Between Google Maps and OSM @ 32.121435,-110.857969
-        edgeFilter = new NameSimilarityEdgeFilter(new DefaultEdgeFilter(new CarFlagEncoder()), "7202 S Wilmot Rd, Tucson, AZ 85701");
+        edgeFilter = createNameSimilarityEdgeFilter("7202 S Wilmot Rd, Tucson, AZ 85701");
         edge = createTestEdgeIterator("South Wilmot Road");
         assertTrue(edgeFilter.accept(edge));
 
         // @ 37.307774,13.581259
-        edgeFilter = new NameSimilarityEdgeFilter(new DefaultEdgeFilter(new CarFlagEncoder()), "Via Manzoni, 50/52, 92100 Agrigento AG, Italy");
+        edgeFilter = createNameSimilarityEdgeFilter("Via Manzoni, 50/52, 92100 Agrigento AG, Italy");
         edge = createTestEdgeIterator("Via Alessandro Manzoni");
         assertTrue(edgeFilter.accept(edge));
 
-        edgeFilter = new NameSimilarityEdgeFilter(new DefaultEdgeFilter(new CarFlagEncoder()), "Av. Juan Ramón Ramírez, 12, 02630 La Roda, Albacete, Spain");
+        edgeFilter = createNameSimilarityEdgeFilter("Av. Juan Ramón Ramírez, 12, 02630 La Roda, Albacete, Spain");
         edge = createTestEdgeIterator("Avenida Juan Ramón Ramírez");
         assertTrue(edgeFilter.accept(edge));
 
@@ -189,49 +189,53 @@ public class NameSimilarityEdgeFilterTest {
      */
     @Ignore
     public void testAcceptWithTypos() {
-        EdgeFilter edgeFilter = new NameSimilarityEdgeFilter(new DefaultEdgeFilter(new CarFlagEncoder()), "Laufamholzstraße 154 Nürnberg");
+        EdgeFilter edgeFilter = createNameSimilarityEdgeFilter("Laufamholzstraße 154 Nürnberg");
         EdgeIteratorState edge = createTestEdgeIterator("Laufamholzstraße, ST1333");
         assertTrue(edgeFilter.accept(edge));
 
         // Single Typo
-        edgeFilter = new NameSimilarityEdgeFilter(new DefaultEdgeFilter(new CarFlagEncoder()), "Kaufamholzstraße 154 Nürnberg");
+        edgeFilter = createNameSimilarityEdgeFilter("Kaufamholzstraße 154 Nürnberg");
         assertTrue(edgeFilter.accept(edge));
 
         // Two Typos
-        edgeFilter = new NameSimilarityEdgeFilter(new DefaultEdgeFilter(new CarFlagEncoder()), "Kaufamholystraße 154 Nürnberg");
+        edgeFilter = createNameSimilarityEdgeFilter("Kaufamholystraße 154 Nürnberg");
         assertTrue(edgeFilter.accept(edge));
 
         // Three Typos
-        edgeFilter = new NameSimilarityEdgeFilter(new DefaultEdgeFilter(new CarFlagEncoder()), "Kaufmholystraße 154 Nürnberg");
+        edgeFilter = createNameSimilarityEdgeFilter("Kaufmholystraße 154 Nürnberg");
         assertFalse(edgeFilter.accept(edge));
 
-        edgeFilter = new NameSimilarityEdgeFilter(new DefaultEdgeFilter(new CarFlagEncoder()), "Hauptstraße");
+        edgeFilter = createNameSimilarityEdgeFilter("Hauptstraße");
         edge = createTestEdgeIterator("Hauptstraße");
         assertTrue(edgeFilter.accept(edge));
 
         // Single Typo
-        edgeFilter = new NameSimilarityEdgeFilter(new DefaultEdgeFilter(new CarFlagEncoder()), "Hauptstrase");
+        edgeFilter = createNameSimilarityEdgeFilter("Hauptstrase");
         assertTrue(edgeFilter.accept(edge));
 
         // Two Typos
-        edgeFilter = new NameSimilarityEdgeFilter(new DefaultEdgeFilter(new CarFlagEncoder()), "Lauptstrase");
+        edgeFilter = createNameSimilarityEdgeFilter("Lauptstrase");
         assertTrue(edgeFilter.accept(edge));
 
         // We ignore too short Strings for now
         /*
         // Distance - PerfectDistance = 1
-        edgeFilter = new NameSimilarityEdgeFilter(new DefaultEdgeFilter(new CarFlagEncoder()), "z");
+        edgeFilter = createNameSimilarityEdgeFilter("z");
         assertFalse(edgeFilter.accept(edge));
         // Distance - PerfectDistance = 1
-        edgeFilter = new NameSimilarityEdgeFilter(new DefaultEdgeFilter(new CarFlagEncoder()), "az");
+        edgeFilter = createNameSimilarityEdgeFilter("az");
         assertFalse(edgeFilter.accept(edge));
 
         // Distance - PerfectDistance = 2
-        edgeFilter = new NameSimilarityEdgeFilter(new DefaultEdgeFilter(new CarFlagEncoder()), "xy");
+        edgeFilter = createNameSimilarityEdgeFilter("xy");
         assertFalse(edgeFilter.accept(edge));
         */
     }
 
+    private NameSimilarityEdgeFilter createNameSimilarityEdgeFilter(String s) {
+        return new NameSimilarityEdgeFilter(DefaultEdgeFilter.allEdges(new CarFlagEncoder()), s);
+    }
+    
     private EdgeIteratorState createTestEdgeIterator(final String name) {
         return new GHUtility.DisabledEdgeIterator() {
 

--- a/core/src/test/java/com/graphhopper/storage/AbstractGraphStorageTester.java
+++ b/core/src/test/java/com/graphhopper/storage/AbstractGraphStorageTester.java
@@ -49,8 +49,8 @@ public abstract class AbstractGraphStorageTester {
     protected CarFlagEncoder carEncoder = (CarFlagEncoder) encodingManager.getEncoder("car");
     protected FootFlagEncoder footEncoder = (FootFlagEncoder) encodingManager.getEncoder("foot");
     protected GraphHopperStorage graph;
-    EdgeFilter carOutFilter = new DefaultEdgeFilter(carEncoder, false, true);
-    EdgeFilter carInFilter = new DefaultEdgeFilter(carEncoder, true, false);
+    EdgeFilter carOutFilter = DefaultEdgeFilter.outEdges(carEncoder);
+    EdgeFilter carInFilter = DefaultEdgeFilter.inEdges(carEncoder);
     EdgeExplorer carOutExplorer;
     EdgeExplorer carInExplorer;
     EdgeExplorer carAllExplorer;
@@ -881,7 +881,7 @@ public abstract class AbstractGraphStorageTester {
         graph.edge(0, 1).setDistance(10).setFlags(footEncoder.setProperties(10, true, true));
         graph.edge(0, 2).setDistance(10).setFlags(carEncoder.setProperties(10, true, true));
         graph.edge(0, 3).setDistance(10).setFlags(footEncoder.setProperties(10, true, true) | carEncoder.setProperties(10, true, true));
-        EdgeExplorer footOutExplorer = graph.createEdgeExplorer(new DefaultEdgeFilter(footEncoder, false, true));
+        EdgeExplorer footOutExplorer = graph.createEdgeExplorer(DefaultEdgeFilter.outEdges(footEncoder));
         assertEquals(GHUtility.asSet(3, 1), GHUtility.getNeighbors(footOutExplorer.setBaseNode(0)));
         assertEquals(GHUtility.asSet(3, 2), GHUtility.getNeighbors(carOutExplorer.setBaseNode(0)));
     }

--- a/core/src/test/java/com/graphhopper/storage/GraphEdgeIdFinderTest.java
+++ b/core/src/test/java/com/graphhopper/storage/GraphEdgeIdFinderTest.java
@@ -62,7 +62,7 @@ public class GraphEdgeIdFinderTest {
                 .prepareIndex();
 
         GraphEdgeIdFinder graphFinder = new GraphEdgeIdFinder(graph, locationIndex);
-        GraphEdgeIdFinder.BlockArea blockArea = graphFinder.parseBlockArea("0.01,0.005,1", new DefaultEdgeFilter(encoder), 1000 * 1000);
+        GraphEdgeIdFinder.BlockArea blockArea = graphFinder.parseBlockArea("0.01,0.005,1", DefaultEdgeFilter.allEdges(encoder), 1000 * 1000);
 
         GHIntHashSet blockedEdges = new GHIntHashSet();
         blockedEdges.add(0);
@@ -72,7 +72,7 @@ public class GraphEdgeIdFinderTest {
 
         // big area converts into shapes
         graphFinder = new GraphEdgeIdFinder(graph, locationIndex);
-        blockArea = graphFinder.parseBlockArea("0,0,1000", new DefaultEdgeFilter(encoder), 1000 * 1000);
+        blockArea = graphFinder.parseBlockArea("0,0,1000", DefaultEdgeFilter.allEdges(encoder), 1000 * 1000);
         blockedEdges.clear();
         assertEquals(blockedEdges, blockArea.blockedEdges);
         blockedShapes.add(new Circle(0, 0, 1000));
@@ -121,13 +121,13 @@ public class GraphEdgeIdFinderTest {
                 .prepareIndex();
 
         GraphEdgeIdFinder graphFinder = new GraphEdgeIdFinder(graph, locationIndex);
-        GraphEdgeIdFinder.BlockArea blockArea = graphFinder.parseBlockArea("2,1, 0,2, 2,3", new DefaultEdgeFilter(encoder), 1000 * 1000);
+        GraphEdgeIdFinder.BlockArea blockArea = graphFinder.parseBlockArea("2,1, 0,2, 2,3", DefaultEdgeFilter.allEdges(encoder), 1000 * 1000);
 
         GHIntHashSet blockedEdges = new GHIntHashSet();
         blockedEdges.addAll(new int[]{1, 2, 6, 7});
         assertEquals(blockedEdges, blockArea.blockedEdges);
 
-        blockArea = graphFinder.parseBlockArea("2,1, 1,3, 1,2, 0,1", new DefaultEdgeFilter(encoder), 1000 * 1000);
+        blockArea = graphFinder.parseBlockArea("2,1, 1,3, 1,2, 0,1", DefaultEdgeFilter.allEdges(encoder), 1000 * 1000);
 
         blockedEdges = new GHIntHashSet();
         blockedEdges.addAll(new int[]{4, 9, 6, 7});

--- a/core/src/test/java/com/graphhopper/storage/GraphHopperStorageCHTest.java
+++ b/core/src/test/java/com/graphhopper/storage/GraphHopperStorageCHTest.java
@@ -338,7 +338,7 @@ public class GraphHopperStorageCHTest extends GraphHopperStorageTest {
         CHGraph lg = graph.getGraph(CHGraph.class);
         lg.shortcut(1, 4).setWeight(3).setFlags(carEncoder.setProperties(10, true, true));
 
-        EdgeExplorer vehicleOutExplorer = lg.createEdgeExplorer(new DefaultEdgeFilter(carEncoder, false, true));
+        EdgeExplorer vehicleOutExplorer = lg.createEdgeExplorer(DefaultEdgeFilter.outEdges(carEncoder));
         // iteration should result in same nodes even if reusing the iterator
         assertEquals(GHUtility.asSet(3, 4), GHUtility.getNeighbors(vehicleOutExplorer.setBaseNode(1)));
         assertEquals(GHUtility.asSet(3, 4), GHUtility.getNeighbors(vehicleOutExplorer.setBaseNode(1)));

--- a/core/src/test/java/com/graphhopper/storage/index/AbstractLocationIndexTester.java
+++ b/core/src/test/java/com/graphhopper/storage/index/AbstractLocationIndexTester.java
@@ -341,7 +341,7 @@ public abstract class AbstractLocationIndexTester {
 
         idx = createIndex(g, -1);
         FootFlagEncoder footEncoder = (FootFlagEncoder) encodingManager.getEncoder("foot");
-        assertEquals(2, idx.findClosest(1, -1, new DefaultEdgeFilter(footEncoder)).getClosestNode());
+        assertEquals(2, idx.findClosest(1, -1, DefaultEdgeFilter.allEdges(footEncoder)).getClosestNode());
         Helper.close((Closeable) g);
     }
 }

--- a/core/src/test/java/com/graphhopper/storage/index/LocationIndexTreeTest.java
+++ b/core/src/test/java/com/graphhopper/storage/index/LocationIndexTreeTest.java
@@ -465,12 +465,12 @@ public class LocationIndexTreeTest extends AbstractLocationIndexTester {
         index.prepareIndex();
         index.setMaxRegionSearch(8);
 
-        EdgeFilter carFilter = new DefaultEdgeFilter(carEncoder, true, true);
+        EdgeFilter carFilter = DefaultEdgeFilter.allEdges(carEncoder);
         QueryResult qr = index.findClosest(0.03, 0.03, carFilter);
         assertTrue(qr.isValid());
         assertEquals(33, qr.getClosestNode());
 
-        EdgeFilter bikeFilter = new DefaultEdgeFilter(bikeEncoder, true, true);
+        EdgeFilter bikeFilter = DefaultEdgeFilter.allEdges(bikeEncoder);
         qr = index.findClosest(0.03, 0.03, bikeFilter);
         assertTrue(qr.isValid());
         assertEquals(2, qr.getClosestNode());

--- a/core/src/test/java/com/graphhopper/util/CHEdgeIteratorTest.java
+++ b/core/src/test/java/com/graphhopper/util/CHEdgeIteratorTest.java
@@ -38,7 +38,7 @@ public class CHEdgeIteratorTest {
         CarFlagEncoder carFlagEncoder = new CarFlagEncoder();
         EncodingManager encodingManager = new EncodingManager(carFlagEncoder);
         FastestWeighting weighting = new FastestWeighting(carFlagEncoder);
-        EdgeFilter carOutFilter = new DefaultEdgeFilter(carFlagEncoder, false, true);
+        EdgeFilter carOutFilter = DefaultEdgeFilter.outEdges(carFlagEncoder);
         GraphHopperStorage ghStorage = new GraphBuilder(encodingManager).setCHGraph(weighting).create();
         CHGraph g = ghStorage.getGraph(CHGraph.class, weighting);
         g.edge(0, 1).setDistance(12).setFlags(carFlagEncoder.setProperties(10, true, true));

--- a/core/src/test/java/com/graphhopper/util/DepthFirstSearchTest.java
+++ b/core/src/test/java/com/graphhopper/util/DepthFirstSearchTest.java
@@ -68,7 +68,7 @@ public class DepthFirstSearchTest {
         g.edge(5, 6, 1, false);
         g.edge(6, 4, 1, false);
 
-        dfs.start(g.createEdgeExplorer(new DefaultEdgeFilter(fe, false, true)), 1);
+        dfs.start(g.createEdgeExplorer(DefaultEdgeFilter.outEdges(fe)), 1);
 
         assertTrue(counter > 0);
         assertEquals("[1, 2, 3, 4, 5, 6]", list.toString());
@@ -96,7 +96,7 @@ public class DepthFirstSearchTest {
         g.edge(2, 3, 1, false);
         g.edge(4, 3, 1, true);
 
-        dfs.start(g.createEdgeExplorer(new DefaultEdgeFilter(fe, false, true)), 1);
+        dfs.start(g.createEdgeExplorer(DefaultEdgeFilter.outEdges(fe)), 1);
 
         assertTrue(counter > 0);
         assertEquals("[1, 2, 3, 4]", list.toString());

--- a/reader-gtfs/src/main/java/com/graphhopper/reader/gtfs/GraphExplorer.java
+++ b/reader-gtfs/src/main/java/com/graphhopper/reader/gtfs/GraphExplorer.java
@@ -55,7 +55,7 @@ final class GraphExplorer {
 
     GraphExplorer(Graph graph, PtTravelTimeWeighting weighting, PtFlagEncoder flagEncoder, GtfsStorage gtfsStorage, RealtimeFeed realtimeFeed, boolean reverse, List<VirtualEdgeIteratorState> extraEdges, boolean walkOnly) {
         this.graph = graph;
-        this.edgeExplorer = graph.createEdgeExplorer(new DefaultEdgeFilter(flagEncoder, reverse, !reverse));
+        this.edgeExplorer = graph.createEdgeExplorer(reverse ? DefaultEdgeFilter.inEdges(flagEncoder) : DefaultEdgeFilter.outEdges(flagEncoder));
         this.flagEncoder = flagEncoder;
         this.weighting = weighting;
         this.gtfsStorage = gtfsStorage;

--- a/reader-gtfs/src/main/java/com/graphhopper/reader/gtfs/GtfsReader.java
+++ b/reader-gtfs/src/main/java/com/graphhopper/reader/gtfs/GtfsReader.java
@@ -274,7 +274,7 @@ class GtfsReader {
                             edge.setFlags(encoder.setTime(edge.getFlags(), after.a-timelineNode.a));
 
 //                            System.out.println(" "+ after);
-//                            EdgeIterator ei = graph.getBaseGraph().createEdgeExplorer(new DefaultEdgeFilter(encoder, true, false)).setBaseNode(after.b);
+//                            EdgeIterator ei = graph.getBaseGraph().createEdgeExplorer(DefaultEdgeFilter.inEdges(encoder)).setBaseNode(after.b);
 //                            while(ei.next()) {
 //                                if (encoder.getEdgeType(ei.getFlags()) == GtfsStorage.EdgeType.TRANSFER) {
 //                                    System.out.println("   "+ei+"   @"+Long.toString(after.a-encoder.getTime(ei.getFlags())));
@@ -338,7 +338,7 @@ class GtfsReader {
             return Stream.empty();
         }
         return StreamSupport.stream(new Spliterators.AbstractSpliterator<EdgeIteratorState>(0, 0) {
-            EdgeIterator edgeIterator = graph.getBaseGraph().createEdgeExplorer(new DefaultEdgeFilter(encoder, false, true)).setBaseNode(node);
+            EdgeIterator edgeIterator = graph.getBaseGraph().createEdgeExplorer(DefaultEdgeFilter.outEdges(encoder)).setBaseNode(node);
             @Override
             public boolean tryAdvance(Consumer<? super EdgeIteratorState> action) {
                 if (edgeIterator.next()) {
@@ -354,7 +354,7 @@ class GtfsReader {
     }
 
     private int findPlatformEnterNode(int stationNode, String routeId) {
-        EdgeIterator i = graph.getBaseGraph().createEdgeExplorer(new DefaultEdgeFilter(encoder, false, true)).setBaseNode(stationNode);
+        EdgeIterator i = graph.getBaseGraph().createEdgeExplorer(DefaultEdgeFilter.outEdges(encoder)).setBaseNode(stationNode);
         while (i.next()) {
             GtfsStorage.EdgeType edgeType = encoder.getEdgeType(i.getFlags());
             if (edgeType == GtfsStorage.EdgeType.ENTER_PT) {
@@ -367,7 +367,7 @@ class GtfsReader {
     }
 
     private int findPlatformExitNode(int stationNode, String routeId) {
-        EdgeIterator i = graph.getBaseGraph().createEdgeExplorer(new DefaultEdgeFilter(encoder, true, false)).setBaseNode(stationNode);
+        EdgeIterator i = graph.getBaseGraph().createEdgeExplorer(DefaultEdgeFilter.inEdges(encoder)).setBaseNode(stationNode);
         while (i.next()) {
             GtfsStorage.EdgeType edgeType = encoder.getEdgeType(i.getFlags());
             if (edgeType == GtfsStorage.EdgeType.EXIT_PT) {

--- a/reader-osm/src/main/java/com/graphhopper/reader/osm/OSMReader.java
+++ b/reader-osm/src/main/java/com/graphhopper/reader/osm/OSMReader.java
@@ -454,10 +454,10 @@ public class OSMReader implements DataReader {
         EdgeExplorer edgeInExplorer = inExplorerMap.get(encoder);
 
         if (edgeOutExplorer == null || edgeInExplorer == null) {
-            edgeOutExplorer = graph.createEdgeExplorer(new DefaultEdgeFilter(encoder, false, true));
+            edgeOutExplorer = graph.createEdgeExplorer(DefaultEdgeFilter.outEdges(encoder));
             outExplorerMap.put(encoder, edgeOutExplorer);
 
-            edgeInExplorer = graph.createEdgeExplorer(new DefaultEdgeFilter(encoder, true, false));
+            edgeInExplorer = graph.createEdgeExplorer(DefaultEdgeFilter.inEdges(encoder));
             inExplorerMap.put(encoder, edgeInExplorer);
         }
         return turnRelation.getRestrictionAsEntries(encoder, edgeOutExplorer, edgeInExplorer, this);

--- a/reader-osm/src/test/java/com/graphhopper/reader/osm/OSMReaderTest.java
+++ b/reader-osm/src/test/java/com/graphhopper/reader/osm/OSMReaderTest.java
@@ -848,7 +848,7 @@ public class OSMReaderTest {
             }
             osmReader.readGraph();
             carOutExplorer = getGraphHopperStorage().createEdgeExplorer(DefaultEdgeFilter.outEdges(carEncoder));
-            carAllExplorer = getGraphHopperStorage().createEdgeExplorer(new DefaultEdgeFilter(carEncoder, true, true));
+            carAllExplorer = getGraphHopperStorage().createEdgeExplorer(DefaultEdgeFilter.allEdges(carEncoder));
             return osmReader;
         }
     }

--- a/reader-osm/src/test/java/com/graphhopper/reader/osm/OSMReaderTest.java
+++ b/reader-osm/src/test/java/com/graphhopper/reader/osm/OSMReaderTest.java
@@ -325,7 +325,7 @@ public class OSMReaderTest {
         assertEquals(GHUtility.asSet(n10, n30, n40), GHUtility.getNeighbors(carAllExplorer.setBaseNode(n20)));
         assertEquals(GHUtility.asSet(n30, n40), GHUtility.getNeighbors(carOutExplorer.setBaseNode(n20)));
 
-        EdgeExplorer footOutExplorer = graph.createEdgeExplorer(new DefaultEdgeFilter(footEncoder, false, true));
+        EdgeExplorer footOutExplorer = graph.createEdgeExplorer(DefaultEdgeFilter.outEdges(footEncoder));
         assertEquals(GHUtility.asSet(n20, n50), GHUtility.getNeighbors(footOutExplorer.setBaseNode(n10)));
         assertEquals(GHUtility.asSet(n20, n50), GHUtility.getNeighbors(footOutExplorer.setBaseNode(n30)));
         assertEquals(GHUtility.asSet(n10, n30), GHUtility.getNeighbors(footOutExplorer.setBaseNode(n20)));
@@ -847,7 +847,7 @@ public class OSMReaderTest {
                 throw new RuntimeException(e);
             }
             osmReader.readGraph();
-            carOutExplorer = getGraphHopperStorage().createEdgeExplorer(new DefaultEdgeFilter(carEncoder, false, true));
+            carOutExplorer = getGraphHopperStorage().createEdgeExplorer(DefaultEdgeFilter.outEdges(carEncoder));
             carAllExplorer = getGraphHopperStorage().createEdgeExplorer(new DefaultEdgeFilter(carEncoder, true, true));
             return osmReader;
         }

--- a/reader-osm/src/test/java/com/graphhopper/routing/RoutingAlgorithmWithOSMIT.java
+++ b/reader-osm/src/test/java/com/graphhopper/routing/RoutingAlgorithmWithOSMIT.java
@@ -547,7 +547,7 @@ public class RoutingAlgorithmWithOSMIT {
 
             Collection<AlgoHelperEntry> prepares = RoutingAlgorithmIT.createAlgos(hopper, hints, tMode);
 
-            EdgeFilter edgeFilter = new DefaultEdgeFilter(encoder);
+            EdgeFilter edgeFilter = DefaultEdgeFilter.allEdges(encoder);
             for (AlgoHelperEntry entry : prepares) {
                 algoEntry = entry;
                 LocationIndex idx = entry.getIdx();
@@ -595,7 +595,7 @@ public class RoutingAlgorithmWithOSMIT {
         // also the preparing is too costly to be called for every thread
         int algosLength = 2;
         final Weighting weighting = new ShortestWeighting(encodingManager.getEncoder("car"));
-        final EdgeFilter filter = new DefaultEdgeFilter(carEncoder);
+        final EdgeFilter filter = DefaultEdgeFilter.allEdges(carEncoder);
         for (int no = 0; no < MAX; no++) {
             for (int instanceNo = 0; instanceNo < instances.size(); instanceNo++) {
                 String[] algos = new String[]{

--- a/tools/src/main/java/com/graphhopper/tools/Measurement.java
+++ b/tools/src/main/java/com/graphhopper/tools/Measurement.java
@@ -260,7 +260,7 @@ public class Measurement {
             print("unit_testsCH.get_weight", miniPerf);
         }
 
-        EdgeFilter outFilter = new DefaultEdgeFilter(encoder, false, true);
+        EdgeFilter outFilter = DefaultEdgeFilter.outEdges(encoder);
         final EdgeExplorer outExplorer = graph.createEdgeExplorer(outFilter);
         MiniPerfTest miniPerf = new MiniPerfTest() {
             @Override

--- a/tools/src/main/java/com/graphhopper/ui/MiniGraphUI.java
+++ b/tools/src/main/java/com/graphhopper/ui/MiniGraphUI.java
@@ -370,7 +370,7 @@ public class MiniGraphUI {
 //
 ////        System.out.println("path " + from + "->" + to);
 //        return algo.calcPath(from, to);
-        // System.out.println(GraphUtility.getNodeInfo(graph, 60139, new DefaultEdgeFilter(new CarFlagEncoder()).direction(false, true)));
+        // System.out.println(GraphUtility.getNodeInfo(graph, 60139, DefaultEdgeFilter.allEdges(new CarFlagEncoder()).direction(false, true)));
         // System.out.println(((GraphStorage) graph).debug(202947, 10));
 //        GraphUtility.printInfo(graph, 106511, 10);
         return algo.calcPath(162810, 35120);

--- a/web-bundle/src/main/java/com/graphhopper/resources/IsochroneResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/IsochroneResource.java
@@ -69,7 +69,7 @@ public class IsochroneResource {
             throwArgExc("vehicle not supported:" + vehicle);
 
         FlagEncoder encoder = encodingManager.getEncoder(vehicle);
-        EdgeFilter edgeFilter = new DefaultEdgeFilter(encoder);
+        EdgeFilter edgeFilter = DefaultEdgeFilter.allEdges(encoder);
         LocationIndex locationIndex = graphHopper.getLocationIndex();
         QueryResult qr = locationIndex.findClosest(point.lat, point.lon, edgeFilter);
         if (!qr.isValid())


### PR DESCRIPTION
#1380 

Replacing the constructor calls in other branches can be done quite easily using this regex search&replace in IntelliJ: 
![replace](https://user-images.githubusercontent.com/17603532/40584893-8fb2127a-61a9-11e8-8d17-b5b9df16239e.png)
