### PR TITLE
in GraphHopper class set minOneWayNetworkSize to 200

### DIFF
--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -242,14 +242,6 @@ public class GraphHopper implements GraphHopperAPI {
     }
 
     /**
-     * For testing, i.e. preserve raw network topology and use in-memory.
-     */
-    public GraphHopper forTesting() {
-        return setStoreOnFlush(false).
-                setMinNetworkSize(0, 0);
-    }
-
-    /**
      * Precise location resolution index means also more space (disc/RAM) could be consumed and
      * probably slower query times, which would be e.g. not suitable for Android. The resolution
      * specifies the tile width (in meter).

--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -106,7 +106,7 @@ public class GraphHopper implements GraphHopperAPI {
     private int maxRegionSearch = 4;
     // for prepare
     private int minNetworkSize = 200;
-    private int minOneWayNetworkSize = 0;
+    private int minOneWayNetworkSize = 200;
 
     // for LM prepare
     private final LMAlgoFactoryDecorator lmFactoryDecorator = new LMAlgoFactoryDecorator();
@@ -239,6 +239,14 @@ public class GraphHopper implements GraphHopperAPI {
     public GraphHopper forMobile() {
         setSimplifyResponse(false);
         return setMemoryMapped();
+    }
+
+    /**
+     * For testing, i.e. preserve raw network topology and use in-memory.
+     */
+    public GraphHopper forTesting() {
+        return setStoreOnFlush(false).
+                setMinNetworkSize(0, 0);
     }
 
     /**

--- a/reader-osm/src/test/java/com/graphhopper/GraphHopperIT.java
+++ b/reader-osm/src/test/java/com/graphhopper/GraphHopperIT.java
@@ -61,7 +61,6 @@ public class GraphHopperIT {
 
         hopper = new GraphHopperOSM().
                 setOSMFile(osmFile).
-                setStoreOnFlush(true).
                 setCHEnabled(false).
                 setGraphHopperLocation(graphFileFoot).
                 setEncodingManager(EncodingManager.create(importVehicles)).
@@ -236,6 +235,7 @@ public class GraphHopperIT {
     public void testPointHint() {
         GraphHopper tmpHopper = new GraphHopperOSM().
                 setOSMFile(DIR + "/Laufamholzstrasse.osm.xml").
+                forTesting().
                 setCHEnabled(false).
                 setGraphHopperLocation(tmpGraphFile).
                 setEncodingManager(EncodingManager.create("car"));
@@ -568,7 +568,6 @@ public class GraphHopperIT {
     public void testSRTMWithInstructions() {
         GraphHopper tmpHopper = new GraphHopperOSM().
                 setOSMFile(osmFile).
-                setStoreOnFlush(true).
                 setCHEnabled(false).
                 setGraphHopperLocation(tmpGraphFile).
                 setEncodingManager(EncodingManager.create(importVehicles));
@@ -617,7 +616,7 @@ public class GraphHopperIT {
 
     @Test
     public void testSRTMWithoutTunnelInterpolation() {
-        GraphHopper tmpHopper = new GraphHopperOSM().setOSMFile(osmFile).setStoreOnFlush(true)
+        GraphHopper tmpHopper = new GraphHopperOSM().setOSMFile(osmFile)
                 .setCHEnabled(false).setGraphHopperLocation(tmpGraphFile)
                 .setEncodingManager(EncodingManager.create(importVehicles, 8));
 
@@ -643,7 +642,7 @@ public class GraphHopperIT {
 
     @Test
     public void testSRTMWithTunnelInterpolation() {
-        GraphHopper tmpHopper = new GraphHopperOSM().setOSMFile(osmFile).setStoreOnFlush(true)
+        GraphHopper tmpHopper = new GraphHopperOSM().setOSMFile(osmFile)
                 .setCHEnabled(false).setGraphHopperLocation(tmpGraphFile)
                 .setEncodingManager(GHUtility.addDefaultEncodedValues(new EncodingManager.Builder(8)).addAll(new DefaultFlagEncoderFactory(), genericImportVehicles).build());
 
@@ -677,7 +676,6 @@ public class GraphHopperIT {
 
         GraphHopper tmpHopper = new GraphHopperOSM().
                 setOSMFile(tmpOsmFile).
-                setStoreOnFlush(true).
                 setCHEnabled(false).
                 setGraphHopperLocation(tmpGraphFile).
                 setEncodingManager(EncodingManager.create(tmpImportVehicles)).
@@ -722,7 +720,7 @@ public class GraphHopperIT {
 
         GraphHopper tmpHopper = new GraphHopperOSM().
                 setOSMFile(tmpOsmFile).
-                setStoreOnFlush(true).
+                forTesting().
                 setGraphHopperLocation(tmpGraphFile).
                 setEncodingManager(EncodingManager.create(tmpImportVehicles)).
                 importOrLoad();
@@ -762,6 +760,7 @@ public class GraphHopperIT {
 
         GraphHopper tmpHopper = new GraphHopperOSM().
                 setOSMFile(tmpOsmFile).
+                forTesting().
                 setStoreOnFlush(true).
                 setGraphHopperLocation(tmpGraphFile).
                 setEncodingManager(EncodingManager.create(tmpImportVehicles)).

--- a/reader-osm/src/test/java/com/graphhopper/GraphHopperIT.java
+++ b/reader-osm/src/test/java/com/graphhopper/GraphHopperIT.java
@@ -19,6 +19,7 @@ package com.graphhopper;
 
 import com.graphhopper.reader.dem.SRTMProvider;
 import com.graphhopper.reader.osm.GraphHopperOSM;
+import com.graphhopper.reader.osm.GraphHopperOSMForTest;
 import com.graphhopper.routing.ch.CHAlgoFactoryDecorator;
 import com.graphhopper.routing.util.CarFlagEncoder;
 import com.graphhopper.routing.util.DefaultFlagEncoderFactory;
@@ -233,9 +234,8 @@ public class GraphHopperIT {
 
     @Test
     public void testPointHint() {
-        GraphHopper tmpHopper = new GraphHopperOSM().
+        GraphHopper tmpHopper = new GraphHopperOSMForTest().
                 setOSMFile(DIR + "/Laufamholzstrasse.osm.xml").
-                forTesting().
                 setCHEnabled(false).
                 setGraphHopperLocation(tmpGraphFile).
                 setEncodingManager(EncodingManager.create("car"));
@@ -718,9 +718,8 @@ public class GraphHopperIT {
         String tmpImportVehicles = "car,bike";
         String tmpWeightCalcStr = "fastest";
 
-        GraphHopper tmpHopper = new GraphHopperOSM().
+        GraphHopper tmpHopper = new GraphHopperOSMForTest().
                 setOSMFile(tmpOsmFile).
-                forTesting().
                 setGraphHopperLocation(tmpGraphFile).
                 setEncodingManager(EncodingManager.create(tmpImportVehicles)).
                 importOrLoad();
@@ -758,9 +757,8 @@ public class GraphHopperIT {
         String tmpImportVehicles = "car,bike";
         String tmpWeightCalcStr = "fastest";
 
-        GraphHopper tmpHopper = new GraphHopperOSM().
+        GraphHopper tmpHopper = new GraphHopperOSMForTest().
                 setOSMFile(tmpOsmFile).
-                forTesting().
                 setStoreOnFlush(true).
                 setGraphHopperLocation(tmpGraphFile).
                 setEncodingManager(EncodingManager.create(tmpImportVehicles)).

--- a/reader-osm/src/test/java/com/graphhopper/reader/osm/GraphHopperOSMForTest.java
+++ b/reader-osm/src/test/java/com/graphhopper/reader/osm/GraphHopperOSMForTest.java
@@ -1,0 +1,11 @@
+package com.graphhopper.reader.osm;
+
+/**
+ * For testing, i.e. preserve raw network topology and use in-memory.
+ */
+public class GraphHopperOSMForTest extends GraphHopperOSM {
+    public GraphHopperOSMForTest() {
+        setMinNetworkSize(0, 0);
+        setStoreOnFlush(false);
+    }
+}

