### PR TITLE
Close mmap for ElevationProvider if not removed

### DIFF
--- a/core/src/main/java/com/graphhopper/reader/dem/AbstractSRTMElevationProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/AbstractSRTMElevationProvider.java
@@ -61,11 +61,11 @@ public abstract class AbstractSRTMElevationProvider extends AbstractElevationPro
     public void release() {
         cacheData.clear();
         if (dir != null) {
-            dir.close();
-
             // for memory mapped type we remove temporary files
             if (autoRemoveTemporary)
                 dir.clear();
+            else
+                dir.close();
         }
     }
 

--- a/core/src/main/java/com/graphhopper/reader/dem/AbstractSRTMElevationProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/AbstractSRTMElevationProvider.java
@@ -60,18 +60,13 @@ public abstract class AbstractSRTMElevationProvider extends AbstractElevationPro
     @Override
     public void release() {
         cacheData.clear();
+        if (dir != null) {
+            dir.close();
 
-        // for memory mapped type we create temporary unpacked files which should be removed
-        if (autoRemoveTemporary && dir != null)
-            dir.clear();
-    }
-
-    /**
-     * Creating temporary files can take a long time to fill our DataAccess object, so this option
-     * can be used to disable the default clear mechanism via specifying 'false'.
-     */
-    public void setAutoRemoveTemporaryFiles(boolean autoRemoveTemporary) {
-        this.autoRemoveTemporary = autoRemoveTemporary;
+            // for memory mapped type we remove temporary files
+            if (autoRemoveTemporary)
+                dir.clear();
+        }
     }
 
     int down(double val) {

--- a/core/src/main/java/com/graphhopper/reader/dem/AbstractTiffElevationProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/AbstractTiffElevationProvider.java
@@ -58,11 +58,11 @@ public abstract class AbstractTiffElevationProvider extends AbstractElevationPro
     public void release() {
         cacheData.clear();
         if (dir != null) {
-            dir.close();
-
             // for memory mapped type we remove temporary files
             if (autoRemoveTemporary)
                 dir.clear();
+            else
+                dir.close();
         }
     }
 

--- a/core/src/main/java/com/graphhopper/reader/dem/AbstractTiffElevationProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/AbstractTiffElevationProvider.java
@@ -57,10 +57,13 @@ public abstract class AbstractTiffElevationProvider extends AbstractElevationPro
     @Override
     public void release() {
         cacheData.clear();
+        if (dir != null) {
+            dir.close();
 
-        // for memory mapped type we create temporary unpacked files which should be removed
-        if (autoRemoveTemporary && dir != null)
-            dir.clear();
+            // for memory mapped type we remove temporary files
+            if (autoRemoveTemporary)
+                dir.clear();
+        }
     }
 
     /**
@@ -186,14 +189,4 @@ public abstract class AbstractTiffElevationProvider extends AbstractElevationPro
             throw new RuntimeException("Problem at x:" + x + ", y:" + y, ex);
         }
     }
-
-    /**
-     * Creating temporary files can take a long time as we need to unpack tiff as well as to fill
-     * our DataAccess object, so this option can be used to disable the default clear mechanism via
-     * specifying 'false'.
-     */
-    public void setAutoRemoveTemporaryFiles(boolean autoRemoveTemporary) {
-        this.autoRemoveTemporary = autoRemoveTemporary;
-    }
-
 }

--- a/core/src/main/java/com/graphhopper/storage/Directory.java
+++ b/core/src/main/java/com/graphhopper/storage/Directory.java
@@ -48,11 +48,6 @@ public interface Directory {
     DataAccess find(String name, DAType type);
 
     /**
-     * Renames the specified DataAccess object into one.
-     */
-    // DataAccess rename( DataAccess da, String newName );
-
-    /**
      * Removes the specified object from the directory.
      */
     void remove(DataAccess da);
@@ -66,6 +61,11 @@ public interface Directory {
      * Removes all contained objects from the directory and releases its resources.
      */
     void clear();
+
+    /**
+     * Releases all allocated resources from the directory without removing backing files.
+     */
+    void close();
 
     /**
      * Returns all created directories.

--- a/core/src/main/java/com/graphhopper/storage/GHDirectory.java
+++ b/core/src/main/java/com/graphhopper/storage/GHDirectory.java
@@ -107,29 +107,35 @@ public class GHDirectory implements Directory {
     }
 
     @Override
+    public void close() {
+        for (DataAccess da : map.values()) {
+            da.close();
+        }
+        map.clear();
+    }
+
+    @Override
     public void clear() {
         for (DataAccess da : map.values()) {
-            removeDA(da, da.getName());
+            da.close();
+            removeBackingFile(da, da.getName());
         }
         map.clear();
     }
 
     @Override
     public void remove(DataAccess da) {
-        removeFromMap(da.getName());
-        removeDA(da, da.getName());
+        DataAccess old = map.remove(da.getName());
+        if (old == null)
+            throw new IllegalStateException("Couldn't remove DataAccess: " + da.getName());
+
+        da.close();
+        removeBackingFile(da, da.getName());
     }
 
-    void removeDA(DataAccess da, String name) {
-        da.close();
+    private void removeBackingFile(DataAccess da, String name) {
         if (da.getType().isStoring())
             removeDir(new File(location + name));
-    }
-
-    void removeFromMap(String name) {
-        DataAccess da = map.remove(name);
-        if (da == null)
-            throw new IllegalStateException("Couldn't remove dataAccess object:" + name);
     }
 
     @Override


### PR DESCRIPTION
If we do not remove the backing files of the ElevationProvider we should still release them.

Should finally fix the issue mentioned in https://github.com/graphhopper/graphhopper/pull/1755#issuecomment-544409278