### PR TITLE
Select appropriate CH profile when no weighting or vehicle is given

### DIFF
--- a/api/src/main/java/com/graphhopper/util/PMap.java
+++ b/api/src/main/java/com/graphhopper/util/PMap.java
@@ -17,7 +17,7 @@
  */
 package com.graphhopper.util;
 
-import java.util.LinkedHashMap;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -34,22 +34,20 @@ public class PMap {
     }
 
     public PMap(int capacity) {
-        // use linked hash map for predictable order
-        this(new LinkedHashMap<>(capacity));
+        this(new HashMap<>(capacity));
     }
 
     public PMap(Map<String, String> map) {
-        // use linked hash map for predictable order
-        this.map = new LinkedHashMap<>(map);
+        this.map = new HashMap<>(map);
     }
 
     public PMap(PMap map) {
-        this(map.map);
+        this.map = new HashMap<>(map.map);
     }
 
     public PMap(String propertiesString) {
         // five chosen as arbitrary initial capacity
-        this(5);
+        this.map = new HashMap<>(5);
 
         for (String s : propertiesString.split("\\|")) {
             s = s.trim();
@@ -165,7 +163,7 @@ public class PMap {
      * This method copies the underlying structure into a new Map object
      */
     public Map<String, String> toMap() {
-        return new LinkedHashMap<>(map);
+        return new HashMap<>(map);
     }
 
     private Map<String, String> getMap() {

--- a/api/src/main/java/com/graphhopper/util/PMap.java
+++ b/api/src/main/java/com/graphhopper/util/PMap.java
@@ -17,7 +17,7 @@
  */
 package com.graphhopper.util;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -34,20 +34,22 @@ public class PMap {
     }
 
     public PMap(int capacity) {
-        this(new HashMap<>(capacity));
+        // use linked hash map for predictable order
+        this(new LinkedHashMap<>(capacity));
     }
 
     public PMap(Map<String, String> map) {
-        this.map = new HashMap<>(map);
+        // use linked hash map for predictable order
+        this.map = new LinkedHashMap<>(map);
     }
 
     public PMap(PMap map) {
-        this.map = new HashMap<>(map.map);
+        this(map.map);
     }
 
     public PMap(String propertiesString) {
         // five chosen as arbitrary initial capacity
-        this.map = new HashMap<>(5);
+        this(5);
 
         for (String s : propertiesString.split("\\|")) {
             s = s.trim();
@@ -163,7 +165,7 @@ public class PMap {
      * This method copies the underlying structure into a new Map object
      */
     public Map<String, String> toMap() {
-        return new HashMap<>(map);
+        return new LinkedHashMap<>(map);
     }
 
     private Map<String, String> getMap() {

--- a/core/src/main/java/com/graphhopper/routing/ch/CHProfileSelector.java
+++ b/core/src/main/java/com/graphhopper/routing/ch/CHProfileSelector.java
@@ -18,13 +18,12 @@
 
 package com.graphhopper.routing.ch;
 
-import com.carrotsearch.hppc.IntObjectHashMap;
-import com.carrotsearch.hppc.IntObjectMap;
 import com.graphhopper.routing.util.HintsMap;
 import com.graphhopper.storage.CHProfile;
 import com.graphhopper.util.Parameters;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
 
 import static com.graphhopper.routing.weighting.TurnWeighting.INFINITE_U_TURN_COSTS;
 
@@ -33,15 +32,18 @@ import static com.graphhopper.routing.weighting.TurnWeighting.INFINITE_U_TURN_CO
  */
 public class CHProfileSelector {
     private final List<CHProfile> chProfiles;
-    private final HintsMap hintsMap;
-    private IntObjectMap<CHProfile> edgeBasedCHProfilesByUTurnCosts;
-    private CHProfile nodeBasedCHProfile;
-    private List<String> entriesStrs;
+    // variables describing the requested CH profile
+    private final String weighting;
+    private final String vehicle;
+    private final Boolean edgeBased;
+    private final Integer uTurnCosts;
 
     private CHProfileSelector(List<CHProfile> chProfiles, HintsMap hintsMap) {
         this.chProfiles = chProfiles;
-        // do not modify the outer object
-        this.hintsMap = new HintsMap(hintsMap);
+        weighting = hintsMap.getWeighting();
+        vehicle = hintsMap.getVehicle();
+        edgeBased = hintsMap.has(Parameters.Routing.EDGE_BASED) ? hintsMap.getBool(Parameters.Routing.EDGE_BASED, false) : null;
+        uTurnCosts = hintsMap.has(Parameters.Routing.U_TURN_COSTS) ? hintsMap.getInt(Parameters.Routing.U_TURN_COSTS, INFINITE_U_TURN_COSTS) : null;
     }
 
     /**
@@ -54,175 +56,60 @@ public class CHProfileSelector {
     }
 
     private CHProfile select() {
-        final Boolean edgeBased = hintsMap.has(Parameters.Routing.EDGE_BASED) ? hintsMap.getBool(Parameters.Routing.EDGE_BASED, false) : null;
-        final Integer uTurnCosts = hintsMap.has(Parameters.Routing.U_TURN_COSTS) ? hintsMap.getInt(Parameters.Routing.U_TURN_COSTS, INFINITE_U_TURN_COSTS) : null;
 
-        Set<String> availableWeightings = getAvailableWeightings(edgeBased);
-        if (hintsMap.getWeighting().isEmpty() && availableWeightings.size() > 1) {
-            throwFieldNotGivenAndMultiplePossibilities(edgeBased, "weighting", availableWeightings);
-        }
-
-        Set<String> availableVehicles = getAvailableVehicles(edgeBased);
-        if (hintsMap.getVehicle().isEmpty() && availableVehicles.size() > 1) {
-            throwFieldNotGivenAndMultiplePossibilities(edgeBased, "vehicle", availableVehicles);
-        }
-
-        String weighting = (hintsMap.getWeighting().isEmpty() && !availableWeightings.isEmpty()) ? availableWeightings.iterator().next() : hintsMap.getWeighting();
-        String vehicle = (hintsMap.getVehicle().isEmpty() && !availableVehicles.isEmpty()) ? availableVehicles.iterator().next() : hintsMap.getVehicle();
-        findProfilesWithMatchingVehicleAndWeighting(weighting, vehicle);
-
-        if (!foundCHProfilesMatchingWeighting()) {
-            throw new CHProfileSelectionException("Cannot find CH profile for hints map " + hintsMap + " in entries: " + entriesStrs + ".");
-        }
-
-        if (edgeBased != null && uTurnCosts != null) {
-            return selectUsingEdgeBasedAndUTurnCosts(edgeBased, uTurnCosts);
-        } else if (edgeBased != null) {
-            return selectUsingEdgeBased(edgeBased);
-        } else if (uTurnCosts != null) {
-            return selectUsingUTurnCosts(uTurnCosts);
-        } else {
-            return selectUsingWeightingOnly();
-        }
-    }
-
-    private CHProfile selectUsingEdgeBasedAndUTurnCosts(boolean edgeBased, int uTurnCosts) {
-        if (edgeBased) {
-            CHProfile edgeBasedCHProfile = edgeBasedCHProfilesByUTurnCosts.get(uTurnCosts);
-            if (edgeBasedCHProfile != null) {
-                return edgeBasedCHProfile;
-            } else if (!edgeBasedCHProfilesByUTurnCosts.isEmpty()) {
-                return throwFoundEdgeBasedButNotForRequestedUTurnCosts(uTurnCosts);
-            } else {
-                return throwRequestedEdgeBasedButOnlyFoundNodeBased();
-            }
-        } else {
-            if (nodeBasedCHProfile != null) {
-                return nodeBasedCHProfile;
-            } else {
-                return throwRequestedNodeBasedButOnlyFoundEdgeBased();
-            }
-        }
-    }
-
-    private CHProfile selectUsingEdgeBased(boolean edgeBased) {
-        if (edgeBased) {
-            // u-turn costs were not specified, so either there is only one edge-based profile and we take it
-            // or we throw an error
-            if (edgeBasedCHProfilesByUTurnCosts.size() == 1) {
-                return edgeBasedCHProfilesByUTurnCosts.iterator().next().value;
-            } else if (edgeBasedCHProfilesByUTurnCosts.isEmpty()) {
-                return throwRequestedEdgeBasedButOnlyFoundNodeBased();
-            } else {
-                return throwFoundEdgeBasedButUnclearWhichOneToTake();
-            }
-        } else {
-            if (nodeBasedCHProfile != null) {
-                return nodeBasedCHProfile;
-            } else {
-                return throwRequestedNodeBasedButOnlyFoundEdgeBased();
-            }
-        }
-    }
-
-    private CHProfile selectUsingUTurnCosts(int uTurnCosts) {
-        // no edge_based parameter was set, we determine the CH profile based on what is there (and prefer edge-based
-        // if we can choose)
-        CHProfile edgeBasedPCH = edgeBasedCHProfilesByUTurnCosts.get(uTurnCosts);
-        if (edgeBasedPCH != null) {
-            return edgeBasedPCH;
-        } else if (!edgeBasedCHProfilesByUTurnCosts.isEmpty()) {
-            return throwFoundEdgeBasedButNotForRequestedUTurnCosts(uTurnCosts);
-        } else {
-            return nodeBasedCHProfile;
-        }
-    }
-
-    private CHProfile selectUsingWeightingOnly() {
-        if (edgeBasedCHProfilesByUTurnCosts.size() == 1) {
-            return edgeBasedCHProfilesByUTurnCosts.iterator().next().value;
-        } else if (!edgeBasedCHProfilesByUTurnCosts.isEmpty()) {
-            return throwFoundEdgeBasedButUnclearWhichOneToTake();
-        } else {
-            return nodeBasedCHProfile;
-        }
-    }
-
-    private void findProfilesWithMatchingVehicleAndWeighting(String weighting, String vehicle) {
-        entriesStrs = new ArrayList<>();
-        edgeBasedCHProfilesByUTurnCosts = new IntObjectHashMap<>(3);
-        nodeBasedCHProfile = null;
-        for (CHProfile p : chProfiles) {
-            boolean weightingMatches =
-                    p.getWeighting().getName().equals(weighting) &&
-                            p.getWeighting().getFlagEncoder().toString().equals(vehicle);
-            if (weightingMatches) {
-                if (p.isEdgeBased()) {
-                    edgeBasedCHProfilesByUTurnCosts.put(p.getUTurnCostsInt(), p);
-                } else {
-                    nodeBasedCHProfile = p;
-                }
-            }
-            entriesStrs.add(p.toString());
-        }
-    }
-
-    private Set<String> getAvailableVehicles(Boolean edgeBased) {
-        Set<String> result = new LinkedHashSet<>();
+        List<CHProfile> matchingProfiles = new ArrayList<>();
         for (CHProfile p : chProfiles) {
             if (edgeBased != null && p.isEdgeBased() != edgeBased) {
                 continue;
             }
-            result.add(p.getWeighting().getFlagEncoder().toString());
-        }
-        return result;
-    }
-
-    private Set<String> getAvailableWeightings(Boolean edgeBased) {
-        Set<String> result = new LinkedHashSet<>();
-        for (CHProfile profile : chProfiles) {
-            if (edgeBased != null && profile.isEdgeBased() != edgeBased) {
+            if (uTurnCosts != null && p.getUTurnCostsInt() != uTurnCosts) {
                 continue;
             }
-            result.add(profile.getWeighting().getName());
+            if (!weighting.isEmpty() && !getWeighting(p).equals(weighting)) {
+                continue;
+            }
+            if (!vehicle.isEmpty() && !getVehicle(p).equals(vehicle)) {
+                continue;
+            }
+            matchingProfiles.add(p);
         }
-        return result;
+
+        if (matchingProfiles.isEmpty()) {
+            throw new CHProfileSelectionException("Cannot find matching CH profile for your request.\nrequested:  " + getRequestAsString() + "\navailable: " + chProfiles);
+        } else if (matchingProfiles.size() == 1) {
+            return matchingProfiles.get(0);
+        } else {
+            // special case: prefer edge-based over node-based if these are the only two options
+            CHProfile match1 = matchingProfiles.get(0);
+            CHProfile match2 = matchingProfiles.get(1);
+            if (edgeBased == null && matchingProfiles.size() == 2 &&
+                    getWeighting(match1).equals(getWeighting(match2)) &&
+                    getVehicle(match1).equals(getVehicle(match2)) &&
+                    match1.isEdgeBased() != match2.isEdgeBased()) {
+                return match1.isEdgeBased() ? match1 : match2;
+            }
+            throw new CHProfileSelectionException("There are multiple CH profiles matching your request. Use the `weighting`,`vehicle`,`edge_based` and/or `u_turn_costs` parameters to be more specific." +
+                    "\nrequested:  " + getRequestAsString() + "\nmatched:   " + matchingProfiles + "\navailable: " + chProfiles);
+        }
     }
 
-    private boolean foundCHProfilesMatchingWeighting() {
-        return !edgeBasedCHProfilesByUTurnCosts.isEmpty() || nodeBasedCHProfile != null;
+    private String getVehicle(CHProfile match1) {
+        return match1.getWeighting().getFlagEncoder().toString();
     }
 
-    private void throwFieldNotGivenAndMultiplePossibilities(Boolean edgeBased, String field, Set<String> available) {
-        throw new CHProfileSelectionException("Found CH profiles for multiple " + field + "s: " + available +
-                ((edgeBased != null ? (" for edge_based=" + edgeBased) : "")) +
-                ", but the request did not specify a " + field + " (requested hints map: " + hintsMap + ").");
+    private String getWeighting(CHProfile match1) {
+        return match1.getWeighting().getName();
     }
 
-    private CHProfile throwFoundEdgeBasedButUnclearWhichOneToTake() {
-        int[] availableUTurnCosts = edgeBasedCHProfilesByUTurnCosts.keys().toArray();
-        Arrays.sort(availableUTurnCosts);
-        throw new CHProfileSelectionException("Found matching edge-based CH profiles for multiple values of u-turn costs: " + Arrays.toString(availableUTurnCosts) +
-                ". You need to specify which one to use using the `" + Parameters.Routing.U_TURN_COSTS + "' parameter");
-    }
-
-    private CHProfile throwRequestedNodeBasedButOnlyFoundEdgeBased() {
-        throw new CHProfileSelectionException("Found " + edgeBasedCHProfilesByUTurnCosts.size() + " edge-based CH profile(s) for hints map " + hintsMap
-                + ", but requested node-based CH. You either need to configure a node-based CH profile or set the '" + Parameters.Routing.EDGE_BASED + "' " +
-                "request parameter to 'true' (was 'false'). all entries: " + entriesStrs);
-    }
-
-    private CHProfile throwRequestedEdgeBasedButOnlyFoundNodeBased() {
-        throw new CHProfileSelectionException("Found a node-based CH profile for hints map " + hintsMap + ", but requested edge-based CH. " +
-                "You either need to configure an edge-based CH profile or set the '" + Parameters.Routing.EDGE_BASED + "' " +
-                "request parameter to 'false' (was 'true'). all entries: " + entriesStrs);
-    }
-
-    private CHProfile throwFoundEdgeBasedButNotForRequestedUTurnCosts(int uTurnCosts) {
-        int[] availableUTurnCosts = edgeBasedCHProfilesByUTurnCosts.keys().toArray();
-        Arrays.sort(availableUTurnCosts);
-        throw new CHProfileSelectionException("Found edge-based CH profiles for hints map " + hintsMap + " but none for requested u-turn costs: " +
-                uTurnCosts + ", available: " + Arrays.toString(availableUTurnCosts) + ". You need to configure an edge-based CH profile for this value of u-turn costs or" +
-                " choose another value using the '" + Parameters.Routing.U_TURN_COSTS + "' request parameter.");
+    private String getRequestAsString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(weighting.isEmpty() ? "*" : weighting);
+        sb.append("|");
+        sb.append(vehicle.isEmpty() ? "*" : vehicle);
+        sb.append("|");
+        sb.append("edge_based=").append(edgeBased != null ? edgeBased : "*");
+        sb.append("|");
+        sb.append("u_turn_costs=").append(uTurnCosts != null ? uTurnCosts : "*");
+        return sb.toString();
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/lm/LMAlgoFactoryDecorator.java
+++ b/core/src/main/java/com/graphhopper/routing/lm/LMAlgoFactoryDecorator.java
@@ -229,6 +229,11 @@ public class LMAlgoFactoryDecorator implements RoutingAlgorithmFactoryDecorator 
         if (preparations.isEmpty())
             throw new IllegalStateException("No preparations added to this decorator");
 
+        // if no weighting or vehicle is specified for this request and there is only one preparation, use it
+        if ((map.getWeighting().isEmpty() || map.getVehicle().isEmpty()) && preparations.size() == 1) {
+            return new LMRAFactory(preparations.get(0), defaultAlgoFactory);
+        }
+
         for (final PrepareLandmarks p : preparations) {
             if (p.getWeighting().matches(map))
                 return new LMRAFactory(p, defaultAlgoFactory);

--- a/core/src/test/java/com/graphhopper/routing/ch/CHProfileSelectorTest.java
+++ b/core/src/test/java/com/graphhopper/routing/ch/CHProfileSelectorTest.java
@@ -18,15 +18,17 @@
 
 package com.graphhopper.routing.ch;
 
-import com.graphhopper.routing.util.EncodingManager;
-import com.graphhopper.routing.util.FlagEncoder;
-import com.graphhopper.routing.util.HintsMap;
+import com.graphhopper.routing.util.*;
 import com.graphhopper.routing.weighting.FastestWeighting;
+import com.graphhopper.routing.weighting.ShortFastestWeighting;
+import com.graphhopper.routing.weighting.ShortestWeighting;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.CHProfile;
+import com.graphhopper.util.Parameters;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -36,36 +38,43 @@ import static org.junit.Assert.*;
 
 public class CHProfileSelectorTest {
 
-    private Weighting fastestWeighting;
+    private Weighting weightingFastestCar;
+    private Weighting weightingFastestBike;
+    private Weighting weightingShortestCar;
+    private Weighting weightingShortestBike;
 
     @Before
     public void setup() {
-        EncodingManager em = EncodingManager.create("car");
-        FlagEncoder carEncoder = em.fetchEdgeEncoders().iterator().next();
-        fastestWeighting = new FastestWeighting(carEncoder);
+        FlagEncoder carEncoder = new CarFlagEncoder();
+        FlagEncoder bikeEncoder = new BikeFlagEncoder();
+        EncodingManager.create(carEncoder, bikeEncoder);
+        weightingFastestCar = new FastestWeighting(carEncoder);
+        weightingFastestBike = new FastestWeighting(bikeEncoder);
+        weightingShortestCar = new ShortestWeighting(carEncoder);
+        weightingShortestBike = new ShortestWeighting(bikeEncoder);
     }
 
     @Test
     public void onlyNodeBasedPresent() {
         List<CHProfile> chProfiles = Collections.singletonList(
-                CHProfile.nodeBased(fastestWeighting)
+                CHProfile.nodeBased(weightingFastestCar)
         );
-        assertCHProfileSelectionError("Found a node-based CH profile for weighting map {weighting=fastest, vehicle=car}, but requested edge-based CH", chProfiles, true, null);
-        assertCHProfileSelectionError("Found a node-based CH profile for weighting map {weighting=fastest, vehicle=car}, but requested edge-based CH", chProfiles, true, 20);
+        assertCHProfileSelectionError("Found a node-based CH profile for hints map {weighting=fastest, vehicle=car, edge_based=true}, but requested edge-based CH", chProfiles, true, null);
+        assertCHProfileSelectionError("Found a node-based CH profile for hints map {weighting=fastest, vehicle=car, edge_based=true, u_turn_costs=20}, but requested edge-based CH", chProfiles, true, 20);
         assertProfileFound(chProfiles.get(0), chProfiles, false, null);
         assertProfileFound(chProfiles.get(0), chProfiles, false, 20);
         assertProfileFound(chProfiles.get(0), chProfiles, null, null);
         assertProfileFound(chProfiles.get(0), chProfiles, null, 30);
-        assertCHProfileSelectionError("Cannot find CH profile for weighting map", chProfiles, "foot", "fastest", false, null);
+        assertCHProfileSelectionError("Cannot find CH profile for hints map", chProfiles, "foot", "fastest", false, null);
     }
 
     @Test
     public void onlyEdgeBasedPresent() {
         List<CHProfile> chProfiles = Collections.singletonList(
-                CHProfile.edgeBased(fastestWeighting, INFINITE_U_TURN_COSTS)
+                CHProfile.edgeBased(weightingFastestCar, INFINITE_U_TURN_COSTS)
         );
-        assertCHProfileSelectionError("Found 1 edge-based CH profile(s) for weighting map {weighting=fastest, vehicle=car}, but requested node-based CH", chProfiles, false, null);
-        assertCHProfileSelectionError("Found 1 edge-based CH profile(s) for weighting map {weighting=fastest, vehicle=car}, but requested node-based CH", chProfiles, false, 20);
+        assertCHProfileSelectionError("Found 1 edge-based CH profile(s) for hints map {weighting=fastest, vehicle=car, edge_based=false}, but requested node-based CH", chProfiles, false, null);
+        assertCHProfileSelectionError("Found 1 edge-based CH profile(s) for hints map {weighting=fastest, vehicle=car, edge_based=false, u_turn_costs=20}, but requested node-based CH", chProfiles, false, 20);
         assertProfileFound(chProfiles.get(0), chProfiles, true, null);
         assertProfileFound(chProfiles.get(0), chProfiles, null, null);
     }
@@ -73,8 +82,8 @@ public class CHProfileSelectorTest {
     @Test
     public void edgeAndNodePresent() {
         List<CHProfile> chProfiles = Arrays.asList(
-                CHProfile.nodeBased(fastestWeighting),
-                CHProfile.edgeBased(fastestWeighting, INFINITE_U_TURN_COSTS)
+                CHProfile.nodeBased(weightingFastestCar),
+                CHProfile.edgeBased(weightingFastestCar, INFINITE_U_TURN_COSTS)
         );
         // in case edge-based is not specified we prefer the edge-based profile over the node-based one
         assertProfileFound(chProfiles.get(1), chProfiles, null, null);
@@ -85,9 +94,9 @@ public class CHProfileSelectorTest {
     @Test
     public void multipleEdgeBased() {
         List<CHProfile> chProfiles = Arrays.asList(
-                CHProfile.nodeBased(fastestWeighting),
-                CHProfile.edgeBased(fastestWeighting, 30),
-                CHProfile.edgeBased(fastestWeighting, 50)
+                CHProfile.nodeBased(weightingFastestCar),
+                CHProfile.edgeBased(weightingFastestCar, 30),
+                CHProfile.edgeBased(weightingFastestCar, 50)
         );
         // when no u-turns are specified we throw
         assertCHProfileSelectionError("Found matching edge-based CH profiles for multiple values of u-turn costs: [30, 50].",
@@ -99,8 +108,98 @@ public class CHProfileSelectorTest {
 
         // without specifying edge-based
         assertProfileFound(chProfiles.get(1), chProfiles, null, 30);
-        assertCHProfileSelectionError("but none for requested u-turn costs: 40, available: [30, 50", chProfiles, null, 40);
+        assertCHProfileSelectionError("but none for requested u-turn costs: 40, available: [30, 50]", chProfiles, null, 40);
         assertCHProfileSelectionError("Found matching edge-based CH profiles for multiple values of u-turn costs: [30, 50].", chProfiles, null, null);
+    }
+
+    @Test
+    public void missingVehicleOrWeighting() {
+        // when we do not set the weighting and/or the car but it can be derived from the profile the profile is returned
+        List<CHProfile> chProfiles = Collections.singletonList(CHProfile.nodeBased(weightingFastestCar));
+        assertProfileFound(chProfiles.get(0), chProfiles, "car", "fastest", null, null);
+        assertProfileFound(chProfiles.get(0), chProfiles, "car", "", null, null);
+        assertProfileFound(chProfiles.get(0), chProfiles, "", "fastest", null, null);
+        assertProfileFound(chProfiles.get(0), chProfiles, "", "", null, null);
+    }
+
+    @Test
+    public void missingVehicleOrWeighting_otherVehicleAndCar() {
+        List<CHProfile> chProfiles = Collections.singletonList(CHProfile.nodeBased(weightingShortestBike));
+        assertProfileFound(chProfiles.get(0), chProfiles, "bike", "shortest", null, null);
+        assertProfileFound(chProfiles.get(0), chProfiles, "bike", "", null, null);
+        assertProfileFound(chProfiles.get(0), chProfiles, "", "shortest", null, null);
+        assertProfileFound(chProfiles.get(0), chProfiles, "", "", null, null);
+    }
+
+
+    @Test
+    public void missingVehicleMultipleProfiles() {
+        List<CHProfile> chProfiles = Arrays.asList(
+                CHProfile.nodeBased(weightingFastestBike),
+                CHProfile.nodeBased(weightingShortestBike),
+                CHProfile.edgeBased(weightingFastestBike, 40)
+        );
+        // the vehicle is not given but only bike is used so its fine. note that we prefer edge-based because no edge_based parameter is specified
+        assertProfileFound(chProfiles.get(2), chProfiles, "", "fastest", null, null);
+        // if we do not specify the weighting its not clear what to return -> there is an error
+        assertCHProfileSelectionError("Found CH profiles for multiple weightings: [fastest, shortest], but the request did not specify a weighting", chProfiles, "", "", null, null);
+        // if we do not specify the weighting but edge_based=true its clear what to return because for edge-based there is only one weighting
+        assertProfileFound(chProfiles.get(2), chProfiles, "", "", true, null);
+        // ... for edge_based=false this is an error because there are two node-based profiles
+        assertCHProfileSelectionError("Found CH profiles for multiple weightings: [fastest, shortest] for edge_based=false, but the request did not specify a weighting", chProfiles, "", "", false, null);
+    }
+
+    @Test
+    public void missingWeightingMultipleProfiles() {
+        List<CHProfile> chProfiles = Arrays.asList(
+                CHProfile.nodeBased(weightingFastestBike),
+                CHProfile.edgeBased(weightingFastestCar, 10),
+                CHProfile.edgeBased(weightingFastestBike, 40)
+        );
+        // the weighting is not given but only fastest is used so its fine. note that we prefer edge-based because no edge_based parameter is specified
+        assertProfileFound(chProfiles.get(2), chProfiles, "bike", "", null, null);
+        // if we do not specify the vehicle its not clear what to return -> there is an error
+        assertCHProfileSelectionError("Found CH profiles for multiple vehicles: [bike, car], but the request did not specify a vehicle", chProfiles, "", "", null, null);
+        // if we do not specify the vehicle but edge_based=false its clear what to return because for node-based there is only one weighting
+        assertProfileFound(chProfiles.get(0), chProfiles, "", "", false, null);
+        // ... for edge_based=true this is an error, because there are two edge_based profiles
+        assertCHProfileSelectionError("Found CH profiles for multiple vehicles: [car, bike] for edge_based=true, but the request did not specify a vehicle", chProfiles, "", "", true, null);
+        // .. we can however get a clear match if we specify the u-turn costs
+        assertCHProfileSelectionError("Found CH profiles for multiple vehicles: [car, bike] for edge_based=true, but the request did not specify a vehicle", chProfiles, "", "", true, 10);
+    }
+
+    @Test
+    public void multipleVehiclesMissingWeighting() {
+        // this is a common use-case, there are multiple vehicles for one weighting
+        EncodingManager em = EncodingManager.create("car,bike,motorcycle,bike2,foot");
+        List<CHProfile> chProfiles = new ArrayList<>();
+        for (FlagEncoder encoder : em.fetchEdgeEncoders()) {
+            chProfiles.add(CHProfile.nodeBased(new ShortFastestWeighting(encoder, 1)));
+        }
+        // we do not specify the weighting but this is ok, because there is only one in use
+        String weighting = "";
+        assertProfileFound(chProfiles.get(0), chProfiles, "car", weighting, null, null);
+        assertProfileFound(chProfiles.get(1), chProfiles, "bike", weighting, null, null);
+        assertProfileFound(chProfiles.get(2), chProfiles, "motorcycle", weighting, null, null);
+        assertProfileFound(chProfiles.get(3), chProfiles, "bike2", weighting, null, null);
+        assertProfileFound(chProfiles.get(4), chProfiles, "foot", weighting, null, null);
+    }
+
+
+    @Test
+    public void missingVehicle_multiplePossibilities_throws() {
+        List<CHProfile> chProfiles = Arrays.asList(
+                CHProfile.nodeBased(weightingFastestBike), CHProfile.nodeBased(weightingFastestCar)
+        );
+        assertCHProfileSelectionError("Found CH profiles for multiple vehicles: [bike, car], but the request did not specify a vehicle", chProfiles, "", "fastest", null, null);
+    }
+
+    @Test
+    public void missingWeighting_multiplePossibilities_throws() {
+        List<CHProfile> chProfiles = Arrays.asList(
+                CHProfile.nodeBased(weightingFastestBike), CHProfile.nodeBased(weightingShortestBike)
+        );
+        assertCHProfileSelectionError("Found CH profiles for multiple weightings: [fastest, shortest], but the request did not specify a weighting", chProfiles, "bike", "", null, null);
     }
 
     private void assertProfileFound(CHProfile expectedProfile, List<CHProfile> profiles, Boolean edgeBased, Integer uTurnCosts) {
@@ -108,9 +207,9 @@ public class CHProfileSelectorTest {
     }
 
     private void assertProfileFound(CHProfile expectedProfile, List<CHProfile> profiles, String vehicle, String weighting, Boolean edgeBased, Integer uTurnCosts) {
-        HintsMap weightingMap = new HintsMap().setWeighting(weighting).setVehicle(vehicle);
+        HintsMap hintsMap = createHintsMap(vehicle, weighting, edgeBased, uTurnCosts);
         try {
-            CHProfile selectedProfile = CHProfileSelector.select(profiles, weightingMap, edgeBased, uTurnCosts);
+            CHProfile selectedProfile = CHProfileSelector.select(profiles, hintsMap);
             assertEquals(expectedProfile, selectedProfile);
         } catch (CHProfileSelectionException e) {
             fail("no profile found, but expected: " + expectedProfile + ", error: " + e.getMessage());
@@ -122,13 +221,24 @@ public class CHProfileSelectorTest {
     }
 
     private void assertCHProfileSelectionError(String expectedError, List<CHProfile> profiles, String vehicle, String weighting, Boolean edgeBased, Integer uTurnCosts) {
-        HintsMap weightingMap = new HintsMap().setWeighting(weighting).setVehicle(vehicle);
+        HintsMap hintsMap = createHintsMap(vehicle, weighting, edgeBased, uTurnCosts);
         try {
-            CHProfileSelector.select(profiles, weightingMap, edgeBased, uTurnCosts);
+            CHProfileSelector.select(profiles, hintsMap);
             fail("There should have been an error");
         } catch (CHProfileSelectionException e) {
             assertTrue("There should have been an error message containing '" + expectedError + "', but was: '" + e.getMessage() + "'",
                     e.getMessage().contains(expectedError));
         }
+    }
+
+    private HintsMap createHintsMap(String vehicle, String weighting, Boolean edgeBased, Integer uTurnCosts) {
+        HintsMap hintsMap = new HintsMap().setWeighting(weighting).setVehicle(vehicle);
+        if (edgeBased != null) {
+            hintsMap.put(Parameters.Routing.EDGE_BASED, edgeBased);
+        }
+        if (uTurnCosts != null) {
+            hintsMap.put(Parameters.Routing.U_TURN_COSTS, uTurnCosts);
+        }
+        return hintsMap;
     }
 }

--- a/core/src/test/java/com/graphhopper/routing/ch/CHProfileSelectorTest.java
+++ b/core/src/test/java/com/graphhopper/routing/ch/CHProfileSelectorTest.java
@@ -104,7 +104,7 @@ public class CHProfileSelectorTest {
         // when no u-turns are specified we throw
         assertCHProfileSelectionError(MULTIPLE_MATCHES_ERROR, chProfiles, true, null);
         // when we request one that does not exist we throw
-        assertCHProfileSelectionError(" " + NO_MATCH_ERROR, chProfiles, true, 40);
+        assertCHProfileSelectionError(NO_MATCH_ERROR, chProfiles, true, 40);
         // when we request one that exists it works
         assertProfileFound(chProfiles.get(1), chProfiles, true, 30);
 

--- a/reader-osm/src/test/java/com/graphhopper/GraphHopperIT.java
+++ b/reader-osm/src/test/java/com/graphhopper/GraphHopperIT.java
@@ -1207,7 +1207,7 @@ public class GraphHopperIT {
         GHResponse rsp = runMoscow(tmpHopper, "true", true);
         assertEquals(1, rsp.getErrors().size());
         assertTrue("unexpected error: " + rsp.getErrors().toString(), rsp.getErrors().toString().contains(
-                "Cannot find CH profile for hints map {edge_based=true, ch.disable=false, vehicle=car} in entries: [fastest|car|edge_based=false|u_turn_costs=-1]"));
+                "Cannot find matching CH profile for your request.\nrequested:  *|car|edge_based=true|u_turn_costs=*\navailable: [fastest|car|edge_based=false|u_turn_costs=-1]"));
     }
 
     @Test
@@ -1230,7 +1230,7 @@ public class GraphHopperIT {
         GHResponse rsp = runMoscow(tmpHopper, "false", true);
         assertTrue(rsp.hasErrors());
         assertTrue("unexpected error: " + rsp.getErrors(), rsp.getErrors().toString().contains(
-                "Cannot find CH profile for hints map {edge_based=false, ch.disable=false, vehicle=car} in entries: [fastest|car|edge_based=true|u_turn_costs=-1]"));
+                "Cannot find matching CH profile for your request.\nrequested:  *|car|edge_based=false|u_turn_costs=*\navailable: [fastest|car|edge_based=true|u_turn_costs=-1]"));
     }
 
     private GHResponse assertMoscowNodeBased(GraphHopper tmpHopper, String edgeBasedParam, boolean ch) {

--- a/reader-osm/src/test/java/com/graphhopper/GraphHopperIT.java
+++ b/reader-osm/src/test/java/com/graphhopper/GraphHopperIT.java
@@ -1206,8 +1206,8 @@ public class GraphHopperIT {
         assertMoscowNodeBased(tmpHopper, "false", true);
         GHResponse rsp = runMoscow(tmpHopper, "true", true);
         assertEquals(1, rsp.getErrors().size());
-        assertTrue(rsp.getErrors().toString().contains("Found a node-based CH profile"));
-        assertTrue(rsp.getErrors().toString().contains("but requested edge-based CH"));
+        assertTrue("unexpected error: " + rsp.getErrors().toString(), rsp.getErrors().toString().contains(
+                "Cannot find CH profile for hints map {edge_based=true, ch.disable=false, vehicle=car} in entries: [fastest|car|edge_based=false|u_turn_costs=-1]"));
     }
 
     @Test
@@ -1229,8 +1229,8 @@ public class GraphHopperIT {
         assertMoscowEdgeBased(tmpHopper, "true", true);
         GHResponse rsp = runMoscow(tmpHopper, "false", true);
         assertTrue(rsp.hasErrors());
-        assertTrue(rsp.getErrors().toString().contains("Found 1 edge-based CH profile"));
-        assertTrue(rsp.getErrors().toString().contains("but requested node-based CH"));
+        assertTrue("unexpected error: " + rsp.getErrors(), rsp.getErrors().toString().contains(
+                "Cannot find CH profile for hints map {edge_based=false, ch.disable=false, vehicle=car} in entries: [fastest|car|edge_based=true|u_turn_costs=-1]"));
     }
 
     private GHResponse assertMoscowNodeBased(GraphHopper tmpHopper, String edgeBasedParam, boolean ch) {
@@ -1379,6 +1379,34 @@ public class GraphHopperIT {
         req.getHints().put(Routing.FORCE_CURBSIDE, force);
         req.setCurbsides(curbsides);
         return tmpHopper.route(req);
+    }
+
+    @Test
+    public void testCHWithFiniteUTurnCostsAndMissingWeighting() {
+        GraphHopper h = new GraphHopperOSM().
+                setDataReaderFile(DIR + "/monaco.osm.gz").
+                setCHEnabled(true).
+                setGraphHopperLocation(tmpGraphFile).
+                setEncodingManager(EncodingManager.create("car|turn_costs=true"));
+        h.getCHFactoryDecorator()
+                .setCHProfileStrings("fastest|u_turn_costs=40")
+                .setEdgeBasedCHMode(CHAlgoFactoryDecorator.EdgeBasedCHMode.EDGE_OR_NODE);
+        h.importOrLoad();
+
+        GHPoint p = new GHPoint(43.73397, 7.414173);
+        GHPoint q = new GHPoint(43.73222, 7.415557);
+        GHRequest req = new GHRequest(p, q);
+        // note that we do *not* set the weighting on the request, it will be determined automatically from the
+        // CH profile, see #1788
+        req.setWeighting("fastest");
+        // we force the start/target directions such that there are u-turns right after we start and right before
+        // we reach the target
+        req.setCurbsides(Arrays.asList("right", "right"));
+        GHResponse res = h.route(req);
+        assertFalse("routing should not fail", res.hasErrors());
+        assertEquals(266.8, res.getBest().getRouteWeight(), 0.1);
+        assertEquals(2116, res.getBest().getDistance(), 1);
+        assertEquals(266800, res.getBest().getTime(), 1000);
     }
 
 }


### PR DESCRIPTION
Fixes #1788 .

This PR reworks the CH profile selection logic and now also handles the cases where the weighting or the vehicle is missing. It now works like this: A request comes in with or without `vehicle,weighting,edge_based,u_turn_costs`. Missing values are treated as wildcards (match everything). This means that we do not need to specify anything on the request as long as there is only one possible match. When there are multiple matches we throw an error (with one exception, see in code). 

The CH profile selection got much simpler. The error responses are now more generic and maybe even more informative. For example if no CH profile matches the request we get:

```
Cannot find matching CH profile for your request.
requested:  fastest|*|edge_based=true|u_turn_costs=40
available: [fastest|car|edge_based=false|u_turn_costs=-1, fastest|car|edge_based=true|u_turn_costs=30, fastest|car|edge_based=true|u_turn_costs=50]
```

And when there are are too many matches we get something like:

```
There are multiple CH profiles matching your request. Use the `weighting`,`vehicle`,`edge_based` and/or `u_turn_costs` parameters to be more specific.
requested:  *|car|edge_based=true|u_turn_costs=*
matched:   [fastest|car|edge_based=true|u_turn_costs=30, fastest|car|edge_based=true|u_turn_costs=50]
available: [fastest|car|edge_based=false|u_turn_costs=-1, fastest|car|edge_based=true|u_turn_costs=30, fastest|car|edge_based=true|u_turn_costs=50]
```

Here `*` represents a wildcard, e.g. if the vehicle/weighting/edge_based/u_turn_costs are not given.


