### PR TITLE
Speed up query and preparation for CH

### DIFF
--- a/core/src/main/java/com/graphhopper/storage/BaseGraph.java
+++ b/core/src/main/java/com/graphhopper/storage/BaseGraph.java
@@ -30,9 +30,9 @@ import com.graphhopper.util.shapes.BBox;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static com.graphhopper.util.Helper.nf;
-
 import java.util.Locale;
+
+import static com.graphhopper.util.Helper.nf;
 
 /**
  * The base graph handles nodes and edges file format. It can be used with different Directory
@@ -94,8 +94,8 @@ class BaseGraph implements Graph {
         this.bitUtil = BitUtil.get(dir.getByteOrder());
         this.wayGeometry = dir.find("geometry");
         this.nameIndex = new NameIndex(dir);
-        this.nodes = dir.find("nodes");
-        this.edges = dir.find("edges");
+        this.nodes = dir.find("nodes", GHDirectory.getPreferredInt(dir.getDefaultType()));
+        this.edges = dir.find("edges", GHDirectory.getPreferredInt(dir.getDefaultType()));
         this.listener = listener;
         this.edgeAccess = new EdgeAccess(edges, bitUtil) {
             @Override

--- a/core/src/main/java/com/graphhopper/storage/BaseGraph.java
+++ b/core/src/main/java/com/graphhopper/storage/BaseGraph.java
@@ -94,8 +94,8 @@ class BaseGraph implements Graph {
         this.bitUtil = BitUtil.get(dir.getByteOrder());
         this.wayGeometry = dir.find("geometry");
         this.nameIndex = new NameIndex(dir);
-        this.nodes = dir.find("nodes", GHDirectory.getPreferredInt(dir.getDefaultType()));
-        this.edges = dir.find("edges", GHDirectory.getPreferredInt(dir.getDefaultType()));
+        this.nodes = dir.find("nodes", DAType.getPreferredInt(dir.getDefaultType()));
+        this.edges = dir.find("edges", DAType.getPreferredInt(dir.getDefaultType()));
         this.listener = listener;
         this.edgeAccess = new EdgeAccess(edges, bitUtil) {
             @Override

--- a/core/src/main/java/com/graphhopper/storage/CHGraphImpl.java
+++ b/core/src/main/java/com/graphhopper/storage/CHGraphImpl.java
@@ -69,8 +69,8 @@ public class CHGraphImpl implements CHGraph, Storable<CHGraph> {
         this.weighting = w;
         this.baseGraph = baseGraph;
         final String name = AbstractWeighting.weightingToFileName(w);
-        this.nodesCH = dir.find("nodes_ch_" + name);
-        this.shortcuts = dir.find("shortcuts_" + name);
+        this.nodesCH = dir.find("nodes_ch_" + name, dir.getDefaultType().isStoring() ? DAType.RAM_INT_STORE : DAType.RAM_INT);
+        this.shortcuts = dir.find("shortcuts_" + name, dir.getDefaultType().isStoring() ? DAType.RAM_INT_STORE : DAType.RAM_INT);
         this.chEdgeAccess = new EdgeAccess(shortcuts, baseGraph.bitUtil) {
             @Override
             final EdgeIterable createSingleEdge(EdgeFilter edgeFilter) {

--- a/core/src/main/java/com/graphhopper/storage/CHGraphImpl.java
+++ b/core/src/main/java/com/graphhopper/storage/CHGraphImpl.java
@@ -69,8 +69,8 @@ public class CHGraphImpl implements CHGraph, Storable<CHGraph> {
         this.weighting = w;
         this.baseGraph = baseGraph;
         final String name = AbstractWeighting.weightingToFileName(w);
-        this.nodesCH = dir.find("nodes_ch_" + name, dir.getDefaultType().isStoring() ? DAType.RAM_INT_STORE : DAType.RAM_INT);
-        this.shortcuts = dir.find("shortcuts_" + name, dir.getDefaultType().isStoring() ? DAType.RAM_INT_STORE : DAType.RAM_INT);
+        this.nodesCH = dir.find("nodes_ch_" + name, GHDirectory.getPreferredInt(dir.getDefaultType()));
+        this.shortcuts = dir.find("shortcuts_" + name, GHDirectory.getPreferredInt(dir.getDefaultType()));
         this.chEdgeAccess = new EdgeAccess(shortcuts, baseGraph.bitUtil) {
             @Override
             final EdgeIterable createSingleEdge(EdgeFilter edgeFilter) {

--- a/core/src/main/java/com/graphhopper/storage/CHGraphImpl.java
+++ b/core/src/main/java/com/graphhopper/storage/CHGraphImpl.java
@@ -69,8 +69,8 @@ public class CHGraphImpl implements CHGraph, Storable<CHGraph> {
         this.weighting = w;
         this.baseGraph = baseGraph;
         final String name = AbstractWeighting.weightingToFileName(w);
-        this.nodesCH = dir.find("nodes_ch_" + name, GHDirectory.getPreferredInt(dir.getDefaultType()));
-        this.shortcuts = dir.find("shortcuts_" + name, GHDirectory.getPreferredInt(dir.getDefaultType()));
+        this.nodesCH = dir.find("nodes_ch_" + name, DAType.getPreferredInt(dir.getDefaultType()));
+        this.shortcuts = dir.find("shortcuts_" + name, DAType.getPreferredInt(dir.getDefaultType()));
         this.chEdgeAccess = new EdgeAccess(shortcuts, baseGraph.bitUtil) {
             @Override
             final EdgeIterable createSingleEdge(EdgeFilter edgeFilter) {

--- a/core/src/main/java/com/graphhopper/storage/DAType.java
+++ b/core/src/main/java/com/graphhopper/storage/DAType.java
@@ -90,6 +90,15 @@ public class DAType {
     }
 
     /**
+     * This method returns RAM_INT if the specified type is in-memory.
+     */
+    public static DAType getPreferredInt(DAType type) {
+        if (type.isInMemory())
+            return type.isStoring() ? RAM_INT_STORE : RAM_INT;
+        return type;
+    }
+
+    /**
      * Memory mapped or purely in memory? default is HEAP
      */
     MemRef getMemRef() {

--- a/core/src/main/java/com/graphhopper/storage/GHDirectory.java
+++ b/core/src/main/java/com/graphhopper/storage/GHDirectory.java
@@ -52,15 +52,6 @@ public class GHDirectory implements Directory {
             throw new RuntimeException("file '" + dir + "' exists but is not a directory");
     }
 
-    /**
-     * This method returns RAM_INT if the specified type is in-memory.
-     */
-    public static DAType getPreferredInt(DAType type) {
-        if (type.isInMemory())
-            return type.isStoring() ? DAType.RAM_INT_STORE : DAType.RAM_INT;
-        return type;
-    }
-
     @Override
     public ByteOrder getByteOrder() {
         return byteOrder;

--- a/core/src/main/java/com/graphhopper/storage/GHDirectory.java
+++ b/core/src/main/java/com/graphhopper/storage/GHDirectory.java
@@ -17,8 +17,6 @@
  */
 package com.graphhopper.storage;
 
-import com.graphhopper.util.Helper;
-
 import java.io.File;
 import java.nio.ByteOrder;
 import java.util.Collection;
@@ -52,20 +50,15 @@ public class GHDirectory implements Directory {
         File dir = new File(location);
         if (dir.exists() && !dir.isDirectory())
             throw new RuntimeException("file '" + dir + "' exists but is not a directory");
+    }
 
-        // set default access to integer based
-        // improves performance on server side, 10% faster for queries and preparation
-        if (this.defaultType.isInMemory()) {
-            if (isStoring()) {
-                put("location_index", DAType.RAM_INT_STORE);
-                put("edges", DAType.RAM_INT_STORE);
-                put("nodes", DAType.RAM_INT_STORE);
-            } else {
-                put("location_index", DAType.RAM_INT);
-                put("edges", DAType.RAM_INT);
-                put("nodes", DAType.RAM_INT);
-            }
-        }
+    /**
+     * This method returns RAM_INT if the specified type is in-memory.
+     */
+    public static DAType getPreferredInt(DAType type) {
+        if (type.isInMemory())
+            return type.isStoring() ? DAType.RAM_INT_STORE : DAType.RAM_INT;
+        return type;
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/storage/index/LocationIndexTree.java
+++ b/core/src/main/java/com/graphhopper/storage/index/LocationIndexTree.java
@@ -87,7 +87,7 @@ public class LocationIndexTree implements LocationIndex {
         MAGIC_INT = Integer.MAX_VALUE / 22316;
         this.graph = g;
         this.nodeAccess = g.getNodeAccess();
-        dataAccess = dir.find("location_index", GHDirectory.getPreferredInt(dir.getDefaultType()));
+        dataAccess = dir.find("location_index", DAType.getPreferredInt(dir.getDefaultType()));
     }
 
     public int getMinResolutionInMeter() {

--- a/core/src/main/java/com/graphhopper/storage/index/LocationIndexTree.java
+++ b/core/src/main/java/com/graphhopper/storage/index/LocationIndexTree.java
@@ -29,18 +29,10 @@ import com.graphhopper.storage.*;
 import com.graphhopper.util.*;
 import com.graphhopper.util.shapes.BBox;
 import com.graphhopper.util.shapes.GHPoint;
-
-import java.util.ArrayList;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 
 /**
  * This implementation implements an n-tree to get the closest node or edge from GPS coordinates.
@@ -95,7 +87,7 @@ public class LocationIndexTree implements LocationIndex {
         MAGIC_INT = Integer.MAX_VALUE / 22316;
         this.graph = g;
         this.nodeAccess = g.getNodeAccess();
-        dataAccess = dir.find("location_index");
+        dataAccess = dir.find("location_index", GHDirectory.getPreferredInt(dir.getDefaultType()));
     }
 
     public int getMinResolutionInMeter() {
@@ -571,13 +563,13 @@ public class LocationIndexTree implements LocationIndex {
 
         return closestMatch;
     }
-    
+
     /**
      * Returns all edges that are within the specified radius around the queried position.
      * Searches at most 9 cells to avoid performance problems. Hence, if the radius is larger than
      * the cell width then not all edges might be returned.
-     * 
-     * TODO: either clarify the method name and description (to only search e.g. 9 tiles) or 
+     * <p>
+     * TODO: either clarify the method name and description (to only search e.g. 9 tiles) or
      * refactor so it can handle a radius larger than 9 tiles. Also remove reference to 'NClosest',
      * which is misleading, and don't always return at least one value. See map-matching #65.
      * TODO: tidy up logic - see comments in graphhopper #994.
@@ -585,7 +577,7 @@ public class LocationIndexTree implements LocationIndex {
      * @param radius in meters
      */
     public List<QueryResult> findNClosest(final double queryLat, final double queryLon,
-            final EdgeFilter edgeFilter, double radius) {
+                                          final EdgeFilter edgeFilter, double radius) {
         // Return ALL results which are very close and e.g. within the GPS signal accuracy.
         // Also important to get all edges if GPS point is close to a junction.
         final double returnAllResultsWithin = distCalc.calcNormalizedDist(radius);
@@ -684,7 +676,7 @@ public class LocationIndexTree implements LocationIndex {
 
         return queryResults;
     }
-    
+
     // make entries static as otherwise we get an additional reference to this class (memory waste)
     interface InMemEntry {
         boolean isLeaf();

--- a/core/src/test/java/com/graphhopper/storage/GraphHopperStorageTest.java
+++ b/core/src/test/java/com/graphhopper/storage/GraphHopperStorageTest.java
@@ -181,7 +181,7 @@ public class GraphHopperStorageTest extends AbstractGraphStorageTester {
         Directory dir = new RAMDirectory();
         graph = newGHStorage(dir, false).create(defaultSize);
         int roughEdgeRowLength = 4 * 8;
-        int testIndex = dir.find("edges").getSegmentSize() * 3 / roughEdgeRowLength;
+        int testIndex = dir.find("edges", DAType.RAM_INT).getSegmentSize() * 3 / roughEdgeRowLength;
         // we need a big node index to trigger multiple segments, but low enough to avoid OOM
         graph.edge(0, testIndex, 10, true);
 


### PR DESCRIPTION
This PR makes the CH-query speed 7% faster (without instructions it is 12% faster) and CH-preparation will be 15% faster.

While working on the performance problem in #1447 I stumbled over the fact that we use RAMIntDataAccess for the BaseGraph+LocationIndexTree only, but not for the shortcuts (CHGraphImpl.java).

TODO: 

 - [x] better fallback for Unsafe or MMap etc
 - [x] instead of the special handling in the GHDirectory constructor use the same logic for the DataAccess `edges` and `nodes`