### PR TITLE
Choose edge-based CH if it was prepared and the `edge_based` parameter was not set

### DIFF
--- a/core/files/changelog.txt
+++ b/core/files/changelog.txt
@@ -16,6 +16,7 @@
     GraphHopperStorage.getGraph(Class) was replaced by GraphHopperStorage.getBase/CHGraph(), #1669
     CHGraph.shortcut(int, int) was removed (use .shortcut(int, int, ...) and/or .shortcutEdgeBased(int, int, ...) instead, #1693
     CH graphs are now identified using CHProfile instead of Weighting, #1670
+    removed the 'traversal_mode` request parameter for /route, instead of 'traversal_mode=edge_based_2dir' use edge_based=true
 
 0.12
     renamed VirtualEdgeIteratorState.getOriginalEdgeKey to more precise getOriginalEdgeKey #1549

--- a/core/files/changelog.txt
+++ b/core/files/changelog.txt
@@ -18,7 +18,7 @@
     CH graphs are now identified using CHProfile instead of Weighting, #1670
     removed the 'traversal_mode` request parameter for /route, instead of 'traversal_mode=edge_based_2dir' use edge_based=true
     removed GraphHopper.set/getTraversalMode() methods, #1705
-    removed the 'traversal_mode` request parameter for /route, instead of 'traversal_mode=edge_based_2dir' use edge_based=true
+    edge-based CH is now chosen by default if it was prepared, #1706
 
 0.12
     renamed VirtualEdgeIteratorState.getOriginalEdgeKey to more precise getOriginalEdgeKey #1549

--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -96,7 +96,6 @@ public class GraphHopper implements GraphHopperAPI {
     // for routing
     private int maxRoundTripRetries = 3;
     private boolean simplifyResponse = true;
-    private TraversalMode traversalMode = TraversalMode.NODE_BASED;
     private int maxVisitedNodes = Integer.MAX_VALUE;
 
     private int nonChMaxWaypointDistance = Integer.MAX_VALUE;
@@ -166,9 +165,6 @@ public class GraphHopper implements GraphHopperAPI {
     public GraphHopper setEncodingManager(EncodingManager em) {
         ensureNotLoaded();
         this.encodingManager = em;
-        if (em.needsTurnCostsSupport())
-            traversalMode = TraversalMode.EDGE_BASED;
-
         return this;
     }
 
@@ -205,18 +201,6 @@ public class GraphHopper implements GraphHopperAPI {
      */
     public GraphHopper setWayPointMaxDistance(double wayPointMaxDistance) {
         this.dataReaderWayPointMaxDistance = wayPointMaxDistance;
-        return this;
-    }
-
-    public TraversalMode getTraversalMode() {
-        return traversalMode;
-    }
-
-    /**
-     * Sets the default traversal mode used for the algorithms and preparation.
-     */
-    public GraphHopper setTraversalMode(TraversalMode traversalMode) {
-        this.traversalMode = traversalMode;
         return this;
     }
 
@@ -972,13 +956,15 @@ public class GraphHopper implements GraphHopperAPI {
             if (!encodingManager.hasEncoder(vehicle))
                 throw new IllegalArgumentException("Vehicle not supported: " + vehicle + ". Supported are: " + encodingManager.toString());
 
+            FlagEncoder encoder = encodingManager.getEncoder(vehicle);
             HintsMap hints = request.getHints();
-            String tModeStr = hints.get("traversal_mode", traversalMode.toString());
-            TraversalMode tMode = TraversalMode.fromString(tModeStr);
+
+            TraversalMode tMode = encoder.supports(TurnWeighting.class) ? TraversalMode.EDGE_BASED : TraversalMode.NODE_BASED;
+
+            String tModeStr = hints.get("traversal_mode", tMode.toString());
+            tMode = TraversalMode.fromString(tModeStr);
             if (hints.has(Routing.EDGE_BASED))
                 tMode = hints.getBool(Routing.EDGE_BASED, false) ? TraversalMode.EDGE_BASED : TraversalMode.NODE_BASED;
-
-            FlagEncoder encoder = encodingManager.getEncoder(vehicle);
 
             if (tMode.isEdgeBased() && !encoder.supports(TurnWeighting.class)) {
                 throw new IllegalArgumentException("You need a turn cost extension to make use of edge_based=true, e.g. use car|turn_costs=true");

--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -959,10 +959,9 @@ public class GraphHopper implements GraphHopperAPI {
             FlagEncoder encoder = encodingManager.getEncoder(vehicle);
             HintsMap hints = request.getHints();
 
+            // we use edge-based routing if the encoder supports turn-costs *unless* the edge_based parameter is set
+            // explicitly
             TraversalMode tMode = encoder.supports(TurnWeighting.class) ? TraversalMode.EDGE_BASED : TraversalMode.NODE_BASED;
-
-            String tModeStr = hints.get("traversal_mode", tMode.toString());
-            tMode = TraversalMode.fromString(tModeStr);
             if (hints.has(Routing.EDGE_BASED))
                 tMode = hints.getBool(Routing.EDGE_BASED, false) ? TraversalMode.EDGE_BASED : TraversalMode.NODE_BASED;
 

--- a/core/src/main/java/com/graphhopper/routing/ch/CHAlgoFactoryDecorator.java
+++ b/core/src/main/java/com/graphhopper/routing/ch/CHAlgoFactoryDecorator.java
@@ -271,30 +271,26 @@ public class CHAlgoFactoryDecorator implements RoutingAlgorithmFactoryDecorator 
         }
         if (map.has(Parameters.Routing.EDGE_BASED)) {
             boolean edgeBased = map.getBool(Parameters.Routing.EDGE_BASED, false);
-            if (edgeBased) {
-                if (edgeBasedPCH != null) {
-                    return edgeBasedPCH;
-                } else {
-                    throw new IllegalArgumentException("Found a node-based CH preparation for weighting map " + map + ", but requested edge-based CH. " +
-                            "You either need to configure edge-based CH preparation or set the '" + Parameters.Routing.EDGE_BASED + "' " +
-                            "request parameter to 'false' (was 'true'). all entries: " + entriesStrs);
-                }
-            } else {
-                if (nodeBasedPCH != null) {
-                    return nodeBasedPCH;
-                } else {
-                    throw new IllegalArgumentException("Found an edge-based CH preparation for weighting map " + map + ", but requested node-based CH. " +
-                            "You either need to configure edge-based CH preparation or set the '" + Parameters.Routing.EDGE_BASED + "' " +
-                            "request parameter to 'true' (was 'false'). all entries: " + entriesStrs);
-                }
-            }
-        } else {
-            // no edge_based parameter was set, we determine the CH preparation based on what is there
-            if (edgeBasedPCH != null) {
+            if (edgeBased && edgeBasedPCH != null) {
                 return edgeBasedPCH;
-            } else {
+            }
+            if (!edgeBased && nodeBasedPCH != null) {
                 return nodeBasedPCH;
             }
+
+            if (edgeBased) {
+                throw new IllegalArgumentException("Found a node-based CH preparation for weighting map " + map + ", but requested edge-based CH. " +
+                        "You either need to configure edge-based CH preparation or set the '" + Parameters.Routing.EDGE_BASED + "' " +
+                        "request parameter to 'false' (was 'true'). all entries: " + entriesStrs);
+            } else {
+                throw new IllegalArgumentException("Found an edge-based CH preparation for weighting map " + map + ", but requested node-based CH. " +
+                        "You either need to configure node-based CH preparation or set the '" + Parameters.Routing.EDGE_BASED + "' " +
+                        "request parameter to 'true' (was 'false'). all entries: " + entriesStrs);
+            }
+        } else {
+            // no edge_based parameter was set, we determine the CH preparation based on what is there (and prefer edge-based
+            // if we can choose)
+            return edgeBasedPCH != null ? edgeBasedPCH : nodeBasedPCH;
         }
     }
 

--- a/core/src/main/java/com/graphhopper/routing/ch/CHAlgoFactoryDecorator.java
+++ b/core/src/main/java/com/graphhopper/routing/ch/CHAlgoFactoryDecorator.java
@@ -220,7 +220,7 @@ public class CHAlgoFactoryDecorator implements RoutingAlgorithmFactoryDecorator 
      * Enables the use of contraction hierarchies to reduce query times. Enabled by default.
      *
      * @param profileString String representation of a CH profile like: "fastest", "shortest|edge_based=true",
-     *                       "fastest|u_turn_costs=30 or your own weight-calculation type.
+     *                      "fastest|u_turn_costs=30 or your own weight-calculation type.
      */
     public CHAlgoFactoryDecorator addCHProfileAsString(String profileString) {
         chProfileStrings.add(profileString);
@@ -251,23 +251,51 @@ public class CHAlgoFactoryDecorator implements RoutingAlgorithmFactoryDecorator 
     }
 
     public PrepareContractionHierarchies getPreparation(HintsMap map) {
-        boolean edgeBased = map.getBool(Parameters.Routing.EDGE_BASED, false);
         List<String> entriesStrs = new ArrayList<>();
-        boolean weightingMatchesButNotEdgeBased = false;
+        PrepareContractionHierarchies edgeBasedPCH = null;
+        PrepareContractionHierarchies nodeBasedPCH = null;
         for (PrepareContractionHierarchies p : getPreparations()) {
             boolean weightingMatches = p.getCHProfile().getWeighting().matches(map);
-            if (p.isEdgeBased() == edgeBased && weightingMatches)
-                return p;
-            else if (weightingMatches)
-                weightingMatchesButNotEdgeBased = true;
-
+            if (weightingMatches) {
+                if (p.isEdgeBased()) {
+                    edgeBasedPCH = p;
+                } else {
+                    nodeBasedPCH = p;
+                }
+            }
             entriesStrs.add(p.getCHProfile().getWeighting() + "|" + (p.getCHProfile().isEdgeBased() ? "edge" : "node"));
         }
 
-        String hint = weightingMatchesButNotEdgeBased
-                ? " The '" + Parameters.Routing.EDGE_BASED + "' url parameter is missing or does not fit the weightings. Its value was: '" + edgeBased + "'"
-                : "";
-        throw new IllegalArgumentException("Cannot find CH RoutingAlgorithmFactory for weighting map " + map + " in entries: " + entriesStrs + "." + hint);
+        if (edgeBasedPCH == null && nodeBasedPCH == null) {
+            throw new IllegalArgumentException("Cannot find CH RoutingAlgorithmFactory for weighting map " + map + " in entries: " + entriesStrs + ".");
+        }
+        if (map.has(Parameters.Routing.EDGE_BASED)) {
+            boolean edgeBased = map.getBool(Parameters.Routing.EDGE_BASED, false);
+            if (edgeBased) {
+                if (edgeBasedPCH != null) {
+                    return edgeBasedPCH;
+                } else {
+                    throw new IllegalArgumentException("Found a node-based CH preparation for weighting map " + map + ", but requested edge-based CH. " +
+                            "You either need to configure edge-based CH preparation or set the '" + Parameters.Routing.EDGE_BASED + "' " +
+                            "request parameter to 'false' (was 'true'). all entries: " + entriesStrs);
+                }
+            } else {
+                if (nodeBasedPCH != null) {
+                    return nodeBasedPCH;
+                } else {
+                    throw new IllegalArgumentException("Found an edge-based CH preparation for weighting map " + map + ", but requested node-based CH. " +
+                            "You either need to configure edge-based CH preparation or set the '" + Parameters.Routing.EDGE_BASED + "' " +
+                            "request parameter to 'true' (was 'false'). all entries: " + entriesStrs);
+                }
+            }
+        } else {
+            // no edge_based parameter was set, we determine the CH preparation based on what is there
+            if (edgeBasedPCH != null) {
+                return edgeBasedPCH;
+            } else {
+                return nodeBasedPCH;
+            }
+        }
     }
 
     public int getPreparationThreads() {

--- a/reader-osm/src/test/java/com/graphhopper/GraphHopperIT.java
+++ b/reader-osm/src/test/java/com/graphhopper/GraphHopperIT.java
@@ -1084,4 +1084,21 @@ public class GraphHopperIT {
                 rsp.getErrors().toString().contains("You need a turn cost extension to make use of edge_based=true, e.g. use car|turn_costs=true"));
     }
 
+    @Test
+    public void testEncoderWithTurnCostSupport_stillAllows_nodeBasedRouting() {
+        // see #1698
+        GraphHopper tmpHopper = new GraphHopperOSM().
+                setOSMFile(DIR + "/moscow.osm.gz").
+                setGraphHopperLocation(tmpGraphFile).
+                setCHEnabled(false).
+                setEncodingManager(EncodingManager.create("foot,car|turn_costs=true"));
+        tmpHopper.importOrLoad();
+        GHPoint p = new GHPoint(55.813357, 37.5958585);
+        GHPoint q = new GHPoint(55.811042, 37.594689);
+        GHRequest req = new GHRequest(p, q);
+        req.setVehicle("foot");
+        GHResponse rsp = tmpHopper.route(req);
+        assertEquals("there should not be an error, but was: " + rsp.getErrors(), 0, rsp.getErrors().size());
+    }
+
 }

--- a/reader-osm/src/test/java/com/graphhopper/GraphHopperIT.java
+++ b/reader-osm/src/test/java/com/graphhopper/GraphHopperIT.java
@@ -1078,6 +1078,29 @@ public class GraphHopperIT {
         assertTrue(rsp.getErrors().toString().contains("Cannot find CH RoutingAlgorithmFactory"));
     }
 
+    @Test
+    public void testEdgeBasedByDefaultIfOnlyEdgeBased() {
+        // when there is only one edge-based CH profile, there is no need to specify edge_based=true explicitly,
+        // see #1637
+        GraphHopper tmpHopper = new GraphHopperOSM().
+                setOSMFile(DIR + "/moscow.osm.gz").
+                setStoreOnFlush(true).
+                setCHEnabled(true).
+                setGraphHopperLocation(tmpGraphFile).
+                setEncodingManager(EncodingManager.create("car|turn_costs=true"));
+        tmpHopper.getCHFactoryDecorator().setDisablingAllowed(true);
+        tmpHopper.getCHFactoryDecorator().setEdgeBasedCHMode(CHAlgoFactoryDecorator.EdgeBasedCHMode.EDGE_OR_NODE);
+        tmpHopper.importOrLoad();
+
+        // even when we omit the edge_based parameter we get edge-based CH, unless we disable it explicitly
+        assertMoscowEdgeBased(tmpHopper, "none", true);
+        assertMoscowEdgeBased(tmpHopper, "true", true);
+        GHResponse rsp = runMoscow(tmpHopper, "false", true);
+        assertTrue(rsp.hasErrors());
+        assertTrue(rsp.getErrors().toString().contains("Found an edge-based CH preparation"));
+        assertTrue(rsp.getErrors().toString().contains("but requested node-based CH"));
+    }
+
     private GHResponse assertMoscowNodeBased(GraphHopper tmpHopper, String edgeBasedParam, boolean ch) {
         GHResponse rsp = runMoscow(tmpHopper, edgeBasedParam, ch);
         assertEquals(400, rsp.getBest().getDistance(), 1);

--- a/reader-osm/src/test/java/com/graphhopper/GraphHopperIT.java
+++ b/reader-osm/src/test/java/com/graphhopper/GraphHopperIT.java
@@ -1022,8 +1022,8 @@ public class GraphHopperIT {
         tmpHopper.getCHFactoryDecorator().setEdgeBasedCHMode(CHAlgoFactoryDecorator.EdgeBasedCHMode.EDGE_AND_NODE);
         tmpHopper.importOrLoad();
 
-        // no edge_based parameter -> use node-based (because its faster)
-        assertMoscowNodeBased(tmpHopper, "none", true);
+        // no edge_based parameter -> use edge-based (because its there)
+        assertMoscowEdgeBased(tmpHopper, "none", true);
         // edge_based=false -> use node-based
         assertMoscowNodeBased(tmpHopper, "false", true);
         // edge_based=true -> use edge-based
@@ -1075,7 +1075,8 @@ public class GraphHopperIT {
         assertMoscowNodeBased(tmpHopper, "false", true);
         GHResponse rsp = runMoscow(tmpHopper, "true", true);
         assertEquals(1, rsp.getErrors().size());
-        assertTrue(rsp.getErrors().toString().contains("Cannot find CH RoutingAlgorithmFactory"));
+        assertTrue(rsp.getErrors().toString().contains("Found a node-based CH preparation"));
+        assertTrue(rsp.getErrors().toString().contains("but requested edge-based CH"));
     }
 
     @Test


### PR DESCRIPTION
This fixes #1637 and is based on #1705.

When we are determining the traversal mode and when the `edge_based` parameter is missing, we check what CH preparations are there (instead of looking at the turn cost support of the *encoder* as for non-CH).

So with this change we do no longer need to set `edge_based=true` to get edge-based CH and instead edge-based CH is picked automatically if it was prepared (if not we fall back to node-based CH). If `edge_based` is set on the request its value is respected (and there will be an error if the specified preparation is missing).

Note that with this PR we now choose edge-based CH when there are node *and* edge-based CH preparations for the chosen weighting **and** the `edge_based` parameter was not set. 

