### PR TITLE
Add snap prevention option: pedestrian_area

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/profiles/RoadEnvironment.java
+++ b/core/src/main/java/com/graphhopper/routing/profiles/RoadEnvironment.java
@@ -25,7 +25,8 @@ import com.graphhopper.util.Helper;
  */
 public enum RoadEnvironment {
     OTHER("other"), ROAD("road"), FERRY("ferry"),
-    TUNNEL("tunnel"), BRIDGE("bridge"), FORD("ford"), SHUTTLE_TRAIN("shuttle_train");
+    TUNNEL("tunnel"), BRIDGE("bridge"), FORD("ford"), SHUTTLE_TRAIN("shuttle_train"),
+    PEDESTRIAN_AREA("pedestrian_area");
 
     public static final String KEY = "road_environment";
 

--- a/core/src/main/java/com/graphhopper/routing/util/SnapPreventionEdgeFilter.java
+++ b/core/src/main/java/com/graphhopper/routing/util/SnapPreventionEdgeFilter.java
@@ -18,7 +18,7 @@ public class SnapPreventionEdgeFilter implements EdgeFilter {
     private final EnumEncodedValue<RoadClass> rcEnc;
     private final EdgeFilter filter;
     private boolean avoidMotorway = false, avoidTrunk;
-    private boolean avoidTunnel, avoidBridge, avoidFerry, avoidFord;
+    private boolean avoidTunnel, avoidBridge, avoidFerry, avoidFord, avoidPedestrianArea;
 
     public SnapPreventionEdgeFilter(EdgeFilter filter, EnumEncodedValue<RoadClass> rcEnc,
                                     EnumEncodedValue<RoadEnvironment> reEnc, List<String> snapPreventions) {
@@ -44,6 +44,8 @@ public class SnapPreventionEdgeFilter implements EdgeFilter {
                 avoidFerry = true;
             else if (rc == FORD)
                 avoidFord = true;
+            else if (rc == PEDESTRIAN_AREA)
+                avoidPedestrianArea = true;
             else
                 throw new IllegalArgumentException("Cannot find " + Parameters.Routing.SNAP_PREVENTION + ": " + roadClassOrRoadEnv);
         }
@@ -57,6 +59,7 @@ public class SnapPreventionEdgeFilter implements EdgeFilter {
                 && !(avoidTunnel && edgeState.get(reEnc) == TUNNEL)
                 && !(avoidBridge && edgeState.get(reEnc) == BRIDGE)
                 && !(avoidFord && edgeState.get(reEnc) == FORD)
-                && !(avoidFerry && edgeState.get(reEnc) == FERRY);
+                && !(avoidFerry && edgeState.get(reEnc) == FERRY)
+                && !(avoidPedestrianArea && edgeState.get(reEnc) == PEDESTRIAN_AREA);
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMRoadEnvironmentParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMRoadEnvironmentParser.java
@@ -56,6 +56,8 @@ public class OSMRoadEnvironmentParser implements TagParser {
         else if (readerWay.hasTag("route", "shuttle_train"))
             // TODO how to feed this information from a relation like https://www.openstreetmap.org/relation/1932780
             roadEnvironment = SHUTTLE_TRAIN;
+        else if (readerWay.hasTag("highway", "pedestrian") && readerWay.hasTag("area", "yes"))
+            roadEnvironment = PEDESTRIAN_AREA;
         else if (readerWay.hasTag("highway"))
             roadEnvironment = ROAD;
 


### PR DESCRIPTION
In order to avoid snapping to the "wrong side" of a long pedestrian area.
The typical pedestrian area (`highway=pedestrian, area=true`) that causes
problems is a long coastal esplanade: There are several connecting edges
from the land side, but none from the water side. If we snap to the water
side of the esplanade, the route will trackaround  the edges of the area
before getting to the connecting land side edges. This results in routes
that are way too long (a route that should be a few meters can become
several kilometers).

One example of such esplanade is Norra Hammarbyhamnen, Stockholm, Sweden.