### PR TITLE
Landmarks+QueryGraph bug

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/lm/PrepareLandmarks.java
+++ b/core/src/main/java/com/graphhopper/routing/lm/PrepareLandmarks.java
@@ -143,7 +143,7 @@ public class PrepareLandmarks extends AbstractAlgoPreparation {
 
             double epsilon = opts.getHints().getDouble(Parameters.Algorithms.AStar.EPSILON, 1);
             AStar astar = (AStar) algo;
-            astar.setApproximation(new LMApproximator(qGraph, this.graph.getNodes(), lms, activeLM, lms.getFactor(), false).
+            astar.setApproximation(new LMApproximator(qGraph, weighting, this.graph.getNodes(), lms, activeLM, lms.getFactor(), false).
                     setEpsilon(epsilon));
             return algo;
         } else if (algo instanceof AStarBidirection) {
@@ -152,7 +152,7 @@ public class PrepareLandmarks extends AbstractAlgoPreparation {
 
             double epsilon = opts.getHints().getDouble(Parameters.Algorithms.AStarBi.EPSILON, 1);
             AStarBidirection astarbi = (AStarBidirection) algo;
-            astarbi.setApproximation(new LMApproximator(qGraph, this.graph.getNodes(), lms, activeLM, lms.getFactor(), false).
+            astarbi.setApproximation(new LMApproximator(qGraph, weighting, this.graph.getNodes(), lms, activeLM, lms.getFactor(), false).
                     setEpsilon(epsilon));
             return algo;
         } else if (algo instanceof AlternativeRoute) {
@@ -161,7 +161,7 @@ public class PrepareLandmarks extends AbstractAlgoPreparation {
 
             double epsilon = opts.getHints().getDouble(Parameters.Algorithms.AStarBi.EPSILON, 1);
             AlternativeRoute altRoute = (AlternativeRoute) algo;
-            altRoute.setApproximation(new LMApproximator(qGraph, this.graph.getNodes(), lms, activeLM, lms.getFactor(), false).
+            altRoute.setApproximation(new LMApproximator(qGraph, weighting, this.graph.getNodes(), lms, activeLM, lms.getFactor(), false).
                     setEpsilon(epsilon));
             // landmark algorithm follows good compromise between fast response and exploring 'interesting' paths so we
             // can decrease this exploration factor further (1->dijkstra, 0.8->bidir. A*)

--- a/reader-osm/src/test/java/com/graphhopper/routing/RoutingAlgorithmWithOSMIT.java
+++ b/reader-osm/src/test/java/com/graphhopper/routing/RoutingAlgorithmWithOSMIT.java
@@ -324,20 +324,19 @@ public class RoutingAlgorithmWithOSMIT {
         assertEquals(testCollector.toString(), 0, testCollector.errors.size());
     }
 
-    // TODO fix later, see #1525, #1531
-//    @Test
-//    public void testLandmarkBug() {
-//        List<OneRun> list = new ArrayList<>();
-//        OneRun run = new OneRun();
-//        run.add(50.016923, 11.514187, 0, 0);
-//        run.add(50.019129, 11.500325, 0, 0);
-//        run.add(50.023623, 11.56929, 7069, 178);
-//        list.add(run);
-//
-//        runAlgo(testCollector, DIR + "/north-bayreuth.osm.gz", "target/north-bayreuth-gh",
-//                list, "bike", true, "bike", "fastest", false);
-//        assertEquals(testCollector.toString(), 0, testCollector.errors.size());
-//    }
+    @Test
+    public void testLandmarkBug() {
+        List<OneRun> list = new ArrayList<>();
+        OneRun run = new OneRun();
+        run.add(50.016923, 11.514187, 0, 0);
+        run.add(50.019129, 11.500325, 0, 0);
+        run.add(50.023623, 11.56929, 7069, 178);
+        list.add(run);
+
+        runAlgo(testCollector, DIR + "/north-bayreuth.osm.gz", "target/north-bayreuth-gh",
+                list, "bike", true, "bike", "fastest", false);
+        assertEquals(testCollector.toString(), 0, testCollector.errors.size());
+    }
 
     @Test
     public void testBug1014() {


### PR DESCRIPTION
I think this was all about finding the _closest_ non-virtual node to the destination node, i.e. with Dijkstra, instead of guessing. Actually, it's less code than the workaround.

Correcting for the edge length is not necessary for correctness, I think [citation needed]. And I'm sure it's not necessary for the _current_ node `v` (we can just return 0 if it's virtual*). If anything, something has to be done for the _destination_ node (`a` or `b`), but so far I don't see anything failing.

*) That shouldn't be a performance problem. It should just mean that the algorithm behaves like Dijkstra (approximation 0) until it has expanded the virtual edges around `a` and `b`, and when it finds virtual edges on the way, it should just "explode" into them before doing anything else. Seems safe.