### PR TITLE
Add Motorroad RoadClass

### DIFF
--- a/config-example.yml
+++ b/config-example.yml
@@ -15,7 +15,7 @@ graphhopper:
 
   # Add additional information to every edge. Used for path details.
   # If road_environment is added and elevation is enabled then also a tunnel and bridge interpolation is done, see #798.
-  # More options are: surface,max_width,max_height,max_weight,max_axle_load,max_length,hazmat,hazmat_tunnel,hazmat_water,toll,track_type
+  # More options are: surface,max_width,max_height,max_weight,max_axle_load,max_length,hazmat,hazmat_tunnel,hazmat_water,toll,track_type,motorroad
   graph.encoded_values: road_class,road_class_link,road_environment,max_speed,road_access
 
   ##### Elevation #####

--- a/core/src/main/java/com/graphhopper/routing/profiles/DefaultEncodedValueFactory.java
+++ b/core/src/main/java/com/graphhopper/routing/profiles/DefaultEncodedValueFactory.java
@@ -70,6 +70,8 @@ public class DefaultEncodedValueFactory implements EncodedValueFactory {
             enc = new EnumEncodedValue<>(HazmatTunnel.KEY, HazmatTunnel.class);
         } else if (HazmatWater.KEY.equals(name)) {
             enc = new EnumEncodedValue<>(HazmatWater.KEY, HazmatWater.class);
+        } else if (Motorroad.KEY.equals(name)) {
+            enc = Motorroad.create();
         } else {
             throw new IllegalArgumentException("DefaultEncodedValueFactory cannot find EncodedValue " + name);
         }

--- a/core/src/main/java/com/graphhopper/routing/profiles/Motorroad.java
+++ b/core/src/main/java/com/graphhopper/routing/profiles/Motorroad.java
@@ -1,0 +1,13 @@
+package com.graphhopper.routing.profiles;
+
+public final class Motorroad {
+    public static final String KEY = "motorroad";
+
+    public static BooleanEncodedValue create() {
+        return new SimpleBooleanEncodedValue(KEY, false);
+    }
+    
+    private Motorroad() {
+        // utility class
+    }
+}

--- a/core/src/main/java/com/graphhopper/routing/profiles/RoadClass.java
+++ b/core/src/main/java/com/graphhopper/routing/profiles/RoadClass.java
@@ -17,8 +17,6 @@
  */
 package com.graphhopper.routing.profiles;
 
