### PR TITLE
Simplifies path unpacking code for CH.

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/ch/Path4CH.java
+++ b/core/src/main/java/com/graphhopper/routing/ch/Path4CH.java
@@ -18,7 +18,6 @@
 package com.graphhopper.routing.ch;
 
 import com.graphhopper.routing.PathBidirRef;
-import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.Graph;
 import com.graphhopper.util.CHEdgeIteratorState;
@@ -40,60 +39,42 @@ public class Path4CH extends PathBidirRef {
     }
 
     @Override
-    protected final void processEdge(int tmpEdge, int endNode, int prevEdgeId) {
+    protected final void processEdge(int edgeId, int endNode, int prevEdgeId) {
         // Shortcuts do only contain valid weight so first expand before adding
         // to distance and time
-        expandEdge((CHEdgeIteratorState) routingGraph.getEdgeIteratorState(tmpEdge, endNode), false);
+        expandEdge(getEdge(edgeId, endNode), false);
     }
 
-    private void expandEdge(CHEdgeIteratorState mainEdgeState, boolean reverse) {
-        if (!mainEdgeState.isShortcut()) {
-            distance += mainEdgeState.getDistance();
-            time += weighting.calcMillis(mainEdgeState, reverse, EdgeIterator.NO_EDGE);
-            addEdge(mainEdgeState.getEdge());
+    private void expandEdge(CHEdgeIteratorState edge, boolean reverse) {
+        if (!edge.isShortcut()) {
+            distance += edge.getDistance();
+            time += weighting.calcMillis(edge, reverse, EdgeIterator.NO_EDGE);
+            addEdge(edge.getEdge());
             return;
         }
+        expandSkippedEdges(edge.getSkippedEdge1(), edge.getSkippedEdge2(), edge.getBaseNode(), edge.getAdjNode(), reverse);
+    }
 
-        int skippedEdge1 = mainEdgeState.getSkippedEdge1();
-        int skippedEdge2 = mainEdgeState.getSkippedEdge2();
-        int from = mainEdgeState.getBaseNode(), to = mainEdgeState.getAdjNode();
-
+    private void expandSkippedEdges(int skippedEdge1, int skippedEdge2, int from, int to, boolean reverse) {
         // get properties like speed of the edge in the correct direction
-        if (reverse) {
+        if (reverseOrder == reverse) {
             int tmp = from;
             from = to;
             to = tmp;
         }
 
         // getEdgeProps could possibly return an empty edge if the shortcut is available for both directions
-        if (reverseOrder) {
-            CHEdgeIteratorState edgeState = (CHEdgeIteratorState) routingGraph.getEdgeIteratorState(skippedEdge1, to);
-            boolean empty = edgeState == null;
-            if (empty)
-                edgeState = (CHEdgeIteratorState) routingGraph.getEdgeIteratorState(skippedEdge2, to);
-
-            expandEdge(edgeState, false);
-
-            if (empty)
-                edgeState = (CHEdgeIteratorState) routingGraph.getEdgeIteratorState(skippedEdge1, from);
-            else
-                edgeState = (CHEdgeIteratorState) routingGraph.getEdgeIteratorState(skippedEdge2, from);
-
-            expandEdge(edgeState, true);
+        CHEdgeIteratorState sk2to = getEdge(skippedEdge2, to);
+        if (sk2to != null) {
+            expandEdge(sk2to, !reverseOrder);
+            expandEdge(getEdge(skippedEdge1, from), reverseOrder);
         } else {
-            CHEdgeIteratorState iter = (CHEdgeIteratorState) routingGraph.getEdgeIteratorState(skippedEdge1, from);
-            boolean empty = iter == null;
-            if (empty)
-                iter = (CHEdgeIteratorState) routingGraph.getEdgeIteratorState(skippedEdge2, from);
-
-            expandEdge(iter, true);
-
-            if (empty)
-                iter = (CHEdgeIteratorState) routingGraph.getEdgeIteratorState(skippedEdge1, to);
-            else
-                iter = (CHEdgeIteratorState) routingGraph.getEdgeIteratorState(skippedEdge2, to);
-
-            expandEdge(iter, false);
+            expandEdge(getEdge(skippedEdge1, to), !reverseOrder);
+            expandEdge(getEdge(skippedEdge2, from), reverseOrder);
         }
+    }
+
+    private CHEdgeIteratorState getEdge(int edgeId, int adjNode) {
+        return (CHEdgeIteratorState) routingGraph.getEdgeIteratorState(edgeId, adjNode);
     }
 }


### PR DESCRIPTION
In this PR the path unpacking code in Path4CH is simplified.
The simplification makes the code easier to understand (hopefully, for me at least) and makes it easier to adjust for the turn-cost supporting version of CH.
I could not measure any significant performance difference running several comparisons on the map for Germany.