--- a/reader-osm/src/test/java/com/graphhopper/reader/osm/GraphHopperOSMTest.java
+++ b/reader-osm/src/test/java/com/graphhopper/reader/osm/GraphHopperOSMTest.java
@@ -79,6 +79,7 @@ public class GraphHopperOSMTest {
     @Test
     public void testLoadOSM() {
         GraphHopper closableInstance = new GraphHopperOSM().
+                forTesting().
                 setStoreOnFlush(true).
                 setEncodingManager(EncodingManager.create("car")).
                 setGraphHopperLocation(ghLoc).
@@ -116,7 +117,9 @@ public class GraphHopperOSMTest {
 
     @Test
     public void testLoadOSMNoCH() {
-        GraphHopper gh = new GraphHopperOSM().setStoreOnFlush(true).setCHEnabled(false).
+        GraphHopper gh = new GraphHopperOSM().
+                forTesting().
+                setStoreOnFlush(true).setCHEnabled(false).
                 setEncodingManager(EncodingManager.create("car")).
                 setGraphHopperLocation(ghLoc).
                 setDataReaderFile(testOsm);
@@ -149,7 +152,8 @@ public class GraphHopperOSMTest {
 
     @Test
     public void testQueryLocationIndexWithBBox() {
-        final GraphHopper gh = new GraphHopperOSM().setStoreOnFlush(true).
+        final GraphHopper gh = new GraphHopperOSM().
+                forTesting().
                 setEncodingManager(EncodingManager.create("car")).
                 setCHEnabled(false).
                 setGraphHopperLocation(ghLoc).
@@ -209,7 +213,9 @@ public class GraphHopperOSMTest {
     @Test
     public void testLoadingWithDifferentCHConfig_issue471() {
         // with CH should not be loadable without CH configured
-        GraphHopper gh = new GraphHopperOSM().setStoreOnFlush(true).
+        GraphHopper gh = new GraphHopperOSM().
+                forTesting().
+                setStoreOnFlush(true).
                 setEncodingManager(EncodingManager.create("car")).
                 setGraphHopperLocation(ghLoc).
                 setDataReaderFile(testOsm);
@@ -231,7 +237,9 @@ public class GraphHopperOSMTest {
         Helper.removeDir(new File(ghLoc));
 
         // without CH should not be loadable with CH enabled
-        gh = new GraphHopperOSM().setStoreOnFlush(true).setCHEnabled(false).
+        gh = new GraphHopperOSM().
+                forTesting().
+                setStoreOnFlush(true).setCHEnabled(false).
                 setEncodingManager(EncodingManager.create("car")).
                 setGraphHopperLocation(ghLoc).
                 setDataReaderFile(testOsm);
@@ -253,13 +261,17 @@ public class GraphHopperOSMTest {
 
     @Test
     public void testAllowMultipleReadingInstances() {
-        GraphHopper instance1 = new GraphHopperOSM().setStoreOnFlush(true).
+        GraphHopper instance1 = new GraphHopperOSM().
+                forTesting().
+                setStoreOnFlush(true).
                 setEncodingManager(EncodingManager.create("car")).
                 setGraphHopperLocation(ghLoc).
                 setDataReaderFile(testOsm);
         instance1.importOrLoad();
 
-        GraphHopper instance2 = new GraphHopperOSM().setStoreOnFlush(true).
+        GraphHopper instance2 = new GraphHopperOSM().
+                forTesting().
+                setStoreOnFlush(true).
                 setEncodingManager(EncodingManager.create("car")).
                 setDataReaderFile(testOsm);
         instance2.load(ghLoc);
@@ -289,7 +301,8 @@ public class GraphHopperOSMTest {
                 }
                 return super.importData();
             }
-        }.setStoreOnFlush(true).
+        }.forTesting().
+                setStoreOnFlush(true).
                 setEncodingManager(EncodingManager.create("car")).
                 setGraphHopperLocation(ghLoc).
                 setDataReaderFile(testOsm);
@@ -333,7 +346,7 @@ public class GraphHopperOSMTest {
     @Test
     public void testPrepare() {
         instance = new GraphHopperOSM().
-                setStoreOnFlush(false).
+                forTesting().
                 setEncodingManager(EncodingManager.create("car")).
                 setGraphHopperLocation(ghLoc).
                 setDataReaderFile(testOsm);
@@ -348,9 +361,11 @@ public class GraphHopperOSMTest {
 
     @Test
     public void testSortedGraph_noCH() {
-        instance = new GraphHopperOSM().setStoreOnFlush(false).
+        instance = new GraphHopperOSM().
+                forTesting().
                 setSortGraph(true).
-                setEncodingManager(EncodingManager.create("car")).setCHEnabled(false).
+                setCHEnabled(false).
+                setEncodingManager(EncodingManager.create("car")).
                 setGraphHopperLocation(ghLoc).
                 setDataReaderFile(testOsm);
         instance.importOrLoad();
@@ -376,8 +391,10 @@ public class GraphHopperOSMTest {
     @Test
     public void testFootAndCar() {
         // now all ways are imported
-        instance = new GraphHopperOSM().setStoreOnFlush(false).
-                setEncodingManager(EncodingManager.create("car,foot")).setCHEnabled(false).
+        instance = new GraphHopperOSM().
+                forTesting().
+                setCHEnabled(false).
+                setEncodingManager(EncodingManager.create("car,foot")).
                 setGraphHopperLocation(ghLoc).
                 setDataReaderFile(testOsm3);
         instance.importOrLoad();
@@ -420,10 +437,10 @@ public class GraphHopperOSMTest {
 
     @Test
     public void testFailsForWrongConfig() {
-        instance = new GraphHopperOSM().init(
-                new CmdArgs().
+        instance = new GraphHopperOSM().
+                forTesting().
+                init(new CmdArgs().
                         put("datareader.file", testOsm3).
-                        put("datareader.dataaccess", "RAM").
                         put("graph.flag_encoders", "foot,car").
                         put(Parameters.CH.PREPARE + "weightings", "no")).
                 setGraphHopperLocation(ghLoc);
@@ -433,12 +450,10 @@ public class GraphHopperOSMTest {
 
         // different config (flagEncoder list)
         try {
-            GraphHopper tmpGH = new GraphHopperOSM().init(
-                    new CmdArgs().
-                            put("datareader.file", testOsm3).
-                            put("datareader.dataaccess", "RAM").
-                            put("graph.flag_encoders", "foot").
-                            put(Parameters.CH.PREPARE + "weightings", "no")).
+            GraphHopper tmpGH = new GraphHopperOSM().init(new CmdArgs().
+                    put("datareader.file", testOsm3).
+                    put("graph.flag_encoders", "foot").
+                    put(Parameters.CH.PREPARE + "weightings", "no")).
                     setDataReaderFile(testOsm3);
             tmpGH.load(ghLoc);
             fail();
@@ -447,13 +462,11 @@ public class GraphHopperOSMTest {
         }
 
         // different bytesForFlags should fail to load
-        instance = new GraphHopperOSM().init(
-                new CmdArgs().
-                        put("datareader.file", testOsm3).
-                        put("datareader.dataaccess", "RAM").
-                        put("graph.flag_encoders", "foot,car").
-                        put("graph.bytes_for_flags", 8).
-                        put(Parameters.CH.PREPARE + "weightings", "no")).
+        instance = new GraphHopperOSM().init(new CmdArgs().
+                put("datareader.file", testOsm3).
+                put("graph.flag_encoders", "foot,car").
+                put("graph.bytes_for_flags", 8).
+                put(Parameters.CH.PREPARE + "weightings", "no")).
                 setDataReaderFile(testOsm3);
         try {
             instance.load(ghLoc);
@@ -466,7 +479,6 @@ public class GraphHopperOSMTest {
         try {
             GraphHopper tmpGH = new GraphHopperOSM().init(new CmdArgs().
                     put("datareader.file", testOsm3).
-                    put("datareader.dataaccess", "RAM").
                     put(Parameters.CH.PREPARE + "weightings", "no").
                     put("graph.flag_encoders", "car,foot")).
                     setDataReaderFile(testOsm3);
@@ -493,15 +505,16 @@ public class GraphHopperOSMTest {
         }
 
         // different version for car should fail
-        instance = new GraphHopperOSM().setEncodingManager(EncodingManager.create(new FootFlagEncoder(), new CarFlagEncoder() {
-            @Override
-            public int getVersion() {
-                return 0;
-            }
-        })).init(
+        instance = new GraphHopperOSM().
+                forTesting().
+                setEncodingManager(EncodingManager.create(new FootFlagEncoder(), new CarFlagEncoder() {
+                    @Override
+                    public int getVersion() {
+                        return 0;
+                    }
+                })).init(
                 new CmdArgs().
                         put("datareader.file", testOsm3).
-                        put("datareader.dataaccess", "RAM").
                         put(Parameters.CH.PREPARE + "weightings", "no")).
                 setDataReaderFile(testOsm3);
         try {
@@ -514,10 +527,10 @@ public class GraphHopperOSMTest {
 
     @Test
     public void testFailsForWrongEVConfig() {
-        instance = new GraphHopperOSM().init(
-                new CmdArgs().
+        instance = new GraphHopperOSM().
+                forTesting().
+                init(new CmdArgs().
                         put("datareader.file", testOsm3).
-                        put("datareader.dataaccess", "RAM").
                         put("graph.flag_encoders", "foot,car").
                         put(Parameters.CH.PREPARE + "weightings", "no")).
                 setGraphHopperLocation(ghLoc);
@@ -529,10 +542,10 @@ public class GraphHopperOSMTest {
         instance.close();
 
         // different encoded values should fail to load
-        instance = new GraphHopperOSM().init(
-                new CmdArgs().
+        instance = new GraphHopperOSM().
+                forTesting().
+                init(new CmdArgs().
                         put("datareader.file", testOsm3).
-                        put("datareader.dataaccess", "RAM").
                         put("graph.encoded_values", "road_environment,road_class").
                         put("graph.flag_encoders", "foot,car").
                         put(Parameters.CH.PREPARE + "weightings", "no")).
@@ -640,7 +653,8 @@ public class GraphHopperOSMTest {
     @Test
     public void testFootOnly() {
         // now only footable ways are imported => no A D C and B D E => the other both ways have pillar nodes!
-        instance = new GraphHopperOSM().setStoreOnFlush(false).
+        instance = new GraphHopperOSM().
+                forTesting().
                 setEncodingManager(EncodingManager.create("foot")).
                 setGraphHopperLocation(ghLoc).
                 setDataReaderFile(testOsm3);
@@ -659,10 +673,12 @@ public class GraphHopperOSMTest {
 
     @Test
     public void testVia() {
-        instance = new GraphHopperOSM().setStoreOnFlush(true).
+        instance = new GraphHopperOSM().
+                forTesting().
                 init(new CmdArgs().
                         put("datareader.file", testOsm3).
                         put("prepare.min_network_size", "1").
+                        put("prepare.min_one_way_network_size", "0").
                         put("graph.flag_encoders", "car")).
                 setGraphHopperLocation(ghLoc);
         instance.importOrLoad();
@@ -859,7 +875,9 @@ public class GraphHopperOSMTest {
         CarFlagEncoder carEncoder = new CarFlagEncoder();
         EncodingManager em = EncodingManager.create(carEncoder);
         // Weighting weighting = new FastestWeighting(carEncoder);
-        instance = new GraphHopperOSM().setStoreOnFlush(false).setCHEnabled(false).
+        instance = new GraphHopperOSM().
+                forTesting().
+                setCHEnabled(false).
                 setEncodingManager(em).
                 setGraphHopperLocation(ghLoc).
                 setDataReaderFile(testOsm);
@@ -921,7 +939,7 @@ public class GraphHopperOSMTest {
                     new MountainBikeFlagEncoder(), new RacingBikeFlagEncoder(), new FootFlagEncoder()), 8);
 
             GraphHopper tmpGH = new GraphHopperOSM().
-                    setStoreOnFlush(false).
+                    forTesting().
                     setEncodingManager(em).
                     setGraphHopperLocation(ghLoc).
                     setDataReaderFile(testOsm);
@@ -932,7 +950,7 @@ public class GraphHopperOSMTest {
             assertEquals(5, tmpGH.getCHFactoryDecorator().getPreparations().size());
             for (RoutingAlgorithmFactory raf : tmpGH.getCHFactoryDecorator().getPreparations()) {
                 PrepareContractionHierarchies pch = (PrepareContractionHierarchies) raf;
-                assertTrue("Preparation wasn't run! [" + threadCount + "]", pch.isPrepared());
+                assertTrue("CH Preparation wasn't run! [" + threadCount + "]", pch.isPrepared());
 
                 String name = pch.getCHProfile().toFileName();
                 Long singleThreadShortcutCount = shortcutCountMap.get(name);
@@ -962,7 +980,7 @@ public class GraphHopperOSMTest {
                     new MountainBikeFlagEncoder(), new RacingBikeFlagEncoder(), new FootFlagEncoder()), 8);
 
             GraphHopper tmpGH = new GraphHopperOSM().
-                    setStoreOnFlush(false).
+                    forTesting().
                     setCHEnabled(false).
                     setEncodingManager(em).
                     setGraphHopperLocation(ghLoc).
@@ -976,7 +994,7 @@ public class GraphHopperOSMTest {
 
             assertEquals(5, tmpGH.getLMFactoryDecorator().getPreparations().size());
             for (PrepareLandmarks prepLM : tmpGH.getLMFactoryDecorator().getPreparations()) {
-                assertTrue("Preparation wasn't run! [" + threadCount + "]", prepLM.isPrepared());
+                assertTrue("LM Preparation wasn't run! [" + threadCount + "]", prepLM.isPrepared());
 
                 String name = AbstractWeighting.weightingToFileName(prepLM.getWeighting());
                 Integer singleThreadShortcutCount = landmarkCount.get(name);

--- a/reader-osm/src/test/java/com/graphhopper/reader/osm/OSMReaderTest.java
+++ b/reader-osm/src/test/java/com/graphhopper/reader/osm/OSMReaderTest.java
@@ -844,8 +844,7 @@ public class OSMReaderTest {
 
     @Test
     public void testRoutingRequestFails_issue665() {
-        GraphHopper hopper = new GraphHopperOSM().
-                forTesting().
+        GraphHopper hopper = new GraphHopperOSMForTest().
                 setDataReaderFile(getClass().getResource(file7).getFile()).
                 setEncodingManager(EncodingManager.create("car,motorcycle")).
                 setGraphHopperLocation(dir);
@@ -861,7 +860,7 @@ public class OSMReaderTest {
 
     @Test
     public void testRoadClassInfo() {
-        GraphHopper gh = new GraphHopperOSM() {
+        GraphHopper gh = new GraphHopperOSMForTest() {
 
             @Override
             protected DataReader importData() {
@@ -873,8 +872,7 @@ public class OSMReaderTest {
                     throw new RuntimeException(e);
                 }
             }
-        }.forTesting().
-                setEncodingManager(new EncodingManager.Builder(4).add(carEncoder = new CarFlagEncoder()).add(new OSMRoadClassParser()).build()).
+        }.setEncodingManager(new EncodingManager.Builder(4).add(carEncoder = new CarFlagEncoder()).add(new OSMRoadClassParser()).build()).
                 setGraphHopperLocation(dir).setCHEnabled(false).
                 importOrLoad();
 
@@ -888,14 +886,12 @@ public class OSMReaderTest {
         assertTrue(ex.getMessage(), ex.getMessage().contains("You requested the details [road_access]"));
     }
 
-    class GraphHopperFacade extends GraphHopperOSM {
+    class GraphHopperFacade extends GraphHopperOSMForTest {
         public GraphHopperFacade(String osmFile) {
             this(osmFile, false, "");
         }
 
         public GraphHopperFacade(String osmFile, boolean turnCosts, String prefLang) {
-            forTesting();
-            setStoreOnFlush(false);
             setOSMFile(osmFile);
             setGraphHopperLocation(dir);
             setCHEnabled(false);

--- a/reader-osm/src/test/java/com/graphhopper/reader/osm/OSMReaderTest.java
+++ b/reader-osm/src/test/java/com/graphhopper/reader/osm/OSMReaderTest.java
@@ -844,10 +844,11 @@ public class OSMReaderTest {
 
     @Test
     public void testRoutingRequestFails_issue665() {
-        GraphHopper hopper = new GraphHopperOSM()
-                .setDataReaderFile(getClass().getResource(file7).getFile())
-                .setEncodingManager(EncodingManager.create("car,motorcycle"))
-                .setGraphHopperLocation(dir);
+        GraphHopper hopper = new GraphHopperOSM().
+                forTesting().
+                setDataReaderFile(getClass().getResource(file7).getFile()).
+                setEncodingManager(EncodingManager.create("car,motorcycle")).
+                setGraphHopperLocation(dir);
         hopper.getCHFactoryDecorator().setEnabled(false);
         hopper.importOrLoad();
         GHRequest req = new GHRequest(48.977277, 8.256896, 48.978876, 8.254884).
@@ -872,7 +873,8 @@ public class OSMReaderTest {
                     throw new RuntimeException(e);
                 }
             }
-        }.setEncodingManager(new EncodingManager.Builder(4).add(carEncoder = new CarFlagEncoder()).add(new OSMRoadClassParser()).build()).
+        }.forTesting().
+                setEncodingManager(new EncodingManager.Builder(4).add(carEncoder = new CarFlagEncoder()).add(new OSMRoadClassParser()).build()).
                 setGraphHopperLocation(dir).setCHEnabled(false).
                 importOrLoad();
 
@@ -892,6 +894,7 @@ public class OSMReaderTest {
         }
 
         public GraphHopperFacade(String osmFile, boolean turnCosts, String prefLang) {
+            forTesting();
             setStoreOnFlush(false);
             setOSMFile(osmFile);
             setGraphHopperLocation(dir);

--- a/reader-osm/src/test/java/com/graphhopper/routing/RoutingAlgorithmWithOSMIT.java
+++ b/reader-osm/src/test/java/com/graphhopper/routing/RoutingAlgorithmWithOSMIT.java
@@ -20,6 +20,7 @@ package com.graphhopper.routing;
 import com.graphhopper.GraphHopper;
 import com.graphhopper.reader.dem.SRTMProvider;
 import com.graphhopper.reader.osm.GraphHopperOSM;
+import com.graphhopper.reader.osm.GraphHopperOSMForTest;
 import com.graphhopper.routing.ch.CHAlgoFactoryDecorator;
 import com.graphhopper.routing.util.*;
 import com.graphhopper.routing.util.TestAlgoCollector.AlgoHelperEntry;
@@ -614,13 +615,12 @@ public class RoutingAlgorithmWithOSMIT {
     }
 
     @Test
-    public void testMonacoParallel() throws IOException {
+    public void testMonacoParallel() {
         System.out.println("testMonacoParallel takes a bit time...");
         String graphFile = "target/monaco-gh";
         Helper.removeDir(new File(graphFile));
         final EncodingManager encodingManager = EncodingManager.create("car");
-        final GraphHopper hopper = new GraphHopperOSM().
-                forTesting().
+        final GraphHopper hopper = new GraphHopperOSMForTest().
                 setStoreOnFlush(true).
                 setEncodingManager(encodingManager).setCHEnabled(false).
                 setWayPointMaxDistance(0).

--- a/reader-osm/src/test/java/com/graphhopper/routing/RoutingAlgorithmWithOSMIT.java
+++ b/reader-osm/src/test/java/com/graphhopper/routing/RoutingAlgorithmWithOSMIT.java
@@ -552,6 +552,7 @@ public class RoutingAlgorithmWithOSMIT {
         try {
             Helper.removeDir(new File(graphFile));
             GraphHopper hopper = new GraphHopperOSM().
+                    setMinNetworkSize(200, 0).
                     setStoreOnFlush(true).
                     setCHEnabled(withCH).
                     setDataReaderFile(osmFile).
@@ -619,6 +620,7 @@ public class RoutingAlgorithmWithOSMIT {
         Helper.removeDir(new File(graphFile));
         final EncodingManager encodingManager = EncodingManager.create("car");
         final GraphHopper hopper = new GraphHopperOSM().
+                forTesting().
                 setStoreOnFlush(true).
                 setEncodingManager(encodingManager).setCHEnabled(false).
                 setWayPointMaxDistance(0).


### PR DESCRIPTION
We currently have  
```yml
  prepare.min_network_size: 200
  prepare.min_one_way_network_size: 200
```

in config-example.yml and so we need to make it consistent in the GraphHopper class too. Unfortunately many tests need a change as the do not expect the PrepareRoutingSubnetworks to kick in. To make it a bit convenient I introduced GraphHopper.forTesting, but I'm unsure if we should introduce this there or better create a GraphHopperOSMTest class with this method instead.