### PR TITLE
rename implementations of IntEncodedValue and DecimalEncodedValue

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/profiles/DecimalEncodedValue.java
+++ b/core/src/main/java/com/graphhopper/routing/profiles/DecimalEncodedValue.java
@@ -8,7 +8,7 @@ import com.graphhopper.storage.IntsRef;
  * so that the storable part of it fits into the specified number of bits (maximum 32 at the moment
  * for all implementations) and 2. the default value is always 0.
  *
- * @see FactorizedDecimalEncodedValue
+ * @see UnsignedDecimalEncodedValue
  */
 public interface DecimalEncodedValue extends EncodedValue {
 

--- a/core/src/main/java/com/graphhopper/routing/profiles/EnumEncodedValue.java
+++ b/core/src/main/java/com/graphhopper/routing/profiles/EnumEncodedValue.java
@@ -24,7 +24,7 @@ import java.util.Arrays;
 /**
  * This class allows to store distinct values via an enum. I.e. it stores just the indices
  */
-public final class EnumEncodedValue<E extends Enum> extends SimpleIntEncodedValue {
+public final class EnumEncodedValue<E extends Enum> extends UnsignedIntEncodedValue {
     private final E[] arr;
 
     public EnumEncodedValue(String name, Class<E> enumType) {

--- a/core/src/main/java/com/graphhopper/routing/profiles/IntEncodedValue.java
+++ b/core/src/main/java/com/graphhopper/routing/profiles/IntEncodedValue.java
@@ -7,7 +7,7 @@ import com.graphhopper.storage.IntsRef;
  * integer is highly limited (unlike the Java 32bit integer values) so that the storable part of it fits into the
  * specified number of bits (maximum 32) and 2. the default value is always 0.
  *
- * @see SimpleIntEncodedValue
+ * @see UnsignedIntEncodedValue
  */
 public interface IntEncodedValue extends EncodedValue {
 

--- a/core/src/main/java/com/graphhopper/routing/profiles/MaxHeight.java
+++ b/core/src/main/java/com/graphhopper/routing/profiles/MaxHeight.java
@@ -31,6 +31,6 @@ public class MaxHeight {
      * it is assumed to use the maximum value.
      */
     public static DecimalEncodedValue create() {
-        return new FactorizedDecimalEncodedValue(KEY, 7, 0.1, Double.POSITIVE_INFINITY, false);
+        return new UnsignedDecimalEncodedValue(KEY, 7, 0.1, Double.POSITIVE_INFINITY, false);
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/profiles/MaxSpeed.java
+++ b/core/src/main/java/com/graphhopper/routing/profiles/MaxSpeed.java
@@ -35,6 +35,6 @@ public class MaxSpeed {
     public static final double UNSET_SPEED = Double.POSITIVE_INFINITY;
 
     public static DecimalEncodedValue create() {
-        return new FactorizedDecimalEncodedValue(KEY, 5, 5, UNSET_SPEED, true);
+        return new UnsignedDecimalEncodedValue(KEY, 5, 5, UNSET_SPEED, true);
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/profiles/MaxWeight.java
+++ b/core/src/main/java/com/graphhopper/routing/profiles/MaxWeight.java
@@ -32,6 +32,6 @@ public class MaxWeight {
      * it was done with the MappedDecimalEncodedValue still handling (or rounding) of unknown values is unclear.
      */
     public static DecimalEncodedValue create() {
-        return new FactorizedDecimalEncodedValue(KEY, 8, 0.1, Double.POSITIVE_INFINITY, false);
+        return new UnsignedDecimalEncodedValue(KEY, 8, 0.1, Double.POSITIVE_INFINITY, false);
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/profiles/MaxWidth.java
+++ b/core/src/main/java/com/graphhopper/routing/profiles/MaxWidth.java
@@ -31,6 +31,6 @@ public class MaxWidth {
      * it is assumed to use the maximum value.
      */
     public static DecimalEncodedValue create() {
-        return new FactorizedDecimalEncodedValue(KEY, 7, 0.1, Double.POSITIVE_INFINITY, false);
+        return new UnsignedDecimalEncodedValue(KEY, 7, 0.1, Double.POSITIVE_INFINITY, false);
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/profiles/SimpleBooleanEncodedValue.java
+++ b/core/src/main/java/com/graphhopper/routing/profiles/SimpleBooleanEncodedValue.java
@@ -20,9 +20,9 @@ package com.graphhopper.routing.profiles;
 import com.graphhopper.storage.IntsRef;
 
 /**
- * This class implements a simple Boolean storage via a FactoredIntEncodedValue with 1 bit.
+ * This class implements a simple boolean storage via an UnsignedIntEncodedValue with 1 bit.
  */
-public final class SimpleBooleanEncodedValue extends SimpleIntEncodedValue implements BooleanEncodedValue {
+public final class SimpleBooleanEncodedValue extends UnsignedIntEncodedValue implements BooleanEncodedValue {
 
     public SimpleBooleanEncodedValue(String name) {
         this(name, false);

--- a/core/src/main/java/com/graphhopper/routing/profiles/UnsignedDecimalEncodedValue.java
+++ b/core/src/main/java/com/graphhopper/routing/profiles/UnsignedDecimalEncodedValue.java
@@ -22,14 +22,14 @@ import com.graphhopper.storage.IntsRef;
 import java.util.Objects;
 
 /**
- * This class holds a decimal value and stores it as an integer value via a conversion factor and a maximum number
+ * This class holds a decimal value and stores it as an unsigned integer value via a conversion factor and a maximum number
  * of bits.
  */
-public final class FactorizedDecimalEncodedValue extends SimpleIntEncodedValue implements DecimalEncodedValue {
+public final class UnsignedDecimalEncodedValue extends UnsignedIntEncodedValue implements DecimalEncodedValue {
     private final double factor;
     private final double defaultValue;
 
-    public FactorizedDecimalEncodedValue(String name, int bits, double factor, boolean storeTwoDirections) {
+    public UnsignedDecimalEncodedValue(String name, int bits, double factor, boolean storeTwoDirections) {
         this(name, bits, factor, 0, storeTwoDirections);
     }
 
@@ -40,7 +40,7 @@ public final class FactorizedDecimalEncodedValue extends SimpleIntEncodedValue i
      * @param defaultValue       the value that should be returned if the stored value is 0.
      * @param storeTwoDirections true if forward and backward direction of the edge should get two independent values.
      */
-    public FactorizedDecimalEncodedValue(String name, int bits, double factor, double defaultValue, boolean storeTwoDirections) {
+    public UnsignedDecimalEncodedValue(String name, int bits, double factor, double defaultValue, boolean storeTwoDirections) {
         super(name, bits, storeTwoDirections);
         this.factor = factor;
         this.defaultValue = defaultValue;
@@ -82,7 +82,7 @@ public final class FactorizedDecimalEncodedValue extends SimpleIntEncodedValue i
     @Override
     public boolean equals(Object o) {
         if (!super.equals(o)) return false;
-        FactorizedDecimalEncodedValue that = (FactorizedDecimalEncodedValue) o;
+        UnsignedDecimalEncodedValue that = (UnsignedDecimalEncodedValue) o;
         return Double.compare(that.factor, factor) == 0;
     }
 

--- a/core/src/main/java/com/graphhopper/routing/profiles/UnsignedIntEncodedValue.java
+++ b/core/src/main/java/com/graphhopper/routing/profiles/UnsignedIntEncodedValue.java
@@ -23,10 +23,10 @@ import java.util.Locale;
 import java.util.Objects;
 
 /**
- * Implementation of the IntEncodedValue via a limited number of bits. It introduces simple handling of "backward"- and
- * "forward"-edge information.
+ * Implementation of the IntEncodedValue via a limited number of bits and without a sign. It introduces handling
+ * of "backward"- and "forward"-edge information.
  */
-public class SimpleIntEncodedValue implements IntEncodedValue {
+public class UnsignedIntEncodedValue implements IntEncodedValue {
 
     private final String name;
 
@@ -50,13 +50,13 @@ public class SimpleIntEncodedValue implements IntEncodedValue {
      * @param storeTwoDirections if true this EncodedValue can store different values for the forward and backward
      *                           direction.
      */
-    public SimpleIntEncodedValue(String name, int bits, boolean storeTwoDirections) {
+    public UnsignedIntEncodedValue(String name, int bits, boolean storeTwoDirections) {
         if (!name.toLowerCase(Locale.ROOT).equals(name))
             throw new IllegalArgumentException("EncodedValue name must be lower case but was " + name);
         if (bits <= 0)
             throw new IllegalArgumentException(name + ": bits cannot be zero or negative");
         if (bits > 31)
-            throw new IllegalArgumentException(name + ": at the moment bits cannot be >32");
+            throw new IllegalArgumentException(name + ": at the moment the number of reserved bits cannot be more than 31");
         this.bits = bits;
         this.name = name;
         this.storeTwoDirections = storeTwoDirections;
@@ -157,7 +157,7 @@ public class SimpleIntEncodedValue implements IntEncodedValue {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        SimpleIntEncodedValue that = (SimpleIntEncodedValue) o;
+        UnsignedIntEncodedValue that = (UnsignedIntEncodedValue) o;
         return fwdDataIndex == that.fwdDataIndex &&
                 bwdDataIndex == that.bwdDataIndex &&
                 bits == that.bits &&

--- a/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
@@ -214,10 +214,10 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
     public void createEncodedValues(List<EncodedValue> registerNewEncodedValue, String prefix, int index) {
         // first two bits are reserved for route handling in superclass
         super.createEncodedValues(registerNewEncodedValue, prefix, index);
-        registerNewEncodedValue.add(speedEncoder = new FactorizedDecimalEncodedValue(getKey(prefix, "average_speed"), speedBits, speedFactor, speedTwoDirections));
+        registerNewEncodedValue.add(speedEncoder = new UnsignedDecimalEncodedValue(getKey(prefix, "average_speed"), speedBits, speedFactor, speedTwoDirections));
         registerNewEncodedValue.add(unpavedEncoder = new SimpleBooleanEncodedValue(getKey(prefix, "paved"), false));
-        registerNewEncodedValue.add(wayTypeEncoder = new SimpleIntEncodedValue(getKey(prefix, "waytype"), 2, false));
-        registerNewEncodedValue.add(priorityWayEncoder = new FactorizedDecimalEncodedValue(getKey(prefix, "priority"), 3, PriorityCode.getFactor(1), false));
+        registerNewEncodedValue.add(wayTypeEncoder = new UnsignedIntEncodedValue(getKey(prefix, "waytype"), 2, false));
+        registerNewEncodedValue.add(priorityWayEncoder = new UnsignedDecimalEncodedValue(getKey(prefix, "priority"), 3, PriorityCode.getFactor(1), false));
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/util/CarFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/CarFlagEncoder.java
@@ -20,7 +20,7 @@ package com.graphhopper.routing.util;
 import com.graphhopper.reader.ReaderRelation;
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.profiles.EncodedValue;
-import com.graphhopper.routing.profiles.FactorizedDecimalEncodedValue;
+import com.graphhopper.routing.profiles.UnsignedDecimalEncodedValue;
 import com.graphhopper.storage.IntsRef;
 import com.graphhopper.util.Helper;
 import com.graphhopper.util.PMap;
@@ -161,7 +161,7 @@ public class CarFlagEncoder extends AbstractFlagEncoder {
     public void createEncodedValues(List<EncodedValue> registerNewEncodedValue, String prefix, int index) {
         // first two bits are reserved for route handling in superclass
         super.createEncodedValues(registerNewEncodedValue, prefix, index);
-        registerNewEncodedValue.add(speedEncoder = new FactorizedDecimalEncodedValue(EncodingManager.getKey(prefix, "average_speed"), speedBits, speedFactor, speedTwoDirections));
+        registerNewEncodedValue.add(speedEncoder = new UnsignedDecimalEncodedValue(EncodingManager.getKey(prefix, "average_speed"), speedBits, speedFactor, speedTwoDirections));
     }
 
     protected double getSpeed(ReaderWay way) {

--- a/core/src/main/java/com/graphhopper/routing/util/DataFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/DataFlagEncoder.java
@@ -20,7 +20,6 @@ package com.graphhopper.routing.util;
 import com.graphhopper.reader.ReaderRelation;
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.profiles.*;
-import com.graphhopper.routing.util.parsers.OSMMaxSpeedParser;
 import com.graphhopper.routing.weighting.GenericWeighting;
 import com.graphhopper.storage.IntsRef;
 import com.graphhopper.util.EdgeIteratorState;
@@ -102,7 +101,7 @@ public class DataFlagEncoder extends AbstractFlagEncoder {
         }
 
         // workaround to init AbstractWeighting.avSpeedEnc variable that GenericWeighting does not need
-        speedEncoder = new FactorizedDecimalEncodedValue("fake", 1, 1, false);
+        speedEncoder = new UnsignedDecimalEncodedValue("fake", 1, 1, false);
         roadEnvironmentEnc = getEnumEncodedValue(RoadEnvironment.KEY, RoadEnvironment.class);
     }
 

--- a/core/src/main/java/com/graphhopper/routing/util/FootFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/FootFlagEncoder.java
@@ -21,7 +21,7 @@ import com.graphhopper.reader.ReaderRelation;
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.profiles.DecimalEncodedValue;
 import com.graphhopper.routing.profiles.EncodedValue;
-import com.graphhopper.routing.profiles.FactorizedDecimalEncodedValue;
+import com.graphhopper.routing.profiles.UnsignedDecimalEncodedValue;
 import com.graphhopper.routing.weighting.PriorityWeighting;
 import com.graphhopper.storage.IntsRef;
 import com.graphhopper.util.PMap;
@@ -151,8 +151,8 @@ public class FootFlagEncoder extends AbstractFlagEncoder {
         // first two bits are reserved for route handling in superclass
         super.createEncodedValues(registerNewEncodedValue, prefix, index);
         // larger value required - ferries are faster than pedestrians
-        registerNewEncodedValue.add(speedEncoder = new FactorizedDecimalEncodedValue(getKey(prefix, "average_speed"), speedBits, speedFactor, false));
-        registerNewEncodedValue.add(priorityWayEncoder = new FactorizedDecimalEncodedValue(getKey(prefix, "priority"), 3, PriorityCode.getFactor(1), false));
+        registerNewEncodedValue.add(speedEncoder = new UnsignedDecimalEncodedValue(getKey(prefix, "average_speed"), speedBits, speedFactor, false));
+        registerNewEncodedValue.add(priorityWayEncoder = new UnsignedDecimalEncodedValue(getKey(prefix, "priority"), 3, PriorityCode.getFactor(1), false));
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/util/MotorcycleFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/MotorcycleFlagEncoder.java
@@ -20,7 +20,7 @@ package com.graphhopper.routing.util;
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.profiles.DecimalEncodedValue;
 import com.graphhopper.routing.profiles.EncodedValue;
-import com.graphhopper.routing.profiles.FactorizedDecimalEncodedValue;
+import com.graphhopper.routing.profiles.UnsignedDecimalEncodedValue;
 import com.graphhopper.routing.weighting.CurvatureWeighting;
 import com.graphhopper.routing.weighting.PriorityWeighting;
 import com.graphhopper.storage.IntsRef;
@@ -134,8 +134,8 @@ public class MotorcycleFlagEncoder extends CarFlagEncoder {
         // first two bits are reserved for route handling in superclass
         super.createEncodedValues(registerNewEncodedValue, prefix, index);
 
-        registerNewEncodedValue.add(priorityWayEncoder = new FactorizedDecimalEncodedValue(getKey(prefix, "priority"), 3, PriorityCode.getFactor(1), false));
-        registerNewEncodedValue.add(curvatureEncoder = new FactorizedDecimalEncodedValue(getKey(prefix, "curvature"), 4, 0.1, false));
+        registerNewEncodedValue.add(priorityWayEncoder = new UnsignedDecimalEncodedValue(getKey(prefix, "priority"), 3, PriorityCode.getFactor(1), false));
+        registerNewEncodedValue.add(curvatureEncoder = new UnsignedDecimalEncodedValue(getKey(prefix, "curvature"), 4, 0.1, false));
     }
 
     @Override

--- a/core/src/test/java/com/graphhopper/routing/profiles/BooleanEncodedValueTest.java
+++ b/core/src/test/java/com/graphhopper/routing/profiles/BooleanEncodedValueTest.java
@@ -12,7 +12,7 @@ public class BooleanEncodedValueTest {
     @Test
     public void testBit() {
         EncodedValue.InitializerConfig config = new EncodedValue.InitializerConfig();
-        IntEncodedValue intProp = new SimpleIntEncodedValue("somevalue", 5, false);
+        IntEncodedValue intProp = new UnsignedIntEncodedValue("somevalue", 5, false);
         intProp.init(config);
 
         BooleanEncodedValue bool = new SimpleBooleanEncodedValue("access", false);

--- a/core/src/test/java/com/graphhopper/routing/profiles/DecimalEncodedValueTest.java
+++ b/core/src/test/java/com/graphhopper/routing/profiles/DecimalEncodedValueTest.java
@@ -13,7 +13,7 @@ public class DecimalEncodedValueTest {
 
     @Test
     public void testInit() {
-        DecimalEncodedValue prop = new FactorizedDecimalEncodedValue("test", 10, 2, false);
+        DecimalEncodedValue prop = new UnsignedDecimalEncodedValue("test", 10, 2, false);
         prop.init(new EncodedValue.InitializerConfig());
         IntsRef ref = new IntsRef(1);
         prop.setDecimal(false, ref, 10d);
@@ -32,7 +32,7 @@ public class DecimalEncodedValueTest {
         IntsRef flags = carEncoder.handleWayTags(em.createEdgeFlags(), way, carEncoder.getAccess(way), 0);
         assertEquals(101.5, carAverageSpeedEnc.getDecimal(true, flags), 1e-1);
 
-        DecimalEncodedValue instance1 = new FactorizedDecimalEncodedValue("test1", 8, 0.5, false);
+        DecimalEncodedValue instance1 = new UnsignedDecimalEncodedValue("test1", 8, 0.5, false);
         instance1.init(new EncodedValue.InitializerConfig());
         flags = em.createEdgeFlags();
         instance1.setDecimal(false, flags, 100d);
@@ -41,7 +41,7 @@ public class DecimalEncodedValueTest {
 
     @Test
     public void testNegativeBounds() {
-        DecimalEncodedValue prop = new FactorizedDecimalEncodedValue("test", 10, 5, false);
+        DecimalEncodedValue prop = new UnsignedDecimalEncodedValue("test", 10, 5, false);
         prop.init(new EncodedValue.InitializerConfig());
         try {
             prop.setDecimal(false, new IntsRef(1), -1);

--- a/core/src/test/java/com/graphhopper/routing/profiles/DefaultEncodedValueFactoryTest.java
+++ b/core/src/test/java/com/graphhopper/routing/profiles/DefaultEncodedValueFactoryTest.java
@@ -18,7 +18,7 @@ public class DefaultEncodedValueFactoryTest {
     @Test
     public void loadCarMaxSpeed() {
         EncodedValue enc = MaxSpeed.create();
-        FactorizedDecimalEncodedValue loadedEnc = (FactorizedDecimalEncodedValue) factory.create(enc.toString());
+        UnsignedDecimalEncodedValue loadedEnc = (UnsignedDecimalEncodedValue) factory.create(enc.toString());
         assertEquals(loadedEnc, enc);
     }
 

--- a/core/src/test/java/com/graphhopper/routing/profiles/IntEncodedValueTest.java
+++ b/core/src/test/java/com/graphhopper/routing/profiles/IntEncodedValueTest.java
@@ -1,17 +1,15 @@
 package com.graphhopper.routing.profiles;
 
 import com.graphhopper.storage.IntsRef;
-import com.graphhopper.util.PMap;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class IntEncodedValueTest {
 
     @Test
     public void testInvalidReverseAccess() {
-        IntEncodedValue prop = new SimpleIntEncodedValue("test", 10, false);
+        IntEncodedValue prop = new UnsignedIntEncodedValue("test", 10, false);
         prop.init(new EncodedValue.InitializerConfig());
         try {
             prop.setInt(true, new IntsRef(1), -1);
@@ -22,7 +20,7 @@ public class IntEncodedValueTest {
 
     @Test
     public void testDirectedValue() {
-        IntEncodedValue prop = new SimpleIntEncodedValue("test", 10, true);
+        IntEncodedValue prop = new UnsignedIntEncodedValue("test", 10, true);
         prop.init(new EncodedValue.InitializerConfig());
         IntsRef ref = new IntsRef(1);
         prop.setInt(false, ref, 10);
@@ -33,7 +31,7 @@ public class IntEncodedValueTest {
 
     @Test
     public void multiIntsUsage() {
-        IntEncodedValue prop = new SimpleIntEncodedValue("test", 31, true);
+        IntEncodedValue prop = new UnsignedIntEncodedValue("test", 31, true);
         prop.init(new EncodedValue.InitializerConfig());
         IntsRef ref = new IntsRef(2);
         prop.setInt(false, ref, 10);
@@ -44,12 +42,33 @@ public class IntEncodedValueTest {
 
     @Test
     public void padding() {
-        IntEncodedValue prop = new SimpleIntEncodedValue("test", 30, true);
+        IntEncodedValue prop = new UnsignedIntEncodedValue("test", 30, true);
         prop.init(new EncodedValue.InitializerConfig());
         IntsRef ref = new IntsRef(2);
         prop.setInt(false, ref, 10);
         prop.setInt(true, ref, 20);
         assertEquals(10, prop.getInt(false, ref));
         assertEquals(20, prop.getInt(true, ref));
+    }
+
+    @Test
+    public void testSignedInt() {
+        IntEncodedValue prop = new UnsignedIntEncodedValue("test", 31, false);
+        BooleanEncodedValue sign = new SimpleBooleanEncodedValue("a");
+        EncodedValue.InitializerConfig config = new EncodedValue.InitializerConfig();
+        prop.init(config);
+        sign.init(config);
+
+        IntsRef ref = new IntsRef(1);
+
+        prop.setInt(false, ref, Integer.MAX_VALUE);
+        sign.setBool(false, ref, true);
+        assertEquals(Integer.MAX_VALUE, prop.getInt(false, ref));
+        assertTrue(sign.getBool(false, ref));
+
+        prop.setInt(false, ref, Integer.MAX_VALUE);
+        sign.setBool(false, ref, false);
+        assertEquals(Integer.MAX_VALUE, prop.getInt(false, ref));
+        assertFalse(sign.getBool(false, ref));
     }
 }

--- a/core/src/test/java/com/graphhopper/routing/profiles/UnsignedDecimalEncodedValueTest.java
+++ b/core/src/test/java/com/graphhopper/routing/profiles/UnsignedDecimalEncodedValueTest.java
@@ -6,11 +6,11 @@ import org.junit.Test;
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
 
-public class FactorizedDecimalEncodedValueTest {
+public class UnsignedDecimalEncodedValueTest {
 
     @Test
     public void getDecimal() {
-        FactorizedDecimalEncodedValue testEnc = new FactorizedDecimalEncodedValue("test", 3, 1, 100, false);
+        UnsignedDecimalEncodedValue testEnc = new UnsignedDecimalEncodedValue("test", 3, 1, 100, false);
         testEnc.init(new EncodedValue.InitializerConfig());
 
         IntsRef intsRef = new IntsRef(1);
@@ -21,14 +21,14 @@ public class FactorizedDecimalEncodedValueTest {
     @Test
     public void testDefault() {
         // default value 100
-        FactorizedDecimalEncodedValue testEnc = new FactorizedDecimalEncodedValue("test", 3, 1, 100, false);
+        UnsignedDecimalEncodedValue testEnc = new UnsignedDecimalEncodedValue("test", 3, 1, 100, false);
         testEnc.init(new EncodedValue.InitializerConfig());
         IntsRef intsRef = new IntsRef(1);
         testEnc.setDecimal(false, intsRef, 0);
         assertEquals(100, testEnc.getDecimal(false, intsRef), .1);
 
         // try positive infinity
-        testEnc = new FactorizedDecimalEncodedValue("test", 3, 1, Double.POSITIVE_INFINITY, false);
+        testEnc = new UnsignedDecimalEncodedValue("test", 3, 1, Double.POSITIVE_INFINITY, false);
         testEnc.init(new EncodedValue.InitializerConfig());
         testEnc.setDecimal(false, intsRef, 0);
         assertTrue(Double.isInfinite(testEnc.getDecimal(false, intsRef)));

--- a/reader-gtfs/src/main/java/com/graphhopper/reader/gtfs/PtFlagEncoder.java
+++ b/reader-gtfs/src/main/java/com/graphhopper/reader/gtfs/PtFlagEncoder.java
@@ -23,11 +23,10 @@ import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.profiles.EncodedValue;
 import com.graphhopper.routing.profiles.EnumEncodedValue;
 import com.graphhopper.routing.profiles.IntEncodedValue;
-import com.graphhopper.routing.profiles.SimpleIntEncodedValue;
+import com.graphhopper.routing.profiles.UnsignedIntEncodedValue;
 import com.graphhopper.routing.util.AbstractFlagEncoder;
 import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.storage.IntsRef;
-import com.graphhopper.util.EdgeIteratorState;
 
 import java.util.List;
 
@@ -47,10 +46,10 @@ public class PtFlagEncoder extends AbstractFlagEncoder {
         // do we really need 2 bits for pt.access?
         super.createEncodedValues(list, prefix, index);
 
-        list.add(validityIdEnc = new SimpleIntEncodedValue(prefix + "validity_id", 20, false));
-        list.add(transfersEnc = new SimpleIntEncodedValue(prefix + "transfers", 1, false));
+        list.add(validityIdEnc = new UnsignedIntEncodedValue(prefix + "validity_id", 20, false));
+        list.add(transfersEnc = new UnsignedIntEncodedValue(prefix + "transfers", 1, false));
         list.add(typeEnc = new EnumEncodedValue<>(prefix + "type", GtfsStorage.EdgeType.class));
-        list.add(timeEnc = new SimpleIntEncodedValue(prefix + "time", 17, false));
+        list.add(timeEnc = new UnsignedIntEncodedValue(prefix + "time", 17, false));
     }
 
     @Override


### PR DESCRIPTION
Fixes #1619 via renaming.

Supporting negative values is doable but introduces further complexity and overhead in the EncodedValue classes which I wouldn't want to do. At least not now, as the most use cases what to store per edge should be positive.