### PR TITLE
Replace synchronized frozen with atomic

### DIFF
--- a/core/src/main/java/com/graphhopper/storage/BaseGraph.java
+++ b/core/src/main/java/com/graphhopper/storage/BaseGraph.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
 import static com.graphhopper.util.Helper.nf;
 
 import java.util.Locale;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * The base graph handles nodes and edges file format. It can be used with different Directory


### PR DESCRIPTION
It allows high performance improvement while using multiple threads, moreover - frozen should change state only once, but it is checked much more often - then other threads are blocked on this check.

When testing with yourkit, previous implementation caused nearly 60% of time in lock (using ForkJoinPool but this makes no difference). After this change I have noticed whole this lock dissapeared (with about 60% performance improvement).
I would even think if this lock is necessary, because graph cannot be unfrozen, and even after receiving false from `isFrozen`, it gives you nothing because all after is not atomic operation. 

PS: I have also tried `ReentrantReadWriteLock` but it was even worse than `synchronized`... :disappointed: