### PR TITLE
destination support for car that doesn't modify the speed

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/CarFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/CarFlagEncoder.java
@@ -41,8 +41,6 @@ public class CarFlagEncoder extends AbstractFlagEncoder {
     // This value determines the maximal possible on roads with bad surfaces
     protected int badSurfaceSpeed;
 
-    // This value determines the speed for roads with access=destination
-    protected int destinationSpeed;
     protected boolean speedTwoDirections;
     /**
      * A map which associates string to speed. Get some impression:
@@ -143,7 +141,6 @@ public class CarFlagEncoder extends AbstractFlagEncoder {
 
         // limit speed on bad surfaces to 30 km/h
         badSurfaceSpeed = 30;
-        destinationSpeed = 5;
         maxPossibleSpeed = 140;
         speedDefault = defaultSpeedMap.get("secondary");
 
@@ -280,14 +277,6 @@ public class CarFlagEncoder extends AbstractFlagEncoder {
                 setSpeed(true, edgeFlags, ferrySpeed);
         }
 
-        for (String restriction : restrictions) {
-            if (way.hasTag(restriction, "destination")) {
-                // This is problematic as Speed != Time
-                setSpeed(false, edgeFlags, destinationSpeed);
-                if (speedTwoDirections)
-                    setSpeed(true, edgeFlags, destinationSpeed);
-            }
-        }
         return edgeFlags;
     }
 

--- a/core/src/main/java/com/graphhopper/routing/weighting/FastestWeighting.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/FastestWeighting.java
@@ -42,6 +42,7 @@ public class FastestWeighting extends AbstractWeighting {
     private final long headingPenaltyMillis;
     private final double maxSpeed;
     private EnumEncodedValue<RoadAccess> roadAccessEnc = null;
+    // this factor puts a penalty on roads with a "destination"-only access, see #733
     private double roadAccessPenalty;
 
     public FastestWeighting(FlagEncoder encoder, PMap map) {
@@ -51,7 +52,7 @@ public class FastestWeighting extends AbstractWeighting {
         maxSpeed = encoder.getMaxSpeed() / SPEED_CONV;
 
         if (encoder.hasEncodedValue(RoadAccess.KEY)) {
-            // ensure that we do not need to change getMinWeight, i.e. road_access_delay is actual a penalty
+            // ensure that we do not need to change getMinWeight, i.e. road_access_factor >= 1
             roadAccessPenalty = checkBounds("road_access_factor", map.getDouble("road_access_factor", 10), 1, 10);
             roadAccessEnc = encoder.getEnumEncodedValue(RoadAccess.KEY, RoadAccess.class);
         }

--- a/core/src/main/java/com/graphhopper/routing/weighting/FastestWeighting.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/FastestWeighting.java
@@ -17,6 +17,8 @@
  */
 package com.graphhopper.routing.weighting;
 
+import com.graphhopper.routing.profiles.EnumEncodedValue;
+import com.graphhopper.routing.profiles.RoadAccess;
 import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.routing.util.HintsMap;
 import com.graphhopper.util.EdgeIteratorState;
@@ -39,12 +41,20 @@ public class FastestWeighting extends AbstractWeighting {
     private final double headingPenalty;
     private final long headingPenaltyMillis;
     private final double maxSpeed;
+    private EnumEncodedValue<RoadAccess> roadAccessEnc = null;
+    private double roadAccessPenalty;
 
     public FastestWeighting(FlagEncoder encoder, PMap map) {
         super(encoder);
         headingPenalty = map.getDouble(Routing.HEADING_PENALTY, Routing.DEFAULT_HEADING_PENALTY);
         headingPenaltyMillis = Math.round(headingPenalty * 1000);
         maxSpeed = encoder.getMaxSpeed() / SPEED_CONV;
+
+        if (encoder.hasEncodedValue(RoadAccess.KEY)) {
+            // ensure that we do not need to change getMinWeight, i.e. road_access_delay is actual a penalty
+            roadAccessPenalty = checkBounds("road_access_factor", map.getDouble("road_access_factor", 10), 1, 10);
+            roadAccessEnc = encoder.getEnumEncodedValue(RoadAccess.KEY, RoadAccess.class);
+        }
     }
 
     public FastestWeighting(FlagEncoder encoder) {
@@ -64,6 +74,9 @@ public class FastestWeighting extends AbstractWeighting {
 
         double time = edge.getDistance() / speed * SPEED_CONV;
 
+        if (roadAccessEnc != null && edge.get(roadAccessEnc) == RoadAccess.DESTINATION)
+            time *= roadAccessPenalty;
+
         // add direction penalties at start/stop/via points
         boolean unfavoredEdge = edge.get(EdgeIteratorState.UNFAVORED_EDGE);
         if (unfavoredEdge)
@@ -81,6 +94,13 @@ public class FastestWeighting extends AbstractWeighting {
             time += headingPenaltyMillis;
 
         return time + super.calcMillis(edgeState, reverse, prevOrNextEdgeId);
+    }
+
+    static double checkBounds(String key, double val, double from, double to) {
+        if (val < from || val > to)
+            throw new IllegalArgumentException(key + " has invalid range should be within [" + from + ", " + to + "]");
+
+        return val;
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/weighting/ShortFastestWeighting.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/ShortFastestWeighting.java
@@ -37,11 +37,10 @@ public class ShortFastestWeighting extends FastestWeighting {
 
     public ShortFastestWeighting(FlagEncoder encoder, PMap map) {
         super(encoder);
-        timeFactor = checkBounds(TIME_FACTOR, map.getDouble(TIME_FACTOR, 1));
+        timeFactor = checkBounds(TIME_FACTOR, map.getDouble(TIME_FACTOR, 1), 0, 10);
 
-        // is it faster to include timeFactor via distanceFactor = tmp / timeFactor?
         // default value derived from the cost for time e.g. 25€/hour and for distance 0.5€/km
-        distanceFactor = checkBounds(DISTANCE_FACTOR, map.getDouble(DISTANCE_FACTOR, 0.07));
+        distanceFactor = checkBounds(DISTANCE_FACTOR, map.getDouble(DISTANCE_FACTOR, 0.07), 0, 10);
 
         if (timeFactor < 1e-5 && distanceFactor < 1e-5)
             throw new IllegalArgumentException("[" + NAME + "] one of distance_factor or time_factor has to be non-zero");
@@ -49,7 +48,7 @@ public class ShortFastestWeighting extends FastestWeighting {
 
     public ShortFastestWeighting(FlagEncoder encoder, double distanceFactor) {
         super(encoder);
-        this.distanceFactor = checkBounds(DISTANCE_FACTOR, distanceFactor);
+        this.distanceFactor = checkBounds(DISTANCE_FACTOR, distanceFactor, 0, 10);
         this.timeFactor = 1;
     }
 
@@ -67,12 +66,5 @@ public class ShortFastestWeighting extends FastestWeighting {
     @Override
     public String getName() {
         return NAME;
-    }
-
-    private double checkBounds(String key, double val) {
-        if (val < 0 || val > 10)
-            throw new IllegalArgumentException(key + " has invalid range should be within [0, 10]");
-
-        return val;
     }
 }


### PR DESCRIPTION
fixes #733

Basically it moves the priorityEncoder to the CarFlagEncoder and fills it with bad priority if e.g. `vehicle` or `motor_vehicle` tag is `destination`