### PR TITLE
Don't show the heightgraph on small screens

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -27,7 +27,7 @@
     "leaflet.vectorgrid": "1.3.0",
     "browserify": "16.2.0",
     "browserify-swap": "0.2.2",
-    "d3": "5.9.1",
+    "d3": "5.9.7",
     "jquery": "3.4.1",
     "leaflet": "1.3.1",
     "leaflet-contextmenu": "1.4.0",

--- a/web/src/main/resources/assets/js/map.js
+++ b/web/src/main/resources/assets/js/map.js
@@ -267,6 +267,12 @@ module.exports.initMap = initMap;
 module.exports.adjustMapSize = adjustMapSize;
 
 module.exports.addElevation = function (geoJsonFeature, useMiles, details) {
+
+    // Don't show the elevation graph on small displays
+    if(window.innerWidth < 900 || window.innerHeight < 400){
+        return;
+    }
+
     // TODO no option to switch to miles yet
     var options = {
        width: 600,


### PR DESCRIPTION
This PR hides the heightgraph on small screens.

In general there are two options for hiding:
- css
- js

The benefit of the css solution would be that on some devices the heightgraph would show up, when you turn the screen. Right now you would have to recalculate the route.

The benefit of the js solution is that we can avoid unnecessary calculations, which might speed up the overall performance, especially on potentially less powerful devices and long routes.