### PR TITLE
Mention how main.js is build without fetching it from pre-build JAR files

### DIFF
--- a/docs/core/quickstart-from-source.md
+++ b/docs/core/quickstart-from-source.md
@@ -15,8 +15,12 @@ Then do:
 ```bash
 git clone git://github.com/graphhopper/graphhopper.git
 cd graphhopper; git checkout 0.13
-# fetches main.js, can be omitted if no UI is needed
+# Build main.js. This can be omitted if no UI is needed.
+# If you have a working JavaScript development environment, you can build main.js yourself:
+cd web && npm install && npm run bundleProduction && cd ..
+# Otherwiese you can extract it from published JAR files:
 cd web/src/main/resources/ && ZFILE=/tmp/gh.jar && wget -O $ZFILE "https://repository.sonatype.org/service/local/artifact/maven/redirect?r=central-proxy&g=com.graphhopper&a=graphhopper-web&v=LATEST" && unzip $ZFILE assets/js/main.js && rm $ZFILE && cd ../../../..
+# Build JAR file from source, download an OSM data extract, build the routing graph and start the web service:
 ./graphhopper.sh -a web -i europe_germany_berlin.pbf
 # now go to http://localhost:8989/ and you should see something similar to GraphHopper Maps: https://graphhopper.com/maps/
 ```


### PR DESCRIPTION
#1641 removed the artifact called `main.js` from the Git repository which is good. However, I think that just mentioning that it can be extracted from pre-build JAR files is not optimal. If a project is open source, it should explain to how it is build and not say "download build artefact from $location".

After an upgrade of my development environment to 0.13 and building it, I was confused why the web frontend did not work any more. It took me a moment to figure out how to call npm from the Docker and Travis configuration (I basically run `git log -p -- web/src/main/resources/assets/js/main.js` to find the pull request). I don't see why building the project fully from the sources should be hidden.