### PR TITLE
Work with interfaces instead of specific RoutingAlgorithmFactory implementations

### DIFF
--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -1062,8 +1062,8 @@ public class GraphHopper implements GraphHopperAPI {
                     }
                     // if LM is enabled we have the LMFactory with the CH algo!
                     RoutingAlgorithmFactory chAlgoFactory = tmpAlgoFactory;
-                    if (tmpAlgoFactory instanceof LMAlgoFactoryDecorator.LMRAFactory)
-                        chAlgoFactory = ((LMAlgoFactoryDecorator.LMRAFactory) tmpAlgoFactory).getDefaultAlgoFactory();
+                    if (tmpAlgoFactory instanceof DecoratingRoutingAlgorithmFactory)
+                        chAlgoFactory = ((DecoratingRoutingAlgorithmFactory) tmpAlgoFactory).getDefaultAlgoFactory();
 
                     if (chAlgoFactory instanceof CHRoutingAlgorithmFactory) {
                         CHProfile chProfile = ((CHRoutingAlgorithmFactory) chAlgoFactory).getCHProfile();

--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -23,7 +23,7 @@ import com.graphhopper.reader.dem.*;
 import com.graphhopper.reader.osm.conditional.DateRangeParser;
 import com.graphhopper.routing.*;
 import com.graphhopper.routing.ch.CHAlgoFactoryDecorator;
-import com.graphhopper.routing.ch.CHRoutingAlgorithmFactory;
+import com.graphhopper.routing.ch.DefaultCHRoutingAlgorithmFactory;
 import com.graphhopper.routing.lm.LMAlgoFactoryDecorator;
 import com.graphhopper.routing.profiles.DefaultEncodedValueFactory;
 import com.graphhopper.routing.profiles.EncodedValueFactory;
@@ -1065,8 +1065,8 @@ public class GraphHopper implements GraphHopperAPI {
                     if (tmpAlgoFactory instanceof LMAlgoFactoryDecorator.LMRAFactory)
                         chAlgoFactory = ((LMAlgoFactoryDecorator.LMRAFactory) tmpAlgoFactory).getDefaultAlgoFactory();
 
-                    if (chAlgoFactory instanceof CHRoutingAlgorithmFactory) {
-                        CHProfile chProfile = ((CHRoutingAlgorithmFactory) chAlgoFactory).getCHProfile();
+                    if (chAlgoFactory instanceof DefaultCHRoutingAlgorithmFactory) {
+                        CHProfile chProfile = ((DefaultCHRoutingAlgorithmFactory) chAlgoFactory).getCHProfile();
                         queryGraph = QueryGraph.lookup(ghStorage.getCHGraph(chProfile), qResults);
                         weighting = chProfile.getWeighting();
                     } else {

--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -23,7 +23,7 @@ import com.graphhopper.reader.dem.*;
 import com.graphhopper.reader.osm.conditional.DateRangeParser;
 import com.graphhopper.routing.*;
 import com.graphhopper.routing.ch.CHAlgoFactoryDecorator;
-import com.graphhopper.routing.ch.DefaultCHRoutingAlgorithmFactory;
+import com.graphhopper.routing.ch.CHRoutingAlgorithmFactory;
 import com.graphhopper.routing.lm.LMAlgoFactoryDecorator;
 import com.graphhopper.routing.profiles.DefaultEncodedValueFactory;
 import com.graphhopper.routing.profiles.EncodedValueFactory;
@@ -1065,8 +1065,8 @@ public class GraphHopper implements GraphHopperAPI {
                     if (tmpAlgoFactory instanceof LMAlgoFactoryDecorator.LMRAFactory)
                         chAlgoFactory = ((LMAlgoFactoryDecorator.LMRAFactory) tmpAlgoFactory).getDefaultAlgoFactory();
 
-                    if (chAlgoFactory instanceof DefaultCHRoutingAlgorithmFactory) {
-                        CHProfile chProfile = ((DefaultCHRoutingAlgorithmFactory) chAlgoFactory).getCHProfile();
+                    if (chAlgoFactory instanceof CHRoutingAlgorithmFactory) {
+                        CHProfile chProfile = ((CHRoutingAlgorithmFactory) chAlgoFactory).getCHProfile();
                         queryGraph = QueryGraph.lookup(ghStorage.getCHGraph(chProfile), qResults);
                         weighting = chProfile.getWeighting();
                     } else {

--- a/core/src/main/java/com/graphhopper/routing/DecoratingRoutingAlgorithmFactory.java
+++ b/core/src/main/java/com/graphhopper/routing/DecoratingRoutingAlgorithmFactory.java
@@ -1,0 +1,23 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.routing;
+
+public interface DecoratingRoutingAlgorithmFactory extends RoutingAlgorithmFactory {
+
+    RoutingAlgorithmFactory getDefaultAlgoFactory();
+}

--- a/core/src/main/java/com/graphhopper/routing/ch/CHRoutingAlgorithmFactory.java
+++ b/core/src/main/java/com/graphhopper/routing/ch/CHRoutingAlgorithmFactory.java
@@ -1,0 +1,26 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.routing.ch;
+
+import com.graphhopper.routing.RoutingAlgorithmFactory;
+import com.graphhopper.storage.CHProfile;
+
+public interface CHRoutingAlgorithmFactory extends RoutingAlgorithmFactory {
+
+    CHProfile getCHProfile();
+}

--- a/core/src/main/java/com/graphhopper/routing/ch/DefaultCHRoutingAlgorithmFactory.java
+++ b/core/src/main/java/com/graphhopper/routing/ch/DefaultCHRoutingAlgorithmFactory.java
@@ -30,7 +30,7 @@ import com.graphhopper.storage.TurnCostStorage;
 import static com.graphhopper.util.Parameters.Algorithms.ASTAR_BI;
 import static com.graphhopper.util.Parameters.Algorithms.DIJKSTRA_BI;
 
-public class DefaultCHRoutingAlgorithmFactory implements RoutingAlgorithmFactory {
+public class DefaultCHRoutingAlgorithmFactory implements CHRoutingAlgorithmFactory {
     private final CHGraph chGraph;
     private final CHProfile chProfile;
     private final PreparationWeighting prepareWeighting;
@@ -101,6 +101,7 @@ public class DefaultCHRoutingAlgorithmFactory implements RoutingAlgorithmFactory
         return chProfile.getWeighting();
     }
 
+    @Override
     public CHProfile getCHProfile() {
         return chProfile;
     }

--- a/core/src/main/java/com/graphhopper/routing/ch/DefaultCHRoutingAlgorithmFactory.java
+++ b/core/src/main/java/com/graphhopper/routing/ch/DefaultCHRoutingAlgorithmFactory.java
@@ -30,12 +30,12 @@ import com.graphhopper.storage.TurnCostStorage;
 import static com.graphhopper.util.Parameters.Algorithms.ASTAR_BI;
 import static com.graphhopper.util.Parameters.Algorithms.DIJKSTRA_BI;
 
-public class CHRoutingAlgorithmFactory implements RoutingAlgorithmFactory {
+public class DefaultCHRoutingAlgorithmFactory implements RoutingAlgorithmFactory {
     private final CHGraph chGraph;
     private final CHProfile chProfile;
     private final PreparationWeighting prepareWeighting;
 
-    public CHRoutingAlgorithmFactory(CHGraph chGraph) {
+    public DefaultCHRoutingAlgorithmFactory(CHGraph chGraph) {
         this.chGraph = chGraph;
         this.chProfile = chGraph.getCHProfile();
         prepareWeighting = new PreparationWeighting(chProfile.getWeighting());

--- a/core/src/main/java/com/graphhopper/routing/ch/PrepareContractionHierarchies.java
+++ b/core/src/main/java/com/graphhopper/routing/ch/PrepareContractionHierarchies.java
@@ -439,7 +439,7 @@ public class PrepareContractionHierarchies extends AbstractAlgoPreparation {
     }
 
     public RoutingAlgorithmFactory getRoutingAlgorithmFactory() {
-        return new CHRoutingAlgorithmFactory(chGraph);
+        return new DefaultCHRoutingAlgorithmFactory(chGraph);
     }
 
     private static class Params {

--- a/core/src/main/java/com/graphhopper/routing/lm/LMAlgoFactoryDecorator.java
+++ b/core/src/main/java/com/graphhopper/routing/lm/LMAlgoFactoryDecorator.java
@@ -20,6 +20,7 @@ package com.graphhopper.routing.lm;
 import com.graphhopper.GHRequest;
 import com.graphhopper.GHResponse;
 import com.graphhopper.routing.AlgorithmOptions;
+import com.graphhopper.routing.DecoratingRoutingAlgorithmFactory;
 import com.graphhopper.routing.RoutingAlgorithm;
 import com.graphhopper.routing.RoutingAlgorithmFactory;
 import com.graphhopper.routing.RoutingAlgorithmFactoryDecorator;
@@ -244,11 +245,9 @@ public class LMAlgoFactoryDecorator implements RoutingAlgorithmFactoryDecorator 
     }
 
     /**
-     * TODO needs to be public to pick defaultAlgoFactory.weighting if the defaultAlgoFactory is a CH one.
-     *
      * @see com.graphhopper.GraphHopper#calcPaths(GHRequest, GHResponse)
      */
-    public static class LMRAFactory implements RoutingAlgorithmFactory {
+    private static class LMRAFactory implements DecoratingRoutingAlgorithmFactory {
         private RoutingAlgorithmFactory defaultAlgoFactory;
         private PrepareLandmarks p;
 
@@ -257,6 +256,7 @@ public class LMAlgoFactoryDecorator implements RoutingAlgorithmFactoryDecorator 
             this.p = p;
         }
 
+        @Override
         public RoutingAlgorithmFactory getDefaultAlgoFactory() {
             return defaultAlgoFactory;
         }

--- a/core/src/test/java/com/graphhopper/routing/DijkstraBidirectionCHTest.java
+++ b/core/src/test/java/com/graphhopper/routing/DijkstraBidirectionCHTest.java
@@ -18,7 +18,7 @@
 package com.graphhopper.routing;
 
 import com.carrotsearch.hppc.IntArrayList;
-import com.graphhopper.routing.ch.CHRoutingAlgorithmFactory;
+import com.graphhopper.routing.ch.DefaultCHRoutingAlgorithmFactory;
 import com.graphhopper.routing.ch.PrepareContractionHierarchies;
 import com.graphhopper.routing.ch.PrepareEncoder;
 import com.graphhopper.routing.profiles.DecimalEncodedValue;
@@ -109,7 +109,7 @@ public class DijkstraBidirectionCHTest extends AbstractRoutingAlgorithmTester {
         lg.setLevel(0, 7);
 
         AlgorithmOptions opts = new AlgorithmOptions(Parameters.Algorithms.DIJKSTRA_BI, weighting);
-        Path p = new CHRoutingAlgorithmFactory(lg).createAlgo(lg, opts).calcPath(0, 7);
+        Path p = new DefaultCHRoutingAlgorithmFactory(lg).createAlgo(lg, opts).calcPath(0, 7);
 
         assertEquals(IntArrayList.from(0, 2, 5, 7), p.calcNodes());
         assertEquals(1064, p.getTime());
@@ -264,6 +264,6 @@ public class DijkstraBidirectionCHTest extends AbstractRoutingAlgorithmTester {
         if (!withSOD) {
             algorithmOptions.getHints().put("stall_on_demand", false);
         }
-        return new CHRoutingAlgorithmFactory(chGraph).createAlgo(chGraph, algorithmOptions);
+        return new DefaultCHRoutingAlgorithmFactory(chGraph).createAlgo(chGraph, algorithmOptions);
     }
 }

--- a/reader-osm/src/test/java/com/graphhopper/reader/osm/GraphHopperOSMTest.java
+++ b/reader-osm/src/test/java/com/graphhopper/reader/osm/GraphHopperOSMTest.java
@@ -27,7 +27,7 @@ import com.graphhopper.coll.GHBitSetImpl;
 import com.graphhopper.reader.DataReader;
 import com.graphhopper.routing.*;
 import com.graphhopper.routing.ch.CHAlgoFactoryDecorator;
-import com.graphhopper.routing.ch.CHRoutingAlgorithmFactory;
+import com.graphhopper.routing.ch.DefaultCHRoutingAlgorithmFactory;
 import com.graphhopper.routing.ch.PrepareContractionHierarchies;
 import com.graphhopper.routing.lm.PrepareLandmarks;
 import com.graphhopper.routing.util.*;
@@ -1000,9 +1000,9 @@ public class GraphHopperOSMTest {
 
         HintsMap wMap = new HintsMap("fastest");
         wMap.put("vehicle", "truck");
-        assertEquals("fastest|truck", ((CHRoutingAlgorithmFactory) decorator.getDecoratedAlgorithmFactory(null, wMap)).getWeighting().toString());
+        assertEquals("fastest|truck", ((DefaultCHRoutingAlgorithmFactory) decorator.getDecoratedAlgorithmFactory(null, wMap)).getWeighting().toString());
         wMap.put("vehicle", "simple_truck");
-        assertEquals("fastest|simple_truck", ((CHRoutingAlgorithmFactory) decorator.getDecoratedAlgorithmFactory(null, wMap)).getWeighting().toString());
+        assertEquals("fastest|simple_truck", ((DefaultCHRoutingAlgorithmFactory) decorator.getDecoratedAlgorithmFactory(null, wMap)).getWeighting().toString());
 
         // make sure weighting cannot be mixed
         decorator.addCHProfile(CHProfile.nodeBased(fwTruck));


### PR DESCRIPTION
This PR adds support to inject custom RoutingAlgorithmFactoryDecorators without breaking LM/CH routing compatibility. The generated factories only need to implement `CHRoutingAlgorithmFactory` and `DecoratingRoutingAlgorithmFactory`.