### PR TITLE
Makes parameters available to CH classes via PMap.

### DIFF
--- a/api/src/main/java/com/graphhopper/util/PMap.java
+++ b/api/src/main/java/com/graphhopper/util/PMap.java
@@ -85,101 +85,78 @@ public class PMap {
     }
 
     public long getLong(String key, long _default) {
-        Long longOrNull = getLongOrNull(key);
-        return longOrNull != null ? longOrNull : _default;
-    }
-
-    public Long getLongOrNull(String key) {
-        String str = getStringOrNull(key);
-        if (str == null) {
-            return null;
+        String str = get(key);
+        if (!Helper.isEmpty(str)) {
+            try {
+                return Long.parseLong(str);
+            } catch (Exception ex) {
+            }
         }
-        try {
-            return Long.parseLong(str);
-        } catch (NumberFormatException ex) {
-            return null;
-        }
+        return _default;
     }
 
     public int getInt(String key, int _default) {
-        Integer intOrNull = getIntOrNull(key);
-        return intOrNull != null ? intOrNull : _default;
-    }
-
-    public Integer getIntOrNull(String key) {
-        String str = getStringOrNull(key);
-        if (str == null) {
-            return null;
+        String str = get(key);
+        if (!Helper.isEmpty(str)) {
+            try {
+                return Integer.parseInt(str);
+            } catch (Exception ex) {
+            }
         }
-        try {
-            return Integer.parseInt(str);
-        } catch (NumberFormatException e) {
-            return null;
-        }
+        return _default;
     }
 
     public boolean getBool(String key, boolean _default) {
-        Boolean boolOrNull = getBoolOrNull(key);
-        return boolOrNull != null ? boolOrNull : _default;
-    }
-
-    public Boolean getBoolOrNull(String key) {
-        String str = getStringOrNull(key);
-        if (str == null) {
-            return null;
+        String str = get(key);
+        if (!Helper.isEmpty(str)) {
+            try {
+                return Boolean.parseBoolean(str);
+            } catch (Exception ex) {
+            }
         }
-        try {
-            return Boolean.parseBoolean(str);
-        } catch (NumberFormatException ex) {
-            return null;
-        }
-    }
-
-    public float getFloat(String key, float _default) {
-        Float floatOrNull = getFloatOrNull(key);
-        return floatOrNull != null ? floatOrNull : _default;
-    }
-
-    public Float getFloatOrNull(String key) {
-        String str = getStringOrNull(key);
-        if (str == null) {
-            return null;
-        }
-        try {
-            return Float.parseFloat(str);
-        } catch (NumberFormatException ex) {
-            return null;
-        }
+        return _default;
     }
 
     public double getDouble(String key, double _default) {
-        Double doubleOrNull = getDoubleOrNull(key);
-        return doubleOrNull != null ? doubleOrNull : _default;
+        String str = get(key);
+        if (!Helper.isEmpty(str)) {
+            try {
+                return Double.parseDouble(str);
+            } catch (Exception ex) {
+            }
+        }
+        return _default;
     }
 
-    public Double getDoubleOrNull(String key) {
-        String str = getStringOrNull(key);
-        if (str == null) {
-            return null;
+    public float getFloat(String key, float _default) {
+        String str = get(key);
+        if (!Helper.isEmpty(str)) {
+            try {
+                return Float.parseFloat(str);
+            } catch (Exception ex) {
+            }
         }
-        try {
-            return Double.parseDouble(str);
-        } catch (NumberFormatException ex) {
-            return null;
-        }
+        return _default;
     }
 
     public String get(String key, String _default) {
-        String str = getStringOrNull(key);
-        return str != null ? str : _default;
+        String str = get(key);
+        if (Helper.isEmpty(str))
+            return _default;
+
+        return str;
     }
 
-    public String getStringOrNull(String key) {
-        if (Helper.isEmpty(key)) {
-            return null;
-        }
+    String get(String key) {
+        if (Helper.isEmpty(key))
+            return "";
+
         // query accepts camelCase and under_score
-        return map.get(Helper.camelCaseToUnderScore(key));
+        String val = map.get(Helper.camelCaseToUnderScore(key));
+        if (val == null)
+            return "";
+
+        return val;
     }
 
     /**

--- a/api/src/main/java/com/graphhopper/util/PMap.java
+++ b/api/src/main/java/com/graphhopper/util/PMap.java
@@ -34,7 +34,7 @@ public class PMap {
     }
 
     public PMap(int capacity) {
-        this(new HashMap<String, String>(capacity));
+        this(new HashMap<>(capacity));
     }
 
     public PMap(Map<String, String> map) {
@@ -85,67 +85,101 @@ public class PMap {
     }
 
     public long getLong(String key, long _default) {
-        String str = get(key);
-        if (!Helper.isEmpty(str)) {
-            try {
-                return Long.parseLong(str);
-            } catch (Exception ex) {
-            }
+        Long longOrNull = getLongOrNull(key);
+        return longOrNull != null ? longOrNull : _default;
+    }
+
+    public Long getLongOrNull(String key) {
+        String str = getStringOrNull(key);
+        if (str == null) {
+            return null;
         }
-        return _default;
+        try {
+            return Long.parseLong(str);
+        } catch (NumberFormatException ex) {
+            return null;
+        }
     }
 
     public int getInt(String key, int _default) {
-        String str = get(key);
-        if (!Helper.isEmpty(str)) {
-            try {
-                return Integer.parseInt(str);
-            } catch (Exception ex) {
-            }
+        Integer intOrNull = getIntOrNull(key);
+        return intOrNull != null ? intOrNull : _default;
+    }
+
+    public Integer getIntOrNull(String key) {
+        String str = getStringOrNull(key);
+        if (str == null) {
+            return null;
         }
-        return _default;
+        try {
+            return Integer.parseInt(str);
+        } catch (NumberFormatException e) {
+            return null;
+        }
     }
 
     public boolean getBool(String key, boolean _default) {
-        String str = get(key);
-        if (!Helper.isEmpty(str)) {
-            try {
-                return Boolean.parseBoolean(str);
-            } catch (Exception ex) {
-            }
+        Boolean boolOrNull = getBoolOrNull(key);
+        return boolOrNull != null ? boolOrNull : _default;
+    }
+
+    public Boolean getBoolOrNull(String key) {
+        String str = getStringOrNull(key);
+        if (str == null) {
+            return null;
         }
-        return _default;
+        try {
+            return Boolean.parseBoolean(str);
+        } catch (NumberFormatException ex) {
+            return null;
+        }
+    }
+
+    public float getFloat(String key, float _default) {
+        Float floatOrNull = getFloatOrNull(key);
+        return floatOrNull != null ? floatOrNull : _default;
+    }
+
+    public Float getFloatOrNull(String key) {
+        String str = getStringOrNull(key);
+        if (str == null) {
+            return null;
+        }
+        try {
+            return Float.parseFloat(str);
+        } catch (NumberFormatException ex) {
+            return null;
+        }
     }
 
     public double getDouble(String key, double _default) {
-        String str = get(key);
-        if (!Helper.isEmpty(str)) {
-            try {
-                return Double.parseDouble(str);
-            } catch (Exception ex) {
-            }
+        Double doubleOrNull = getDoubleOrNull(key);
+        return doubleOrNull != null ? doubleOrNull : _default;
+    }
+
+    public Double getDoubleOrNull(String key) {
+        String str = getStringOrNull(key);
+        if (str == null) {
+            return null;
         }
-        return _default;
+        try {
+            return Double.parseDouble(str);
+        } catch (NumberFormatException ex) {
+            return null;
+        }
     }
 
     public String get(String key, String _default) {
-        String str = get(key);
-        if (Helper.isEmpty(str))
-            return _default;
-
-        return str;
+        String str = getStringOrNull(key);
+        return str != null ? str : _default;
     }
 
-    String get(String key) {
-        if (Helper.isEmpty(key))
-            return "";
-
+    public String getStringOrNull(String key) {
+        if (Helper.isEmpty(key)) {
+            return null;
+        }
         // query accepts camelCase and under_score
-        String val = map.get(Helper.camelCaseToUnderScore(key));
-        if (val == null)
-            return "";
-
-        return val;
+        return map.get(Helper.camelCaseToUnderScore(key));
     }
 
     /**

--- a/api/src/test/java/com/graphhopper/util/PMapTest.java
+++ b/api/src/test/java/com/graphhopper/util/PMapTest.java
@@ -28,7 +28,7 @@ public class PMapTest {
     public void singleStringPropertyCanBeRetrieved() {
         PMap subject = new PMap("foo=bar");
 
-        Assert.assertEquals("bar", subject.get("foo"));
+        Assert.assertEquals("bar", subject.get("foo", ""));
     }
 
     @Test
@@ -59,6 +59,17 @@ public class PMapTest {
         PMap subject = new PMap("foo=123.45|bar=56.78");
 
         assertEquals(123.45, subject.getDouble("foo", 0), 1e-4);
+    }
+
+    @Test
+    public void numericPropertiesCanBeRetrievedWithNull() {
+        PMap subject = new PMap("x=123|y=26.3|z=6garble");
+        assertEquals(123, (int) subject.getIntOrNull("x"));
+        assertNull(subject.getIntOrNull("y"));
+        assertNull(subject.getIntOrNull("z"));
+        assertNull(subject.getIntOrNull("xyz"));
+        assertEquals(123, subject.getDoubleOrNull("x"), 1.e-4);
+        assertNull(subject.getLongOrNull("y"));
     }
 
     @Test

--- a/api/src/test/java/com/graphhopper/util/PMapTest.java
+++ b/api/src/test/java/com/graphhopper/util/PMapTest.java
@@ -28,7 +28,7 @@ public class PMapTest {
     public void singleStringPropertyCanBeRetrieved() {
         PMap subject = new PMap("foo=bar");
 
-        Assert.assertEquals("bar", subject.get("foo", ""));
+        Assert.assertEquals("bar", subject.get("foo"));
     }
 
     @Test
@@ -59,17 +59,6 @@ public class PMapTest {
         PMap subject = new PMap("foo=123.45|bar=56.78");
 
         assertEquals(123.45, subject.getDouble("foo", 0), 1e-4);
-    }
-
-    @Test
-    public void numericPropertiesCanBeRetrievedWithNull() {
-        PMap subject = new PMap("x=123|y=26.3|z=6garble");
-        assertEquals(123, (int) subject.getIntOrNull("x"));
-        assertNull(subject.getIntOrNull("y"));
-        assertNull(subject.getIntOrNull("z"));
-        assertNull(subject.getIntOrNull("xyz"));
-        assertEquals(123, subject.getDoubleOrNull("x"), 1.e-4);
-        assertNull(subject.getLongOrNull("y"));
     }
 
     @Test

--- a/core/src/main/java/com/graphhopper/routing/ch/CHAlgoFactoryDecorator.java
+++ b/core/src/main/java/com/graphhopper/routing/ch/CHAlgoFactoryDecorator.java
@@ -22,12 +22,10 @@ import com.graphhopper.routing.RoutingAlgorithmFactoryDecorator;
 import com.graphhopper.routing.util.HintsMap;
 import com.graphhopper.routing.util.TraversalMode;
 import com.graphhopper.routing.weighting.AbstractWeighting;
-import com.graphhopper.routing.weighting.BlockAreaWeighting;
-import com.graphhopper.routing.weighting.GenericWeighting;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.*;
 import com.graphhopper.util.CmdArgs;
-import com.graphhopper.util.Helper;
+import com.graphhopper.util.PMap;
 import com.graphhopper.util.Parameters.CH;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,11 +54,7 @@ public class CHAlgoFactoryDecorator implements RoutingAlgorithmFactoryDecorator 
     private boolean enabled = true;
     private int preparationThreads;
     private ExecutorService threadPool;
-    private int preparationPeriodicUpdates = -1;
-    private int preparationLazyUpdates = -1;
-    private int preparationNeighborUpdates = -1;
-    private int preparationContractedNodes = -1;
-    private double preparationLogMessages = -1;
+    private PMap pMap = new PMap();
 
     public CHAlgoFactoryDecorator() {
         setPreparationThreads(1);
@@ -81,7 +75,7 @@ public class CHAlgoFactoryDecorator implements RoutingAlgorithmFactoryDecorator 
         String chWeightingsStr = args.get(CH.PREPARE + "weightings", "");
 
         if ("no".equals(chWeightingsStr) || "false".equals(chWeightingsStr)) {
-            // default is fastest and we need to clear this explicitely
+            // default is fastest and we need to clear this explicitly
             weightingsAsStrings.clear();
         } else if (!chWeightingsStr.isEmpty()) {
             List<String> tmpCHWeightingList = Arrays.asList(chWeightingsStr.split(","));
@@ -93,56 +87,7 @@ public class CHAlgoFactoryDecorator implements RoutingAlgorithmFactoryDecorator 
         if (enableThis)
             setDisablingAllowed(args.getBool(CH.INIT_DISABLING_ALLOWED, isDisablingAllowed()));
 
-        setPreparationPeriodicUpdates(args.getInt(CH.PREPARE + "updates.periodic", getPreparationPeriodicUpdates()));
-        setPreparationLazyUpdates(args.getInt(CH.PREPARE + "updates.lazy", getPreparationLazyUpdates()));
-        setPreparationNeighborUpdates(args.getInt(CH.PREPARE + "updates.neighbor", getPreparationNeighborUpdates()));
-        setPreparationContractedNodes(args.getInt(CH.PREPARE + "contracted_nodes", getPreparationContractedNodes()));
-        setPreparationLogMessages(args.getDouble(CH.PREPARE + "log_messages", getPreparationLogMessages()));
-    }
-
-    public int getPreparationPeriodicUpdates() {
-        return preparationPeriodicUpdates;
-    }
-
-    public CHAlgoFactoryDecorator setPreparationPeriodicUpdates(int preparePeriodicUpdates) {
-        this.preparationPeriodicUpdates = preparePeriodicUpdates;
-        return this;
-    }
-
-    public int getPreparationContractedNodes() {
-        return preparationContractedNodes;
-    }
-
-    public CHAlgoFactoryDecorator setPreparationContractedNodes(int prepareContractedNodes) {
-        this.preparationContractedNodes = prepareContractedNodes;
-        return this;
-    }
-
-    public int getPreparationLazyUpdates() {
-        return preparationLazyUpdates;
-    }
-
-    public CHAlgoFactoryDecorator setPreparationLazyUpdates(int prepareLazyUpdates) {
-        this.preparationLazyUpdates = prepareLazyUpdates;
-        return this;
-    }
-
-    public double getPreparationLogMessages() {
-        return preparationLogMessages;
-    }
-
-    public CHAlgoFactoryDecorator setPreparationLogMessages(double prepareLogMessages) {
-        this.preparationLogMessages = prepareLogMessages;
-        return this;
-    }
-
-    public int getPreparationNeighborUpdates() {
-        return preparationNeighborUpdates;
-    }
-
-    public CHAlgoFactoryDecorator setPreparationNeighborUpdates(int prepareNeighborUpdates) {
-        this.preparationNeighborUpdates = prepareNeighborUpdates;
-        return this;
+        pMap = args;
     }
 
     @Override
@@ -321,11 +266,7 @@ public class CHAlgoFactoryDecorator implements RoutingAlgorithmFactoryDecorator 
             PrepareContractionHierarchies tmpPrepareCH = new PrepareContractionHierarchies(
                     new GHDirectory("", DAType.RAM_INT), ghStorage, ghStorage.getGraph(CHGraph.class, weighting),
                     weighting, traversalMode);
-            tmpPrepareCH.setPeriodicUpdates(preparationPeriodicUpdates).
-                    setLazyUpdates(preparationLazyUpdates).
-                    setNeighborUpdates(preparationNeighborUpdates).
-                    setLogMessages(preparationLogMessages);
-
+            tmpPrepareCH.setParams(pMap);
             addPreparation(tmpPrepareCH);
         }
     }

--- a/core/src/main/java/com/graphhopper/routing/ch/CHParameters.java
+++ b/core/src/main/java/com/graphhopper/routing/ch/CHParameters.java
@@ -1,0 +1,17 @@
+package com.graphhopper.routing.ch;
+
+import com.graphhopper.util.Parameters;
+
+public final class CHParameters {
+    static final String PERIODIC_UPDATES = Parameters.CH.PREPARE + "updates.periodic";
+    static final String LAST_LAZY_NODES_UPDATES = Parameters.CH.PREPARE + "updates.lazy";
+    static final String NEIGHBOR_UPDATES = Parameters.CH.PREPARE + "updates.neighbor";
+    static final String CONTRACTED_NODES = Parameters.CH.PREPARE + "contracted_nodes";
+    static final String LOG_MESSAGES = Parameters.CH.PREPARE + "log_messages";
+    static final String EDGE_DIFFERENCE_WEIGHT = Parameters.CH.PREPARE + "node.edge_difference_weight";
+    static final String ORIGINAL_EDGE_COUNT_WEIGHT = Parameters.CH.PREPARE + "node.original_edge_count_weight";
+    static final String CONTRACTED_NEIGHBORS_WEIGHT = Parameters.CH.PREPARE + "node.contracted_neighbors_weight";
+
+    private CHParameters() {
+    }
+}

--- a/core/src/main/java/com/graphhopper/routing/ch/NodeBasedNodeContractor.java
+++ b/core/src/main/java/com/graphhopper/routing/ch/NodeBasedNodeContractor.java
@@ -54,20 +54,9 @@ class NodeBasedNodeContractor extends AbstractNodeContractor {
     }
 
     private void extractParams(PMap pMap) {
-        Float edgeDifferenceWeight = pMap.getFloatOrNull(EDGE_DIFFERENCE_WEIGHT);
-        if (edgeDifferenceWeight != null) {
-            params.edgeDifferenceWeight = edgeDifferenceWeight;
-        }
-
-        Float originalEdgeCountWeight = pMap.getFloatOrNull(ORIGINAL_EDGE_COUNT_WEIGHT);
-        if (originalEdgeCountWeight != null) {
-            params.contractedNeighborsWeight = originalEdgeCountWeight;
-        }
-
-        Float contractedNeighborsWeight = pMap.getFloatOrNull(CONTRACTED_NEIGHBORS_WEIGHT);
-        if (contractedNeighborsWeight != null) {
-            params.contractedNeighborsWeight = contractedNeighborsWeight;
-        }
+        params.edgeDifferenceWeight = pMap.getFloat(EDGE_DIFFERENCE_WEIGHT, params.edgeDifferenceWeight);
+        params.originalEdgesCountWeight = pMap.getFloat(ORIGINAL_EDGE_COUNT_WEIGHT, params.originalEdgesCountWeight);
+        params.contractedNeighborsWeight = pMap.getFloat(CONTRACTED_NEIGHBORS_WEIGHT, params.contractedNeighborsWeight);
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/ch/PrepareContractionHierarchies.java
+++ b/core/src/main/java/com/graphhopper/routing/ch/PrepareContractionHierarchies.java
@@ -22,16 +22,14 @@ import com.graphhopper.routing.*;
 import com.graphhopper.routing.util.*;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.*;
-import com.graphhopper.util.CHEdgeExplorer;
-import com.graphhopper.util.CHEdgeIterator;
-import com.graphhopper.util.Helper;
-import com.graphhopper.util.StopWatch;
+import com.graphhopper.util.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Locale;
 import java.util.Random;
 
+import static com.graphhopper.routing.ch.CHParameters.*;
 import static com.graphhopper.util.Helper.nf;
 import static com.graphhopper.util.Parameters.Algorithms.ASTAR_BI;
 import static com.graphhopper.util.Parameters.Algorithms.DIJKSTRA_BI;
@@ -63,6 +61,7 @@ public class PrepareContractionHierarchies extends AbstractAlgoPreparation imple
     private final StopWatch lazyUpdateSW = new StopWatch();
     private final StopWatch neighborUpdateSW = new StopWatch();
     private final StopWatch contractionSW = new StopWatch();
+    private final Params params;
     private NodeContractor nodeContractor;
     private CHEdgeExplorer vehicleAllExplorer;
     private CHEdgeExplorer vehicleAllTmpExplorer;
@@ -70,11 +69,7 @@ public class PrepareContractionHierarchies extends AbstractAlgoPreparation imple
     // nodes with highest priority come last
     private GHTreeMapComposed sortedNodes;
     private float oldPriorities[];
-    private int periodicUpdatesPercentage = 20;
-    private int lastNodesLazyUpdatePercentage = 10;
-    private int neighborUpdatePercentage = 20;
-    private double nodesContractedPercentage = 100;
-    private double logMessagesPercentage = 20;
+    private PMap pMap = new PMap();
     private int initSize;
     private int checkCounter;
 
@@ -86,77 +81,32 @@ public class PrepareContractionHierarchies extends AbstractAlgoPreparation imple
         this.traversalMode = traversalMode;
         this.weighting = weighting;
         prepareWeighting = new PreparationWeighting(weighting);
+        this.params = Params.forTraversalMode(traversalMode);
     }
 
-    /**
-     * The higher the values are the longer the preparation takes but the less shortcuts are
-     * produced.
-     * <p>
-     *
-     * @param periodicUpdates specifies how often periodic updates will happen. Use something less
-     *                        than 10.
-     */
-    public PrepareContractionHierarchies setPeriodicUpdates(int periodicUpdates) {
-        if (periodicUpdates < 0)
-            return this;
-        if (periodicUpdates > 100)
-            throw new IllegalArgumentException("periodicUpdates has to be in [0, 100], to disable it use 0");
+    public PrepareContractionHierarchies setParams(PMap pMap) {
+        this.pMap = pMap;
 
-        this.periodicUpdatesPercentage = periodicUpdates;
-        return this;
-    }
-
-    /**
-     * @param lazyUpdates specifies when lazy updates will happen, measured relative to all existing
-     *                    nodes. 100 means always.
-     */
-    public PrepareContractionHierarchies setLazyUpdates(int lazyUpdates) {
-        if (lazyUpdates < 0)
-            return this;
-
-        if (lazyUpdates > 100)
-            throw new IllegalArgumentException("lazyUpdates has to be in [0, 100], to disable it use 0");
-
-        this.lastNodesLazyUpdatePercentage = lazyUpdates;
-        return this;
-    }
-
-    /**
-     * @param neighborUpdates specifies how often neighbor updates will happen. 100 means always.
-     */
-    public PrepareContractionHierarchies setNeighborUpdates(int neighborUpdates) {
-        if (neighborUpdates < 0)
-            return this;
-
-        if (neighborUpdates > 100)
-            throw new IllegalArgumentException("neighborUpdates has to be in [0, 100], to disable it use 0");
-
-        this.neighborUpdatePercentage = neighborUpdates;
-        return this;
-    }
-
-    /**
-     * Specifies how often a log message should be printed. Specify something around 20 (20% of the
-     * start nodes).
-     */
-    public PrepareContractionHierarchies setLogMessages(double logMessages) {
-        if (logMessages >= 0)
-            this.logMessagesPercentage = logMessages;
-        return this;
-    }
-
-    /**
-     * Define how many nodes (percentage) should be contracted. Less nodes means slower query but
-     * faster contraction duration.
-     */
-    public PrepareContractionHierarchies setContractedNodes(double nodesContracted) {
-        if (nodesContracted < 0)
-            return this;
-
-        if (nodesContracted > 100)
-            throw new IllegalArgumentException("setNodesContracted can be 100% maximum");
-
-        this.nodesContractedPercentage = nodesContracted;
+        Integer periodicUpdates = pMap.getIntOrNull(PERIODIC_UPDATES);
+        if (periodicUpdates != null) {
+            params.setPeriodicUpdatesPercentage(periodicUpdates);
+        }
+        Integer lastNodesLazyUpdates = pMap.getIntOrNull(LAST_LAZY_NODES_UPDATES);
+        if (lastNodesLazyUpdates != null) {
+            params.setLastNodesLazyUpdatePercentage(lastNodesLazyUpdates);
+        }
+        Integer neighborUpdates = pMap.getIntOrNull(NEIGHBOR_UPDATES);
+        if (neighborUpdates != null) {
+            params.setNeighborUpdatePercentage(neighborUpdates);
+        }
+        Integer nodesContracted = pMap.getIntOrNull(CONTRACTED_NODES);
+        if (nodesContracted != null) {
+            params.setNodesContractedPercentage(nodesContracted);
+        }
+        Integer logMessages = pMap.getIntOrNull(LOG_MESSAGES);
+        if (logMessages != null) {
+            params.setLogMessagesPercentage(logMessages);
+        }
         return this;
     }
 
@@ -170,9 +120,9 @@ public class PrepareContractionHierarchies extends AbstractAlgoPreparation imple
                 + ", new shortcuts: " + nf(nodeContractor.getAddedShortcutsCount())
                 + ", initSize:" + nf(initSize)
                 + ", " + prepareWeighting
-                + ", periodic:" + periodicUpdatesPercentage
-                + ", lazy:" + lastNodesLazyUpdatePercentage
-                + ", neighbor:" + neighborUpdatePercentage
+                + ", periodic:" + params.getPeriodicUpdatesPercentage()
+                + ", lazy:" + params.getLastNodesLazyUpdatePercentage()
+                + ", neighbor:" + params.getNeighborUpdatePercentage()
                 + ", " + getTimesAsString()
                 + ", lazy-overhead: " + (int) (100 * ((checkCounter / (double) initSize) - 1)) + "%"
                 + ", " + Helper.getMemInfo());
@@ -226,7 +176,7 @@ public class PrepareContractionHierarchies extends AbstractAlgoPreparation imple
         //   but we need the additional oldPriorities array to keep the old value which is necessary for the update method
         sortedNodes = new GHTreeMapComposed();
         oldPriorities = new float[prepareGraph.getNodes()];
-        nodeContractor = new NodeBasedNodeContractor(dir, ghStorage, prepareGraph, weighting);
+        nodeContractor = new NodeBasedNodeContractor(dir, ghStorage, prepareGraph, weighting, pMap);
         nodeContractor.initFromGraph();
     }
 
@@ -250,31 +200,31 @@ public class PrepareContractionHierarchies extends AbstractAlgoPreparation imple
         initSize = sortedNodes.getSize();
         int level = 0;
         checkCounter = 0;
-        long logSize = Math.round(Math.max(10, initSize / 100d * logMessagesPercentage));
-        if (logMessagesPercentage == 0)
+        long logSize = Math.round(Math.max(10, initSize / 100d * params.getLogMessagesPercentage()));
+        if (params.getLogMessagesPercentage() == 0)
             logSize = Integer.MAX_VALUE;
 
         // preparation takes longer but queries are slightly faster with preparation
         // => enable it but call not so often
         boolean periodicUpdate = true;
         int updateCounter = 0;
-        long periodicUpdatesCount = Math.round(Math.max(10, sortedNodes.getSize() / 100d * periodicUpdatesPercentage));
-        if (periodicUpdatesPercentage == 0)
+        long periodicUpdatesCount = Math.round(Math.max(10, sortedNodes.getSize() / 100d * params.getPeriodicUpdatesPercentage()));
+        if (params.getPeriodicUpdatesPercentage() == 0)
             periodicUpdate = false;
 
         // disable lazy updates for last x percentage of nodes as preparation is then a lot slower
         // and query time does not really benefit
-        long lastNodesLazyUpdates = Math.round(sortedNodes.getSize() / 100d * lastNodesLazyUpdatePercentage);
+        long lastNodesLazyUpdates = Math.round(sortedNodes.getSize() / 100d * params.getLastNodesLazyUpdatePercentage());
 
         // according to paper "Polynomial-time Construction of Contraction Hierarchies for Multi-criteria Objectives" by Funke and Storandt
         // we don't need to wait for all nodes to be contracted
-        long nodesToAvoidContract = Math.round((100 - nodesContractedPercentage) / 100d * sortedNodes.getSize());
+        long nodesToAvoidContract = Math.round((100 - params.getNodesContractedPercentage()) / 100d * sortedNodes.getSize());
 
         // Recompute priority of uncontracted neighbors.
         // Without neighbor updates preparation is faster but we need them
         // to slightly improve query time. Also if not applied too often it decreases the shortcut number.
         boolean neighborUpdate = true;
-        if (neighborUpdatePercentage == 0)
+        if (params.getNeighborUpdatePercentage() == 0)
             neighborUpdate = false;
 
         while (!sortedNodes.isEmpty()) {
@@ -336,7 +286,7 @@ public class PrepareContractionHierarchies extends AbstractAlgoPreparation imple
                 if (prepareGraph.getLevel(nn) != maxLevel)
                     continue;
 
-                if (neighborUpdate && rand.nextInt(100) < neighborUpdatePercentage) {
+                if (neighborUpdate && rand.nextInt(100) < params.getNeighborUpdatePercentage()) {
                     neighborUpdateSW.start();
                     float oldPrio = oldPriorities[nn];
                     float priority = oldPriorities[nn] = calculatePriority(nn);
@@ -420,5 +370,99 @@ public class PrepareContractionHierarchies extends AbstractAlgoPreparation imple
                 getTimesAsString(),
                 nodeContractor.getStatisticsString(),
                 Helper.getMemInfo()));
+    }
+
+    private static class Params {
+        /**
+         * Specifies how often periodic updates will happen. The higher the value the longer the preparation takes
+         * but the less shortcuts are produced.
+         */
+        private int periodicUpdatesPercentage;
+        /**
+         * Specifies when lazy updates will happen, measured relative to all existing nodes. 100 means always.
+         */
+        private int lastNodesLazyUpdatePercentage;
+        /**
+         * Specifies how often neighbor updates will happen. 100 means always.
+         */
+        private int neighborUpdatePercentage;
+        /**
+         * Defines how many nodes (percentage) should be contracted. Less nodes means slower query but
+         * faster contraction.
+         */
+        private int nodesContractedPercentage;
+        /**
+         * Specifies how often a log message should be printed. Specify something around 20 (20% of the
+         * start nodes).
+         */
+        private int logMessagesPercentage;
+
+        static Params forTraversalMode(TraversalMode traversalMode) {
+            if (traversalMode.isEdgeBased()) {
+                throw new IllegalArgumentException("Contraction Hierarchies are not supported for edge-based traversal yet");
+            } else {
+                return new Params(20, 10, 20, 100, 20);
+            }
+        }
+
+        private Params(int periodicUpdatesPercentage, int lastNodesLazyUpdatePercentage, int neighborUpdatePercentage,
+                       int nodesContractedPercentage, int logMessagesPercentage) {
+            this.periodicUpdatesPercentage = periodicUpdatesPercentage;
+            this.lastNodesLazyUpdatePercentage = lastNodesLazyUpdatePercentage;
+            this.neighborUpdatePercentage = neighborUpdatePercentage;
+            this.nodesContractedPercentage = nodesContractedPercentage;
+            this.logMessagesPercentage = logMessagesPercentage;
+        }
+
+        int getPeriodicUpdatesPercentage() {
+            return periodicUpdatesPercentage;
+        }
+
+        void setPeriodicUpdatesPercentage(int periodicUpdatesPercentage) {
+            checkPercentage(PERIODIC_UPDATES, periodicUpdatesPercentage);
+            this.periodicUpdatesPercentage = periodicUpdatesPercentage;
+        }
+
+        int getLastNodesLazyUpdatePercentage() {
+            return lastNodesLazyUpdatePercentage;
+        }
+
+        void setLastNodesLazyUpdatePercentage(int lastNodesLazyUpdatePercentage) {
+            checkPercentage(LAST_LAZY_NODES_UPDATES, lastNodesLazyUpdatePercentage);
+            this.lastNodesLazyUpdatePercentage = lastNodesLazyUpdatePercentage;
+        }
+
+        int getNeighborUpdatePercentage() {
+            return neighborUpdatePercentage;
+        }
+
+        void setNeighborUpdatePercentage(int neighborUpdatePercentage) {
+            checkPercentage(NEIGHBOR_UPDATES, neighborUpdatePercentage);
+            this.neighborUpdatePercentage = neighborUpdatePercentage;
+        }
+
+        int getNodesContractedPercentage() {
+            return nodesContractedPercentage;
+        }
+
+        void setNodesContractedPercentage(int nodesContractedPercentage) {
+            checkPercentage(CONTRACTED_NODES, nodesContractedPercentage);
+            this.nodesContractedPercentage = nodesContractedPercentage;
+        }
+
+        int getLogMessagesPercentage() {
+            return logMessagesPercentage;
+        }
+
+        void setLogMessagesPercentage(int logMessagesPercentage) {
+            checkPercentage(LOG_MESSAGES, logMessagesPercentage);
+            this.logMessagesPercentage = logMessagesPercentage;
+        }
+
+        private void checkPercentage(String name, int value) {
+            if (value < 0 || value > 100) {
+                throw new IllegalArgumentException(name + " has to be in [0, 100], to disable it use 0");
+            }
+        }
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/ch/PrepareContractionHierarchies.java
+++ b/core/src/main/java/com/graphhopper/routing/ch/PrepareContractionHierarchies.java
@@ -86,27 +86,11 @@ public class PrepareContractionHierarchies extends AbstractAlgoPreparation imple
 
     public PrepareContractionHierarchies setParams(PMap pMap) {
         this.pMap = pMap;
-
-        Integer periodicUpdates = pMap.getIntOrNull(PERIODIC_UPDATES);
-        if (periodicUpdates != null) {
-            params.setPeriodicUpdatesPercentage(periodicUpdates);
-        }
-        Integer lastNodesLazyUpdates = pMap.getIntOrNull(LAST_LAZY_NODES_UPDATES);
-        if (lastNodesLazyUpdates != null) {
-            params.setLastNodesLazyUpdatePercentage(lastNodesLazyUpdates);
-        }
-        Integer neighborUpdates = pMap.getIntOrNull(NEIGHBOR_UPDATES);
-        if (neighborUpdates != null) {
-            params.setNeighborUpdatePercentage(neighborUpdates);
-        }
-        Integer nodesContracted = pMap.getIntOrNull(CONTRACTED_NODES);
-        if (nodesContracted != null) {
-            params.setNodesContractedPercentage(nodesContracted);
-        }
-        Integer logMessages = pMap.getIntOrNull(LOG_MESSAGES);
-        if (logMessages != null) {
-            params.setLogMessagesPercentage(logMessages);
-        }
+        params.setPeriodicUpdatesPercentage(pMap.getInt(PERIODIC_UPDATES, params.getPeriodicUpdatesPercentage()));
+        params.setLastNodesLazyUpdatePercentage(pMap.getInt(LAST_LAZY_NODES_UPDATES, params.getLastNodesLazyUpdatePercentage()));
+        params.setNeighborUpdatePercentage(pMap.getInt(NEIGHBOR_UPDATES, params.getNeighborUpdatePercentage()));
+        params.setNodesContractedPercentage(pMap.getInt(CONTRACTED_NODES, params.getNodesContractedPercentage()));
+        params.setLogMessagesPercentage(pMap.getInt(LOG_MESSAGES, params.getLogMessagesPercentage()));
         return this;
     }
 
@@ -407,11 +391,11 @@ public class PrepareContractionHierarchies extends AbstractAlgoPreparation imple
 
         private Params(int periodicUpdatesPercentage, int lastNodesLazyUpdatePercentage, int neighborUpdatePercentage,
                        int nodesContractedPercentage, int logMessagesPercentage) {
-            this.periodicUpdatesPercentage = periodicUpdatesPercentage;
-            this.lastNodesLazyUpdatePercentage = lastNodesLazyUpdatePercentage;
-            this.neighborUpdatePercentage = neighborUpdatePercentage;
-            this.nodesContractedPercentage = nodesContractedPercentage;
-            this.logMessagesPercentage = logMessagesPercentage;
+            setPeriodicUpdatesPercentage(periodicUpdatesPercentage);
+            setLastNodesLazyUpdatePercentage(lastNodesLazyUpdatePercentage);
+            setNeighborUpdatePercentage(neighborUpdatePercentage);
+            setNodesContractedPercentage(nodesContractedPercentage);
+            setLogMessagesPercentage(logMessagesPercentage);
         }
 
         int getPeriodicUpdatesPercentage() {

--- a/core/src/test/java/com/graphhopper/routing/ch/NodeBasedNodeContractorTest.java
+++ b/core/src/test/java/com/graphhopper/routing/ch/NodeBasedNodeContractorTest.java
@@ -26,6 +26,7 @@ import com.graphhopper.storage.*;
 import com.graphhopper.util.CHEdgeIteratorState;
 import com.graphhopper.util.EdgeIterator;
 import com.graphhopper.util.EdgeIteratorState;
+import com.graphhopper.util.PMap;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -51,7 +52,7 @@ public class NodeBasedNodeContractorTest {
     }
 
     private NodeContractor createNodeContractor() {
-        NodeContractor nodeContractor = new NodeBasedNodeContractor(dir, graph, lg, weighting);
+        NodeContractor nodeContractor = new NodeBasedNodeContractor(dir, graph, lg, weighting, new PMap());
         nodeContractor.initFromGraph();
         nodeContractor.prepareContraction();
         return nodeContractor;


### PR DESCRIPTION
Following the discussion in #1368 I have tried to improve the parameter handling for CH and made the following changes:

1. `CHAlgoFactoryDecorator` is no longer aware of which parameters are used for `PrepareContractionHierarchies` and `NodeBasedNodeContractor`, but instead passes on the `CmdArgs` it is given in its `init()` method to `PrepareContractionHierarchies`. I think this is an improvement, because the decorator is no longer 'polluted' by CH-specific parameters. There will be more parameters when we add edge-based CH and even right now there are some parameters that are simply hard-coded and can't be changed at all (like the weightings in `NodeBasedNodeContractor#calculatePriority`). On the other hand since I removed the setters (`setPreparationContractedNodes` etc.) there is no longer a Java API to modify these parameters (not sure if that is ok regarding backwards-compatibility!). However, I think these really are expert settings and if someone really wants to make changes its still possible to add them to the `CmdArgs` object passed to the `init()` method. 

2. Since the `PMap` is simply passed along the parsing of the parameters now happens in `PrepareContractionHierarchies` and `NodeBasedNodeContractor` and can be used to overwrite the defaults that are hard-coded in these classes. This mechanism is mostly useful to overwrite the defaults for very specific use-cases or performance analysis.

3. I added/changed a few methods in `PMap` to be able to only take action / overwrite the defaults if the `PMap` does contain a valid value for a certain key.

4. I have encapsulated the parameters in `PrepareContractionHierarchies` into an inner class, for example this will be useful to be able to easily switch these parameters depending on the `TraversalMode`.

5. As application/demonstration of this method to pass parameters I have made the above mentioned node priority weights in `NodeBasedNodeContractor` configurable via the `PMap`.

I think this PR allows adding new parameters (if needed) with very little code and there is no coupling of higher-order classes (like the decorator) to details of the lower-lying classes (like the node priority weights of the node contractor).

Another philosophy would be to parse the input parameters / configurations much earlier in the application, create Java objects from them and pass these along. This would lead to more type-safety of course, but I came to the conclusion that I like using the `PMap` better for the reasons I gave. 
I'll be very happy to hear your opinion on this 'exciting' topic ;)

Minor: I changed the logMessages parameter from double to int for consistency with the other parameters.
