### PR TITLE
Remove FlagEncoder.getAnnotation

### DIFF
--- a/core/src/main/java/com/graphhopper/reader/ReaderElement.java
+++ b/core/src/main/java/com/graphhopper/reader/ReaderElement.java
@@ -136,7 +136,7 @@ public abstract class ReaderElement {
     /**
      * Check that a given tag has one of the specified values.
      */
-    public final boolean hasTag(String key, Set<String> values) {
+    public final boolean hasTag(String key, Collection<String> values) {
         return values.contains(getTag(key, ""));
     }
 
@@ -144,7 +144,7 @@ public abstract class ReaderElement {
      * Check a number of tags in the given order for the any of the given values. Used to parse
      * hierarchical access restrictions
      */
-    public boolean hasTag(List<String> keyList, Set<String> values) {
+    public boolean hasTag(List<String> keyList, Collection<String> values) {
         for (String key : keyList) {
             if (values.contains(getTag(key, "")))
                 return true;

--- a/core/src/main/java/com/graphhopper/routing/InstructionsOutgoingEdges.java
+++ b/core/src/main/java/com/graphhopper/routing/InstructionsOutgoingEdges.java
@@ -18,8 +18,8 @@
 package com.graphhopper.routing;
 
 import com.graphhopper.routing.profiles.BooleanEncodedValue;
-import com.graphhopper.routing.profiles.MaxSpeed;
 import com.graphhopper.routing.profiles.DecimalEncodedValue;
+import com.graphhopper.routing.profiles.MaxSpeed;
 import com.graphhopper.routing.util.DataFlagEncoder;
 import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.storage.IntsRef;
@@ -57,19 +57,14 @@ import java.util.List;
  */
 class InstructionsOutgoingEdges {
 
-    final EdgeIteratorState prevEdge;
-    final EdgeIteratorState currentEdge;
-
+    private final EdgeIteratorState prevEdge;
+    private final EdgeIteratorState currentEdge;
     // Outgoing edges that we would be allowed to turn on
-    final List<EdgeIteratorState> allowedOutgoingEdges;
-
+    private final List<EdgeIteratorState> allowedOutgoingEdges;
     // All outgoing edges, including oneways in the wrong direction
-    final List<EdgeIteratorState> allOutgoingEdges;
-
-    final FlagEncoder encoder;
-    final BooleanEncodedValue accessEnc;
-    final DecimalEncodedValue speedEnc;
-    final NodeAccess nodeAccess;
+    private final List<EdgeIteratorState> allOutgoingEdges;
+    private final DecimalEncodedValue speedEnc;
+    private final NodeAccess nodeAccess;
 
     public InstructionsOutgoingEdges(EdgeIteratorState prevEdge,
                                      EdgeIteratorState currentEdge,
@@ -81,8 +76,7 @@ class InstructionsOutgoingEdges {
                                      int adjNode) {
         this.prevEdge = prevEdge;
         this.currentEdge = currentEdge;
-        this.encoder = encoder;
-        this.accessEnc = encoder.getAccessEnc();
+        BooleanEncodedValue accessEnc = encoder.getAccessEnc();
         this.speedEnc = (encoder instanceof DataFlagEncoder) ? encoder.getDecimalEncodedValue(MaxSpeed.KEY) : encoder.getAverageSpeedEnc();
         this.nodeAccess = nodeAccess;
 

--- a/core/src/main/java/com/graphhopper/routing/profiles/DefaultEncodedValueFactory.java
+++ b/core/src/main/java/com/graphhopper/routing/profiles/DefaultEncodedValueFactory.java
@@ -34,6 +34,8 @@ public class DefaultEncodedValueFactory implements EncodedValueFactory {
         // creating the Country EV is done while SpatialRuleIndex is created and not here
         if (Roundabout.KEY.equals(name)) {
             enc = Roundabout.create();
+        } else if (GetOffBike.KEY.equals(name)) {
+            enc = GetOffBike.create();
         } else if (RoadClass.KEY.equals(name)) {
             enc = new EnumEncodedValue<>(RoadClass.KEY, RoadClass.class);
         } else if (RoadClassLink.KEY.equals(name)) {

--- a/core/src/main/java/com/graphhopper/routing/profiles/GetOffBike.java
+++ b/core/src/main/java/com/graphhopper/routing/profiles/GetOffBike.java
@@ -1,7 +1,7 @@
 package com.graphhopper.routing.profiles;
 
 public class GetOffBike {
-    public static final String KEY = "off_bike";
+    public static final String KEY = "get_off_bike";
 
     public static BooleanEncodedValue create() {
         return new SimpleBooleanEncodedValue(KEY, false);

--- a/core/src/main/java/com/graphhopper/routing/profiles/GetOffBike.java
+++ b/core/src/main/java/com/graphhopper/routing/profiles/GetOffBike.java
@@ -1,0 +1,9 @@
+package com.graphhopper.routing.profiles;
+
+public class GetOffBike {
+    public static final String KEY = "off_bike";
+
+    public static BooleanEncodedValue create() {
+        return new SimpleBooleanEncodedValue(KEY, false);
+    }
+}

--- a/core/src/main/java/com/graphhopper/routing/util/AbstractFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/AbstractFlagEncoder.java
@@ -228,11 +228,6 @@ public abstract class AbstractFlagEncoder implements FlagEncoder {
         return 0;
     }
 
-    @Override
-    public InstructionAnnotation getAnnotation(IntsRef edgeFlags, Translation tr) {
-        return InstructionAnnotation.EMPTY;
-    }
-
     /**
      * Sets default flags with specified access.
      */

--- a/core/src/main/java/com/graphhopper/routing/util/BikeFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/BikeFlagEncoder.java
@@ -76,13 +76,6 @@ public class BikeFlagEncoder extends BikeCommonFlagEncoder {
     }
 
     @Override
-    boolean isPushingSection(ReaderWay way) {
-        String highway = way.getTag("highway");
-        String trackType = way.getTag("tracktype");
-        return super.isPushingSection(way) || "track".equals(highway) && trackType != null && !"grade1".equals(trackType);
-    }
-
-    @Override
     public String toString() {
         return "bike";
     }

--- a/core/src/main/java/com/graphhopper/routing/util/DataFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/DataFlagEncoder.java
@@ -211,15 +211,6 @@ public class DataFlagEncoder extends AbstractFlagEncoder {
     }
 
     @Override
-    public InstructionAnnotation getAnnotation(IntsRef flags, Translation tr) {
-        if (roadEnvironmentEnc.getEnum(false, flags) == RoadEnvironment.FORD) {
-            return new InstructionAnnotation(1, tr.tr("way_contains_ford"));
-        }
-
-        return super.getAnnotation(flags, tr);
-    }
-
-    @Override
     public int getVersion() {
         return 4;
     }

--- a/core/src/main/java/com/graphhopper/routing/util/EncodingManager.java
+++ b/core/src/main/java/com/graphhopper/routing/util/EncodingManager.java
@@ -315,10 +315,15 @@ public class EncodingManager implements EncodedValueLookup {
             }
 
             for (AbstractFlagEncoder encoder : flagEncoderList) {
-                if (encoder instanceof BikeCommonFlagEncoder && !em.hasEncodedValue(getKey("bike", RouteNetwork.EV_SUFFIX))) {
-                    _addRelationTagParser(new OSMBikeNetworkTagParser());
-                } else if (encoder instanceof FootFlagEncoder && !em.hasEncodedValue(getKey("foot", RouteNetwork.EV_SUFFIX))) {
-                    _addRelationTagParser(new OSMFootNetworkTagParser());
+                if (encoder instanceof BikeCommonFlagEncoder) {
+                    if (!em.hasEncodedValue(getKey("bike", RouteNetwork.EV_SUFFIX)))
+                        _addRelationTagParser(new OSMBikeNetworkTagParser());
+                    if (!em.encodedValueMap.containsKey(GetOffBike.KEY))
+                        _addEdgeTagParser(new OSMGetOffBikeParser(), false, false);
+
+                } else if (encoder instanceof FootFlagEncoder) {
+                    if (!em.hasEncodedValue(getKey("foot", RouteNetwork.EV_SUFFIX)))
+                        _addRelationTagParser(new OSMFootNetworkTagParser());
                 }
 
                 em.addEncoder(encoder);

--- a/core/src/main/java/com/graphhopper/routing/util/FlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/FlagEncoder.java
@@ -61,11 +61,6 @@ public interface FlagEncoder extends EncodedValueLookup {
     boolean supports(Class<?> feature);
 
     /**
-     * @return additional cost or warning information for an instruction like ferry or road charges.
-     */
-    InstructionAnnotation getAnnotation(IntsRef intsRef, Translation tr);
-
-    /**
      * @return true if already registered in an EncodingManager
      */
     boolean isRegistered();

--- a/core/src/main/java/com/graphhopper/routing/util/RacingBikeFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/RacingBikeFlagEncoder.java
@@ -145,16 +145,6 @@ public class RacingBikeFlagEncoder extends BikeCommonFlagEncoder {
     }
 
     @Override
-    boolean isPushingSection(ReaderWay way) {
-        String highway = way.getTag("highway");
-        String trackType = way.getTag("tracktype");
-        return way.hasTag("highway", pushingSectionsHighways)
-                || way.hasTag("railway", "platform")
-                || way.hasTag("bicycle", "dismount")
-                || "track".equals(highway) && trackType != null && !"grade1".equals(trackType);
-    }
-
-    @Override
     boolean isSacScaleAllowed(String sacScale) {
         // for racing bike it is only allowed if empty
         return false;

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMGetOffBikeParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMGetOffBikeParser.java
@@ -8,6 +8,7 @@ import com.graphhopper.routing.profiles.GetOffBike;
 import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.storage.IntsRef;
 
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 
@@ -16,20 +17,17 @@ import java.util.List;
  */
 public class OSMGetOffBikeParser implements TagParser {
 
-    // roads where you get off your bike and push it
-    private final HashSet<String> pushBikeTags = new HashSet<>();
-    private final HashSet<String> accepted = new HashSet<>();
+    private final HashSet<String> pushBikeHighwayTags = new HashSet<>();
+    private final List<String> accepted = Arrays.asList("designated", "yes");
     private final BooleanEncodedValue offBikeEnc;
 
     public OSMGetOffBikeParser() {
         offBikeEnc = GetOffBike.create();
-        pushBikeTags.add("path");
-        pushBikeTags.add("footway");
-        pushBikeTags.add("pedestrian");
-        pushBikeTags.add("platform");
-
-        accepted.add("designated");
-        accepted.add("yes");
+        pushBikeHighwayTags.add("path");
+        // pushBikeHighwayTags.add("steps"); special handling
+        pushBikeHighwayTags.add("footway");
+        pushBikeHighwayTags.add("pedestrian");
+        pushBikeHighwayTags.add("platform");
     }
 
     @Override
@@ -40,12 +38,10 @@ public class OSMGetOffBikeParser implements TagParser {
     @Override
     public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay way, EncodingManager.Access access, IntsRef relationFlags) {
         String highway = way.getTag("highway");
-        // String trackType = way.getTag("tracktype");
-        if ((pushBikeTags.contains(highway) || way.hasTag("railway", "platform")) && !way.hasTag("bicycle", accepted)
-                || "steps".equals(highway)
-                || way.hasTag("bicycle", "dismount"))
-            // || "track".equals(highway) && !"grade1".equals(trackType))
+        if (!way.hasTag("bicycle", accepted) && (pushBikeHighwayTags.contains(highway) || way.hasTag("railway", "platform"))
+                || "steps".equals(highway) || way.hasTag("bicycle", "dismount")) {
             offBikeEnc.setBool(false, edgeFlags, true);
+        }
         return edgeFlags;
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMGetOffBikeParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMGetOffBikeParser.java
@@ -1,0 +1,51 @@
+package com.graphhopper.routing.util.parsers;
+
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.profiles.BooleanEncodedValue;
+import com.graphhopper.routing.profiles.EncodedValue;
+import com.graphhopper.routing.profiles.EncodedValueLookup;
+import com.graphhopper.routing.profiles.GetOffBike;
+import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.storage.IntsRef;
+
+import java.util.HashSet;
+import java.util.List;
+
+/**
+ * This parser scans different OSM tags to identify ways where a cyclist has to get off her bike.
+ */
+public class OSMGetOffBikeParser implements TagParser {
+
+    // roads where you get off your bike and push it
+    private final HashSet<String> pushBikeTags = new HashSet<>();
+    private final HashSet<String> accepted = new HashSet<>();
+    private final BooleanEncodedValue offBikeEnc;
+
+    public OSMGetOffBikeParser() {
+        offBikeEnc = GetOffBike.create();
+        pushBikeTags.add("path");
+        pushBikeTags.add("footway");
+        pushBikeTags.add("pedestrian");
+        pushBikeTags.add("platform");
+
+        accepted.add("designated");
+        accepted.add("yes");
+    }
+
+    @Override
+    public void createEncodedValues(EncodedValueLookup lookup, List<EncodedValue> registerNewEncodedValue) {
+        registerNewEncodedValue.add(offBikeEnc);
+    }
+
+    @Override
+    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay way, EncodingManager.Access access, IntsRef relationFlags) {
+        String highway = way.getTag("highway");
+        // String trackType = way.getTag("tracktype");
+        if ((pushBikeTags.contains(highway) || way.hasTag("railway", "platform")) && !way.hasTag("bicycle", accepted)
+                || "steps".equals(highway)
+                || way.hasTag("bicycle", "dismount"))
+            // || "track".equals(highway) && !"grade1".equals(trackType))
+            offBikeEnc.setBool(false, edgeFlags, true);
+        return edgeFlags;
+    }
+}

--- a/core/src/main/java/com/graphhopper/util/PathMerger.java
+++ b/core/src/main/java/com/graphhopper/util/PathMerger.java
@@ -21,6 +21,7 @@ import com.graphhopper.PathWrapper;
 import com.graphhopper.routing.InstructionsFromEdges;
 import com.graphhopper.routing.Path;
 import com.graphhopper.routing.profiles.BooleanEncodedValue;
+import com.graphhopper.routing.profiles.EncodedValueLookup;
 import com.graphhopper.routing.profiles.Roundabout;
 import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.routing.weighting.Weighting;
@@ -90,7 +91,7 @@ public class PathMerger {
         return this;
     }
 
-    public void doWork(PathWrapper altRsp, List<Path> paths, EncodingManager encodingManager, Translation tr) {
+    public void doWork(PathWrapper altRsp, List<Path> paths, EncodedValueLookup evLookup, Translation tr) {
         int origPoints = 0;
         long fullTimeInMillis = 0;
         double fullWeight = 0;
@@ -100,7 +101,6 @@ public class PathMerger {
         InstructionList fullInstructions = new InstructionList(tr);
         PointList fullPoints = PointList.EMPTY;
         List<String> description = new ArrayList<>();
-        BooleanEncodedValue roundaboutEnc = encodingManager.getBooleanEncodedValue(Roundabout.KEY);
         for (int pathIndex = 0; pathIndex < paths.size(); pathIndex++) {
             Path path = paths.get(pathIndex);
             if (!path.isFound()) {
@@ -112,7 +112,7 @@ public class PathMerger {
             fullDistance += path.getDistance();
             fullWeight += path.getWeight();
             if (enableInstructions) {
-                InstructionList il = InstructionsFromEdges.calcInstructions(path, graph, weighting, roundaboutEnc, tr);
+                InstructionList il = InstructionsFromEdges.calcInstructions(path, graph, weighting, evLookup, tr);
 
                 if (!il.isEmpty()) {
                     fullInstructions.addAll(il);
@@ -137,7 +137,7 @@ public class PathMerger {
                 }
 
                 fullPoints.add(tmpPoints);
-                altRsp.addPathDetails(PathDetailsFromEdges.calcDetails(path, encodingManager, weighting, requestedPathDetails, pathBuilderFactory, origPoints));
+                altRsp.addPathDetails(PathDetailsFromEdges.calcDetails(path, evLookup, weighting, requestedPathDetails, pathBuilderFactory, origPoints));
                 origPoints = fullPoints.size();
             }
 

--- a/core/src/main/java/com/graphhopper/util/details/PathDetailsBuilderFactory.java
+++ b/core/src/main/java/com/graphhopper/util/details/PathDetailsBuilderFactory.java
@@ -37,7 +37,7 @@ import static com.graphhopper.util.Parameters.Details.*;
  */
 public class PathDetailsBuilderFactory {
 
-    public List<PathDetailsBuilder> createPathDetailsBuilders(List<String> requestedPathDetails, EncodingManager em, Weighting weighting) {
+    public List<PathDetailsBuilder> createPathDetailsBuilders(List<String> requestedPathDetails, EncodedValueLookup evl, Weighting weighting) {
         List<PathDetailsBuilder> builders = new ArrayList<>();
 
         if (requestedPathDetails.contains(AVERAGE_SPEED))
@@ -59,14 +59,14 @@ public class PathDetailsBuilderFactory {
             builders.add(new DistanceDetails());
 
         for (String checkSuffix : requestedPathDetails) {
-            if (checkSuffix.contains(getKey("", "priority")) && em.hasEncodedValue(checkSuffix))
-                builders.add(new DecimalDetails(checkSuffix, em.getDecimalEncodedValue(checkSuffix)));
+            if (checkSuffix.contains(getKey("", "priority")) && evl.hasEncodedValue(checkSuffix))
+                builders.add(new DecimalDetails(checkSuffix, evl.getDecimalEncodedValue(checkSuffix)));
         }
 
         for (String key : Arrays.asList(MaxSpeed.KEY, MaxWidth.KEY, MaxHeight.KEY, MaxWeight.KEY,
                 MaxAxleLoad.KEY, MaxLength.KEY)) {
-            if (requestedPathDetails.contains(key) && em.hasEncodedValue(key))
-                builders.add(new DecimalDetails(key, em.getDecimalEncodedValue(key)));
+            if (requestedPathDetails.contains(key) && evl.hasEncodedValue(key))
+                builders.add(new DecimalDetails(key, evl.getDecimalEncodedValue(key)));
         }
 
         for (Map.Entry entry : Arrays.asList(new MapEntry<>(RoadClass.KEY, RoadClass.class),
@@ -76,8 +76,8 @@ public class PathDetailsBuilderFactory {
                 new MapEntry<>(HazmatTunnel.KEY, HazmatTunnel.class), new MapEntry<>(HazmatWater.KEY, HazmatWater.class),
                 new MapEntry<>(Country.KEY, Country.class))) {
             String key = (String) entry.getKey();
-            if (requestedPathDetails.contains(key) && em.hasEncodedValue(key))
-                builders.add(new EnumDetails(key, em.getEnumEncodedValue(key, (Class<Enum>) entry.getValue())));
+            if (requestedPathDetails.contains(key) && evl.hasEncodedValue(key))
+                builders.add(new EnumDetails(key, evl.getEnumEncodedValue(key, (Class<Enum>) entry.getValue())));
         }
 
         if (requestedPathDetails.size() != builders.size()) {

--- a/core/src/main/java/com/graphhopper/util/details/PathDetailsFromEdges.java
+++ b/core/src/main/java/com/graphhopper/util/details/PathDetailsFromEdges.java
@@ -18,7 +18,7 @@
 package com.graphhopper.util.details;
 
 import com.graphhopper.routing.Path;
-import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.routing.profiles.EncodedValueLookup;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.util.EdgeIteratorState;
 
@@ -55,11 +55,11 @@ public class PathDetailsFromEdges implements Path.EdgeVisitor {
      * @param pathBuilderFactory Generates the relevant PathBuilders
      * @return List of PathDetails for this Path
      */
-    public static Map<String, List<PathDetail>> calcDetails(Path path, EncodingManager encodingManager, Weighting weighting,
+    public static Map<String, List<PathDetail>> calcDetails(Path path, EncodedValueLookup evLookup, Weighting weighting,
                                                             List<String> requestedPathDetails, PathDetailsBuilderFactory pathBuilderFactory, int previousIndex) {
         if (!path.isFound() || requestedPathDetails.isEmpty())
             return Collections.emptyMap();
-        List<PathDetailsBuilder> pathBuilders = pathBuilderFactory.createPathDetailsBuilders(requestedPathDetails, encodingManager, weighting);
+        List<PathDetailsBuilder> pathBuilders = pathBuilderFactory.createPathDetailsBuilders(requestedPathDetails, evLookup, weighting);
         if (pathBuilders.isEmpty())
             return Collections.emptyMap();
 

--- a/core/src/test/java/com/graphhopper/routing/util/AbstractBikeFlagEncoderTester.java
+++ b/core/src/test/java/com/graphhopper/routing/util/AbstractBikeFlagEncoderTester.java
@@ -77,16 +77,6 @@ public abstract class AbstractBikeFlagEncoderTester {
         return avSpeedEnc.getDecimal(false, flags);
     }
 
-    protected String getWayTypeFromFlags(ReaderWay way) {
-        return getWayTypeFromFlags(way, encodingManager.createRelationFlags());
-    }
-
-    protected String getWayTypeFromFlags(ReaderWay way, IntsRef relationFlags) {
-        IntsRef flags = encodingManager.handleWayTags(way, new EncodingManager.AcceptWay().put(encoder.toString(), WAY), relationFlags);
-        Translation enMap = SINGLETON.getWithFallBack(Locale.UK);
-        return encoder.getAnnotation(flags, enMap).getMessage();
-    }
-
     @Test
     public void testAccess() {
         ReaderWay way = new ReaderWay(1);
@@ -313,108 +303,6 @@ public abstract class AbstractBikeFlagEncoderTester {
         // should be safe now
         way.setTag("bicycle", "designated");
         assertPriority(PREFER.getValue(), way);
-    }
-
-    @Test
-    public void testHandleCommonWayTags() {
-        ReaderWay way = new ReaderWay(1);
-        String wayType;
-
-        way.setTag("highway", "steps");
-        wayType = getWayTypeFromFlags(way);
-        assertEquals("get off the bike", wayType);
-
-        way.setTag("highway", "footway");
-        wayType = getWayTypeFromFlags(way);
-        assertEquals("get off the bike", wayType);
-
-        way.setTag("highway", "footway");
-        way.setTag("surface", "pebblestone");
-        wayType = getWayTypeFromFlags(way);
-        assertEquals("get off the bike", wayType);
-
-        way.setTag("highway", "residential");
-        wayType = getWayTypeFromFlags(way);
-        assertEquals("", wayType);
-        assertPriority(PREFER.getValue(), way);
-
-        way.clearTags();
-        way.setTag("highway", "residential");
-        way.setTag("bicycle", "yes");
-        wayType = getWayTypeFromFlags(way);
-        assertEquals("", wayType);
-
-        way.clearTags();
-        way.setTag("highway", "residential");
-        way.setTag("bicycle", "designated");
-        wayType = getWayTypeFromFlags(way);
-        assertEquals("", wayType);
-
-        way.clearTags();
-        way.setTag("highway", "track");
-        way.setTag("bicycle", "designated");
-        wayType = getWayTypeFromFlags(way);
-        assertEquals("cycleway, unpaved", wayType);
-
-        way.clearTags();
-        way.setTag("highway", "cycleway");
-        wayType = getWayTypeFromFlags(way);
-        assertEquals("cycleway", wayType);
-        assertPriority(VERY_NICE.getValue(), way);
-
-        way.setTag("surface", "grass");
-        wayType = getWayTypeFromFlags(way);
-        assertEquals("cycleway, unpaved", wayType);
-
-        way.setTag("surface", "asphalt");
-        wayType = getWayTypeFromFlags(way);
-        assertEquals("cycleway", wayType);
-        assertPriority(VERY_NICE.getValue(), way);
-
-        way.setTag("highway", "footway");
-        way.setTag("bicycle", "yes");
-        way.setTag("surface", "grass");
-        wayType = getWayTypeFromFlags(way);
-        assertEquals("small way, unpaved", wayType);
-
-        way.setTag("bicycle", "designated");
-        wayType = getWayTypeFromFlags(way);
-        assertEquals("cycleway, unpaved", wayType);
-
-        way.clearTags();
-        way.setTag("highway", "footway");
-        way.setTag("bicycle", "yes");
-        way.setTag("surface", "grass");
-        wayType = getWayTypeFromFlags(way);
-        assertEquals("small way, unpaved", wayType);
-
-        way.clearTags();
-        way.setTag("railway", "platform");
-        wayType = getWayTypeFromFlags(way);
-        assertEquals("get off the bike", wayType);
-
-        way.clearTags();
-        way.setTag("highway", "track");
-        way.setTag("railway", "platform");
-        wayType = getWayTypeFromFlags(way);
-        assertEquals("get off the bike, unpaved", wayType);
-
-        way.clearTags();
-        way.setTag("highway", "secondary");
-        way.setTag("bicycle", "dismount");
-        wayType = getWayTypeFromFlags(way);
-        assertEquals("get off the bike", wayType);
-
-        way.clearTags();
-        way.setTag("highway", "platform");
-        wayType = getWayTypeFromFlags(way);
-        assertEquals("get off the bike", wayType);
-
-        way.clearTags();
-        way.setTag("highway", "platform");
-        way.setTag("bicycle", "yes");
-        wayType = getWayTypeFromFlags(way);
-        assertEquals("", wayType);
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/routing/util/BikeFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/BikeFlagEncoderTest.java
@@ -283,44 +283,6 @@ public class BikeFlagEncoderTest extends AbstractBikeFlagEncoderTester {
     }
 
     @Test
-    public void testHandleWayTags() {
-        ReaderWay way = new ReaderWay(1);
-        String wayType;
-        way.setTag("highway", "track");
-        wayType = getWayTypeFromFlags(way);
-        assertEquals("small way, unpaved", wayType);
-
-        way.clearTags();
-        way.setTag("highway", "path");
-        wayType = getWayTypeFromFlags(way);
-        assertEquals("get off the bike, unpaved", wayType);
-
-        way.clearTags();
-        way.setTag("highway", "path");
-        way.setTag("surface", "grass");
-        wayType = getWayTypeFromFlags(way);
-        assertEquals("get off the bike, unpaved", wayType);
-
-        way.clearTags();
-        way.setTag("highway", "path");
-        way.setTag("surface", "concrete");
-        wayType = getWayTypeFromFlags(way);
-        assertEquals("get off the bike", wayType);
-
-        way.clearTags();
-        way.setTag("highway", "track");
-        way.setTag("foot", "yes");
-        way.setTag("surface", "paved");
-        way.setTag("tracktype", "grade1");
-        wayType = getWayTypeFromFlags(way);
-        assertEquals("", wayType);
-
-        way.setTag("tracktype", "grade2");
-        wayType = getWayTypeFromFlags(way);
-        assertEquals("get off the bike, unpaved", wayType);
-    }
-
-    @Test
     public void testWayAcceptance() {
         ReaderWay way = new ReaderWay(1);
         way.setTag("highway", "cycleway");
@@ -478,50 +440,6 @@ public class BikeFlagEncoderTest extends AbstractBikeFlagEncoderTester {
         osmRel.setTag("route", "bicycle");
         osmRel.setTag("network", "lcn");
         assertPriority(PREFER.getValue(), osmWay, osmRel);
-
-        // A footway is not of waytype get off the bike in case that it is part of a cycle route
-        osmRel.clearTags();
-        osmWay.clearTags();
-        osmWay.setTag("highway", "footway");
-        osmWay.setTag("surface", "grass");
-
-        // First tests without a cycle route relation, this is a get off the bike
-        IntsRef relFlags = encodingManager.handleRelationTags(osmRel, encodingManager.createRelationFlags());
-        String wayType = getWayTypeFromFlags(osmWay, relFlags);
-        assertEquals("get off the bike, unpaved", wayType);
-
-        // now as part of a cycle route relation
-        osmRel.setTag("type", "route");
-        osmRel.setTag("route", "bicycle");
-        osmRel.setTag("network", "lcn");
-        relFlags = encodingManager.handleRelationTags(osmRel, encodingManager.createRelationFlags());
-        wayType = getWayTypeFromFlags(osmWay, relFlags);
-        assertEquals("small way, unpaved", wayType);
-
-        // steps are still shown as get off the bike
-        osmWay.clearTags();
-        osmWay.setTag("highway", "steps");
-        relFlags = encodingManager.handleRelationTags(osmRel, encodingManager.createRelationFlags());
-        wayType = getWayTypeFromFlags(osmWay, relFlags);
-        assertEquals("get off the bike", wayType);
-
-        // Test for highway=platform.
-        osmRel.clearTags();
-        osmWay.clearTags();
-        osmWay.setTag("highway", "platform");
-
-        // First tests without a cycle route relation, this is a get off the bike
-        relFlags = encodingManager.handleRelationTags(osmRel, encodingManager.createRelationFlags());
-        wayType = getWayTypeFromFlags(osmWay, relFlags);
-        assertEquals("get off the bike", wayType);
-
-        // now as part of a cycle route relation
-        osmRel.setTag("type", "route");
-        osmRel.setTag("route", "bicycle");
-        osmRel.setTag("network", "lcn");
-        relFlags = encodingManager.handleRelationTags(osmRel, encodingManager.createRelationFlags());
-        wayType = getWayTypeFromFlags(osmWay, relFlags);
-        assertEquals("", wayType);
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/routing/util/DataFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/DataFlagEncoderTest.java
@@ -133,18 +133,6 @@ public class DataFlagEncoderTest {
     }
 
     @Test
-    public void testFord() {
-        ReaderWay osmWay = new ReaderWay(0);
-        osmWay.setTag("highway", "unclassified");
-        osmWay.setTag("ford", "yes");
-        IntsRef flags = encodingManager.handleWayTags(osmWay, map, relFlags);
-        EdgeIteratorState edge = GHUtility.createMockedEdgeIteratorState(0, flags);
-        assertEquals("ford", edge.get(roadEnvironmentEnc).toString());
-        assertTrue(edge.get(roadEnvironmentEnc) == RoadEnvironment.FORD);
-        assertTrue(encoder.getAnnotation(edge.getFlags(), TranslationMapTest.SINGLETON.get("en")).getMessage().contains("ford"));
-    }
-
-    @Test
     public void testHighwaySpeed() {
         PMap map = new PMap();
         map.put("motorway", 100d);

--- a/core/src/test/java/com/graphhopper/routing/util/MountainBikeFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/MountainBikeFlagEncoderTest.java
@@ -102,54 +102,6 @@ public class MountainBikeFlagEncoderTest extends AbstractBikeFlagEncoderTester {
     }
 
     @Test
-    public void testHandleWayTags() {
-        ReaderWay way = new ReaderWay(1);
-        String wayType;
-
-        way.setTag("highway", "track");
-        wayType = getWayTypeFromFlags(way);
-        assertEquals("small way, unpaved", wayType);
-
-        way.clearTags();
-        way.setTag("highway", "path");
-        wayType = getWayTypeFromFlags(way);
-        assertEquals("small way, unpaved", wayType);
-
-        way.clearTags();
-        way.setTag("highway", "path");
-        way.setTag("surface", "grass");
-        wayType = getWayTypeFromFlags(way);
-        assertEquals("small way, unpaved", wayType);
-
-        way.clearTags();
-        way.setTag("highway", "path");
-        way.setTag("surface", "concrete");
-        wayType = getWayTypeFromFlags(way);
-        assertEquals("", wayType);
-
-        way.clearTags();
-        way.setTag("highway", "track");
-        way.setTag("foot", "yes");
-        way.setTag("surface", "paved");
-        way.setTag("tracktype", "grade1");
-        wayType = getWayTypeFromFlags(way);
-        assertEquals("", wayType);
-
-        way.clearTags();
-        way.setTag("highway", "track");
-        way.setTag("foot", "yes");
-        way.setTag("surface", "paved");
-        way.setTag("tracktype", "grade2");
-        wayType = getWayTypeFromFlags(way);
-        assertEquals("small way, unpaved", wayType);
-
-        way.clearTags();
-        way.setTag("highway", "pedestrian");
-        wayType = getWayTypeFromFlags(way);
-        assertEquals("get off the bike", wayType);
-    }
-
-    @Test
     public void testHandleWayTagsInfluencedByRelation() {
         ReaderWay osmWay = new ReaderWay(1);
         osmWay.setTag("highway", "track");
@@ -160,7 +112,6 @@ public class MountainBikeFlagEncoderTest extends AbstractBikeFlagEncoderTester {
         IntsRef flags = encodingManager.handleWayTags(osmWay, accessMap, relFlags);
         assertEquals(18, encoder.getSpeed(flags), 1e-1);
         assertPriority(PriorityCode.PREFER.getValue(), osmWay);
-        assertEquals("small way, unpaved", getWayTypeFromFlags(osmWay));
 
         // relation code is PREFER
         osmRel.setTag("route", "bicycle");
@@ -169,7 +120,6 @@ public class MountainBikeFlagEncoderTest extends AbstractBikeFlagEncoderTester {
         flags = encodingManager.handleWayTags(osmWay, accessMap, relFlags);
         assertEquals(18, encoder.getSpeed(flags), 1e-1);
         assertPriority(PriorityCode.PREFER.getValue(), osmWay);
-        assertEquals("small way, unpaved", getWayTypeFromFlags(osmWay));
 
         // relation code is PREFER
         osmRel.setTag("network", "rcn");
@@ -197,7 +147,6 @@ public class MountainBikeFlagEncoderTest extends AbstractBikeFlagEncoderTester {
         flags = encodingManager.handleWayTags(osmWay, accessMap, relFlags);
         assertEquals(18, encoder.getSpeed(flags), 1e-1);
         assertPriority(PriorityCode.PREFER.getValue(), osmWay);
-        assertEquals("", getWayTypeFromFlags(osmWay));
     }
 
     // Issue 407 : Always block kissing_gate execpt for mountainbikes

--- a/core/src/test/java/com/graphhopper/routing/util/RacingBikeFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/RacingBikeFlagEncoderTest.java
@@ -130,7 +130,6 @@ public class RacingBikeFlagEncoderTest extends AbstractBikeFlagEncoderTester {
         ReaderWay osmWay = new ReaderWay(1);
         osmWay.setTag("highway", "track");
         assertEquals(PUSHING_SECTION_SPEED / 2, getSpeedFromFlags(osmWay), 1e-1);
-        assertEquals("small way, unpaved", getWayTypeFromFlags(osmWay, encodingManager.createRelationFlags()));
 
         // relation code is PREFER
         ReaderRelation osmRel = new ReaderRelation(1);
@@ -138,9 +137,6 @@ public class RacingBikeFlagEncoderTest extends AbstractBikeFlagEncoderTester {
         osmRel.setTag("network", "lcn");
         IntsRef flags = assertPriority(AVOID_AT_ALL_COSTS.getValue(), osmWay, osmRel);
         assertEquals(2, encoder.getSpeed(flags), 1e-1);
-        IntsRef relFlags = encodingManager.handleRelationTags(osmRel, encodingManager.createRelationFlags());
-        assertEquals("small way, unpaved", getWayTypeFromFlags(osmWay, relFlags));
-
         // relation code is OUTSTANDING NICE but as unpaved, the speed is still PUSHING_SECTION_SPEED/2
         osmRel.setTag("network", "icn");
         flags = assertPriority(AVOID_AT_ALL_COSTS.getValue(), osmWay, osmRel);
@@ -155,16 +151,12 @@ public class RacingBikeFlagEncoderTest extends AbstractBikeFlagEncoderTester {
         osmWay.setTag("tracktype", "grade1");
         flags = assertPriority(PREFER.getValue(), osmWay, osmRel);
         assertEquals(20, encoder.getSpeed(flags), 1e-1);
-        relFlags = encodingManager.handleRelationTags(osmRel, encodingManager.createRelationFlags());
-        assertEquals("cycleway", getWayTypeFromFlags(osmWay, relFlags));
 
         // Now we assume bicycle=yes, and unpaved as part of a cycle relation
         osmWay.setTag("tracktype", "grade2");
         osmWay.setTag("bicycle", "yes");
         flags = assertPriority(AVOID_AT_ALL_COSTS.getValue(), osmWay, osmRel);
         assertEquals(10, encoder.getSpeed(flags), 1e-1);
-        relFlags = encodingManager.handleRelationTags(osmRel, encodingManager.createRelationFlags());
-        assertEquals("small way, unpaved", getWayTypeFromFlags(osmWay, relFlags));
 
         // Now we assume bicycle=yes, and unpaved not part of a cycle relation
         osmWay.clearTags();
@@ -172,16 +164,12 @@ public class RacingBikeFlagEncoderTest extends AbstractBikeFlagEncoderTester {
         osmWay.setTag("tracktype", "grade3");
         flags = assertPriority(AVOID_AT_ALL_COSTS.getValue(), osmWay);
         assertEquals(PUSHING_SECTION_SPEED, encoder.getSpeed(flags), 1e-1);
-        relFlags = encodingManager.handleRelationTags(new ReaderRelation(1), encodingManager.createRelationFlags());
-        assertEquals("get off the bike, unpaved", getWayTypeFromFlags(osmWay, relFlags));
 
         // Now we assume bicycle=yes, and tracktype = null
         osmWay.clearTags();
         osmWay.setTag("highway", "track");
         flags = assertPriority(AVOID_AT_ALL_COSTS.getValue(), osmWay);
         assertEquals(2, encoder.getSpeed(flags), 1e-1);
-        relFlags = encodingManager.handleRelationTags(new ReaderRelation(1), encodingManager.createRelationFlags());
-        assertEquals("small way, unpaved", getWayTypeFromFlags(osmWay, relFlags));
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMGetOffBikeParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMGetOffBikeParserTest.java
@@ -1,5 +1,6 @@
 package com.graphhopper.routing.util.parsers;
 
+import com.graphhopper.reader.ReaderRelation;
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.profiles.BooleanEncodedValue;
 import com.graphhopper.routing.profiles.EnumEncodedValue;
@@ -44,10 +45,10 @@ public class OSMGetOffBikeParserTest {
         assertEquals(getRoadClass(way), RoadClass.CYCLEWAY);
 
         way.setTag("highway", "footway");
-        way.setTag("bicycle", "yes");
         way.setTag("surface", "grass");
+        assertTrue(isGetOffBike(way));
+        way.setTag("bicycle", "yes");
         assertFalse(isGetOffBike(way));
-
         way.setTag("bicycle", "designated");
         assertFalse(isGetOffBike(way));
 
@@ -83,53 +84,6 @@ public class OSMGetOffBikeParserTest {
         way.setTag("highway", "track");
         assertFalse(isGetOffBike(way));
     }
-
-//    @Test
-//    public void oldTest() {
-//        // A footway is not of waytype get off the bike in case that it is part of a cycle route
-//        ReaderRelation osmRel = new ReaderRelation(1);
-//        ReaderWay osmWay = new ReaderWay(1);
-//        osmWay.setTag("highway", "footway");
-//        osmWay.setTag("surface", "grass");
-//
-//        // First tests without a cycle route relation, this is a get off the bike
-//        IntsRef relFlags = encodingManager.handleRelationTags(osmRel, encodingManager.createRelationFlags());
-//        String wayType = getWayTypeFromFlags(osmWay, relFlags);
-//        assertEquals("get off the bike, unpaved", wayType);
-//
-//        // now as part of a cycle route relation
-//        osmRel.setTag("type", "route");
-//        osmRel.setTag("route", "bicycle");
-//        osmRel.setTag("network", "lcn");
-//        relFlags = encodingManager.handleRelationTags(osmRel, encodingManager.createRelationFlags());
-//        wayType = getWayTypeFromFlags(osmWay, relFlags);
-//        assertEquals("small way, unpaved", wayType);
-//
-//        // steps are still shown as get off the bike
-//        osmWay.clearTags();
-//        osmWay.setTag("highway", "steps");
-//        relFlags = encodingManager.handleRelationTags(osmRel, encodingManager.createRelationFlags());
-//        wayType = getWayTypeFromFlags(osmWay, relFlags);
-//        assertEquals("get off the bike", wayType);
-//
-//        // Test for highway=platform.
-//        osmRel.clearTags();
-//        osmWay.clearTags();
-//        osmWay.setTag("highway", "platform");
-//
-//        // First tests without a cycle route relation, this is a get off the bike
-//        relFlags = encodingManager.handleRelationTags(osmRel, encodingManager.createRelationFlags());
-//        wayType = getWayTypeFromFlags(osmWay, relFlags);
-//        assertEquals("get off the bike", wayType);
-//
-//        // now as part of a cycle route relation
-//        osmRel.setTag("type", "route");
-//        osmRel.setTag("route", "bicycle");
-//        osmRel.setTag("network", "lcn");
-//        relFlags = encodingManager.handleRelationTags(osmRel, encodingManager.createRelationFlags());
-//        wayType = getWayTypeFromFlags(osmWay, relFlags);
-//        assertEquals("", wayType);
-//    }
 
     private RoadClass getRoadClass(ReaderWay way) {
         IntsRef edgeFlags = em.handleWayTags(way, new EncodingManager.AcceptWay().put("bike", EncodingManager.Access.WAY), em.createRelationFlags());

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMGetOffBikeParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMGetOffBikeParserTest.java
@@ -1,0 +1,143 @@
+package com.graphhopper.routing.util.parsers;
+
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.profiles.BooleanEncodedValue;
+import com.graphhopper.routing.profiles.EnumEncodedValue;
+import com.graphhopper.routing.profiles.GetOffBike;
+import com.graphhopper.routing.profiles.RoadClass;
+import com.graphhopper.routing.util.BikeFlagEncoder;
+import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.storage.IntsRef;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class OSMGetOffBikeParserTest {
+
+    private EncodingManager em = EncodingManager.start().add(new BikeFlagEncoder()).build();
+    private BooleanEncodedValue offBikeEnc = em.getBooleanEncodedValue(GetOffBike.KEY);
+    private EnumEncodedValue<RoadClass> roadClassEnc = em.getEnumEncodedValue(RoadClass.KEY, RoadClass.class);
+
+    @Test
+    public void testHandleCommonWayTags() {
+        ReaderWay way = new ReaderWay(1);
+        way.setTag("highway", "steps");
+        assertTrue(isGetOffBike(way));
+
+        way.setTag("highway", "footway");
+        assertTrue(isGetOffBike(way));
+
+        way.setTag("highway", "footway");
+        way.setTag("surface", "pebblestone");
+        assertTrue(isGetOffBike(way));
+
+        way.setTag("highway", "residential");
+        assertFalse(isGetOffBike(way));
+
+        way = new ReaderWay(1);
+        way.setTag("highway", "residential");
+        way.setTag("bicycle", "yes");
+        assertFalse(isGetOffBike(way));
+
+        way = new ReaderWay(1);
+        way.setTag("highway", "cycleway");
+        assertEquals(getRoadClass(way), RoadClass.CYCLEWAY);
+
+        way.setTag("highway", "footway");
+        way.setTag("bicycle", "yes");
+        way.setTag("surface", "grass");
+        assertFalse(isGetOffBike(way));
+
+        way.setTag("bicycle", "designated");
+        assertFalse(isGetOffBike(way));
+
+        way = new ReaderWay(1);
+        way.setTag("railway", "platform");
+        assertTrue(isGetOffBike(way));
+
+        way = new ReaderWay(1);
+        way.setTag("highway", "secondary");
+        way.setTag("bicycle", "dismount");
+        assertTrue(isGetOffBike(way));
+
+        way = new ReaderWay(1);
+        way.setTag("highway", "platform");
+        way.setTag("bicycle", "yes");
+        assertFalse(isGetOffBike(way));
+
+        way = new ReaderWay(1);
+        way.setTag("highway", "track");
+        way.setTag("foot", "yes");
+        assertFalse(isGetOffBike(way));
+
+        way = new ReaderWay(1);
+        way.setTag("highway", "pedestrian");
+        assertTrue(isGetOffBike(way));
+
+        way = new ReaderWay(1);
+        way.setTag("highway", "path");
+        way.setTag("surface", "concrete");
+        assertTrue(isGetOffBike(way));
+
+        way = new ReaderWay(1);
+        way.setTag("highway", "track");
+        assertFalse(isGetOffBike(way));
+    }
+
+//    @Test
+//    public void oldTest() {
+//        // A footway is not of waytype get off the bike in case that it is part of a cycle route
+//        ReaderRelation osmRel = new ReaderRelation(1);
+//        ReaderWay osmWay = new ReaderWay(1);
+//        osmWay.setTag("highway", "footway");
+//        osmWay.setTag("surface", "grass");
+//
+//        // First tests without a cycle route relation, this is a get off the bike
+//        IntsRef relFlags = encodingManager.handleRelationTags(osmRel, encodingManager.createRelationFlags());
+//        String wayType = getWayTypeFromFlags(osmWay, relFlags);
+//        assertEquals("get off the bike, unpaved", wayType);
+//
+//        // now as part of a cycle route relation
+//        osmRel.setTag("type", "route");
+//        osmRel.setTag("route", "bicycle");
+//        osmRel.setTag("network", "lcn");
+//        relFlags = encodingManager.handleRelationTags(osmRel, encodingManager.createRelationFlags());
+//        wayType = getWayTypeFromFlags(osmWay, relFlags);
+//        assertEquals("small way, unpaved", wayType);
+//
+//        // steps are still shown as get off the bike
+//        osmWay.clearTags();
+//        osmWay.setTag("highway", "steps");
+//        relFlags = encodingManager.handleRelationTags(osmRel, encodingManager.createRelationFlags());
+//        wayType = getWayTypeFromFlags(osmWay, relFlags);
+//        assertEquals("get off the bike", wayType);
+//
+//        // Test for highway=platform.
+//        osmRel.clearTags();
+//        osmWay.clearTags();
+//        osmWay.setTag("highway", "platform");
+//
+//        // First tests without a cycle route relation, this is a get off the bike
+//        relFlags = encodingManager.handleRelationTags(osmRel, encodingManager.createRelationFlags());
+//        wayType = getWayTypeFromFlags(osmWay, relFlags);
+//        assertEquals("get off the bike", wayType);
+//
+//        // now as part of a cycle route relation
+//        osmRel.setTag("type", "route");
+//        osmRel.setTag("route", "bicycle");
+//        osmRel.setTag("network", "lcn");
+//        relFlags = encodingManager.handleRelationTags(osmRel, encodingManager.createRelationFlags());
+//        wayType = getWayTypeFromFlags(osmWay, relFlags);
+//        assertEquals("", wayType);
+//    }
+
+    private RoadClass getRoadClass(ReaderWay way) {
+        IntsRef edgeFlags = em.handleWayTags(way, new EncodingManager.AcceptWay().put("bike", EncodingManager.Access.WAY), em.createRelationFlags());
+        return roadClassEnc.getEnum(false, edgeFlags);
+    }
+
+    private boolean isGetOffBike(ReaderWay way) {
+        IntsRef edgeFlags = em.handleWayTags(way, new EncodingManager.AcceptWay().put("bike", EncodingManager.Access.WAY), em.createRelationFlags());
+        return offBikeEnc.getBool(false, edgeFlags);
+    }
+}

--- a/core/src/test/java/com/graphhopper/util/InstructionListTest.java
+++ b/core/src/test/java/com/graphhopper/util/InstructionListTest.java
@@ -47,13 +47,11 @@ public class InstructionListTest {
     private final TraversalMode tMode = TraversalMode.NODE_BASED;
     private EncodingManager carManager;
     private FlagEncoder carEncoder;
-    private BooleanEncodedValue roundaboutEnc;
 
     @Before
     public void setUp() {
         carEncoder = new CarFlagEncoder();
         carManager = EncodingManager.create(carEncoder);
-        roundaboutEnc = carManager.getBooleanEncodedValue(Roundabout.KEY);
     }
 
     private List<String> getTurnDescriptions(InstructionList instructionList) {
@@ -117,12 +115,12 @@ public class InstructionListTest {
 
         ShortestWeighting weighting = new ShortestWeighting(carEncoder);
         Path p = new Dijkstra(g, weighting, TraversalMode.NODE_BASED).calcPath(0, 10);
-        InstructionList wayList = InstructionsFromEdges.calcInstructions(p, g, weighting, roundaboutEnc, trMap.getWithFallBack(Locale.US));
+        InstructionList wayList = InstructionsFromEdges.calcInstructions(p, g, weighting, carManager, trMap.getWithFallBack(Locale.US));
         List<String> tmpList = getTurnDescriptions(wayList);
         assertEquals(Arrays.asList("continue onto 0-1", "turn right onto 1-4", "turn left onto 7-8", "arrive at destination"),
                 tmpList);
 
-        wayList = InstructionsFromEdges.calcInstructions(p, g, weighting, roundaboutEnc, trMap.getWithFallBack(Locale.GERMAN));
+        wayList = InstructionsFromEdges.calcInstructions(p, g, weighting, carManager, trMap.getWithFallBack(Locale.GERMAN));
         tmpList = getTurnDescriptions(wayList, trMap.getWithFallBack(Locale.GERMAN));
         assertEquals(Arrays.asList("dem Straßenverlauf von 0-1 folgen", "rechts abbiegen auf 1-4", "links abbiegen auf 7-8", "Ziel erreicht"),
                 tmpList);
@@ -146,7 +144,7 @@ public class InstructionListTest {
         assertEquals(42000, p.getDistance(), 1e-2);
         assertEquals(IntArrayList.from(6, 7, 8, 5, 2), p.calcNodes());
 
-        wayList = InstructionsFromEdges.calcInstructions(p, g, weighting, roundaboutEnc, trMap.getWithFallBack(Locale.US));
+        wayList = InstructionsFromEdges.calcInstructions(p, g, weighting, carManager, trMap.getWithFallBack(Locale.US));
         tmpList = getTurnDescriptions(wayList);
         assertEquals(Arrays.asList("continue onto 6-7", "turn left onto 5-8", "arrive at destination"),
                 tmpList);
@@ -156,7 +154,7 @@ public class InstructionListTest {
 
         // special case of identical start and end
         p = new Dijkstra(g, weighting, TraversalMode.NODE_BASED).calcPath(0, 0);
-        wayList = InstructionsFromEdges.calcInstructions(p, g, weighting, roundaboutEnc, trMap.getWithFallBack(Locale.US));
+        wayList = InstructionsFromEdges.calcInstructions(p, g, weighting, carManager, trMap.getWithFallBack(Locale.US));
         assertEquals(1, wayList.size());
         assertEquals("arrive at destination", wayList.get(0).getTurnDescription(trMap.getWithFallBack(Locale.US)));
     }
@@ -187,13 +185,13 @@ public class InstructionListTest {
         ShortestWeighting weighting = new ShortestWeighting(carEncoder);
         Path p = new Dijkstra(g, weighting, tMode).calcPath(2, 3);
 
-        InstructionList wayList = InstructionsFromEdges.calcInstructions(p, g, weighting, roundaboutEnc, usTR);
+        InstructionList wayList = InstructionsFromEdges.calcInstructions(p, g, weighting, carManager, usTR);
         List<String> tmpList = getTurnDescriptions(wayList);
         assertEquals(Arrays.asList("continue onto 2-4", "turn slight right onto 3-4", "arrive at destination"),
                 tmpList);
 
         p = new Dijkstra(g, weighting, tMode).calcPath(3, 5);
-        wayList = InstructionsFromEdges.calcInstructions(p, g, weighting, roundaboutEnc, usTR);
+        wayList = InstructionsFromEdges.calcInstructions(p, g, weighting, carManager, usTR);
         tmpList = getTurnDescriptions( wayList);
         assertEquals(Arrays.asList("continue onto 3-4", "keep right onto 4-5", "arrive at destination"),
                 tmpList);
@@ -226,7 +224,7 @@ public class InstructionListTest {
 
         ShortestWeighting weighting = new ShortestWeighting(carEncoder);
         Path p = new Dijkstra(g, weighting, tMode).calcPath(2, 3);
-        InstructionList wayList = InstructionsFromEdges.calcInstructions(p, g, weighting, roundaboutEnc, usTR);
+        InstructionList wayList = InstructionsFromEdges.calcInstructions(p, g, weighting, carManager, usTR);
         List<String> tmpList = getTurnDescriptions( wayList);
         assertEquals(Arrays.asList("continue onto street", "turn right onto street", "arrive at destination"), tmpList);
     }
@@ -255,7 +253,7 @@ public class InstructionListTest {
 
         ShortestWeighting weighting = new ShortestWeighting(carEncoder);
         Path p = new Dijkstra(g, weighting, tMode).calcPath(1, 3);
-        InstructionList wayList = InstructionsFromEdges.calcInstructions(p, g, weighting, roundaboutEnc, usTR);
+        InstructionList wayList = InstructionsFromEdges.calcInstructions(p, g, weighting, carManager, usTR);
         List<String> tmpList = getTurnDescriptions( wayList);
         assertEquals(Arrays.asList("continue", "arrive at destination"), tmpList);
     }
@@ -284,7 +282,7 @@ public class InstructionListTest {
 
         ShortestWeighting weighting = new ShortestWeighting(carEncoder);
         Path p = new Dijkstra(g, weighting, tMode).calcPath(1, 3);
-        InstructionList wayList = InstructionsFromEdges.calcInstructions(p, g, weighting, roundaboutEnc, usTR);
+        InstructionList wayList = InstructionsFromEdges.calcInstructions(p, g, weighting, carManager, usTR);
         List<String> tmpList = getTurnDescriptions( wayList);
         assertEquals(Arrays.asList("continue", "arrive at destination"), tmpList);
     }
@@ -294,7 +292,7 @@ public class InstructionListTest {
         Graph g = new GraphBuilder(carManager).create();
         ShortestWeighting weighting = new ShortestWeighting(carEncoder);
         Path p = new Dijkstra(g, weighting, tMode).calcPath(0, 1);
-        InstructionList il = InstructionsFromEdges.calcInstructions(p, g, weighting, roundaboutEnc, usTR);
+        InstructionList il = InstructionsFromEdges.calcInstructions(p, g, weighting, carManager, usTR);
         assertEquals(0, il.size());
     }
 
@@ -326,7 +324,7 @@ public class InstructionListTest {
 
         ShortestWeighting weighting = new ShortestWeighting(carEncoder);
         Path p = new Dijkstra(g, weighting, tMode).calcPath(1, 5);
-        InstructionList wayList = InstructionsFromEdges.calcInstructions(p, g, weighting, roundaboutEnc, usTR);
+        InstructionList wayList = InstructionsFromEdges.calcInstructions(p, g, weighting, carManager, usTR);
 
         // query on first edge, get instruction for second edge
         assertEquals("2-3", wayList.find(15.05, 10, 1000).getName());

--- a/core/src/test/java/com/graphhopper/util/PathSimplificationTest.java
+++ b/core/src/test/java/com/graphhopper/util/PathSimplificationTest.java
@@ -140,7 +140,7 @@ public class PathSimplificationTest {
         // Path is: [0 0-1, 3 1-4, 6 4-7, 9 7-8, 11 8-9, 10 9-10]
         ShortestWeighting weighting = new ShortestWeighting(carEncoder);
         Path p = new Dijkstra(g, weighting, tMode).calcPath(0, 10);
-        InstructionList wayList = InstructionsFromEdges.calcInstructions(p, g, weighting, carManager.getBooleanEncodedValue(Roundabout.KEY), usTR);
+        InstructionList wayList = InstructionsFromEdges.calcInstructions(p, g, weighting, carManager, usTR);
         Map<String, List<PathDetail>> details = PathDetailsFromEdges.calcDetails(p, carManager, weighting,
                 Arrays.asList(AVERAGE_SPEED), new PathDetailsBuilderFactory(), 0);
 

--- a/reader-gtfs/src/main/java/com/graphhopper/reader/gtfs/TripFromLabel.java
+++ b/reader-gtfs/src/main/java/com/graphhopper/reader/gtfs/TripFromLabel.java
@@ -27,7 +27,6 @@ import com.graphhopper.PathWrapper;
 import com.graphhopper.Trip;
 import com.graphhopper.gtfs.fare.Fares;
 import com.graphhopper.routing.InstructionsFromEdges;
-import com.graphhopper.routing.profiles.Roundabout;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.Graph;
 import com.graphhopper.util.*;
@@ -357,7 +356,7 @@ class TripFromLabel {
         } else {
             InstructionList instructions = new InstructionList(tr);
             InstructionsFromEdges instructionsFromEdges = new InstructionsFromEdges(graph,
-                    weighting, weighting.getFlagEncoder().getBooleanEncodedValue(Roundabout.KEY), tr, instructions);
+                    weighting, weighting.getFlagEncoder(), tr, instructions);
             int prevEdgeId = -1;
             for (int i = 1; i < path.size(); i++) {
                 if (path.get(i).edge.edgeType != GtfsStorage.EdgeType.HIGHWAY) {

--- a/reader-osm/src/test/java/com/graphhopper/GraphHopperIT.java
+++ b/reader-osm/src/test/java/com/graphhopper/GraphHopperIT.java
@@ -820,10 +820,10 @@ public class GraphHopperIT {
 
         PathWrapper arsp = rsp.getBest();
         assertEquals(6932.2, arsp.getDistance(), .1);
-        assertEquals(106, arsp.getPoints().getSize());
+        assertEquals(105, arsp.getPoints().getSize());
 
         InstructionList il = arsp.getInstructions();
-        assertEquals(22, il.size());
+        assertEquals(21, il.size());
 
         assertEquals("continue onto Obere Landstraße", il.get(0).getTurnDescription(tr));
         assertEquals("get off the bike", il.get(0).getAnnotation().getMessage());
@@ -840,8 +840,8 @@ public class GraphHopperIT {
         assertEquals("keep left onto Austraße", il.get(11).getTurnDescription(tr));
         assertEquals("keep left onto Rechte Kremszeile", il.get(12).getTurnDescription(tr));
         //..
-        assertEquals("turn right onto Treppelweg", il.get(18).getTurnDescription(tr));
-        assertEquals("cycleway", il.get(18).getAnnotation().getMessage());
+        assertEquals("turn right onto Treppelweg", il.get(17).getTurnDescription(tr));
+        assertEquals("cycleway", il.get(17).getAnnotation().getMessage());
     }
 
     @Test

--- a/web-bundle/src/test/java/com/graphhopper/util/gpx/GpxFromInstructionsTest.java
+++ b/web-bundle/src/test/java/com/graphhopper/util/gpx/GpxFromInstructionsTest.java
@@ -55,14 +55,12 @@ public class GpxFromInstructionsTest {
 
     private EncodingManager carManager;
     private FlagEncoder carEncoder;
-    private BooleanEncodedValue roundaboutEnc;
     private TranslationMap trMap;
 
     @Before
     public void setUp() {
         carEncoder = new CarFlagEncoder();
         carManager = EncodingManager.create(carEncoder);
-        roundaboutEnc = carManager.getBooleanEncodedValue(Roundabout.KEY);
         trMap = new TranslationMap().doImport();
     }
 
@@ -92,7 +90,7 @@ public class GpxFromInstructionsTest {
 
         ShortestWeighting weighting = new ShortestWeighting(carEncoder);
         Path p = new Dijkstra(g, weighting, TraversalMode.NODE_BASED).calcPath(1, 5);
-        InstructionList wayList = InstructionsFromEdges.calcInstructions(p, g, weighting, roundaboutEnc, trMap.getWithFallBack(Locale.US));
+        InstructionList wayList = InstructionsFromEdges.calcInstructions(p, g, weighting, carManager, trMap.getWithFallBack(Locale.US));
         PointList points = p.calcPoints();
         assertEquals(4, wayList.size());
 


### PR DESCRIPTION
This removes the method and also a bit the ability to customize such annotations, but if this is really needed we can introduce it later. (There will follow up channges where we add warnings for fords and tolls.)

When multiple bike vehicles are used, this change will also reduce bit usage by 8 bits as it does no longer store the way type and paved/unpaved boolean in a separate EncodedValue but relies on `RoadClass` and could rely on `Surface`.

It also introduces a "ford warning" in all cases, so that we can switch defaults to handle #236 later (not in this PR)