### PR TITLE
Replaces some == NO_EDGE comparisons with isValid calls.

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/ch/EdgeBasedNodeContractor.java
+++ b/core/src/main/java/com/graphhopper/routing/ch/EdgeBasedNodeContractor.java
@@ -491,7 +491,7 @@ class EdgeBasedNodeContractor extends AbstractNodeContractor {
                                 continue;
                             }
                             CHEntry root = entry.getParent();
-                            while (root.parent.edge != EdgeIterator.NO_EDGE) {
+                            while (EdgeIterator.Edge.isValid(root.parent.edge)) {
                                 root = root.getParent();
                             }
                             // todo: removing this 'optimization' improves contraction time significantly, but introduces 

--- a/core/src/main/java/com/graphhopper/routing/ch/WitnessPathSearcher.java
+++ b/core/src/main/java/com/graphhopper/routing/ch/WitnessPathSearcher.java
@@ -183,7 +183,7 @@ public class WitnessPathSearcher {
         while (inIter.next()) {
             final int incEdge = inIter.getOrigEdgeLast();
             final int edgeKey = getEdgeKey(incEdge, targetNode);
-            if (edges[edgeKey] != NO_EDGE) {
+            if (EdgeIterator.Edge.isValid(edges[edgeKey])) {
                 boolean isZeroWeightLoop = parents[edgeKey] >= 0 && targetNode == adjNodes[parents[edgeKey]] &&
                         weights[edgeKey] - weights[parents[edgeKey]] <= MAX_ZERO_WEIGHT_LOOP;
                 if (!isZeroWeightLoop) {
@@ -239,7 +239,7 @@ public class WitnessPathSearcher {
 
                 // dijkstra expansion: add or update current entries
                 int key = getEdgeKey(iter.getOrigEdgeLast(), iter.getAdjNode());
-                if (edges[key] == NO_EDGE) {
+                if (!EdgeIterator.Edge.isValid(edges[key])) {
                     setEntry(key, iter, weight, currKey, isPathToCenter);
                     changedEdges.add(key);
                     dijkstraHeap.insert_(weight, key);
@@ -348,7 +348,7 @@ public class WitnessPathSearcher {
                     NO_EDGE,
                     outIter.getOrigEdgeFirst(),
                     sourceNode, turnWeight);
-            if (edges[key] == NO_EDGE) {
+            if (!EdgeIterator.Edge.isValid(edges[key])) {
                 // add new initial entry
                 edges[key] = outIter.getEdge();
                 incEdges[key] = incEdge;

--- a/core/src/main/java/com/graphhopper/routing/weighting/TurnWeighting.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/TurnWeighting.java
@@ -76,7 +76,7 @@ public class TurnWeighting implements Weighting {
     @Override
     public double calcWeight(EdgeIteratorState edgeState, boolean reverse, int prevOrNextEdgeId) {
         double weight = superWeighting.calcWeight(edgeState, reverse, prevOrNextEdgeId);
-        if (prevOrNextEdgeId == EdgeIterator.NO_EDGE)
+        if (!EdgeIterator.Edge.isValid(prevOrNextEdgeId))
             return weight;
 
         final int origEdgeId = reverse ? edgeState.getOrigEdgeLast() : edgeState.getOrigEdgeFirst();

--- a/core/src/main/java/com/graphhopper/storage/BaseGraph.java
+++ b/core/src/main/java/com/graphhopper/storage/BaseGraph.java
@@ -1012,7 +1012,7 @@ class BaseGraph implements Graph {
         @Override
         public final boolean next() {
             while (true) {
-                if (nextEdgeId == EdgeIterator.NO_EDGE)
+                if (!EdgeIterator.Edge.isValid(nextEdgeId))
                     return false;
 
                 selectEdgeAccess();
@@ -1036,7 +1036,7 @@ class BaseGraph implements Graph {
 
         @Override
         public EdgeIteratorState detach(boolean reverseArg) {
-            if (edgeId == nextEdgeId || edgeId == EdgeIterator.NO_EDGE)
+            if (edgeId == nextEdgeId || !EdgeIterator.Edge.isValid(edgeId))
                 throw new IllegalStateException("call next before detaching or setEdgeId (edgeId:" + edgeId + " vs. next " + nextEdgeId + ")");
 
             EdgeIterable iter = edgeAccess.createSingleEdge(filter);

--- a/core/src/main/java/com/graphhopper/storage/CHGraphImpl.java
+++ b/core/src/main/java/com/graphhopper/storage/CHGraphImpl.java
@@ -283,7 +283,7 @@ public class CHGraphImpl implements CHGraph, Storable<CHGraph> {
             // even though this is not optimal from a speed performance point of view.
             if (tmpIter.isShortcut() && tmpIter.getEdge() == edgeState.getEdge()) {
                 // TODO this is ugly, move this somehow into the underlying iteration logic
-                long edgePointer = tmpPrevEdge == EdgeIterator.NO_EDGE ? -1
+                long edgePointer = !EdgeIterator.Edge.isValid(tmpPrevEdge) ? -1
                         : isShortcut(tmpPrevEdge) ? chEdgeAccess.toPointer(tmpPrevEdge) : baseGraph.edgeAccess.toPointer(tmpPrevEdge);
                 chEdgeAccess.internalEdgeDisconnect(edgeState.getEdge(), edgePointer, edgeState.getAdjNode());
                 break;

--- a/core/src/main/java/com/graphhopper/storage/EdgeAccess.java
+++ b/core/src/main/java/com/graphhopper/storage/EdgeAccess.java
@@ -156,7 +156,7 @@ abstract class EdgeAccess {
      * Writes plain edge information to the edges index
      */
     final long writeEdge(int edgeId, int nodeA, int nodeB, int nextEdgeA, int nextEdgeB) {
-        if (edgeId < 0 || edgeId == EdgeIterator.NO_EDGE)
+        if (!EdgeIterator.Edge.isValid(edgeId))
             throw new IllegalStateException("Cannot write edge with illegal ID:" + edgeId + "; nodeA:" + nodeA + ", nodeB:" + nodeB);
 
         long edgePointer = toPointer(edgeId);

--- a/core/src/main/java/com/graphhopper/storage/TurnCostExtension.java
+++ b/core/src/main/java/com/graphhopper/storage/TurnCostExtension.java
@@ -189,7 +189,7 @@ public class TurnCostExtension implements GraphExtension {
      * @return turn flags of the specified node and edge properties.
      */
     public long getTurnCostFlags(int edgeFrom, int nodeVia, int edgeTo) {
-        if (edgeFrom == EdgeIterator.NO_EDGE || edgeTo == EdgeIterator.NO_EDGE)
+        if (!EdgeIterator.Edge.isValid(edgeFrom) || !EdgeIterator.Edge.isValid(edgeTo))
             throw new IllegalArgumentException("from and to edge cannot be NO_EDGE");
         if (nodeVia < 0)
             throw new IllegalArgumentException("via node cannot be negative");

--- a/reader-osm/src/main/java/com/graphhopper/reader/osm/OSMTurnRelation.java
+++ b/reader-osm/src/main/java/com/graphhopper/reader/osm/OSMTurnRelation.java
@@ -79,7 +79,7 @@ public class OSMTurnRelation {
                 }
             }
 
-            if (edgeIdFrom == EdgeIterator.NO_EDGE)
+            if (!EdgeIterator.Edge.isValid(edgeIdFrom))
                 return Collections.emptyList();
 
             final Collection<TurnCostTableEntry> entries = new ArrayList<>();


### PR DESCRIPTION
Are there any situations where we use edge ids that are `<0` and are not `-1` ? I added a check in `isValid` and ran the tests and there were no such situations in the tests.