### PR TITLE
WIP: Add new `turn_costs=true/false` routing parameter

### DIFF
--- a/api/src/main/java/com/graphhopper/util/Parameters.java
+++ b/api/src/main/java/com/graphhopper/util/Parameters.java
@@ -92,6 +92,7 @@ public class Parameters {
      */
     public static final class Routing {
         public static final String EDGE_BASED = "edge_based";
+        public static final String TURN_COSTS = "turn_costs";
         public static final String U_TURN_COSTS = "u_turn_costs";
         public static final String MAX_VISITED_NODES = "max_visited_nodes";
         public static final String INIT_MAX_VISITED_NODES = ROUTING_INIT_PREFIX + "max_visited_nodes";

--- a/web-bundle/src/main/java/com/graphhopper/resources/RouteResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/RouteResource.java
@@ -122,6 +122,7 @@ public class RouteResource {
         }
 
         initHints(request.getHints(), uriInfo.getQueryParameters());
+        translateTurnCostsParamToEdgeBased(request, uriInfo.getQueryParameters());
         request.setVehicle(vehicleStr).
                 setWeighting(weighting).
                 setAlgorithm(algoStr).
@@ -160,6 +161,16 @@ public class RouteResource {
                     Response.ok(WebHelper.jsonObject(ghResponse, instructions, calcPoints, enableElevation, pointsEncoded, took)).
                             header("X-GH-Took", "" + Math.round(took * 1000)).
                             build();
+        }
+    }
+
+    private void translateTurnCostsParamToEdgeBased(GHRequest request, MultivaluedMap<String, String> queryParams) {
+        if (queryParams.containsKey(TURN_COSTS)) {
+            List<String> turnCosts = queryParams.get(TURN_COSTS);
+            if (turnCosts.size() != 1) {
+                throw new IllegalArgumentException("You may only specify the turn_costs parameter once");
+            }
+            request.getHints().put(EDGE_BASED, turnCosts.get(0));
         }
     }
 


### PR DESCRIPTION
This PR adds a new parameter `turn_costs=true/false`. This does the exact same as `edge_based=true/false` at the moment but is supposed to be more user-friendly (users who want to enable turn costs (or at least OSM turn restrictions) most likely do not know (and should not need to know) about the routing algorithm being edge-based.

This is basically the minimum change that adds this parameter, but I am not really happy with it, see #1725.