### PR TITLE
Add support for hgv toll sub-categories

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMTollParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMTollParser.java
@@ -46,6 +46,10 @@ public class OSMTollParser implements TagParser {
             tollEnc.setEnum(false, edgeFlags, Toll.ALL);
         else if (readerWay.hasTag("toll:hgv", "yes"))
             tollEnc.setEnum(false, edgeFlags, Toll.HGV);
+        else if (readerWay.hasTag("toll:N2", "yes"))
+            tollEnc.setEnum(false, edgeFlags, Toll.HGV);
+        else if (readerWay.hasTag("toll:N3", "yes"))
+            tollEnc.setEnum(false, edgeFlags, Toll.HGV);
         return edgeFlags;
     }
 }

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMTollParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMTollParserTest.java
@@ -36,6 +36,18 @@ public class OSMTollParserTest {
         readerWay.setTag("toll:hgv", "yes");
         parser.handleWayTags(intsRef, readerWay, WAY, 0);
         assertEquals(Toll.HGV, tollEnc.getEnum(false, intsRef));
+        
+        intsRef = em.createEdgeFlags();
+        readerWay.setTag("highway", "primary");
+        readerWay.setTag("toll:N2", "yes");
+        parser.handleWayTags(intsRef, readerWay, WAY, 0);
+        assertEquals(Toll.HGV, tollEnc.getEnum(false, intsRef));
+        
+        intsRef = em.createEdgeFlags();
+        readerWay.setTag("highway", "primary");
+        readerWay.setTag("toll:N3", "yes");
+        parser.handleWayTags(intsRef, readerWay, WAY, 0);
+        assertEquals(Toll.HGV, tollEnc.getEnum(false, intsRef));
 
         intsRef = em.createEdgeFlags();
         readerWay.setTag("highway", "primary");
@@ -47,6 +59,8 @@ public class OSMTollParserTest {
         readerWay.setTag("highway", "primary");
         readerWay.setTag("toll", "yes");
         readerWay.setTag("toll:hgv", "yes");
+        readerWay.setTag("toll:N2", "yes");
+        readerWay.setTag("toll:N3", "yes");
         parser.handleWayTags(intsRef, readerWay, WAY, 0);
         assertEquals(Toll.ALL, tollEnc.getEnum(false, intsRef));
     }


### PR DESCRIPTION
This PR modifies the OSMTollParser to treat `toll:N2` and `toll:N3` as special cases of `toll:hgv`.

[Wikipedia](https://en.wikipedia.org/wiki/Large_goods_vehicle):
> A heavy goods vehicle (HGV), also large goods vehicle (LGV) or medium goods vehicle, is the European Union (EU) term for any truck with a gross combination mass (GCM) of over 3,500 kilograms (7,716 lb). Sub-category N2 is used for vehicles between 3,500 kilograms (7,716 lb) and 12,000 kilograms (26,455 lb) and N3 for all goods vehicles over 12,000 kilograms (26,455 lb) as defined in Directive 2001/116/EC.