### PR TITLE
Fix sort corrupting graph

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -44,6 +44,7 @@ Here is an overview:
  * lmar, improved instructions
  * michaz, one of the core developers
  * mprins, improvements for travis CI and regarding JDK9 #806
+ * msb5014, improvements like #1733
  * NopMap, massive improvements regarding OSM, parsing and encoding, route relations
  * ocampana, initial implementation for instructions
  * PGWelch, shapefile reader #874

--- a/core/src/main/java/com/graphhopper/storage/BaseGraph.java
+++ b/core/src/main/java/com/graphhopper/storage/BaseGraph.java
@@ -478,16 +478,7 @@ class BaseGraph implements Graph {
      * @return the updated iterator the properties where copied to.
      */
     EdgeIteratorState copyProperties(EdgeIteratorState from, CommonEdgeIterator to) {
-        boolean reverse = from.get(REVERSE_STATE);
-        if (to.reverse)
-            reverse = !reverse;
-        // in case reverse is true we have to swap the nodes to store flags correctly in its "storage direction"
-        int nodeA = reverse ? to.getAdjNode() : to.getBaseNode();
-        int nodeB = reverse ? to.getBaseNode() : to.getAdjNode();
         long edgePointer = edgeAccess.toPointer(to.getEdge());
-        int linkA = reverse ? edgeAccess.getLinkB(edgePointer) : edgeAccess.getLinkA(edgePointer);
-        int linkB = reverse ? edgeAccess.getLinkA(edgePointer) : edgeAccess.getLinkB(edgePointer);
-        edgeAccess.writeEdge(to.getEdge(), nodeA, nodeB, linkA, linkB);
         edgeAccess.writeFlags(edgePointer, from.getFlags());
 
         // copy the rest with higher level API

--- a/core/src/main/java/com/graphhopper/storage/BaseGraph.java
+++ b/core/src/main/java/com/graphhopper/storage/BaseGraph.java
@@ -482,8 +482,8 @@ class BaseGraph implements Graph {
         if (to.reverse)
             reverse = !reverse;
         // in case reverse is true we have to swap the nodes to store flags correctly in its "storage direction"
-        int nodeA = reverse ? from.getAdjNode() : from.getBaseNode();
-        int nodeB = reverse ? from.getBaseNode() : from.getAdjNode();
+        int nodeA = reverse ? to.getAdjNode() : to.getBaseNode();
+        int nodeB = reverse ? to.getBaseNode() : to.getAdjNode();
         long edgePointer = edgeAccess.toPointer(to.getEdge());
         int linkA = reverse ? edgeAccess.getLinkB(edgePointer) : edgeAccess.getLinkA(edgePointer);
         int linkB = reverse ? edgeAccess.getLinkA(edgePointer) : edgeAccess.getLinkB(edgePointer);

--- a/core/src/test/java/com/graphhopper/util/GHUtilityTest.java
+++ b/core/src/test/java/com/graphhopper/util/GHUtilityTest.java
@@ -73,6 +73,9 @@ public class GHUtilityTest {
         DistanceCalc calc = new DistanceCalc2D();
         AllEdgesIterator iter = graph.getAllEdges();
         while (iter.next()) {
+            // This is meant to verify that all of the same edges (including tower nodes)
+            // are included in the copied graph. Can not use iter.getDistance() since it
+            // does not verify new geometry. See #1732
             distance += iter.fetchWayGeometry(3).calcDistance(calc);
         }
         return distance;

--- a/core/src/test/java/com/graphhopper/util/GHUtilityTest.java
+++ b/core/src/test/java/com/graphhopper/util/GHUtilityTest.java
@@ -19,6 +19,7 @@ package com.graphhopper.util;
 
 import com.graphhopper.coll.GHIntLongHashMap;
 import com.graphhopper.routing.profiles.BooleanEncodedValue;
+import com.graphhopper.routing.util.AllEdgesIterator;
 import com.graphhopper.routing.util.CarFlagEncoder;
 import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.routing.util.FlagEncoder;
@@ -67,6 +68,16 @@ public class GHUtilityTest {
         return g;
     }
 
+    double getLengthOfAllEdges(Graph graph) {
+        double distance = 0;
+        DistanceCalc calc = new DistanceCalc2D();
+        AllEdgesIterator iter = graph.getAllEdges();
+        while (iter.next()) {
+            distance += iter.fetchWayGeometry(3).calcDistance(calc);
+        }
+        return distance;
+    }
+
     @Test
     public void testSort() {
         Graph g = initUnsorted(createGraph());
@@ -80,6 +91,7 @@ public class GHUtilityTest {
         assertEquals(3.0, na.getLatitude(4), 1e-4); // 3
         assertEquals(5.0, na.getLatitude(5), 1e-4); // 7
         assertEquals(4.2, na.getLatitude(6), 1e-4); // 5
+        assertEquals(getLengthOfAllEdges(g), getLengthOfAllEdges(newG), 1e-4);
     }
 
     @Test


### PR DESCRIPTION
Fix #1732 by making `copyProperties` not copy over the node IDs from old to new edge. No tests fail if I just remove the the call to `writeEdge` entirely in that method, but I'm assuming the reverse handling needs to be in there for a reason.