### PR TITLE
Fix point-edge calculations in DistanceCalc2D (shrink factor = 1)

### DIFF
--- a/api/src/main/java/com/graphhopper/util/DistanceCalcEarth.java
+++ b/api/src/main/java/com/graphhopper/util/DistanceCalcEarth.java
@@ -17,10 +17,10 @@
  */
 package com.graphhopper.util;
 
+import static java.lang.Math.*;
+
 import com.graphhopper.util.shapes.BBox;
 import com.graphhopper.util.shapes.GHPoint;
-
-import static java.lang.Math.*;
 
 /**
  * @author Peter Karich
@@ -155,7 +155,7 @@ public class DistanceCalcEarth implements DistanceCalc {
         return calcNormalizedDist(c_lat, c_lon / shrinkFactor, r_lat_deg, r_lon_deg);
     }
 
-    private double calcShrinkFactor(double a_lat_deg, double b_lat_deg) {
+    double calcShrinkFactor(double a_lat_deg, double b_lat_deg) {
         return cos(toRadians((a_lat_deg + b_lat_deg) / 2));
     }
 

--- a/core/src/main/java/com/graphhopper/util/DistanceCalc2D.java
+++ b/core/src/main/java/com/graphhopper/util/DistanceCalc2D.java
@@ -19,6 +19,9 @@ package com.graphhopper.util;
 
 import static java.lang.Math.sqrt;
 
+import com.graphhopper.util.shapes.BBox;
+import com.graphhopper.util.shapes.GHPoint;
+
 /**
  * Calculates the distance of two points or one point and an edge in euclidean space.
  * <p>
@@ -61,5 +64,31 @@ public class DistanceCalc2D extends DistanceCalcEarth {
     @Override
     public String toString() {
         return "2D";
+    }
+
+    @Override
+    public double calcCircumference(double lat) {
+        throw new UnsupportedOperationException("Not supported for the 2D Euclidean space");
+    }
+
+    @Override
+    public boolean isDateLineCrossOver(double lon1, double lon2) {
+        throw new UnsupportedOperationException("Not supported for the 2D Euclidean space");
+    }
+
+    @Override
+    public BBox createBBox(double lat, double lon, double radiusInMeter) {
+        throw new UnsupportedOperationException("Not supported for the 2D Euclidean space");
+    }
+
+    @Override
+    public GHPoint projectCoordinate(double latInDeg, double lonInDeg, double distanceInMeter,
+            double headingClockwiseFromNorth) {
+        throw new UnsupportedOperationException("Not supported for the 2D Euclidean space");
+    }
+
+    @Override
+    public boolean isCrossBoundary(double lon1, double lon2) {
+        throw new UnsupportedOperationException("Not supported for the 2D Euclidean space");
     }
 }

--- a/core/src/main/java/com/graphhopper/util/DistanceCalc2D.java
+++ b/core/src/main/java/com/graphhopper/util/DistanceCalc2D.java
@@ -44,6 +44,10 @@ public class DistanceCalc2D extends DistanceCalcEarth {
         return dist * dist;
     }
 
+    double calcShrinkFactor(double a_lat_deg, double b_lat_deg) {
+        return 1.;
+    }
+
     /**
      * Calculates in normalized meter
      */

--- a/core/src/test/java/com/graphhopper/util/DistanceCalc2DTest.java
+++ b/core/src/test/java/com/graphhopper/util/DistanceCalc2DTest.java
@@ -1,0 +1,51 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.graphhopper.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.graphhopper.util.shapes.GHPoint;
+
+public class DistanceCalc2DTest {
+
+    @Test
+    public void testCrossingPointToEdge() {
+        DistanceCalc2D distanceCalc = new DistanceCalc2D();
+        GHPoint point = distanceCalc.calcCrossingPointToEdge(0, 10, 0, 0, 10, 10);
+        Assert.assertEquals(5, point.getLat(), 0);
+        Assert.assertEquals(5, point.getLon(), 0);
+    }
+
+    @Test
+    public void testCalcNormalizedEdgeDistance() {
+        DistanceCalc2D distanceCalc = new DistanceCalc2D();
+        double distance = distanceCalc.calcNormalizedEdgeDistance(0, 10, 0, 0, 10, 10);
+        Assert.assertEquals(50, distance, 0);
+    }
+
+    @Test
+    public void testValidEdgeDistance() {
+        DistanceCalc2D distanceCalc = new DistanceCalc2D();
+        boolean validEdgeDistance = distanceCalc.validEdgeDistance(5, 15, 0, 0, 10, 10);
+        Assert.assertEquals(false, validEdgeDistance);
+        validEdgeDistance = distanceCalc.validEdgeDistance(15, 5, 0, 0, 10, 10);
+        Assert.assertEquals(false, validEdgeDistance);
+    }
+}


### PR DESCRIPTION
Since `DistanceCalc2D` operates on a flat Euclidean 2D space:
- the shrink factor is always 1
- some methods from the `DistanceCalc` interface are not supported

BTW. I suggest considering extraction of a super interface from `DistanceCalc` that would contain only those methods that are applicable in both cases (2D and Earth).
