### PR TITLE
Add test cases for bike encoder on piers with access restrictions

### DIFF
--- a/core/src/test/java/com/graphhopper/routing/util/BikeFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/BikeFlagEncoderTest.java
@@ -339,6 +339,26 @@ public class BikeFlagEncoderTest extends AbstractBikeFlagEncoderTester {
         way.setTag("bicycle", "yes");
         way.setTag("access", "no");
         assertTrue(encoder.getAccess(way).isWay());
+
+        way.clearTags();
+        way.setTag("man_made", "pier");
+        way.setTag("bicycle", "no");
+        assertTrue(encoder.getAccess(way).canSkip());
+
+        way.clearTags();
+        way.setTag("man_made", "pier");
+        way.setTag("bicycle", "yes");
+        assertTrue(encoder.getAccess(way).isWay());
+
+        way.clearTags();
+        way.setTag("railway", "platform");
+        way.setTag("bicycle", "no");
+        assertTrue(encoder.getAccess(way).canSkip());
+
+        way.clearTags();
+        way.setTag("railway", "platform");
+        way.setTag("bicycle", "yes");
+        assertTrue(encoder.getAccess(way).isWay());
     }
 
     @Test


### PR DESCRIPTION
A few weeks ago I investigated a complaint about the acceptance of a pier with `bicycle=no` for bicycles. I found out that it was my fault but in the meanwhile I added this test.