### PR TITLE
Make OSMInputFile call callback methods for each read OSM object

### DIFF
--- a/reader-osm/src/main/java/com/graphhopper/reader/osm/OSMHandler.java
+++ b/reader-osm/src/main/java/com/graphhopper/reader/osm/OSMHandler.java
@@ -1,0 +1,38 @@
+package com.graphhopper.reader.osm;
+
+import com.graphhopper.reader.ReaderElement;
+import com.graphhopper.reader.ReaderNode;
+import com.graphhopper.reader.ReaderRelation;
+import com.graphhopper.reader.ReaderWay;
+
+/**
+ * Interface with some callback methods to called with each OSM object read from an OSM input file.
+ *
+ * @author Michael Reichert
+ */
+public interface OSMHandler {
+    /**
+     * Called for each node, way or relation read from the input file
+     */
+    public void osm_object(ReaderElement element);
+    
+    /**
+     * Called for each node read from the input file
+     */
+    public void node(ReaderNode node);
+
+    /**
+     * Called for each way read from the input file
+     */
+    public void way(ReaderWay way);
+
+    /**
+     * Called for each relation read from the input file
+     */
+    public void relation(ReaderRelation relation);
+
+    /**
+     * Called for the file header of the input file
+     */
+    public void header(OSMFileHeader relation);
+}

--- a/reader-osm/src/main/java/com/graphhopper/reader/osm/OSMInput.java
+++ b/reader-osm/src/main/java/com/graphhopper/reader/osm/OSMInput.java
@@ -17,12 +17,11 @@
  */
 package com.graphhopper.reader.osm;
 
-import com.graphhopper.reader.ReaderElement;
-
-import javax.xml.stream.XMLStreamException;
-
 public interface OSMInput extends AutoCloseable {
-    ReaderElement getNext() throws XMLStreamException;
+    /**
+     * Register a handler.
+     */
+    OSMInput addHandler(OSMHandler handler);
 
     int getUnprocessedElements();
 }

--- a/reader-osm/src/test/java/com/graphhopper/reader/osm/OSMReaderTest.java
+++ b/reader-osm/src/test/java/com/graphhopper/reader/osm/OSMReaderTest.java
@@ -666,7 +666,7 @@ public class OSMReaderTest {
         way.setTag("highway", "motorway");
         osmreader.getNodeMap().put(1, 1);
         osmreader.getNodeMap().put(2, 2);
-        osmreader.processWay(way);
+        osmreader.getHandler2().way(way);
 
         GHPoint p = way.getTag("estimated_center", null);
         assertEquals(1.15, p.lat, 1e-3);


### PR DESCRIPTION
This pull request is a first step to make extending OSMReader easier without inheriting from it. It adds a new handler interface which provides callback methods. They are called by OSMInputFile for each OSM element (node, way, relation, file header) from the input file. The design is inspired (but simplified) from the Libosmium C++ library.

Advantages:
* Switch-case statements deciding which processing method of OSMReader call and the loops iterating over all elements of the input file are moved to OSMInputFile, i.e. OSMReader becomes a bit more separated from lower level stuff (dealing with OSM objects).
* It becomes way easier to do multiple things while reading the input file. During each reading of the input file, multiple classes can access the objects and do something with them. I presume this is helpful if you desire to split OSMReader somehow in future. In addition, it is a first step to have the extendibility of OSMReader by additional hooks by downstream developers as a feature of OSMReader (and that feature not requiring to inherit from OSMReader).

I have such a feature in my own fork of GraphHopper which I use for [railway routing](https://github.com/geofabrik/OpenRailRouting) and the [OSM Inspector Routing View](https://github.com/geofabrik/osmi_routing):

* https://github.com/Nakaner/graphhopper/blob/osm-reader-callbacks/reader-osm/src/main/java/com/graphhopper/reader/osm/OSMReaderHook.java
* https://github.com/Nakaner/graphhopper/blob/osm-reader-callbacks/reader-osm/src/main/java/com/graphhopper/reader/osm/OSMReader.java#L132

I would like to get rid of the fork and this feature into upstream.

See also https://github.com/graphhopper/graphhopper/issues/1370

Existing tests pass. If you are fine with the design and implementation, I will add a unit test for the handler. I am happy to create a way to add one's own handlers to OSMReader which will add them to OSMInputFile.