### PR TITLE
Adds getEdges() to graph interface. No more GraphHopperStorage in PrepareCH.

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/QueryGraph.java
+++ b/core/src/main/java/com/graphhopper/routing/QueryGraph.java
@@ -531,6 +531,11 @@ public class QueryGraph implements Graph {
     }
 
     @Override
+    public int getEdges() {
+        return virtualEdges.size() + mainEdges;
+    }
+
+    @Override
     public NodeAccess getNodeAccess() {
         return nodeAccess;
     }

--- a/core/src/main/java/com/graphhopper/routing/ch/AbstractNodeContractor.java
+++ b/core/src/main/java/com/graphhopper/routing/ch/AbstractNodeContractor.java
@@ -25,7 +25,6 @@ import com.graphhopper.storage.*;
 import com.graphhopper.util.CHEdgeExplorer;
 
 abstract class AbstractNodeContractor implements NodeContractor {
-    private final GraphHopperStorage ghStorage;
     final CHGraph prepareGraph;
     final FlagEncoder encoder;
     CHEdgeExplorer inEdgeExplorer;
@@ -34,8 +33,7 @@ abstract class AbstractNodeContractor implements NodeContractor {
     int maxLevel;
     private int maxEdgesCount;
 
-    public AbstractNodeContractor(GraphHopperStorage ghStorage, CHGraph prepareGraph, Weighting weighting) {
-        this.ghStorage = ghStorage;
+    public AbstractNodeContractor(CHGraph prepareGraph, Weighting weighting) {
         this.prepareGraph = prepareGraph;
         this.encoder = weighting.getFlagEncoder();
         originalEdges = new GHDirectory("", DAType.RAM_INT).find("");
@@ -47,7 +45,7 @@ abstract class AbstractNodeContractor implements NodeContractor {
         inEdgeExplorer = prepareGraph.createEdgeExplorer(DefaultEdgeFilter.inEdges(encoder));
         outEdgeExplorer = prepareGraph.createEdgeExplorer(DefaultEdgeFilter.outEdges(encoder));
         maxLevel = prepareGraph.getNodes();
-        maxEdgesCount = ghStorage.getAllEdges().length();
+        maxEdgesCount = prepareGraph.getOriginalEdges();
     }
 
     @Override
@@ -66,7 +64,7 @@ abstract class AbstractNodeContractor implements NodeContractor {
             if (value != 1)
                 throw new IllegalStateException("Trying to set original edge count for normal edge to a value = " + value
                         + ", edge:" + (edgeId + maxEdgesCount) + ", max:" + maxEdgesCount + ", graph.max:" +
-                        prepareGraph.getAllEdges().length());
+                        prepareGraph.getEdges());
             return;
         }
 

--- a/core/src/main/java/com/graphhopper/routing/ch/CHAlgoFactoryDecorator.java
+++ b/core/src/main/java/com/graphhopper/routing/ch/CHAlgoFactoryDecorator.java
@@ -263,8 +263,8 @@ public class CHAlgoFactoryDecorator implements RoutingAlgorithmFactoryDecorator 
         traversalMode = getNodeBase();
 
         for (Weighting weighting : getWeightings()) {
-            PrepareContractionHierarchies tmpPrepareCH = new PrepareContractionHierarchies(
-                    ghStorage, ghStorage.getGraph(CHGraph.class, weighting), traversalMode);
+            PrepareContractionHierarchies tmpPrepareCH = PrepareContractionHierarchies.fromGraphHopperStorage(
+                    ghStorage, weighting, traversalMode);
             tmpPrepareCH.setParams(pMap);
             addPreparation(tmpPrepareCH);
         }

--- a/core/src/main/java/com/graphhopper/routing/ch/NodeBasedNodeContractor.java
+++ b/core/src/main/java/com/graphhopper/routing/ch/NodeBasedNodeContractor.java
@@ -47,8 +47,8 @@ class NodeBasedNodeContractor extends AbstractNodeContractor {
     // each edge can exist in both directions
     private double meanDegree;
 
-    NodeBasedNodeContractor(GraphHopperStorage ghStorage, CHGraph prepareGraph, Weighting weighting, PMap pMap) {
-        super(ghStorage, prepareGraph, weighting);
+    NodeBasedNodeContractor(CHGraph prepareGraph, Weighting weighting, PMap pMap) {
+        super(prepareGraph, weighting);
         this.prepareWeighting = new PreparationWeighting(weighting);
         extractParams(pMap);
     }
@@ -81,7 +81,7 @@ class NodeBasedNodeContractor extends AbstractNodeContractor {
         // no witness path can be found. this is not really what we want, but changing it requires re-optimizing the
         // graph contraction parameters, because it affects the node contraction order.
         // when this is done there should be no need for this method any longer.
-        meanDegree = prepareGraph.getAllEdges().length() / prepareGraph.getNodes();
+        meanDegree = prepareGraph.getEdges() / prepareGraph.getNodes();
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/storage/BaseGraph.java
+++ b/core/src/main/java/com/graphhopper/storage/BaseGraph.java
@@ -314,6 +314,11 @@ class BaseGraph implements Graph {
     }
 
     @Override
+    public int getEdges() {
+        return getAllEdges().length();
+    }
+
+    @Override
     public NodeAccess getNodeAccess() {
         return nodeAccess;
     }

--- a/core/src/main/java/com/graphhopper/storage/CHGraph.java
+++ b/core/src/main/java/com/graphhopper/storage/CHGraph.java
@@ -21,6 +21,7 @@ import com.graphhopper.routing.util.AllCHEdgesIterator;
 import com.graphhopper.routing.util.EdgeFilter;
 import com.graphhopper.util.CHEdgeExplorer;
 import com.graphhopper.util.CHEdgeIteratorState;
+import com.graphhopper.util.EdgeIteratorState;
 
 /**
  * Extended graph interface which supports Contraction Hierarchies. Ie. storing and retrieving the
@@ -31,6 +32,7 @@ import com.graphhopper.util.CHEdgeIteratorState;
  * @author Peter Karich
  */
 public interface CHGraph extends Graph {
+
     /**
      * This methods sets the level of the specified node.
      */
@@ -61,4 +63,18 @@ public interface CHGraph extends Graph {
 
     @Override
     AllCHEdgesIterator getAllEdges();
+
+    /**
+     * Disconnects the edges (higher to lower node) via the specified edgeState pointing from lower to
+     * higher node.
+     * <p>
+     *
+     * @param edgeState the edge from lower to higher
+     */
+    void disconnect(CHEdgeExplorer edgeExplorer, EdgeIteratorState edgeState);
+
+    /**
+     * @return the number of original edges in this graph (without shortcuts)
+     */
+    int getOriginalEdges();
 }

--- a/core/src/main/java/com/graphhopper/storage/CHGraphImpl.java
+++ b/core/src/main/java/com/graphhopper/storage/CHGraphImpl.java
@@ -221,6 +221,16 @@ public class CHGraphImpl implements CHGraph, Storable<CHGraph> {
     }
 
     @Override
+    public int getEdges() {
+        return getAllEdges().length();
+    }
+
+    @Override
+    public int getOriginalEdges() {
+        return baseGraph.getEdges();
+    }
+
+    @Override
     public NodeAccess getNodeAccess() {
         return baseGraph.getNodeAccess();
     }
@@ -251,13 +261,7 @@ public class CHGraphImpl implements CHGraph, Storable<CHGraph> {
         return toString() + ", shortcuts:" + nf(shortcutCount) + ", nodesCH:(" + nodesCH.getCapacity() / Helper.MB + "MB)";
     }
 
-    /**
-     * Disconnects the edges (higher to lower node) via the specified edgeState pointing from lower to
-     * higher node.
-     * <p>
-     *
-     * @param edgeState the edge from lower to higher
-     */
+    @Override
     public void disconnect(CHEdgeExplorer explorer, EdgeIteratorState edgeState) {
         // search edge with opposite direction but we need to know the previousEdge for the internalEdgeDisconnect so we cannot simply do:
         // EdgeIteratorState tmpIter = getEdgeProps(iter.getEdge(), iter.getBaseNode());

--- a/core/src/main/java/com/graphhopper/storage/Graph.java
+++ b/core/src/main/java/com/graphhopper/storage/Graph.java
@@ -43,6 +43,11 @@ public interface Graph {
     int getNodes();
 
     /**
+     * @return the number of edges in this graph. equivalent to getAllEdges().length();
+     */
+    int getEdges();
+
+    /**
      * Creates a node explorer to access node properties.
      */
     NodeAccess getNodeAccess();

--- a/core/src/main/java/com/graphhopper/storage/GraphHopperStorage.java
+++ b/core/src/main/java/com/graphhopper/storage/GraphHopperStorage.java
@@ -25,7 +25,10 @@ import com.graphhopper.util.EdgeExplorer;
 import com.graphhopper.util.EdgeIteratorState;
 import com.graphhopper.util.shapes.BBox;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * This class manages all storage related methods and delegates the calls to the associated graphs.
@@ -369,6 +372,11 @@ public final class GraphHopperStorage implements GraphStorage, Graph {
     @Override
     public int getNodes() {
         return baseGraph.getNodes();
+    }
+
+    @Override
+    public int getEdges() {
+        return getAllEdges().length();
     }
 
     @Override

--- a/core/src/test/java/com/graphhopper/routing/DijkstraBidirectionCHTest.java
+++ b/core/src/test/java/com/graphhopper/routing/DijkstraBidirectionCHTest.java
@@ -57,8 +57,9 @@ public class DijkstraBidirectionCHTest extends AbstractRoutingAlgorithmTester {
 
     @Override
     public RoutingAlgorithmFactory createFactory(GraphHopperStorage ghStorage, AlgorithmOptions opts) {
-        PrepareContractionHierarchies ch = new PrepareContractionHierarchies(
-                ghStorage, getGraph(ghStorage, opts.getWeighting()), TraversalMode.NODE_BASED);
+        ghStorage.freeze();
+        PrepareContractionHierarchies ch = PrepareContractionHierarchies.fromGraphHopperStorage(
+                ghStorage, opts.getWeighting(), TraversalMode.NODE_BASED);
         ch.doWork();
         return ch;
     }
@@ -105,7 +106,7 @@ public class DijkstraBidirectionCHTest extends AbstractRoutingAlgorithmTester {
 
         AlgorithmOptions opts = new AlgorithmOptions(Parameters.Algorithms.DIJKSTRA_BI, weighting);
         Path p = new PrepareContractionHierarchies(
-                ghStorage, g2, TraversalMode.NODE_BASED).
+                g2, weighting, TraversalMode.NODE_BASED).
                 createAlgo(g2, opts).calcPath(0, 7);
 
         assertEquals(IntArrayList.from(0, 2, 5, 7), p.calcNodes());
@@ -261,7 +262,7 @@ public class DijkstraBidirectionCHTest extends AbstractRoutingAlgorithmTester {
 
     private RoutingAlgorithm createCHAlgo(GraphHopperStorage graph, CHGraph chGraph, boolean withSOD, AlgorithmOptions algorithmOptions) {
         PrepareContractionHierarchies ch = new PrepareContractionHierarchies(
-                graph, chGraph, TraversalMode.NODE_BASED);
+                chGraph, algorithmOptions.getWeighting(), TraversalMode.NODE_BASED);
         if (!withSOD) {
             algorithmOptions.getHints().put("stall_on_demand", false);
         }

--- a/core/src/test/java/com/graphhopper/routing/ch/NodeBasedNodeContractorTest.java
+++ b/core/src/test/java/com/graphhopper/routing/ch/NodeBasedNodeContractorTest.java
@@ -45,7 +45,7 @@ public class NodeBasedNodeContractorTest {
     private final TraversalMode traversalMode = TraversalMode.NODE_BASED;
 
     private NodeContractor createNodeContractor() {
-        NodeContractor nodeContractor = new NodeBasedNodeContractor(graph, lg, weighting, new PMap());
+        NodeContractor nodeContractor = new NodeBasedNodeContractor(lg, weighting, new PMap());
         nodeContractor.initFromGraph();
         nodeContractor.prepareContraction();
         return nodeContractor;

--- a/core/src/test/java/com/graphhopper/routing/ch/PrepareContractionHierarchiesTest.java
+++ b/core/src/test/java/com/graphhopper/routing/ch/PrepareContractionHierarchiesTest.java
@@ -162,10 +162,10 @@ public class PrepareContractionHierarchiesTest {
     public void testAddShortcuts() {
         GraphHopperStorage g = createExampleGraph();
         CHGraph lg = g.getGraph(CHGraph.class);
-        int old = lg.getAllEdges().length();
+        int old = lg.getEdges();
         PrepareContractionHierarchies prepare = createPrepareContractionHierarchies(g, lg);
         prepare.doWork();
-        assertEquals(old + 2, lg.getAllEdges().length());
+        assertEquals(old + 2, lg.getEdges());
     }
 
     @Test
@@ -176,8 +176,8 @@ public class PrepareContractionHierarchiesTest {
         int oldCount = g.getAllEdges().length();
         PrepareContractionHierarchies prepare = createPrepareContractionHierarchies(g, lg);
         prepare.doWork();
-        assertEquals(oldCount, g.getAllEdges().length());
-        assertEquals(oldCount + 7, lg.getAllEdges().length());
+        assertEquals(oldCount, g.getEdges());
+        assertEquals(oldCount + 7, lg.getEdges());
     }
 
     @Test
@@ -218,7 +218,7 @@ public class PrepareContractionHierarchiesTest {
 
         long numShortcuts = 9;
         assertEquals(numShortcuts, prepare.getShortcuts());
-        assertEquals(oldCount + numShortcuts, lg.getAllEdges().length());
+        assertEquals(oldCount + numShortcuts, lg.getEdges());
         assertEquals(oldCount + numShortcuts, GHUtility.count(lg.getAllEdges()));
         RoutingAlgorithm algo = prepare.createAlgo(lg, new AlgorithmOptions(DIJKSTRA_BI, weighting, tMode));
         Path p = algo.calcPath(0, 10);
@@ -285,8 +285,8 @@ public class PrepareContractionHierarchiesTest {
         int oldCount = g.getAllEdges().length();
         PrepareContractionHierarchies prepare = createPrepareContractionHierarchies(g, lg);
         prepare.doWork();
-        assertEquals(oldCount, g.getAllEdges().length());
-        assertEquals(oldCount + 23, lg.getAllEdges().length());
+        assertEquals(oldCount, g.getEdges());
+        assertEquals(oldCount + 23, lg.getEdges());
         RoutingAlgorithm algo = prepare.createAlgo(lg, new AlgorithmOptions(DIJKSTRA_BI, weighting, tMode));
         Path p = algo.calcPath(4, 7);
         assertEquals(IntArrayList.from(4, 5, 6, 7), p.calcNodes());
@@ -503,7 +503,7 @@ public class PrepareContractionHierarchiesTest {
 
     private PrepareContractionHierarchies createPrepareContractionHierarchies(GraphHopperStorage g, CHGraph lg, Weighting w) {
         g.freeze();
-        return new PrepareContractionHierarchies(g, lg, tMode);
+        return new PrepareContractionHierarchies(lg, w, tMode);
     }
 
 }

--- a/core/src/test/java/com/graphhopper/storage/GraphHopperStorageCHTest.java
+++ b/core/src/test/java/com/graphhopper/storage/GraphHopperStorageCHTest.java
@@ -310,8 +310,8 @@ public class GraphHopperStorageCHTest extends GraphHopperStorageTest {
 
         chGraph = getGraph(graph);
         assertEquals(10, chGraph.getNodes());
-        assertEquals(2, graph.getAllEdges().length());
-        assertEquals(3, chGraph.getAllEdges().length());
+        assertEquals(2, graph.getEdges());
+        assertEquals(3, chGraph.getEdges());
         assertEquals(1, GHUtility.count(chGraph.createEdgeExplorer().setBaseNode(2)));
 
         AllCHEdgesIterator iter = chGraph.getAllEdges();

--- a/core/src/test/java/com/graphhopper/util/GHUtilityTest.java
+++ b/core/src/test/java/com/graphhopper/util/GHUtilityTest.java
@@ -112,7 +112,7 @@ public class GHUtilityTest {
         CHGraph lg = new GraphBuilder(encodingManager).chGraphCreate(new FastestWeighting(carEncoder));
         GHUtility.copyTo(g, lg);
 
-        assertEquals(g.getAllEdges().length(), lg.getAllEdges().length());
+        assertEquals(g.getAllEdges().length(), lg.getEdges());
     }
 
     @Test

--- a/reader-gtfs/src/main/java/com/graphhopper/reader/gtfs/GraphSupport.java
+++ b/reader-gtfs/src/main/java/com/graphhopper/reader/gtfs/GraphSupport.java
@@ -59,6 +59,11 @@ class GraphSupport {
             }
 
             @Override
+            public int getEdges() {
+                return baseGraph.getEdges();
+            }
+
+            @Override
             public NodeAccess getNodeAccess() {
                 return baseGraph.getNodeAccess();
             }

--- a/reader-gtfs/src/main/java/com/graphhopper/reader/gtfs/RealtimeFeed.java
+++ b/reader-gtfs/src/main/java/com/graphhopper/reader/gtfs/RealtimeFeed.java
@@ -196,6 +196,11 @@ public class RealtimeFeed {
             }
 
             @Override
+            public int getEdges() {
+                return getAllEdges().length();
+            }
+
+            @Override
             public NodeAccess getNodeAccess() {
                 return nodeAccess;
             }

--- a/reader-gtfs/src/main/java/com/graphhopper/reader/gtfs/WrapperGraph.java
+++ b/reader-gtfs/src/main/java/com/graphhopper/reader/gtfs/WrapperGraph.java
@@ -57,6 +57,11 @@ public class WrapperGraph implements Graph {
     }
 
     @Override
+    public int getEdges() {
+        return getAllEdges().length();
+    }
+
+    @Override
     public NodeAccess getNodeAccess() {
         return baseGraph.getNodeAccess();
     }

--- a/reader-osm/src/test/java/com/graphhopper/reader/osm/GraphHopperOSMTest.java
+++ b/reader-osm/src/test/java/com/graphhopper/reader/osm/GraphHopperOSMTest.java
@@ -886,8 +886,8 @@ public class GraphHopperOSMTest {
         GraphHopperStorage storage = new GraphHopperStorage(Arrays.asList(fwSimpleTruck, fwTruck), ramDir, em, false, new GraphExtension.NoOpExtension());
         decorator.addWeighting(fwSimpleTruck);
         decorator.addWeighting(fwTruck);
-        decorator.addPreparation(new PrepareContractionHierarchies(storage, storage.getGraph(CHGraph.class, fwSimpleTruck), TraversalMode.NODE_BASED));
-        decorator.addPreparation(new PrepareContractionHierarchies(storage, storage.getGraph(CHGraph.class, fwTruck), TraversalMode.NODE_BASED));
+        decorator.addPreparation(PrepareContractionHierarchies.fromGraphHopperStorage(storage, fwSimpleTruck, TraversalMode.NODE_BASED));
+        decorator.addPreparation(PrepareContractionHierarchies.fromGraphHopperStorage(storage, fwTruck, TraversalMode.NODE_BASED));
 
         HintsMap wMap = new HintsMap("fastest");
         wMap.put("vehicle", "truck");
@@ -899,7 +899,7 @@ public class GraphHopperOSMTest {
         decorator.addWeighting(fwTruck);
         decorator.addWeighting(fwSimpleTruck);
         try {
-            decorator.addPreparation(new PrepareContractionHierarchies(storage, storage.getGraph(CHGraph.class, fwSimpleTruck), TraversalMode.NODE_BASED));
+            decorator.addPreparation(PrepareContractionHierarchies.fromGraphHopperStorage(storage, fwSimpleTruck, TraversalMode.NODE_BASED));
             fail();
         } catch (Exception ex) {
         }

--- a/tools/src/main/java/com/graphhopper/tools/Measurement.java
+++ b/tools/src/main/java/com/graphhopper/tools/Measurement.java
@@ -94,7 +94,7 @@ public class Measurement {
                 int edges = getGraphHopperStorage().getAllEdges().length();
                 if (getCHFactoryDecorator().hasWeightings()) {
                     Weighting weighting = getCHFactoryDecorator().getWeightings().get(0);
-                    int edgesAndShortcuts = getGraphHopperStorage().getGraph(CHGraph.class, weighting).getAllEdges().length();
+                    int edgesAndShortcuts = getGraphHopperStorage().getGraph(CHGraph.class, weighting).getEdges();
                     put(Parameters.CH.PREPARE + "shortcuts", edgesAndShortcuts - edges);
                 }
             }


### PR DESCRIPTION
So far `PrepareContractionHierarchies` was directly coupled to `GraphHopperStorage`. To be able to use the same algorithm with another `Graph` implementation I did the following: 

-  replaced the `GraphHopperStorage` field with a reference to a `CHGraph`. I had to add `getOriginalEdges()`  and `disconnect()` to `CHGraph`.
- removed the `freeze()` call, which is already done in `GraphHopper#prepareCH`. I only had to add it in two tests.

I also added `getEdges()` to `Graph` which can be used instead of `.getAllEdges().length()`, because I thought this is more consistent with `getNodes()`.