### PR TITLE
Fixes edge-based CH problem with u-turns at virtual edges, fixes #1593

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/QueryGraph.java
+++ b/core/src/main/java/com/graphhopper/routing/QueryGraph.java
@@ -781,10 +781,23 @@ public class QueryGraph implements Graph {
                     edgeTo = queryResults.get((edgeTo - mainEdges) / 4).getClosestEdge().getEdge();
                 }
                 return mainTurnExtension.getTurnCostFlags(edgeFrom, nodeVia, edgeTo);
-
             } else {
                 return mainTurnExtension.getTurnCostFlags(edgeFrom, nodeVia, edgeTo);
             }
+        }
+
+        @Override
+        public boolean isUTurn(int edgeFrom, int edgeTo) {
+            if (!isVirtualEdge(edgeFrom) && !isVirtualEdge(edgeTo)) {
+                return mainTurnExtension.isUTurn(edgeFrom, edgeTo);
+            } else if (isVirtualEdge(edgeFrom) && isVirtualEdge(edgeTo)) {
+                return mainTurnExtension.isUTurn(edgeFrom, edgeTo);
+            } else if (isVirtualEdge(edgeFrom)) {
+                edgeFrom = queryResults.get((edgeFrom - mainEdges) / 4).getClosestEdge().getEdge();
+            } else if (isVirtualEdge(edgeTo)) {
+                edgeTo = queryResults.get((edgeTo - mainEdges) / 4).getClosestEdge().getEdge();
+            }
+            return mainTurnExtension.isUTurn(edgeFrom, edgeTo);
         }
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/QueryGraph.java
+++ b/core/src/main/java/com/graphhopper/routing/QueryGraph.java
@@ -775,10 +775,10 @@ public class QueryGraph implements Graph {
                 return 0;
             } else if (isVirtualEdge(edgeFrom) || isVirtualEdge(edgeTo)) {
                 if (isVirtualEdge(edgeFrom)) {
-                    edgeFrom = queryResults.get((edgeFrom - mainEdges) / 4).getClosestEdge().getEdge();
+                    edgeFrom = getOriginalEdge(edgeFrom);
                 }
                 if (isVirtualEdge(edgeTo)) {
-                    edgeTo = queryResults.get((edgeTo - mainEdges) / 4).getClosestEdge().getEdge();
+                    edgeTo = getOriginalEdge(edgeTo);
                 }
                 return mainTurnExtension.getTurnCostFlags(edgeFrom, nodeVia, edgeTo);
             } else {
@@ -788,16 +788,19 @@ public class QueryGraph implements Graph {
 
         @Override
         public boolean isUTurn(int edgeFrom, int edgeTo) {
-            if (!isVirtualEdge(edgeFrom) && !isVirtualEdge(edgeTo)) {
-                return mainTurnExtension.isUTurn(edgeFrom, edgeTo);
-            } else if (isVirtualEdge(edgeFrom) && isVirtualEdge(edgeTo)) {
-                return mainTurnExtension.isUTurn(edgeFrom, edgeTo);
-            } else if (isVirtualEdge(edgeFrom)) {
-                edgeFrom = queryResults.get((edgeFrom - mainEdges) / 4).getClosestEdge().getEdge();
-            } else if (isVirtualEdge(edgeTo)) {
-                edgeTo = queryResults.get((edgeTo - mainEdges) / 4).getClosestEdge().getEdge();
+            // detecting a u-turn from a virtual to a non-virtual edge requires looking at the original edge of the
+            // virtual edge. however when we are turning between virtual edges we need to compare the virtual edge ids
+            // see #1593
+            if (isVirtualEdge(edgeFrom) && !isVirtualEdge(edgeTo)) {
+                edgeFrom = getOriginalEdge(edgeFrom);
+            } else if (!isVirtualEdge(edgeFrom) && isVirtualEdge(edgeTo)) {
+                edgeTo = getOriginalEdge(edgeTo);
             }
             return mainTurnExtension.isUTurn(edgeFrom, edgeTo);
+        }
+
+        private int getOriginalEdge(int edgeFrom) {
+            return queryResults.get((edgeFrom - mainEdges) / 4).getClosestEdge().getEdge();
         }
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/ch/EdgeBasedNodeContractor.java
+++ b/core/src/main/java/com/graphhopper/routing/ch/EdgeBasedNodeContractor.java
@@ -134,11 +134,11 @@ class EdgeBasedNodeContractor extends AbstractNodeContractor {
         float priority = params.edgeQuotientWeight * edgeQuotient +
                 params.originalEdgeQuotientWeight * origEdgeQuotient +
                 params.hierarchyDepthWeight * hierarchyDepth;
-        LOGGER.trace("node: %d, eq: %d / %d = %f, oeq: %d / %d = %f, depth: %d --> %f\n",
+        LOGGER.trace(String.format("node: %d, eq: %d / %d = %f, oeq: %d / %d = %f, depth: %d --> %f\n",
                 node,
                 numShortcuts, numPrevEdges, edgeQuotient,
                 numOrigEdges, numPrevOrigEdges, origEdgeQuotient,
-                hierarchyDepth, priority);
+                hierarchyDepth, priority));
         return priority;
     }
 

--- a/core/src/main/java/com/graphhopper/routing/ch/EdgeBasedNodeContractor.java
+++ b/core/src/main/java/com/graphhopper/routing/ch/EdgeBasedNodeContractor.java
@@ -134,7 +134,7 @@ class EdgeBasedNodeContractor extends AbstractNodeContractor {
         float priority = params.edgeQuotientWeight * edgeQuotient +
                 params.originalEdgeQuotientWeight * origEdgeQuotient +
                 params.hierarchyDepthWeight * hierarchyDepth;
-        LOGGER.trace(String.format("node: %d, eq: %d / %d = %f, oeq: %d / %d = %f, depth: %d --> %f\n",
+        LOGGER.trace(String.format(Locale.ROOT, "node: %d, eq: %d / %d = %f, oeq: %d / %d = %f, depth: %d --> %f\n",
                 node,
                 numShortcuts, numPrevEdges, edgeQuotient,
                 numOrigEdges, numPrevOrigEdges, origEdgeQuotient,

--- a/core/src/main/java/com/graphhopper/routing/weighting/TurnWeighting.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/TurnWeighting.java
@@ -44,7 +44,7 @@ public class TurnWeighting implements Weighting {
      * @param turnCostExt the turn cost storage to be used
      */
     public TurnWeighting(Weighting superWeighting, TurnCostExtension turnCostExt) {
-        this.turnCostEncoder = (TurnCostEncoder) superWeighting.getFlagEncoder();
+        this.turnCostEncoder = superWeighting.getFlagEncoder();
         this.superWeighting = superWeighting;
         this.turnCostExt = turnCostExt;
 
@@ -57,7 +57,7 @@ public class TurnWeighting implements Weighting {
      * 'tricking' other turn costs or restrictions.
      */
     public TurnWeighting setDefaultUTurnCost(double costInSeconds) {
-        this.defaultUTurnCost = costInSeconds;
+        defaultUTurnCost = costInSeconds;
         return this;
     }
 

--- a/core/src/main/java/com/graphhopper/storage/TurnCostExtension.java
+++ b/core/src/main/java/com/graphhopper/storage/TurnCostExtension.java
@@ -197,6 +197,10 @@ public class TurnCostExtension implements GraphExtension {
         return nextCostFlags(edgeFrom, nodeVia, edgeTo);
     }
 
+    public boolean isUTurn(int edgeFrom, int edgeTo) {
+        return edgeFrom == edgeTo;
+    }
+
     private long nextCostFlags(int edgeFrom, int nodeVia, int edgeTo) {
         int turnCostIndex = nodeAccess.getAdditionalNodeField(nodeVia);
         int i = 0;

--- a/core/src/main/java/com/graphhopper/util/GHUtility.java
+++ b/core/src/main/java/com/graphhopper/util/GHUtility.java
@@ -136,6 +136,7 @@ public class GHUtility {
     }
 
     public static void printGraphForUnitTest(Graph g, FlagEncoder encoder, BBox bBox) {
+        System.out.println("WARNING: printGraphForUnitTest does not pay attention to custom edge speeds at the moment");
         NodeAccess na = g.getNodeAccess();
         for (int node = 0; node < g.getNodes(); ++node) {
             if (bBox.contains(na.getLat(node), na.getLon(node))) {
@@ -201,9 +202,9 @@ public class GHUtility {
             // using bidirectional edges will increase mean degree of graph above given value
             boolean bothDirections = random.nextDouble() < pBothDir;
             EdgeIteratorState edge = graph.edge(from, to, distance, bothDirections);
+            double fwdSpeed = 10 + random.nextDouble() * 120;
+            double bwdSpeed = 10 + random.nextDouble() * 120;
             if (randomSpeedEnc != null) {
-                double fwdSpeed = 10 + random.nextDouble() * 120;
-                double bwdSpeed = 10 + random.nextDouble() * 120;
                 edge.set(randomSpeedEnc, fwdSpeed);
                 edge.setReverse(randomSpeedEnc, bwdSpeed);
             }
@@ -245,8 +246,7 @@ public class GHUtility {
                                 restricted = true;
                             }
                             double cost = restricted ? 0 : random.nextDouble() * maxTurnCost;
-                            turnCostExtension.addTurnInfo(inIter.getEdge(), node, outIter.getEdge(),
-                                    encoder.getTurnFlags(restricted, cost));
+                            turnCostExtension.addTurnInfo(inIter.getEdge(), node, outIter.getEdge(), encoder.getTurnFlags(restricted, cost));
                         }
                     }
                 }

--- a/core/src/test/java/com/graphhopper/routing/RandomCHRoutingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/RandomCHRoutingTest.java
@@ -111,6 +111,16 @@ public class RandomCHRoutingTest {
         runRandomTest(rnd);
     }
 
+    @Test
+    public void issue1593() {
+        Assume.assumeTrue(traversalMode.isEdgeBased());
+        long seed = 60643479675316L;
+        Random rnd = new Random(seed);
+        GHUtility.buildRandomGraph(graph, rnd, 50, 2.5, true, true, encoder.getAverageSpeedEnc(), 0.7, 0.9, 0.0);
+        GHUtility.addRandomTurnCosts(graph, seed, encoder, maxTurnCosts, (TurnCostExtension) graph.getExtension());
+        runRandomTest(rnd);
+    }
+
     private void runRandomTest(Random rnd) {
         locationIndex = new LocationIndexTree(graph, dir);
         locationIndex.prepareIndex();

--- a/core/src/test/java/com/graphhopper/routing/ch/CHTurnCostTest.java
+++ b/core/src/test/java/com/graphhopper/routing/ch/CHTurnCostTest.java
@@ -21,18 +21,15 @@ import com.carrotsearch.hppc.IntArrayList;
 import com.graphhopper.Repeat;
 import com.graphhopper.RepeatRule;
 import com.graphhopper.routing.*;
-import com.graphhopper.routing.util.CarFlagEncoder;
-import com.graphhopper.routing.util.DefaultEdgeFilter;
-import com.graphhopper.routing.util.EncodingManager;
-import com.graphhopper.routing.util.TraversalMode;
+import com.graphhopper.routing.util.*;
 import com.graphhopper.routing.weighting.ShortestWeighting;
 import com.graphhopper.routing.weighting.TurnWeighting;
 import com.graphhopper.routing.weighting.Weighting;
-import com.graphhopper.storage.CHGraph;
-import com.graphhopper.storage.GraphBuilder;
-import com.graphhopper.storage.GraphHopperStorage;
-import com.graphhopper.storage.TurnCostExtension;
+import com.graphhopper.storage.*;
+import com.graphhopper.storage.index.LocationIndexTree;
+import com.graphhopper.storage.index.QueryResult;
 import com.graphhopper.util.*;
+import com.graphhopper.util.shapes.GHPoint;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -42,8 +39,7 @@ import org.slf4j.LoggerFactory;
 import java.util.*;
 
 import static com.graphhopper.routing.ch.CHParameters.*;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 /**
  * Here we test if Contraction Hierarchies work with turn costs, i.e. we first contract the graph and then run
@@ -678,6 +674,64 @@ public class CHTurnCostTest {
         IntArrayList expectedPath = IntArrayList.from(0, 1, 2, 3, 3, 4);
         List<Integer> contractionOrder = Arrays.asList(2, 0, 4, 1, 3);
         checkPath(expectedPath, 8, 0, 4, contractionOrder);
+    }
+
+    @Test
+    public void test_Issue1592() {
+        //      6   5
+        //   1<-x-4-x-3
+        //  ||    |
+        //  |x7   x8
+        //  ||   /
+        //   2---
+        NodeAccess na = graph.getNodeAccess();
+        na.setNode(0, 49.407117, 9.701306);
+        na.setNode(1, 49.406914, 9.703393);
+        na.setNode(2, 49.404004, 9.709110);
+        na.setNode(3, 49.400160, 9.708787);
+        na.setNode(4, 49.400883, 9.706347);
+        EdgeIteratorState edge0 = graph.edge(4, 3, 194.063000, true);
+        EdgeIteratorState edge1 = graph.edge(1, 2, 525.106000, true);
+        EdgeIteratorState edge2 = graph.edge(1, 2, 525.106000, true);
+        EdgeIteratorState edge3 = graph.edge(4, 1, 703.778000, false);
+        EdgeIteratorState edge4 = graph.edge(2, 4, 400.509000, true);
+        // cannot go 4-2-1 and 1-2-4 (at least when using edge1, there is still edge2!)
+        addRestriction(edge4, edge1, 2);
+        addRestriction(edge1, edge4, 2);
+        // cannot go 3-4-1
+        addRestriction(edge0, edge3, 4);
+        graph.freeze();
+        LocationIndexTree index = new LocationIndexTree(graph, new RAMDirectory());
+        index.prepareIndex();
+        List<GHPoint> points = Arrays.asList(
+                // 8 (on edge4)
+                new GHPoint(49.401669187194116, 9.706821649608745),
+                // 5 (on edge0)
+                new GHPoint(49.40056349818417, 9.70767186472369),
+                // 7 (on edge2)
+                new GHPoint(49.406580835146556, 9.704665738628218),
+                // 6 (on edge3)
+                new GHPoint(49.40107534698834, 9.702248694088528)
+        );
+
+        List<QueryResult> queryResults = new ArrayList<>(points.size());
+        for (GHPoint point : points) {
+            queryResults.add(index.findClosest(point.getLat(), point.getLon(), EdgeFilter.ALL_EDGES));
+        }
+
+        QueryGraph queryGraph = new QueryGraph(chGraph);
+        queryGraph.lookup(queryResults);
+        RoutingAlgorithmFactory pch = automaticPrepareCH();
+        RoutingAlgorithm chAlgo = pch.createAlgo(queryGraph, AlgorithmOptions.start()
+                .traversalMode(TraversalMode.EDGE_BASED_2DIR)
+                .build());
+        Path path = chAlgo.calcPath(5, 6);
+        // there should not be a path from 5 to 6, because first we cannot go directly 5-4-6, so we need to go left
+        // to 8. then at 2 we cannot go on edge 1 because of another turn restriction, but we can go on edge 2 so we
+        // travel via the virtual node 7 to node 1. From there we cannot go to 6 because of the one-way so we go back
+        // to node 2 (no u-turn because of the duplicate edge) on edge1. And this is were the journey ends: we cannot
+        // go to 8 because of the turn restriction from edge1 to edge4 -> there should not be a path!
+        assertFalse("there should not be a path", path.isFound());
     }
 
     /**

--- a/core/src/test/java/com/graphhopper/routing/ch/CHTurnCostTest.java
+++ b/core/src/test/java/com/graphhopper/routing/ch/CHTurnCostTest.java
@@ -719,9 +719,9 @@ public class CHTurnCostTest {
             queryResults.add(index.findClosest(point.getLat(), point.getLon(), EdgeFilter.ALL_EDGES));
         }
 
+        RoutingAlgorithmFactory pch = automaticPrepareCH();
         QueryGraph queryGraph = new QueryGraph(chGraph);
         queryGraph.lookup(queryResults);
-        RoutingAlgorithmFactory pch = automaticPrepareCH();
         RoutingAlgorithm chAlgo = pch.createAlgo(queryGraph, AlgorithmOptions.start()
                 .traversalMode(TraversalMode.EDGE_BASED_2DIR)
                 .build());

--- a/core/src/test/java/com/graphhopper/routing/ch/CHTurnCostTest.java
+++ b/core/src/test/java/com/graphhopper/routing/ch/CHTurnCostTest.java
@@ -677,7 +677,7 @@ public class CHTurnCostTest {
     }
 
     @Test
-    public void test_Issue1592() {
+    public void test_Issue1593() {
         //      6   5
         //   1<-x-4-x-3
         //  ||    |

--- a/core/src/test/java/com/graphhopper/routing/ch/CHTurnCostTest.java
+++ b/core/src/test/java/com/graphhopper/routing/ch/CHTurnCostTest.java
@@ -790,7 +790,7 @@ public class CHTurnCostTest {
         LOGGER.info("Seed used to generate graph: {}", seed);
         final Random rnd = new Random(seed);
         // for larger graphs preparation takes much longer the higher the degree is!
-        GHUtility.buildRandomGraph(graph, seed, 20, 3.0, true, true, 0.9, 0.8);
+        GHUtility.buildRandomGraph(graph, rnd, 20, 3.0, true, true, encoder.getAverageSpeedEnc(), 0.7, 0.9, 0.8);
         GHUtility.addRandomTurnCosts(graph, seed, encoder, maxCost, turnCostExtension);
         graph.freeze();
         List<Integer> contractionOrder = getRandomIntegerSequence(chGraph.getNodes(), rnd);
@@ -805,7 +805,7 @@ public class CHTurnCostTest {
     public void testFindPath_heuristic_compareWithDijkstra() {
         long seed = System.nanoTime();
         LOGGER.info("Seed used to generate graph: {}", seed);
-        GHUtility.buildRandomGraph(graph, seed, 20, 3.0, true, true, 0.9, 0.8);
+        GHUtility.buildRandomGraph(graph, new Random(seed), 20, 3.0, true, true, encoder.getAverageSpeedEnc(), 0.7, 0.9, 0.8);
         GHUtility.addRandomTurnCosts(graph, seed, encoder, maxCost, turnCostExtension);
         graph.freeze();
         automaticCompareCHWithDijkstra(100);

--- a/core/src/test/java/com/graphhopper/routing/ch/NodeBasedNodeContractorTest.java
+++ b/core/src/test/java/com/graphhopper/routing/ch/NodeBasedNodeContractorTest.java
@@ -386,7 +386,7 @@ public class NodeBasedNodeContractorTest {
     @Test
     public void testNodeContraction_preventUnnecessaryShortcutWithLoop() {
         // there should not be shortcuts where one of the skipped edges is a loop at the node to be contracted,
-        // see also #1581
+        // see also #1583
         CarFlagEncoder encoder = new CarFlagEncoder();
         EncodingManager encodingManager = EncodingManager.create(encoder);
         Weighting weighting = new FastestWeighting(encoder);

--- a/core/src/test/java/com/graphhopper/routing/ch/PrepareContractionHierarchiesTest.java
+++ b/core/src/test/java/com/graphhopper/routing/ch/PrepareContractionHierarchiesTest.java
@@ -664,7 +664,8 @@ public class PrepareContractionHierarchiesTest {
         int numNodes = 5_000;
         int numQueries = 100;
         long seed = System.nanoTime();
-        GHUtility.buildRandomGraph(ghStorage, seed, numNodes, 1.3, false, false, 0.9, 0.8);
+        Random rnd = new Random(seed);
+        GHUtility.buildRandomGraph(ghStorage, rnd, numNodes, 1.3, true, true, carFlagEncoder.getAverageSpeedEnc(), 0.7, 0.9, 0.8);
         ghStorage.freeze();
 
         // create CH for cars
@@ -685,7 +686,6 @@ public class PrepareContractionHierarchiesTest {
         motorCyclePch.doWork();
 
         // run a few sample queries to check correctness
-        Random rnd = new Random(seed);
         for (int i = 0; i < numQueries; ++i) {
             Dijkstra dijkstra = new Dijkstra(ghStorage, motorCycleWeighting, traversalMode);
             RoutingAlgorithm chAlgo = motorCyclePch.createAlgo(motorCycleCH, AlgorithmOptions.start().weighting(motorCycleWeighting).build());


### PR DESCRIPTION
Fixes #1593.

The problem is this:
![image](https://user-images.githubusercontent.com/17603532/55863082-1e0fcb00-5b7a-11e9-9c5d-777aa09108de.png)

Let's say there are edges like this: 0-1-2 with edge-ids 0:0-1 and 1:1-2 and a shortcut gets introduced from 0 to 2 (skipping 1) (with id 2). Then there is a virtual node (id 3) between 1 and 2 like this: 1-(3)-2 which will add some virtual edges 3:1-3 and 4:3-2. When we detect u-turns we compare the edge ids. So if we travel via the shortcut from 0 to 2 we arrive at 2 with the shortcut id 2, but to calculate the turn costs we use the 'origEdgeLast' (here this is the edge 1-2 with id 1). When we check if going to the virtual node 3 is a u-turn we used to check 1==4 which tells us it is no u-turn (when in reality it is). So instead of the virtual edge id 4 we have to use the original edge id 1 for the comparison.

An important case is also checking for a u-turn at node 3 when coming from node 1 and going to node 2. In this case we must not use the original edge id (1) for both virtual edges, but instead compare 3==4.

In this PR I have:

- cleaned-up and extended `RandomCHRoutingTest` for edge-based CH. In the past there were tests on random graphs, but they did not include `QueryGraph` so such issues with virtual edges did not come up (similar to #1574). 

- fixed the issue by adding a `isUTurn()` method to TurnCostExtension

Ultimately I think the u-turn detection needs some more sophisticated refactoring and we should get rid of the `EDGE_BASED_2DIR_UTURN` traversal mode (#1520), but for now I think it is most important to fix the bugs we already know.

