### PR TITLE
Fixes maven pmd plugin version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-pmd-plugin</artifactId>
-                <version>3.12</version>
+                <version>3.12.0</version>
                 <!-- e.g. under core/target/site/pmd.html
                 <configuration>
                     <format>html</format>


### PR DESCRIPTION
I could not resolve version `3.12` and on maven central it looks like the correct version would be `3.12.0`. The plugin website mentions the same version. Previously I saw errors about not finding the plugin in the CI logs sometimes, probably this was the problem.

- maven central: https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-pmd-plugin
- plugin website: https://maven.apache.org/plugins/maven-pmd-plugin