### PR TITLE
Update docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,13 @@ cd core/files/
 docker-compose up -d
 ```
 
+If you don't want to use docker-compose you can do the following:
+```bash
+docker build -t graphhopper:master .
+docker run -d --name graphhopper -v <path_data_directory>/data:/data -p 11111:11111 graphhopper:master
+```
+
+
 # Features
 
 Here is a list of the more detailed features including a link to the documentation:

--- a/core/files/docker-compose.yml
+++ b/core/files/docker-compose.yml
@@ -6,8 +6,7 @@ services:
         volumes:
             - ../../data:/data
         environment:
-            JETTY_PORT: 11111
-            JAVA_OPTS: "-server -Xconcurrentio -Xmx1g -Xms1g -XX:+UseG1GC -XX:MetaspaceSize=100M"
+            JAVA_OPTS: "-server -Xconcurrentio -Xmx1g -Xms1g -XX:+UseG1GC -XX:MetaspaceSize=100M -Ddw.server.applicationConnectors[0].bindHost=0.0.0.0 -Ddw.server.applicationConnectors[0].port=11111"
         ports:
             - "11111:11111"
         command: /data/europe_germany_berlin.pbf


### PR DESCRIPTION
Fixes #1437.

Updates docker-compose.yml to make it work out of the box.
Adds a little bit of info on how to run the docker container using the Dockerfile directly.
