### PR TITLE
Add support for details=mtb_scale and details=sac_scale

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/profiles/MtbScale.java
+++ b/core/src/main/java/com/graphhopper/routing/profiles/MtbScale.java
@@ -26,15 +26,36 @@ package com.graphhopper.routing.profiles;
  * @author Michael Reichert
  *
  */
-public class MtbScale {
+public enum MtbScale {
+    NONE("none"),
+    MTB_0("0"),
+    MTB_1("1"),
+    MTB_2("2"),
+    MTB_3("3"),
+    MTB_4("4"),
+    MTB_5("5"),
+    MTB_6("6");
+
     public static final String KEY = "mtb_scale";
 
-    /**
-     * Return a encoder for unsigned integers from 0 (no scale or the invalid tag value "0") to
-     * 7 (although the scale ends at "6" according to
-     * https://wiki.openstreetmap.org/wiki/Key:mtb:scale).
-     */
-    public static UnsignedIntEncodedValue create() {
-        return new UnsignedIntEncodedValue(KEY, 3, false);
+    private final String name;
+
+    MtbScale(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+
+    public static MtbScale find(String name) {
+        if (name == null)
+            return NONE;
+        try {
+            return MtbScale.valueOf(name);
+        } catch (IllegalArgumentException ex) {
+            return NONE;
+        }
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/profiles/MtbScale.java
+++ b/core/src/main/java/com/graphhopper/routing/profiles/MtbScale.java
@@ -1,0 +1,40 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.routing.profiles;
+
+/**
+ * Store valid values of the OSM tag mtb:scale=*. See
+ * https://wiki.openstreetmap.org/wiki/Key:mtb:scale for details.
+ * 
+ * Values are stored as unsigned integers because the OSM key uses unsigned integers only.
+ * 
+ * @author Michael Reichert
+ *
+ */
+public class MtbScale {
+    public static final String KEY = "mtb_scale";
+
+    /**
+     * Return a encoder for unsigned integers from 0 (no scale or the invalid tag value "0") to
+     * 7 (although the scale ends at "6" according to
+     * https://wiki.openstreetmap.org/wiki/Key:mtb:scale).
+     */
+    public static UnsignedIntEncodedValue create() {
+        return new UnsignedIntEncodedValue(KEY, 3, false);
+    }
+}

--- a/core/src/main/java/com/graphhopper/routing/profiles/MtbScale.java
+++ b/core/src/main/java/com/graphhopper/routing/profiles/MtbScale.java
@@ -21,7 +21,8 @@ package com.graphhopper.routing.profiles;
  * Store valid values of the OSM tag mtb:scale=*. See
  * https://wiki.openstreetmap.org/wiki/Key:mtb:scale for details.
  * 
- * Values are stored as unsigned integers because the OSM key uses unsigned integers only.
+ * Values are stored as enum because the OSM key has a value 0 with a meaning and we would like to
+ * be able to store an undefined value ("none") as well.
  * 
  * @author Michael Reichert
  *
@@ -50,10 +51,11 @@ public enum MtbScale {
     }
 
     public static MtbScale find(String name) {
-        if (name == null)
+        if (name == null) {
             return NONE;
+        }
         try {
-            return MtbScale.valueOf(name);
+            return MtbScale.valueOf("MTB_" + name);
         } catch (IllegalArgumentException ex) {
             return NONE;
         }

--- a/core/src/main/java/com/graphhopper/routing/profiles/SacScale.java
+++ b/core/src/main/java/com/graphhopper/routing/profiles/SacScale.java
@@ -1,0 +1,60 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.routing.profiles;
+
+import com.graphhopper.util.Helper;
+
+/**
+ * Store valid values of the OSM tag sac_scale=*. See
+ * https://wiki.openstreetmap.org/wiki/Key:sac_scale for details. 
+ * 
+ * @author Michael Reichert
+ *
+ */
+public enum SacScale {
+    NONE("none"),
+    HIKING("hiking"),
+    MOUNTAIN_HIKING("mountain_hiking"),
+    DEMANDING_MOUNTAIN_HIKING("demanding_mountain_hiking"),
+    ALPINE_HIKING("alpine_hiking"),
+    DEMANDING_ALPINE_HIKING("demanding_alpine_hiking"),
+    DIFFICULT_ALPINE_HIKING("difficult_alpine_hiking");
+
+    public static final String KEY = "sac_scale";
+
+    private final String name;
+
+    SacScale(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+
+    public static SacScale find(String name) {
+        if (name == null)
+            return NONE;
+        try {
+            return SacScale.valueOf(Helper.toUpperCase(name));
+        } catch (IllegalArgumentException ex) {
+            return NONE;
+        }
+    }
+}

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/DefaultTagParserFactory.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/DefaultTagParserFactory.java
@@ -64,6 +64,10 @@ public class DefaultTagParserFactory implements TagParserFactory {
             return new OSMHazmatTunnelParser();
         else if (name.equals(HazmatWater.KEY))
             return new OSMHazmatWaterParser();
+        else if (name.equals(MtbScale.KEY))
+            return new OSMMtbScaleParser();
+        else if (name.equals(SacScale.KEY))
+            return new OSMSacScaleParser();
         throw new IllegalArgumentException("entry in encoder list not supported " + name);
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMMtbScaleParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMMtbScaleParser.java
@@ -57,6 +57,9 @@ public class OSMMtbScaleParser implements TagParser {
             if (val > scaleEncoder.getMaxInt()) {
                 val = scaleEncoder.getMaxInt();
             }
+            if (val < 0) {
+                val = 0;
+            }
             scaleEncoder.setInt(false, edgeFlags, val);
         } catch (NumberFormatException ex) {
         }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMMtbScaleParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMMtbScaleParser.java
@@ -1,0 +1,65 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.routing.util.parsers;
+
+import static com.graphhopper.util.Helper.isEmpty;
+
+import java.util.List;
+
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.profiles.EncodedValue;
+import com.graphhopper.routing.profiles.EncodedValueLookup;
+import com.graphhopper.routing.profiles.MtbScale;
+import com.graphhopper.routing.profiles.UnsignedIntEncodedValue;
+import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.storage.IntsRef;
+
+public class OSMMtbScaleParser implements TagParser {
+
+    private final UnsignedIntEncodedValue scaleEncoder;
+
+    public OSMMtbScaleParser() {
+        this(MtbScale.create());
+    }
+
+    public OSMMtbScaleParser(UnsignedIntEncodedValue scaleEncoder) {
+        this.scaleEncoder = scaleEncoder;
+    }
+
+    @Override
+    public void createEncodedValues(EncodedValueLookup lookup, List<EncodedValue> registerNewEncodedValue) {
+        registerNewEncodedValue.add(scaleEncoder);
+    }
+
+    @Override
+    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay readerWay, EncodingManager.Access access, IntsRef relationFlags) {
+        String value = readerWay.getTag("mtb:scale");
+        if (isEmpty(value)) {
+            return edgeFlags;
+        }
+        try {
+            int val = Integer.parseInt(value);
+            if (val > scaleEncoder.getMaxInt()) {
+                val = scaleEncoder.getMaxInt();
+            }
+            scaleEncoder.setInt(false, edgeFlags, val);
+        } catch (NumberFormatException ex) {
+        }
+        return edgeFlags;
+    }
+}

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMMtbScaleParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMMtbScaleParser.java
@@ -50,10 +50,16 @@ public class OSMMtbScaleParser implements TagParser {
         String value = readerWay.getTag("mtb:scale");
         if (value == null)
             return edgeFlags;
+
         // Drop '+' and '-' suffix if there is any. We do not store that level of detail because
         // there are not that many occurences and adding this level of detail would cost us
         // additional two bits per edge.
-        MtbScale scale = MtbScale.find(value.substring(0, 1));
+        MtbScale scale = NONE;
+        if (value.length() == 1) {
+            scale = MtbScale.find(value);
+        } else if (value.length() == 2 && (value.charAt(1) == '+' || value.charAt(1) == '-')) {
+            scale = MtbScale.find(value.substring(0, 1));
+        }
         if (scale != NONE)
             scaleEncoder.setEnum(false, edgeFlags, scale);
         return edgeFlags;

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMSacScaleParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMSacScaleParser.java
@@ -1,0 +1,58 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.routing.util.parsers;
+
+import java.util.List;
+
+import static com.graphhopper.routing.profiles.SacScale.NONE;
+
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.profiles.EncodedValue;
+import com.graphhopper.routing.profiles.EncodedValueLookup;
+import com.graphhopper.routing.profiles.EnumEncodedValue;
+import com.graphhopper.routing.profiles.SacScale;
+import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.storage.IntsRef;
+
+public class OSMSacScaleParser implements TagParser {
+
+    private final EnumEncodedValue<SacScale> sacScaleEnc;
+
+    public OSMSacScaleParser() {
+        this.sacScaleEnc = new EnumEncodedValue<>(SacScale.KEY, SacScale.class);
+    }
+
+    @Override
+    public void createEncodedValues(EncodedValueLookup lookup, List<EncodedValue> link) {
+        link.add(sacScaleEnc);
+    }
+
+    @Override
+    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay readerWay, EncodingManager.Access access, IntsRef relationFlags) {
+        if (!access.isWay())
+            return edgeFlags;
+
+        String value = readerWay.getTag("sac_scale");
+        if (value == null)
+            return edgeFlags;
+        SacScale scale = SacScale.find(value);
+        if (scale != NONE)
+            sacScaleEnc.setEnum(false, edgeFlags, scale);
+        return edgeFlags;
+    }
+}

--- a/core/src/main/java/com/graphhopper/util/details/PathDetailsBuilderFactory.java
+++ b/core/src/main/java/com/graphhopper/util/details/PathDetailsBuilderFactory.java
@@ -74,10 +74,14 @@ public class PathDetailsBuilderFactory {
                 new MapEntry<>(RoadAccess.KEY, RoadAccess.class), new MapEntry<>(Toll.KEY, Toll.class),
                 new MapEntry<>(TrackType.KEY, TrackType.class), new MapEntry<>(Hazmat.KEY, Hazmat.class),
                 new MapEntry<>(HazmatTunnel.KEY, HazmatTunnel.class), new MapEntry<>(HazmatWater.KEY, HazmatWater.class),
-                new MapEntry<>(Country.KEY, Country.class))) {
+                new MapEntry<>(SacScale.KEY, SacScale.class), new MapEntry<>(Country.KEY, Country.class))) {
             String key = (String) entry.getKey();
             if (requestedPathDetails.contains(key) && evl.hasEncodedValue(key))
                 builders.add(new EnumDetails(key, evl.getEnumEncodedValue(key, (Class<Enum>) entry.getValue())));
+        }
+
+        if (requestedPathDetails.contains(MtbScale.KEY) && evl.hasEncodedValue(MtbScale.KEY)) {
+            builders.add(new IntDetails(MtbScale.KEY, evl.getIntEncodedValue(MtbScale.KEY)));
         }
 
         if (requestedPathDetails.size() != builders.size()) {

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMMtbScaleParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMMtbScaleParserTest.java
@@ -1,0 +1,66 @@
+package com.graphhopper.routing.util.parsers;
+
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.profiles.EnumEncodedValue;
+import com.graphhopper.routing.profiles.MtbScale;
+import com.graphhopper.routing.profiles.RoadClass;
+import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.storage.IntsRef;
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.graphhopper.routing.util.EncodingManager.Access.WAY;
+import static org.junit.Assert.assertEquals;
+
+public class OSMMtbScaleParserTest {
+    private EncodingManager em;
+    private IntsRef relFlags;
+    private EnumEncodedValue<MtbScale> mtbEnc;
+    private OSMMtbScaleParser parser;
+
+    @Before
+    public void setUp() {
+        parser = new OSMMtbScaleParser();
+        em = new EncodingManager.Builder().add(parser).build();
+        relFlags = em.createRelationFlags();
+        mtbEnc = em.getEnumEncodedValue(MtbScale.KEY, MtbScale.class);
+    }
+
+    @Test
+    public void testSimple() {
+        ReaderWay readerWay = new ReaderWay(1);
+        IntsRef edgeFlags = em.createEdgeFlags();
+        readerWay.setTag("highway", "path");
+        parser.handleWayTags(edgeFlags, readerWay, WAY, relFlags);
+        assertEquals(MtbScale.NONE, mtbEnc.getEnum(false, edgeFlags));
+
+        readerWay.setTag("mtb:scale", "0");
+        parser.handleWayTags(edgeFlags, readerWay, WAY, relFlags);
+        assertEquals(MtbScale.MTB_0, mtbEnc.getEnum(false, edgeFlags));
+
+        readerWay.setTag("mtb:scale", "1");
+        parser.handleWayTags(edgeFlags, readerWay, WAY, relFlags);
+        assertEquals(MtbScale.MTB_1, mtbEnc.getEnum(false, edgeFlags));
+
+        readerWay.setTag("mtb:scale", "1+");
+        parser.handleWayTags(edgeFlags, readerWay, WAY, relFlags);
+        assertEquals(MtbScale.MTB_1, mtbEnc.getEnum(false, edgeFlags));
+
+        readerWay.setTag("mtb:scale", "1-");
+        parser.handleWayTags(edgeFlags, readerWay, WAY, relFlags);
+        assertEquals(MtbScale.MTB_1, mtbEnc.getEnum(false, edgeFlags));
+    }
+
+    /**
+     * "21" should return as no scale, not scale 2.
+     */
+    @Test
+    public void testInvalid21() {
+        ReaderWay readerWay = new ReaderWay(1);
+        IntsRef edgeFlags = em.createEdgeFlags();
+        readerWay.setTag("highway", "path");
+        readerWay.setTag("mtb:scale", "21");
+        parser.handleWayTags(edgeFlags, readerWay, WAY, relFlags);
+        assertEquals(MtbScale.NONE, mtbEnc.getEnum(false, edgeFlags));
+    }
+}


### PR DESCRIPTION
This pull request adds support to make `mtb:scale=*` and `sac_scale=*` accessible using the `details=*` parameter.

`mtb:scale` (the URL parameter uses `mtb_scale` to be in line with all the other options which are already implemented) is stored as unsigned integer because it has only unsigned integers as values. `sac_scale` uses an enum.