### PR TITLE
upgrade JTS to 0.16.0

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.locationtech.jts</groupId>
             <artifactId>jts-core</artifactId>
-            <version>1.15.1</version>
+            <version>1.16.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/web-api/pom.xml
+++ b/web-api/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>com.graphhopper.external</groupId>
             <artifactId>jackson-datatype-jts</artifactId>
-            <version>0.12-2.5-1</version>
+            <version>1.0-2.7</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>


### PR DESCRIPTION
We also need to update:

 - [x] our jackson-datatype-jts fork
 - [x] [mapbox-vector-tile-java](https://github.com/wdtinc/mapbox-vector-tile-java/pull/44) (-> #2698)

The minor advantage of 0.16.0 over 0.15.1 is that geotools is using 0.16.0 and never used 0.15.1 for its releases.