### PR TITLE
New MaxAxleLoadParser

### DIFF
--- a/config-example.yml
+++ b/config-example.yml
@@ -15,7 +15,7 @@ graphhopper:
 
   # Add additional information to every edge. Used for path details.
   # If road_environment is added and elevation is enabled then also a tunnel and bridge interpolation is done, see #798.
-  # More options are: surface,max_width,max_height,max_weight,toll,track_type
+  # More options are: surface,max_width,max_height,max_weight,max_axle_load,toll,track_type
   graph.encoded_values: road_class,road_class_link,road_environment,max_speed,road_access
   # If many flag_encoders or encoded_values are used you need to increase bytes_for_flags to 8 or more (multiple of 4)
   graph.bytes_for_flags: 4

--- a/core/src/main/java/com/graphhopper/routing/profiles/DefaultEncodedValueFactory.java
+++ b/core/src/main/java/com/graphhopper/routing/profiles/DefaultEncodedValueFactory.java
@@ -49,6 +49,8 @@ public class DefaultEncodedValueFactory implements EncodedValueFactory {
             enc = MaxHeight.create();
         } else if (MaxWidth.KEY.equals(name)) {
             enc = MaxWidth.create();
+        } else if (MaxAxleLoad.KEY.equals(name)) {
+            enc = MaxAxleLoad.create();
         } else if (Surface.KEY.equals(name)) {
             enc = new EnumEncodedValue<>(Surface.KEY, Surface.class);
         } else if (Toll.KEY.equals(name)) {

--- a/core/src/main/java/com/graphhopper/routing/profiles/MaxAxleLoad.java
+++ b/core/src/main/java/com/graphhopper/routing/profiles/MaxAxleLoad.java
@@ -1,0 +1,34 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.routing.profiles;
+
+/**
+ * Defines the maximum weight per axle for an edge.
+ */
+public class MaxAxleLoad {
+    public static final String KEY = "max_axle_load";
+
+    /**
+     * Currently enables to store 0.5 to max=0.5*2⁷ tons and infinity. If a value is between the maximum and infinity
+     * it is assumed to use the maximum value. To save bits it might make more sense to store only a few values like
+     * it was done with the MappedDecimalEncodedValue still handling (or rounding) of unknown values is unclear.
+     */
+    public static DecimalEncodedValue create() {
+        return new UnsignedDecimalEncodedValue(KEY, 7, 0.5, Double.POSITIVE_INFINITY, false);
+    }
+}

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/DefaultTagParserFactory.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/DefaultTagParserFactory.java
@@ -48,6 +48,8 @@ public class DefaultTagParserFactory implements TagParserFactory {
             return new OSMMaxHeightParser();
         else if (name.equals(MaxWidth.KEY))
             return new OSMMaxWidthParser();
+        else if (name.equals(MaxAxleLoad.KEY))
+            return new OSMMaxAxleLoadParser();
         else if (name.equals(Surface.KEY))
             return new OSMSurfaceParser();
         else if (name.equals(Toll.KEY))

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMMaxAxleLoadParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMMaxAxleLoadParser.java
@@ -1,0 +1,59 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.routing.util.parsers;
+
+import java.util.Collections;
+import java.util.List;
+
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.profiles.DecimalEncodedValue;
+import com.graphhopper.routing.profiles.EncodedValue;
+import com.graphhopper.routing.profiles.EncodedValueLookup;
+import com.graphhopper.routing.profiles.MaxAxleLoad;
+import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.routing.util.parsers.helpers.OSMWeightExtractor;
+import com.graphhopper.storage.IntsRef;
+
+public class OSMMaxAxleLoadParser implements TagParser {
+    
+    private final DecimalEncodedValue maxAxleLoadEncoder;
+    private final boolean enableLog;
+
+    public OSMMaxAxleLoadParser() {
+        this(MaxAxleLoad.create(), false);
+    }
+
+    public OSMMaxAxleLoadParser(DecimalEncodedValue maxAxleLoadEncoder, boolean enableLog) {
+        this.maxAxleLoadEncoder = maxAxleLoadEncoder;
+        this.enableLog = enableLog;
+    }
+
+    @Override
+    public void createEncodedValues(EncodedValueLookup lookup,
+                    List<EncodedValue> registerNewEncodedValue) {
+        registerNewEncodedValue.add(maxAxleLoadEncoder);
+    }
+
+    @Override
+    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay way, EncodingManager.Access access,
+                    long relationFlags) {
+        OSMWeightExtractor.extractTons(edgeFlags, way, maxAxleLoadEncoder,
+                        Collections.singletonList("maxaxleload"), enableLog);
+        return edgeFlags;
+    }
+}

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMMaxWeightParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMMaxWeightParser.java
@@ -17,27 +17,22 @@
  */
 package com.graphhopper.routing.util.parsers;
 
+import java.util.Arrays;
+import java.util.List;
+
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.profiles.DecimalEncodedValue;
 import com.graphhopper.routing.profiles.EncodedValue;
 import com.graphhopper.routing.profiles.EncodedValueLookup;
 import com.graphhopper.routing.profiles.MaxWeight;
 import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.routing.util.parsers.helpers.OSMWeightExtractor;
 import com.graphhopper.storage.IntsRef;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.Arrays;
-import java.util.List;
-
-import static com.graphhopper.util.Helper.isEmpty;
-import static com.graphhopper.util.Helper.toLowerCase;
 
 public class OSMMaxWeightParser implements TagParser {
 
-    private static Logger LOG = LoggerFactory.getLogger(OSMMaxWeightParser.class);
-    private final DecimalEncodedValue weightEncoder;
-    private final boolean enableLog;
+    private DecimalEncodedValue weightEncoder;
+    private boolean enableLog;
 
     public OSMMaxWeightParser() {
         this(MaxWeight.create(), false);
@@ -57,38 +52,7 @@ public class OSMMaxWeightParser implements TagParser {
     public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay way, EncodingManager.Access access, long relationFlags) {
         // do not include OSM tag "height" here as it has completely different meaning (height of peak)
         List<String> weightTags = Arrays.asList("maxweight", "maxgcweight");
-        extractTons(edgeFlags, way, weightEncoder, weightTags, enableLog);
+        OSMWeightExtractor.extractTons(edgeFlags, way, weightEncoder, weightTags, enableLog);
         return edgeFlags;
-    }
-
-    static void extractTons(IntsRef edgeFlags, ReaderWay way, DecimalEncodedValue valueEncoder, List<String> keys, boolean enableLog) {
-        String value = way.getFirstPriorityTag(keys);
-        if (isEmpty(value))
-            return;
-        try {
-            double val = stringToTons(value);
-            if (val > valueEncoder.getMaxDecimal())
-                val = valueEncoder.getMaxDecimal();
-            valueEncoder.setDecimal(false, edgeFlags, val);
-        } catch (Exception ex) {
-            if (enableLog)
-                LOG.warn("Unable to extract tons from malformed road attribute '{}' for way (OSM_ID = {}).", value, way.getId());
-        }
-    }
-
-    public static double stringToTons(String value) {
-        value = toLowerCase(value).replaceAll(" ", "").replaceAll("(tons|ton)", "t");
-        value = value.replace("mgw", "").trim();
-        double factor = 1;
-        if (value.equals("default") || value.equals("none")) {
-            return -1;
-        } else if (value.endsWith("t")) {
-            value = value.substring(0, value.length() - 1);
-        } else if (value.endsWith("lbs")) {
-            value = value.substring(0, value.length() - 3);
-            factor = 0.00045359237;
-        }
-
-        return Double.parseDouble(value) * factor;
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/helpers/OSMWeightExtractor.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/helpers/OSMWeightExtractor.java
@@ -1,0 +1,53 @@
+package com.graphhopper.routing.util.parsers.helpers;
+
+import static com.graphhopper.util.Helper.isEmpty;
+import static com.graphhopper.util.Helper.toLowerCase;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.profiles.DecimalEncodedValue;
+import com.graphhopper.storage.IntsRef;
+
+public class OSMWeightExtractor {
+    
+    private static final Logger LOG = LoggerFactory.getLogger(OSMWeightExtractor.class);
+
+    private OSMWeightExtractor() {
+        // utility class
+    }
+
+    public static void extractTons(IntsRef edgeFlags, ReaderWay way, DecimalEncodedValue valueEncoder, List<String> keys, boolean enableLog) {
+        String value = way.getFirstPriorityTag(keys);
+        if (isEmpty(value))
+            return;
+        try {
+            double val = OSMWeightExtractor.stringToTons(value);
+            if (val > valueEncoder.getMaxDecimal())
+                val = valueEncoder.getMaxDecimal();
+            valueEncoder.setDecimal(false, edgeFlags, val);
+        } catch (Exception ex) {
+            if (enableLog)
+                LOG.warn("Unable to extract tons from malformed road attribute '{}' for way (OSM_ID = {}).", value, way.getId());
+        }
+    }
+
+    public static double stringToTons(String value) {
+        value = toLowerCase(value).replaceAll(" ", "").replaceAll("(tons|ton)", "t");
+        value = value.replace("mgw", "").trim();
+        double factor = 1;
+        if (value.equals("default") || value.equals("none")) {
+            return -1;
+        } else if (value.endsWith("t")) {
+            value = value.substring(0, value.length() - 1);
+        } else if (value.endsWith("lbs")) {
+            value = value.substring(0, value.length() - 3);
+            factor = 0.00045359237;
+        }
+    
+        return Double.parseDouble(value) * factor;
+    }
+}

--- a/core/src/main/java/com/graphhopper/util/details/PathDetailsBuilderFactory.java
+++ b/core/src/main/java/com/graphhopper/util/details/PathDetailsBuilderFactory.java
@@ -54,7 +54,7 @@ public class PathDetailsBuilderFactory {
         if (requestedPathDetails.contains(DISTANCE))
             builders.add(new DistanceDetails());
 
-        for (String key : Arrays.asList(MaxSpeed.KEY, MaxWidth.KEY, MaxHeight.KEY, MaxWeight.KEY)) {
+        for (String key : Arrays.asList(MaxSpeed.KEY, MaxWidth.KEY, MaxHeight.KEY, MaxWeight.KEY, MaxAxleLoad.KEY)) {
             if (requestedPathDetails.contains(key) && encoder.hasEncodedValue(key))
                 builders.add(new DecimalDetails(key, encoder.getDecimalEncodedValue(key)));
         }

--- a/core/src/test/java/com/graphhopper/routing/util/DataFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/DataFlagEncoderTest.java
@@ -1,9 +1,34 @@
 package com.graphhopper.routing.util;
 
+import static com.graphhopper.util.GHUtility.updateDistancesFor;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.Test;
+
 import com.graphhopper.reader.ReaderWay;
-import com.graphhopper.routing.profiles.*;
-import com.graphhopper.routing.util.parsers.*;
-import com.graphhopper.routing.util.parsers.helpers.OSMWeightExtractor;
+import com.graphhopper.routing.profiles.BooleanEncodedValue;
+import com.graphhopper.routing.profiles.Country;
+import com.graphhopper.routing.profiles.DecimalEncodedValue;
+import com.graphhopper.routing.profiles.EnumEncodedValue;
+import com.graphhopper.routing.profiles.IntEncodedValue;
+import com.graphhopper.routing.profiles.MaxSpeed;
+import com.graphhopper.routing.profiles.RoadAccess;
+import com.graphhopper.routing.profiles.RoadClass;
+import com.graphhopper.routing.profiles.RoadEnvironment;
+import com.graphhopper.routing.profiles.Surface;
+import com.graphhopper.routing.util.parsers.OSMMaxSpeedParser;
+import com.graphhopper.routing.util.parsers.OSMMaxWidthParser;
+import com.graphhopper.routing.util.parsers.OSMRoadAccessParser;
+import com.graphhopper.routing.util.parsers.OSMRoadClassParser;
+import com.graphhopper.routing.util.parsers.OSMRoadEnvironmentParser;
+import com.graphhopper.routing.util.parsers.OSMSurfaceParser;
+import com.graphhopper.routing.util.parsers.SpatialRuleParser;
 import com.graphhopper.routing.util.spatialrules.SpatialRule;
 import com.graphhopper.routing.util.spatialrules.SpatialRuleLookup;
 import com.graphhopper.routing.util.spatialrules.countries.GermanySpatialRule;
@@ -17,13 +42,6 @@ import com.graphhopper.util.TranslationMapTest;
 import com.graphhopper.util.shapes.BBox;
 import com.graphhopper.util.shapes.GHPoint;
 import com.graphhopper.util.shapes.Polygon;
-import org.junit.Test;
-
-import java.util.Arrays;
-import java.util.Collections;
-
-import static com.graphhopper.util.GHUtility.updateDistancesFor;
-import static org.junit.Assert.*;
 
 /**
  * @author Peter Karich
@@ -332,27 +350,6 @@ public class DataFlagEncoderTest {
     public void stringToMeterException() {
         // Unexpected values
         OSMMaxWidthParser.stringToMeter("height limit 1.5m");
-    }
-
-    @Test
-    public void stringToTons() {
-        assertEquals(1.5, OSMWeightExtractor.stringToTons("1.5"), DELTA);
-        assertEquals(1.5, OSMWeightExtractor.stringToTons("1.5 t"), DELTA);
-        assertEquals(1.5, OSMWeightExtractor.stringToTons("1.5   t"), DELTA);
-        assertEquals(1.5, OSMWeightExtractor.stringToTons("1.5 tons"), DELTA);
-        assertEquals(1.5, OSMWeightExtractor.stringToTons("1.5 ton"), DELTA);
-        assertEquals(1.5, OSMWeightExtractor.stringToTons("3306.9 lbs"), DELTA);
-        assertEquals(3, OSMWeightExtractor.stringToTons("3 T"), DELTA);
-        assertEquals(3, OSMWeightExtractor.stringToTons("3ton"), DELTA);
-
-        // maximum gross weight
-        assertEquals(6, OSMWeightExtractor.stringToTons("6t mgw"), DELTA);
-    }
-
-    @Test(expected = NumberFormatException.class)
-    public void stringToTonsException() {
-        // Unexpected values
-        OSMWeightExtractor.stringToTons("weight limit 1.5t");
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/routing/util/DataFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/DataFlagEncoderTest.java
@@ -3,6 +3,7 @@ package com.graphhopper.routing.util;
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.profiles.*;
 import com.graphhopper.routing.util.parsers.*;
+import com.graphhopper.routing.util.parsers.helpers.OSMWeightExtractor;
 import com.graphhopper.routing.util.spatialrules.SpatialRule;
 import com.graphhopper.routing.util.spatialrules.SpatialRuleLookup;
 import com.graphhopper.routing.util.spatialrules.countries.GermanySpatialRule;
@@ -335,23 +336,23 @@ public class DataFlagEncoderTest {
 
     @Test
     public void stringToTons() {
-        assertEquals(1.5, OSMMaxWeightParser.stringToTons("1.5"), DELTA);
-        assertEquals(1.5, OSMMaxWeightParser.stringToTons("1.5 t"), DELTA);
-        assertEquals(1.5, OSMMaxWeightParser.stringToTons("1.5   t"), DELTA);
-        assertEquals(1.5, OSMMaxWeightParser.stringToTons("1.5 tons"), DELTA);
-        assertEquals(1.5, OSMMaxWeightParser.stringToTons("1.5 ton"), DELTA);
-        assertEquals(1.5, OSMMaxWeightParser.stringToTons("3306.9 lbs"), DELTA);
-        assertEquals(3, OSMMaxWeightParser.stringToTons("3 T"), DELTA);
-        assertEquals(3, OSMMaxWeightParser.stringToTons("3ton"), DELTA);
+        assertEquals(1.5, OSMWeightExtractor.stringToTons("1.5"), DELTA);
+        assertEquals(1.5, OSMWeightExtractor.stringToTons("1.5 t"), DELTA);
+        assertEquals(1.5, OSMWeightExtractor.stringToTons("1.5   t"), DELTA);
+        assertEquals(1.5, OSMWeightExtractor.stringToTons("1.5 tons"), DELTA);
+        assertEquals(1.5, OSMWeightExtractor.stringToTons("1.5 ton"), DELTA);
+        assertEquals(1.5, OSMWeightExtractor.stringToTons("3306.9 lbs"), DELTA);
+        assertEquals(3, OSMWeightExtractor.stringToTons("3 T"), DELTA);
+        assertEquals(3, OSMWeightExtractor.stringToTons("3ton"), DELTA);
 
         // maximum gross weight
-        assertEquals(6, OSMMaxWeightParser.stringToTons("6t mgw"), DELTA);
+        assertEquals(6, OSMWeightExtractor.stringToTons("6t mgw"), DELTA);
     }
 
     @Test(expected = NumberFormatException.class)
     public void stringToTonsException() {
         // Unexpected values
-        OSMMaxWeightParser.stringToTons("weight limit 1.5t");
+        OSMWeightExtractor.stringToTons("weight limit 1.5t");
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMMaxAxleLoadParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMMaxAxleLoadParserTest.java
@@ -1,0 +1,69 @@
+package com.graphhopper.routing.util.parsers;
+
+import static com.graphhopper.routing.util.EncodingManager.Access.WAY;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.profiles.DecimalEncodedValue;
+import com.graphhopper.routing.profiles.MaxAxleLoad;
+import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.storage.IntsRef;
+
+public class OSMMaxAxleLoadParserTest {
+
+    private EncodingManager em;
+    private DecimalEncodedValue malEnc;
+    private OSMMaxAxleLoadParser parser;
+
+    @Before
+    public void setUp() {
+        parser = new OSMMaxAxleLoadParser();
+        em = new EncodingManager.Builder(4).add(parser).build();
+        malEnc = em.getDecimalEncodedValue(MaxAxleLoad.KEY);
+    }
+
+    @Test
+    public void testSimpleTags() {
+        ReaderWay readerWay = new ReaderWay(1);
+        IntsRef intsRef = em.createEdgeFlags();
+        readerWay.setTag("maxaxleload", "11.5");
+        parser.handleWayTags(intsRef, readerWay, WAY, 0);
+        assertEquals(11.5, malEnc.getDecimal(false, intsRef), .01);
+
+        // if value is beyond the maximum then do not use infinity instead fallback to more restrictive maximum
+        intsRef = em.createEdgeFlags();
+        readerWay.setTag("maxaxleload", "80");
+        parser.handleWayTags(intsRef, readerWay, WAY, 0);
+        assertEquals(malEnc.getMaxDecimal(), malEnc.getDecimal(false, intsRef), .01);
+    }
+
+    @Test
+    public void testRounding() {
+        ReaderWay readerWay = new ReaderWay(1);
+        IntsRef intsRef = em.createEdgeFlags();
+        readerWay.setTag("maxaxleload", "4.8");
+        parser.handleWayTags(intsRef, readerWay, WAY, 0);
+        assertEquals(5.0, malEnc.getDecimal(false, intsRef), .01);
+        
+        intsRef = em.createEdgeFlags();
+        readerWay.setTag("maxaxleload", "3.6");
+        parser.handleWayTags(intsRef, readerWay, WAY, 0);
+        assertEquals(3.5, malEnc.getDecimal(false, intsRef), .01);
+        
+        intsRef = em.createEdgeFlags();
+        readerWay.setTag("maxaxleload", "2.4");
+        parser.handleWayTags(intsRef, readerWay, WAY, 0);
+        assertEquals(2.5, malEnc.getDecimal(false, intsRef), .01);
+    }
+    
+    @Test
+    public void testNoLimit() {
+        ReaderWay readerWay = new ReaderWay(1);
+        IntsRef intsRef = em.createEdgeFlags();
+        parser.handleWayTags(intsRef, readerWay, WAY, 0);
+        assertEquals(Double.POSITIVE_INFINITY, malEnc.getDecimal(false, intsRef), .01);
+    }
+}

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMWeightExtractorTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMWeightExtractorTest.java
@@ -1,0 +1,33 @@
+package com.graphhopper.routing.util.parsers;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import com.graphhopper.routing.util.parsers.helpers.OSMWeightExtractor;
+
+public class OSMWeightExtractorTest {
+    
+    private final double DELTA = 0.1;
+
+    @Test
+    public void stringToTons() {
+        assertEquals(1.5, OSMWeightExtractor.stringToTons("1.5"), DELTA);
+        assertEquals(1.5, OSMWeightExtractor.stringToTons("1.5 t"), DELTA);
+        assertEquals(1.5, OSMWeightExtractor.stringToTons("1.5   t"), DELTA);
+        assertEquals(1.5, OSMWeightExtractor.stringToTons("1.5 tons"), DELTA);
+        assertEquals(1.5, OSMWeightExtractor.stringToTons("1.5 ton"), DELTA);
+        assertEquals(1.5, OSMWeightExtractor.stringToTons("3306.9 lbs"), DELTA);
+        assertEquals(3, OSMWeightExtractor.stringToTons("3 T"), DELTA);
+        assertEquals(3, OSMWeightExtractor.stringToTons("3ton"), DELTA);
+
+        // maximum gross weight
+        assertEquals(6, OSMWeightExtractor.stringToTons("6t mgw"), DELTA);
+    }
+
+    @Test(expected = NumberFormatException.class)
+    public void stringToTonsException() {
+        // Unexpected values
+        OSMWeightExtractor.stringToTons("weight limit 1.5t");
+    }
+}


### PR DESCRIPTION
This adds another crucial tag for proper commercial vehicle routing. The `maxaxleload` tag describes how many tonnes a single axle is allowed to have in order for a truck to be able to pass an edge. Like #1711 this may greatly change the possible routes of a vehicle as it dictates if a bridge can or cannot be crossed.

I went with an UnsignedDecimalEncodedValue with 7 bits and a 0.5 factor which allows us to store values up to 64 tonnes with a 0.5 precision. This is fully covers ~97% of [all tagged values](https://taginfo.openstreetmap.org/keys/maxaxleload#values) without loosing information and is still good enough to only be off by max 200kg for cases like `3.8t`.