### PR TITLE
Allow configuring the precision of the polyline encoding

### DIFF
--- a/web-api/src/main/java/com/graphhopper/http/WebHelper.java
+++ b/web-api/src/main/java/com/graphhopper/http/WebHelper.java
@@ -102,16 +102,20 @@ public class WebHelper {
     }
 
     public static String encodePolyline(PointList poly, boolean includeElevation) {
+        return encodePolyline(poly, includeElevation, 1e5);
+    }
+
+    public static String encodePolyline(PointList poly, boolean includeElevation, double precision) {
         StringBuilder sb = new StringBuilder();
         int size = poly.getSize();
         int prevLat = 0;
         int prevLon = 0;
         int prevEle = 0;
         for (int i = 0; i < size; i++) {
-            int num = (int) Math.floor(poly.getLatitude(i) * 1e5);
+            int num = (int) Math.floor(poly.getLatitude(i) * precision);
             encodeNumber(sb, num - prevLat);
             prevLat = num;
-            num = (int) Math.floor(poly.getLongitude(i) * 1e5);
+            num = (int) Math.floor(poly.getLongitude(i) * precision);
             encodeNumber(sb, num - prevLon);
             prevLon = num;
             if (includeElevation) {

--- a/web-api/src/test/java/com/graphhopper/http/WebHelperTest.java
+++ b/web-api/src/test/java/com/graphhopper/http/WebHelperTest.java
@@ -74,4 +74,9 @@ public class WebHelperTest {
         assertEquals("_p~iF~ps|Uo}@_ulLnnqC_anF_mqNvxq`@?", WebHelper.encodePolyline(
                 Helper.createPointList3D(38.5, -120.2, 10, 40.7, -120.95, 1234, 43.252, -126.453, 1234)));
     }
+
+    @Test
+    public void testEncode1e6() throws Exception {
+        assertEquals("ohdfzAgt}bVoEL", WebHelper.encodePolyline(Helper.createPointList(47.827608, 12.123476, 47.827712, 12.123469), false, 1e6));
+    }
 }


### PR DESCRIPTION
As discussed in https://github.com/graphhopper/graphhopper-navigation/issues/1, we should make the precision of the polyline encoding configureable. 

This PR adds the option to change the precision of the Polyline encoding to use for example a precision of `1e6` as used by OSRM/Mapbox.