-import com.graphhopper.util.Helper;
-
 /**
  * This enum defines the road class of an edge. It is heavily influenced from the highway tag in OSM that can be
  * primary, cycleway etc.
@@ -47,10 +45,12 @@ public enum RoadClass {
     public static RoadClass find(String name) {
         if (name == null)
             return OTHER;
-        try {
-            return RoadClass.valueOf(Helper.toUpperCase(name));
-        } catch (IllegalArgumentException ex) {
-            return OTHER;
+        
+        for (RoadClass roadClass : values()) {
+            if (roadClass.name().equalsIgnoreCase(name))
+                return roadClass;
         }
+        
+        return OTHER;
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMMotorroadParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMMotorroadParser.java
@@ -1,0 +1,52 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.routing.util.parsers;
+
+import java.util.List;
+
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.profiles.BooleanEncodedValue;
+import com.graphhopper.routing.profiles.EncodedValue;
+import com.graphhopper.routing.profiles.EncodedValueLookup;
+import com.graphhopper.routing.profiles.Motorroad;
+import com.graphhopper.storage.IntsRef;
+import com.graphhopper.util.Helper;
+
+public class OSMMotorroadParser implements TagParser {
+
+    private final BooleanEncodedValue osmMotorroadEnc;
+
+    public OSMMotorroadParser() {
+        this.osmMotorroadEnc = Motorroad.create();
+    }
+
+    @Override
+    public void createEncodedValues(EncodedValueLookup lookup, List<EncodedValue> link) {
+        link.add(osmMotorroadEnc);
+    }
+
+    @Override
+    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay readerWay, boolean ferry, IntsRef relationFlags) {
+        String highwayTag = readerWay.getTag("highway");
+        if (!Helper.isEmpty(highwayTag) && readerWay.hasTag("motorroad", "yes")
+                        && !"motorway".equals(highwayTag) && !"motorway_link".equals(highwayTag)) {
+            osmMotorroadEnc.setBool(false, edgeFlags, true);
+        }
+        return edgeFlags;
+    }
+}

--- a/core/src/main/java/com/graphhopper/util/details/BooleanDetails.java
+++ b/core/src/main/java/com/graphhopper/util/details/BooleanDetails.java
@@ -1,0 +1,47 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.util.details;
+
+import com.graphhopper.routing.profiles.BooleanEncodedValue;
+import com.graphhopper.util.EdgeIteratorState;
+
+public class BooleanDetails extends AbstractPathDetailsBuilder {
+
+    private final BooleanEncodedValue ev;
+    private Boolean boolValue = null;
+
+    public BooleanDetails(String name, BooleanEncodedValue ev) {
+        super(name);
+        this.ev = ev;
+    }
+
+    @Override
+    protected Object getCurrentValue() {
+        return boolValue;
+    }
+
+    @Override
+    public boolean isEdgeDifferentToLastEdge(EdgeIteratorState edge) {
+        boolean val = edge.get(ev);
+        if (boolValue == null || val != boolValue) {
+            this.boolValue = val;
+            return true;
+        }
+        return false;
+    }
+}

--- a/core/src/main/java/com/graphhopper/util/details/EnumDetails.java
+++ b/core/src/main/java/com/graphhopper/util/details/EnumDetails.java
@@ -20,10 +20,10 @@ package com.graphhopper.util.details;
 import com.graphhopper.routing.profiles.EnumEncodedValue;
 import com.graphhopper.util.EdgeIteratorState;
 
-public class EnumDetails<E extends Enum> extends AbstractPathDetailsBuilder {
+public class EnumDetails<E extends Enum<?>> extends AbstractPathDetailsBuilder {
 
     private final EnumEncodedValue<E> ev;
-    private Enum objVal = null;
+    private E objVal = null;
 
     public EnumDetails(String name, EnumEncodedValue<E> ev) {
         super(name);

--- a/core/src/main/java/com/graphhopper/util/details/PathDetailsBuilderFactory.java
+++ b/core/src/main/java/com/graphhopper/util/details/PathDetailsBuilderFactory.java
@@ -61,6 +61,11 @@ public class PathDetailsBuilderFactory {
             if (checkSuffix.contains(getKey("", "priority")) && evl.hasEncodedValue(checkSuffix))
                 builders.add(new DecimalDetails(checkSuffix, evl.getDecimalEncodedValue(checkSuffix)));
         }
+        
+        for (String key : Arrays.asList(Motorroad.KEY)) {
+            if (requestedPathDetails.contains(key) && evl.hasEncodedValue(key))
+                builders.add(new BooleanDetails(key, evl.getBooleanEncodedValue(key)));
+        }
 
         for (String key : Arrays.asList(MaxSpeed.KEY, MaxWidth.KEY, MaxHeight.KEY, MaxWeight.KEY,
                 MaxAxleLoad.KEY, MaxLength.KEY)) {

--- a/core/src/main/java/com/graphhopper/util/details/PathDetailsBuilderFactory.java
+++ b/core/src/main/java/com/graphhopper/util/details/PathDetailsBuilderFactory.java
@@ -19,13 +19,12 @@ package com.graphhopper.util.details;
 
 import com.graphhopper.coll.MapEntry;
 import com.graphhopper.routing.profiles.*;
-import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.routing.weighting.Weighting;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
+import java.util.Map.Entry;
 
 import static com.graphhopper.routing.util.EncodingManager.getKey;
 import static com.graphhopper.util.Parameters.Details.*;
@@ -69,15 +68,18 @@ public class PathDetailsBuilderFactory {
                 builders.add(new DecimalDetails(key, evl.getDecimalEncodedValue(key)));
         }
 
-        for (Map.Entry entry : Arrays.asList(new MapEntry<>(RoadClass.KEY, RoadClass.class),
+        for (Entry<?, ?> entry : Arrays.asList(new MapEntry<>(RoadClass.KEY, RoadClass.class),
                 new MapEntry<>(RoadEnvironment.KEY, RoadEnvironment.class), new MapEntry<>(Surface.KEY, Surface.class),
                 new MapEntry<>(RoadAccess.KEY, RoadAccess.class), new MapEntry<>(Toll.KEY, Toll.class),
                 new MapEntry<>(TrackType.KEY, TrackType.class), new MapEntry<>(Hazmat.KEY, Hazmat.class),
                 new MapEntry<>(HazmatTunnel.KEY, HazmatTunnel.class), new MapEntry<>(HazmatWater.KEY, HazmatWater.class),
                 new MapEntry<>(Country.KEY, Country.class))) {
             String key = (String) entry.getKey();
-            if (requestedPathDetails.contains(key) && evl.hasEncodedValue(key))
-                builders.add(new EnumDetails(key, evl.getEnumEncodedValue(key, (Class<Enum>) entry.getValue())));
+            if (requestedPathDetails.contains(key) && evl.hasEncodedValue(key)) {
+                @SuppressWarnings("unchecked")
+                EnumDetails<?> details = new EnumDetails<>(key, evl.getEnumEncodedValue(key, (Class<Enum<?>>) entry.getValue()));
+                builders.add(details);
+            }
         }
 
         if (requestedPathDetails.size() != builders.size()) {

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMMotorroadParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMMotorroadParserTest.java
@@ -1,0 +1,48 @@
+package com.graphhopper.routing.util.parsers;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.profiles.BooleanEncodedValue;
+import com.graphhopper.routing.profiles.Motorroad;
+import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.storage.IntsRef;
+
+public class OSMMotorroadParserTest {
+
+    private EncodingManager em;
+    private IntsRef relFlags;
+    private BooleanEncodedValue mrEnc;
+    private OSMMotorroadParser parser;
+
+    @Before
+    public void setUp() {
+        parser = new OSMMotorroadParser();
+        em = new EncodingManager.Builder().add(parser).build();
+        relFlags = em.createRelationFlags();
+        mrEnc = em.getBooleanEncodedValue(Motorroad.KEY);
+    }
+    
+    @Test
+    public void testPrimaryMotorroad() {
+        ReaderWay readerWay = new ReaderWay(1);
+        IntsRef edgeFlags = em.createEdgeFlags();
+        readerWay.setTag("highway", "primary");
+        readerWay.setTag("motorroad", "yes");
+        parser.handleWayTags(edgeFlags, readerWay, false, relFlags);
+        assertEquals(true, mrEnc.getBool(false, edgeFlags));
+    }
+    
+    @Test
+    public void testMotorwayMotorroad() {
+        ReaderWay readerWay = new ReaderWay(1);
+        IntsRef edgeFlags = em.createEdgeFlags();
+        readerWay.setTag("highway", "motorway");
+        readerWay.setTag("motorroad", "yes");
+        parser.handleWayTags(edgeFlags, readerWay, false, relFlags);
+        assertEquals(false, mrEnc.getBool(false, edgeFlags));
+    }
+}


### PR DESCRIPTION
Uses the same logic as the CarFlagEncoder to determine if a highway should be treated as a motorroad and uses a dedicated RoadClass constant to encode it.