### PR TITLE
Adds gitinfo properties file containing git hash used when building.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -108,8 +108,33 @@
                     </executions>
                 </plugin>
 
+                <plugin>
+                    <groupId>pl.project13.maven</groupId>
+                    <artifactId>git-commit-id-plugin</artifactId>
+                    <version>2.2.5</version>
+                </plugin>
             </plugins>
         </pluginManagement>
+
+        <plugins>
+            <plugin>
+                <groupId>pl.project13.maven</groupId>
+                <artifactId>git-commit-id-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                    </execution>
+                </executions>
+
+                <configuration>
+                    <dotGitDirectory>${parent.basedir}/.git</dotGitDirectory>
+                    <failOnNoGitDirectory>false</failOnNoGitDirectory>
+                    <failOnUnableToExtractRepoInfo>false</failOnUnableToExtractRepoInfo>
+                </configuration>
+            </plugin>
+        </plugins>
 
         <!-- make version available at runtime via version file -->
         <resources>
@@ -119,6 +144,7 @@
                 <includes>
                     <include>**/version</include>
                     <include>**/builddate</include>
+                    <include>**/gitinfo</include>
                 </includes>
             </resource>
             <resource>
@@ -127,6 +153,7 @@
                 <excludes>
                     <exclude>**/version</exclude>
                     <exclude>**/builddate</exclude>
+                    <exclude>**/gitinfo</exclude>
                 </excludes>
             </resource>
         </resources>

--- a/core/src/main/resources/com/graphhopper/gitinfo
+++ b/core/src/main/resources/com/graphhopper/gitinfo
@@ -1,0 +1,5 @@
+# properties will be filled by git-commit-id-plugin during maven build
+gitHash=${git.commit.id}
+gitBranch=${git.branch}
+gitDirty=${git.dirty}
+gitCommitTime=${git.commit.time}


### PR DESCRIPTION
Using the maven-git-comit-id-plugin this PR adds a `gitinfo` properties file that contains git commit/hash/branch information after the build, so one can check which commit was used on an existing jar.

The plugin's license is LGPL.

https://github.com/git-commit-id/maven-git-commit-id-plugin