### PR TITLE
Moves segment size setting of graphs into constructor

### DIFF
--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -755,8 +755,7 @@ public class GraphHopper implements GraphHopperAPI {
             chProfiles = Collections.emptyList();
         }
 
-        ghStorage =  new GraphHopperStorage(chProfiles, dir, encodingManager, hasElevation(), encodingManager.needsTurnCostsSupport());
-        ghStorage.setSegmentSize(defaultSegmentSize);
+        ghStorage = new GraphHopperStorage(chProfiles, dir, encodingManager, hasElevation(), encodingManager.needsTurnCostsSupport(), defaultSegmentSize);
 
         if (!new File(graphHopperFolder).exists())
             return false;

--- a/core/src/main/java/com/graphhopper/storage/BaseGraph.java
+++ b/core/src/main/java/com/graphhopper/storage/BaseGraph.java
@@ -97,7 +97,7 @@ class BaseGraph implements Graph {
     private boolean frozen = false;
 
     public BaseGraph(Directory dir, final EncodingManager encodingManager, boolean withElevation,
-                     InternalGraphEventListener listener, boolean withTurnCosts) {
+                     InternalGraphEventListener listener, boolean withTurnCosts, int segmentSize) {
         this.dir = dir;
         this.encodingManager = encodingManager;
         this.intsForFlags = encodingManager.getIntsForFlags();
@@ -150,6 +150,9 @@ class BaseGraph implements Graph {
             turnCostExtension = new TurnCostExtension(nodeAccess, dir.find("turn_costs"));
         } else {
             turnCostExtension = null;
+        }
+        if (segmentSize >= 0) {
+            setSegmentSize(segmentSize);
         }
     }
 
@@ -339,15 +342,12 @@ class BaseGraph implements Graph {
         return edge(a, b).setDistance(distance).setFlags(encodingManager.flagsDefault(true, bothDirection));
     }
 
-    void setSegmentSize(int bytes) {
+    private void setSegmentSize(int bytes) {
         checkInit();
         nodes.setSegmentSize(bytes);
         edges.setSegmentSize(bytes);
         wayGeometry.setSegmentSize(bytes);
         nameIndex.setSegmentSize(bytes);
-        if (supportsTurnCosts()) {
-            turnCostExtension.setSegmentSize(bytes);
-        }
     }
 
     synchronized void freeze() {

--- a/core/src/main/java/com/graphhopper/storage/BaseGraph.java
+++ b/core/src/main/java/com/graphhopper/storage/BaseGraph.java
@@ -348,6 +348,9 @@ class BaseGraph implements Graph {
         edges.setSegmentSize(bytes);
         wayGeometry.setSegmentSize(bytes);
         nameIndex.setSegmentSize(bytes);
+        if (supportsTurnCosts()) {
+            turnCostExtension.setSegmentSize(bytes);
+        }
     }
 
     synchronized void freeze() {

--- a/core/src/main/java/com/graphhopper/storage/CHGraphImpl.java
+++ b/core/src/main/java/com/graphhopper/storage/CHGraphImpl.java
@@ -63,7 +63,7 @@ public class CHGraphImpl implements CHGraph, Storable<CHGraph> {
     private int shortcutCount = 0;
     private boolean isReadyForContraction;
 
-    CHGraphImpl(CHProfile chProfile, Directory dir, final BaseGraph baseGraph) {
+    CHGraphImpl(CHProfile chProfile, Directory dir, final BaseGraph baseGraph, int segmentSize) {
         if (chProfile.getWeighting() == null)
             throw new IllegalStateException("Weighting for CHGraph cannot be null");
         this.chProfile = chProfile;
@@ -72,6 +72,10 @@ public class CHGraphImpl implements CHGraph, Storable<CHGraph> {
         this.nodesCH = dir.find("nodes_ch_" + name, DAType.getPreferredInt(dir.getDefaultType()));
         this.shortcuts = dir.find("shortcuts_" + name, DAType.getPreferredInt(dir.getDefaultType()));
         this.chEdgeAccess = new CHEdgeAccess(name);
+        if (segmentSize >= 0) {
+            nodesCH.setSegmentSize(segmentSize);
+            shortcuts.setSegmentSize(segmentSize);
+        }
     }
 
     @Override
@@ -340,11 +344,6 @@ public class CHGraphImpl implements CHGraph, Storable<CHGraph> {
         N_LEVEL = 0;
         N_CH_REF = N_LEVEL + 4;
         nodeCHEntryBytes = N_CH_REF + 4;
-    }
-
-    void setSegmentSize(int bytes) {
-        nodesCH.setSegmentSize(bytes);
-        shortcuts.setSegmentSize(bytes);
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/storage/GraphBuilder.java
+++ b/core/src/main/java/com/graphhopper/storage/GraphBuilder.java
@@ -44,6 +44,7 @@ public class GraphBuilder {
 
     public GraphBuilder(EncodingManager encodingManager) {
         this.encodingManager = encodingManager;
+        this.turnCosts = encodingManager.needsTurnCostsSupport();
     }
 
     public GraphBuilder setCHProfiles(List<CHProfile> chProfiles) {
@@ -102,8 +103,7 @@ public class GraphBuilder {
      * {@link #create} directly.
      */
     public GraphHopperStorage build() {
-        boolean withTurnCosts = encodingManager.needsTurnCostsSupport() || turnCosts;
-        return new GraphHopperStorage(chProfiles, dir, encodingManager, elevation, withTurnCosts, segmentSize);
+        return new GraphHopperStorage(chProfiles, dir, encodingManager, elevation, turnCosts, segmentSize);
     }
 
     /**

--- a/core/src/main/java/com/graphhopper/storage/GraphBuilder.java
+++ b/core/src/main/java/com/graphhopper/storage/GraphBuilder.java
@@ -19,38 +19,34 @@ package com.graphhopper.storage;
 
 import com.graphhopper.routing.util.EncodingManager;
 
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 
 /**
- * For now this is just a helper class to quickly create a {@link GraphHopperStorage}
- * <p>
+ * Used to build {@link GraphHopperStorage}
  *
  * @author Peter Karich
+ * @author easbar
  */
 public class GraphBuilder {
     private final EncodingManager encodingManager;
-    private String location;
-    private boolean mmap;
-    private boolean store;
+    private Directory dir = new RAMDirectory();
     private boolean elevation;
     private boolean turnCosts;
-    private long byteCapacity = 100;
-    private List<CHProfile> chProfiles = Collections.emptyList();
+    private long bytes = 100;
+    private int segmentSize = -1;
+    private List<CHProfile> chProfiles = new ArrayList<>();
+
+    public static GraphBuilder start(EncodingManager encodingManager) {
+        return new GraphBuilder(encodingManager);
+    }
 
     public GraphBuilder(EncodingManager encodingManager) {
         this.encodingManager = encodingManager;
     }
 
-    /**
-     * This method enables creating CHGraphs with the specified CHProfiles
-     */
     public GraphBuilder setCHProfiles(List<CHProfile> chProfiles) {
-        if (chProfiles.size() != new HashSet<>(chProfiles).size()) {
-            throw new IllegalArgumentException("Given CH profiles contain duplicates, given: " + chProfiles);
-        }
         this.chProfiles = chProfiles;
         return this;
     }
@@ -59,23 +55,29 @@ public class GraphBuilder {
         return setCHProfiles(Arrays.asList(chProfiles));
     }
 
-    public GraphBuilder setLocation(String location) {
-        this.location = location;
+    public GraphBuilder setDir(Directory dir) {
+        this.dir = dir;
         return this;
     }
 
-    public GraphBuilder setStore(boolean store) {
-        this.store = store;
-        return this;
+    public GraphBuilder setMMap(String location) {
+        return setDir(new MMapDirectory(location));
     }
 
-    public GraphBuilder setMmap(boolean mmap) {
-        this.mmap = mmap;
-        return this;
+    public GraphBuilder setRAM() {
+        return setDir(new RAMDirectory());
     }
 
-    public GraphBuilder setExpectedSize(byte cap) {
-        this.byteCapacity = cap;
+    public GraphBuilder setRAM(String location) {
+        return setDir(new RAMDirectory(location));
+    }
+
+    public GraphBuilder setRAM(String location, boolean store) {
+        return setDir(new RAMDirectory(location, store));
+    }
+
+    public GraphBuilder setBytes(long bytes) {
+        this.bytes = bytes;
         return this;
     }
 
@@ -89,15 +91,9 @@ public class GraphBuilder {
         return this;
     }
 
-    public boolean hasElevation() {
-        return elevation;
-    }
-
-    /**
-     * Creates a CHGraph
-     */
-    public CHGraph chGraphCreate(CHProfile chProfile) {
-        return setCHProfiles(chProfile).create().getCHGraph();
+    public GraphBuilder setSegmentSize(int segmentSize) {
+        this.segmentSize = segmentSize;
+        return this;
     }
 
     /**
@@ -106,29 +102,14 @@ public class GraphBuilder {
      * {@link #create} directly.
      */
     public GraphHopperStorage build() {
-        Directory dir = mmap ?
-                new MMapDirectory(location) :
-                new RAMDirectory(location, store);
-
         boolean withTurnCosts = encodingManager.needsTurnCostsSupport() || turnCosts;
-        return new GraphHopperStorage(chProfiles, dir, encodingManager, elevation, withTurnCosts);
+        return new GraphHopperStorage(chProfiles, dir, encodingManager, elevation, withTurnCosts, segmentSize);
     }
 
     /**
      * Default graph is a {@link GraphHopperStorage} with an in memory directory and disabled storing on flush.
      */
     public GraphHopperStorage create() {
-        return build().create(byteCapacity);
-    }
-
-    /**
-     * @throws IllegalStateException if not loadable.
-     */
-    public GraphHopperStorage load() {
-        GraphHopperStorage gs = build();
-        if (!gs.loadExisting()) {
-            throw new IllegalStateException("Cannot load graph " + location);
-        }
-        return gs;
+        return build().create(bytes);
     }
 }

--- a/core/src/main/java/com/graphhopper/storage/GraphHopperStorage.java
+++ b/core/src/main/java/com/graphhopper/storage/GraphHopperStorage.java
@@ -24,10 +24,7 @@ import com.graphhopper.util.EdgeExplorer;
 import com.graphhopper.util.EdgeIteratorState;
 import com.graphhopper.util.shapes.BBox;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 /**
  * This class manages all storage related methods and delegates the calls to the associated graphs.
@@ -66,6 +63,10 @@ public final class GraphHopperStorage implements GraphStorage, Graph {
     public GraphHopperStorage(List<CHProfile> chProfiles, Directory dir, EncodingManager encodingManager, boolean withElevation, boolean withTurnCosts, int segmentSize) {
         if (encodingManager == null)
             throw new IllegalArgumentException("EncodingManager needs to be non-null since 0.7. Create one using EncodingManager.create or EncodingManager.create(flagEncoderFactory, ghLocation)");
+
+        if (chProfiles.size() != new HashSet<>(chProfiles).size()) {
+            throw new IllegalArgumentException("Given CH profiles contain duplicates, given: " + chProfiles);
+        }
 
         this.encodingManager = encodingManager;
         this.dir = dir;

--- a/core/src/main/java/com/graphhopper/storage/GraphHopperStorage.java
+++ b/core/src/main/java/com/graphhopper/storage/GraphHopperStorage.java
@@ -60,6 +60,10 @@ public final class GraphHopperStorage implements GraphStorage, Graph {
     }
 
     public GraphHopperStorage(List<CHProfile> chProfiles, Directory dir, EncodingManager encodingManager, boolean withElevation, boolean withTurnCosts) {
+        this(chProfiles, dir, encodingManager, withElevation, withTurnCosts, -1);
+    }
+
+    public GraphHopperStorage(List<CHProfile> chProfiles, Directory dir, EncodingManager encodingManager, boolean withElevation, boolean withTurnCosts, int segmentSize) {
         if (encodingManager == null)
             throw new IllegalArgumentException("EncodingManager needs to be non-null since 0.7. Create one using EncodingManager.create or EncodingManager.create(flagEncoderFactory, ghLocation)");
 
@@ -82,10 +86,10 @@ public final class GraphHopperStorage implements GraphStorage, Graph {
             }
         };
 
-        baseGraph = new BaseGraph(dir, encodingManager, withElevation, listener, withTurnCosts);
+        baseGraph = new BaseGraph(dir, encodingManager, withElevation, listener, withTurnCosts, segmentSize);
         this.chGraphs = new ArrayList<>(chProfiles.size());
         for (CHProfile chProfile : chProfiles) {
-            chGraphs.add(new CHGraphImpl(chProfile, dir, baseGraph));
+            chGraphs.add(new CHGraphImpl(chProfile, dir, baseGraph, segmentSize));
         }
     }
 
@@ -150,15 +154,6 @@ public final class GraphHopperStorage implements GraphStorage, Graph {
     @Override
     public Directory getDirectory() {
         return dir;
-    }
-
-    @Override
-    public void setSegmentSize(int bytes) {
-        baseGraph.setSegmentSize(bytes);
-
-        for (CHGraphImpl cg : getAllCHGraphs()) {
-            cg.setSegmentSize(bytes);
-        }
     }
 
     /**

--- a/core/src/main/java/com/graphhopper/storage/GraphStorage.java
+++ b/core/src/main/java/com/graphhopper/storage/GraphStorage.java
@@ -24,8 +24,6 @@ public interface GraphStorage extends Storable<GraphStorage> {
 
     EncodingManager getEncodingManager();
 
-    void setSegmentSize(int bytes);
-
     String toDetailsString();
 
     StorableProperties getProperties();

--- a/core/src/test/java/com/graphhopper/GraphHopperAPITest.java
+++ b/core/src/test/java/com/graphhopper/GraphHopperAPITest.java
@@ -116,7 +116,7 @@ public class GraphHopperAPITest {
         String loc = "./target/issue1645";
         Helper.removeDir(new File(loc));
         EncodingManager em = new EncodingManager.Builder().add(new OSMRoadEnvironmentParser()).add(new CarFlagEncoder()).build();
-        GraphHopperStorage graph = new GraphBuilder(em).setLocation(loc).set3D(true).setStore(true).create();
+        GraphHopperStorage graph = GraphBuilder.start(em).setRAM(loc, true).set3D(true).create();
 
         // we need elevation
         NodeAccess na = graph.getNodeAccess();

--- a/core/src/test/java/com/graphhopper/storage/AbstractGraphStorageTester.java
+++ b/core/src/test/java/com/graphhopper/storage/AbstractGraphStorageTester.java
@@ -100,10 +100,6 @@ public abstract class AbstractGraphStorageTester {
 
     abstract GraphHopperStorage createGHStorage(String location, boolean is3D);
 
-    protected final GraphHopperStorage newRAMGHStorage() {
-        return new GraphHopperStorage(new RAMDirectory(), encodingManager, false);
-    }
-
     @Before
     public void setUp() {
         Helper.removeDir(new File(locationParent));
@@ -316,9 +312,7 @@ public abstract class AbstractGraphStorageTester {
     public void testCopyTo() {
         graph = createGHStorage();
         initExampleGraph(graph);
-        GraphHopperStorage gs = newRAMGHStorage();
-        gs.setSegmentSize(8000);
-        gs.create(10);
+        GraphHopperStorage gs = GraphBuilder.start(encodingManager).setSegmentSize(8000).setBytes(10).create();
         graph.copyTo(gs);
         checkExampleGraph(gs);
 

--- a/core/src/test/java/com/graphhopper/storage/GraphHopperStorageCHTest.java
+++ b/core/src/test/java/com/graphhopper/storage/GraphHopperStorageCHTest.java
@@ -49,17 +49,22 @@ public class GraphHopperStorageCHTest extends GraphHopperStorageTest {
     }
 
     @Override
-    public GraphHopperStorage newGHStorage(Directory dir, boolean is3D) {
-        return newGHStorage(dir, is3D, false);
+    protected GraphHopperStorage newGHStorage(Directory dir, boolean enabled3D) {
+        return newGHStorage(dir, enabled3D, -1);
+    }
+
+    @Override
+    public GraphHopperStorage newGHStorage(Directory dir, boolean is3D, int segmentSize) {
+        return newGHStorage(dir, is3D, false, segmentSize);
     }
 
     private GraphHopperStorage newGHStorage(boolean is3D, boolean forEdgeBasedTraversal) {
-        return newGHStorage(new RAMDirectory(defaultGraphLoc, true), is3D, forEdgeBasedTraversal).create(defaultSize);
+        return newGHStorage(new RAMDirectory(defaultGraphLoc, true), is3D, forEdgeBasedTraversal, -1).create(defaultSize);
     }
 
-    private GraphHopperStorage newGHStorage(Directory dir, boolean is3D, boolean forEdgeBasedTraversal) {
+    private GraphHopperStorage newGHStorage(Directory dir, boolean is3D, boolean forEdgeBasedTraversal, int segmentSize) {
         CHProfile chProfile = new CHProfile(new FastestWeighting(carEncoder), forEdgeBasedTraversal, INFINITE_U_TURN_COSTS);
-        return new GraphHopperStorage(Collections.singletonList(chProfile), dir, encodingManager, is3D);
+        return new GraphHopperStorage(Collections.singletonList(chProfile), dir, encodingManager, is3D, false, segmentSize);
     }
 
     @Test
@@ -68,7 +73,7 @@ public class GraphHopperStorageCHTest extends GraphHopperStorageTest {
         graph.flush();
         graph.close();
 
-        graph = new GraphBuilder(encodingManager).setLocation(defaultGraphLoc).setMmap(false).setStore(true).create();
+        graph = GraphBuilder.start(encodingManager).setRAM(defaultGraphLoc, true).create();
         try {
             graph.loadExisting();
             fail();
@@ -521,7 +526,7 @@ public class GraphHopperStorageCHTest extends GraphHopperStorageTest {
 
     private void testLoadingWithWrongWeighting_throws(boolean edgeBased) {
         // we start with one weighting
-        GraphHopperStorage ghStorage = newGHStorage(new GHDirectory(defaultGraphLoc, DAType.RAM_STORE), false, edgeBased);
+        GraphHopperStorage ghStorage = newGHStorage(new GHDirectory(defaultGraphLoc, DAType.RAM_STORE), false, edgeBased, -1);
         ghStorage.create(defaultSize);
         ghStorage.flush();
 

--- a/core/src/test/java/com/graphhopper/storage/GraphHopperStorageForDataFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/storage/GraphHopperStorageForDataFlagEncoderTest.java
@@ -53,7 +53,7 @@ public class GraphHopperStorageForDataFlagEncoderTest {
 
     @Test
     public void testStorageProperties() {
-        graph = new GraphBuilder(encodingManager).setStore(true).setLocation(defaultGraphLoc).create();
+        graph = new GraphBuilder(encodingManager).setRAM(defaultGraphLoc, true).create();
 
         // 0-1
         ReaderWay way_0_1 = new ReaderWay(27l);

--- a/core/src/test/java/com/graphhopper/storage/GraphHopperStorageLMTest.java
+++ b/core/src/test/java/com/graphhopper/storage/GraphHopperStorageLMTest.java
@@ -22,8 +22,7 @@ public class GraphHopperStorageLMTest {
         Helper.removeDir(new File(defaultGraphLoc));
         CarFlagEncoder carFlagEncoder = new CarFlagEncoder();
         EncodingManager encodingManager = EncodingManager.create(carFlagEncoder);
-        GraphHopperStorage graph = new GraphBuilder(encodingManager).setStore(true).
-                setLocation(defaultGraphLoc).create();
+        GraphHopperStorage graph = GraphBuilder.start(encodingManager).setRAM(defaultGraphLoc, true).create();
 
         // 0-1
         ReaderWay way_0_1 = new ReaderWay(27l);

--- a/core/src/test/java/com/graphhopper/storage/GraphHopperStorageTest.java
+++ b/core/src/test/java/com/graphhopper/storage/GraphHopperStorageTest.java
@@ -33,19 +33,22 @@ public class GraphHopperStorageTest extends AbstractGraphStorageTester {
     @Override
     public GraphHopperStorage createGHStorage(String location, boolean enabled3D) {
         // reduce segment size in order to test the case where multiple segments come into the game
-        GraphHopperStorage gs = newGHStorage(new RAMDirectory(location), enabled3D);
-        gs.setSegmentSize(defaultSize / 2);
+        GraphHopperStorage gs = newGHStorage(new RAMDirectory(location), enabled3D, defaultSize / 2);
         gs.create(defaultSize);
         return gs;
     }
 
     protected GraphHopperStorage newGHStorage(Directory dir, boolean enabled3D) {
-        return new GraphHopperStorage(dir, encodingManager, enabled3D);
+        return newGHStorage(dir, enabled3D, -1);
+    }
+
+    protected GraphHopperStorage newGHStorage(Directory dir, boolean enabled3D, int segmentSize) {
+        return GraphBuilder.start(encodingManager).setDir(dir).set3D(enabled3D).setSegmentSize(segmentSize).build();
     }
 
     @Test
     public void testNoCreateCalled() {
-        try (GraphHopperStorage gs = new GraphBuilder(encodingManager).build()) {
+        try (GraphHopperStorage gs = GraphBuilder.start(encodingManager).build()) {
             ((BaseGraph) gs.getBaseGraph()).ensureNodeIndex(123);
             fail("AssertionError should be raised");
         } catch (AssertionError err) {

--- a/core/src/test/java/com/graphhopper/storage/GraphHopperStorageWithTurnCostsTest.java
+++ b/core/src/test/java/com/graphhopper/storage/GraphHopperStorageWithTurnCostsTest.java
@@ -21,7 +21,6 @@ import com.graphhopper.util.EdgeIteratorState;
 import com.graphhopper.util.Helper;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
@@ -35,7 +34,12 @@ public class GraphHopperStorageWithTurnCostsTest extends GraphHopperStorageTest 
 
     @Override
     protected GraphHopperStorage newGHStorage(Directory dir, boolean is3D) {
-        GraphHopperStorage g = new GraphHopperStorage(dir, encodingManager, is3D, true);
+        return newGHStorage(dir, is3D, -1);
+    }
+
+    @Override
+    protected GraphHopperStorage newGHStorage(Directory dir, boolean enabled3D, int segmentSize) {
+        GraphHopperStorage g = GraphBuilder.start(encodingManager).setDir(dir).set3D(enabled3D).withTurnCosts(true).setSegmentSize(segmentSize).build();
         turnCostStorage = g.getTurnCostExtension();
         return g;
     }
@@ -89,8 +93,7 @@ public class GraphHopperStorageWithTurnCostsTest extends GraphHopperStorageTest 
 
     @Test
     public void testEnsureCapacity() {
-        graph = newGHStorage(new MMapDirectory(defaultGraphLoc), false);
-        graph.setSegmentSize(128);
+        graph = newGHStorage(new MMapDirectory(defaultGraphLoc), false, 128);
         graph.create(100); // 100 is the minimum size
 
         // assert that turnCostStorage can hold 104 turn cost entries at the beginning

--- a/core/src/test/java/com/graphhopper/storage/GraphStorageViaMMapTest.java
+++ b/core/src/test/java/com/graphhopper/storage/GraphStorageViaMMapTest.java
@@ -23,8 +23,7 @@ package com.graphhopper.storage;
 public class GraphStorageViaMMapTest extends AbstractGraphStorageTester {
     @Override
     public GraphHopperStorage createGHStorage(String location, boolean is3D) {
-        GraphHopperStorage gs = new GraphBuilder(encodingManager).set3D(is3D).setLocation(location).setMmap(true).build();
-        gs.setSegmentSize(defaultSize / 2);
+        GraphHopperStorage gs = GraphBuilder.start(encodingManager).set3D(is3D).setMMap(location).setSegmentSize(defaultSize / 2).build();
         gs.create(defaultSize);
         return gs;
     }


### PR DESCRIPTION
Related to #1792. Removing the segment size setters from `DataAccess` seems to be a bigger task. For my purposes its sufficient for now to get rid of it on the graphs.