### PR TITLE
Remove unnecessary check if way has at least two nodes

### DIFF
--- a/reader-osm/src/main/java/com/graphhopper/reader/osm/OSMReader.java
+++ b/reader-osm/src/main/java/com/graphhopper/reader/osm/OSMReader.java
@@ -325,17 +325,15 @@ public class OSMReader implements DataReader {
         // TODO move this after we have created the edge and know the coordinates => encodingManager.applyWayTags
         LongArrayList osmNodeIds = way.getNodes();
         // Estimate length of ways containing a route tag e.g. for ferry speed calculation
-        if (osmNodeIds.size() > 1) {
-            int first = getNodeMap().get(osmNodeIds.get(0));
-            int last = getNodeMap().get(osmNodeIds.get(osmNodeIds.size() - 1));
-            double firstLat = getTmpLatitude(first), firstLon = getTmpLongitude(first);
-            double lastLat = getTmpLatitude(last), lastLon = getTmpLongitude(last);
-            if (!Double.isNaN(firstLat) && !Double.isNaN(firstLon) && !Double.isNaN(lastLat) && !Double.isNaN(lastLon)) {
-                double estimatedDist = distCalc.calcDist(firstLat, firstLon, lastLat, lastLon);
-                // Add artificial tag for the estimated distance and center
-                way.setTag("estimated_distance", estimatedDist);
-                way.setTag("estimated_center", new GHPoint((firstLat + lastLat) / 2, (firstLon + lastLon) / 2));
-            }
+        int first = getNodeMap().get(osmNodeIds.get(0));
+        int last = getNodeMap().get(osmNodeIds.get(osmNodeIds.size() - 1));
+        double firstLat = getTmpLatitude(first), firstLon = getTmpLongitude(first);
+        double lastLat = getTmpLatitude(last), lastLon = getTmpLongitude(last);
+        if (!Double.isNaN(firstLat) && !Double.isNaN(firstLon) && !Double.isNaN(lastLat) && !Double.isNaN(lastLon)) {
+            double estimatedDist = distCalc.calcDist(firstLat, firstLon, lastLat, lastLon);
+            // Add artificial tag for the estimated distance and center
+            way.setTag("estimated_distance", estimatedDist);
+            way.setTag("estimated_center", new GHPoint((firstLat + lastLat) / 2, (firstLon + lastLon) / 2));
         }
 
         if (way.getTag("duration") != null) {


### PR DESCRIPTION
This check exists at the top of the method already and immediately returns if it the way has less than 2 nodes.