### PR TITLE
Makes Measurement the default main in gh tools jar with dependencies.

### DIFF
--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -60,7 +60,7 @@
                 <configuration>
                     <archive>
                         <manifest>
-                            <mainClass>com.graphhopper.tools.Import</mainClass>
+                            <mainClass>com.graphhopper.tools.Measurement</mainClass>
                         </manifest>
                     </archive>
                         	                    


### PR DESCRIPTION
The Import class is gone since dropwizard refactoring, so 
```bash
java -jar  ...-with-dependencies.jar
```
yields `ClassNotFoundException`.
I think it is still useful to have the jar with dependencies and changed the main class to Measurement.