### PR TITLE
Work towards removing TurnWeighting

### DIFF
--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -826,10 +826,10 @@ public class GraphHopper implements GraphHopperAPI {
                     int uTurnCosts = config.getInt(Routing.U_TURN_COSTS, INFINITE_U_TURN_COSTS);
 
                     CHAlgoFactoryDecorator.EdgeBasedCHMode edgeBasedCHMode = chFactoryDecorator.getEdgeBasedCHMode();
-                    if (!(edgeBasedCHMode == EDGE_OR_NODE && encoder.supports(TurnWeighting.class))) {
+                    if (!(edgeBasedCHMode == EDGE_OR_NODE && encoder.supportsTurnCosts())) {
                         chFactoryDecorator.addCHProfile(CHProfile.nodeBased(createWeighting(new HintsMap(chWeightingStr), encoder, null)));
                     }
-                    if (edgeBasedCHMode != OFF && encoder.supports(TurnWeighting.class)) {
+                    if (edgeBasedCHMode != OFF && encoder.supportsTurnCosts()) {
                         chFactoryDecorator.addCHProfile(CHProfile.edgeBased(createWeighting(new HintsMap(chWeightingStr), encoder, null), uTurnCosts));
                     }
                 }
@@ -973,7 +973,7 @@ public class GraphHopper implements GraphHopperAPI {
      */
     public Weighting createTurnWeighting(Graph graph, Weighting weighting, TraversalMode tMode, double uTurnCosts) {
         FlagEncoder encoder = weighting.getFlagEncoder();
-        if (encoder.supports(TurnWeighting.class) && tMode.isEdgeBased())
+        if (encoder.supportsTurnCosts() && tMode.isEdgeBased())
             return new TurnWeighting(weighting, graph.getTurnCostStorage(), uTurnCosts);
         return weighting;
     }
@@ -1013,11 +1013,11 @@ public class GraphHopper implements GraphHopperAPI {
 
             // we use edge-based routing if the encoder supports turn-costs *unless* the edge_based parameter is set
             // explicitly.
-            TraversalMode tMode = encoder.supports(TurnWeighting.class) ? TraversalMode.EDGE_BASED : TraversalMode.NODE_BASED;
+            TraversalMode tMode = encoder.supportsTurnCosts() ? TraversalMode.EDGE_BASED : TraversalMode.NODE_BASED;
             if (hints.has(Routing.EDGE_BASED))
                 tMode = hints.getBool(Routing.EDGE_BASED, false) ? TraversalMode.EDGE_BASED : TraversalMode.NODE_BASED;
 
-            if (tMode.isEdgeBased() && !encoder.supports(TurnWeighting.class)) {
+            if (tMode.isEdgeBased() && !encoder.supportsTurnCosts()) {
                 throw new IllegalArgumentException("You need to set up a turn cost storage to make use of edge_based=true, e.g. use car|turn_costs=true");
             }
 

--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -67,7 +67,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static com.graphhopper.routing.ch.CHAlgoFactoryDecorator.EdgeBasedCHMode.EDGE_OR_NODE;
 import static com.graphhopper.routing.ch.CHAlgoFactoryDecorator.EdgeBasedCHMode.OFF;
-import static com.graphhopper.routing.weighting.TurnWeighting.INFINITE_U_TURN_COSTS;
+import static com.graphhopper.routing.weighting.Weighting.INFINITE_U_TURN_COSTS;
 import static com.graphhopper.util.Helper.*;
 import static com.graphhopper.util.Parameters.Algorithms.*;
 import static com.graphhopper.util.Parameters.Routing.CURBSIDE;

--- a/core/src/main/java/com/graphhopper/routing/AbstractBidirAlgo.java
+++ b/core/src/main/java/com/graphhopper/routing/AbstractBidirAlgo.java
@@ -317,7 +317,7 @@ public abstract class AbstractBidirAlgo extends AbstractRoutingAlgorithm impleme
 
             // prevents the path to contain the edge at the meeting point twice and subtracts the weight (excluding turn weight => no previous edge)
             entry = entry.getParent();
-            weight -= weighting.calcWeight(edgeState, reverse, EdgeIterator.NO_EDGE);
+            weight -= weighting.calcEdgeWeight(edgeState, reverse);
         }
 
         if (weight < bestWeight) {

--- a/core/src/main/java/com/graphhopper/routing/DijkstraBidirectionCH.java
+++ b/core/src/main/java/com/graphhopper/routing/DijkstraBidirectionCH.java
@@ -73,7 +73,7 @@ public class DijkstraBidirectionCH extends DijkstraBidirectionCHNoSOD {
             // we have to be careful because of rounded shortcut weights in combination with virtual via nodes, see #1574
             final double precision = 0.001;
             if (adjNode != null &&
-                    adjNode.weight + weighting.calcWeight(iter, !reverse, getIncomingEdge(entry)) - entry.weight < -precision) {
+                    adjNode.weight + weighting.calcEdgeWeight(iter, !reverse) - entry.weight < -precision) {
                 return true;
             }
         }

--- a/core/src/main/java/com/graphhopper/routing/DijkstraOneToMany.java
+++ b/core/src/main/java/com/graphhopper/routing/DijkstraOneToMany.java
@@ -93,7 +93,8 @@ public class DijkstraOneToMany extends AbstractRoutingAlgorithm {
             }
             EdgeIteratorState edgeState = graph.getEdgeIteratorState(edge, node);
             path.addDistance(edgeState.getDistance());
-            path.addTime(weighting.calcMillis(edgeState, false, EdgeIterator.NO_EDGE));
+            // todo: we do not yet account for turn times here!
+            path.addTime(weighting.calcEdgeMillis(edgeState, false));
             path.addEdge(edge);
             node = parents[node];
         }

--- a/core/src/main/java/com/graphhopper/routing/InstructionsFromEdges.java
+++ b/core/src/main/java/com/graphhopper/routing/InstructionsFromEdges.java
@@ -496,8 +496,8 @@ public class InstructionsFromEdges implements Path.EdgeVisitor {
         }
         double newDist = edge.getDistance();
         prevInstruction.setDistance(newDist + prevInstruction.getDistance());
-        prevInstruction.setTime(weighting.calcMillis(edge, false, EdgeIterator.NO_EDGE)
-                + prevInstruction.getTime());
+        // todonow: why do we not account for turn times here ?
+        prevInstruction.setTime(weighting.calcEdgeMillis(edge, false) + prevInstruction.getTime());
     }
 
 }

--- a/core/src/main/java/com/graphhopper/routing/ch/CHProfileSelector.java
+++ b/core/src/main/java/com/graphhopper/routing/ch/CHProfileSelector.java
@@ -25,7 +25,7 @@ import com.graphhopper.util.Parameters;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.graphhopper.routing.weighting.TurnWeighting.INFINITE_U_TURN_COSTS;
+import static com.graphhopper.routing.weighting.Weighting.INFINITE_U_TURN_COSTS;
 
 /**
  * This class is used to determine the appropriate CH profile given (or not given) some (request) parameters

--- a/core/src/main/java/com/graphhopper/routing/ch/CHWeighting.java
+++ b/core/src/main/java/com/graphhopper/routing/ch/CHWeighting.java
@@ -23,6 +23,8 @@ import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.util.CHEdgeIteratorState;
 import com.graphhopper.util.EdgeIteratorState;
 
+import static com.graphhopper.util.EdgeIterator.NO_EDGE;
+
 /**
  * Used by CH algorithms and therefore assumed that all edges are of type CHEdgeIteratorState
  * <p>
@@ -43,6 +45,11 @@ public class CHWeighting implements Weighting {
     }
 
     @Override
+    public final double calcEdgeWeight(EdgeIteratorState edgeState, boolean reverse) {
+        return calcWeight(edgeState, reverse, NO_EDGE);
+    }
+
+    @Override
     public double calcWeight(EdgeIteratorState edgeState, boolean reverse, int prevOrNextEdgeId) {
         CHEdgeIteratorState tmp = (CHEdgeIteratorState) edgeState;
         if (tmp.isShortcut())
@@ -50,6 +57,11 @@ public class CHWeighting implements Weighting {
             return tmp.getWeight();
 
         return userWeighting.calcWeight(edgeState, reverse, prevOrNextEdgeId);
+    }
+
+    @Override
+    public final long calcEdgeMillis(EdgeIteratorState edgeState, boolean reverse) {
+        return calcMillis(edgeState, reverse, NO_EDGE);
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/ch/NodeBasedCHBidirPathExtractor.java
+++ b/core/src/main/java/com/graphhopper/routing/ch/NodeBasedCHBidirPathExtractor.java
@@ -24,8 +24,6 @@ import com.graphhopper.storage.Graph;
 import com.graphhopper.storage.ShortcutUnpacker;
 import com.graphhopper.util.EdgeIteratorState;
 
-import static com.graphhopper.util.EdgeIterator.NO_EDGE;
-
 public class NodeBasedCHBidirPathExtractor extends BidirPathExtractor {
     private final ShortcutUnpacker shortcutUnpacker;
 
@@ -48,7 +46,7 @@ public class NodeBasedCHBidirPathExtractor extends BidirPathExtractor {
             @Override
             public void visit(EdgeIteratorState edge, boolean reverse, int prevOrNextEdgeId) {
                 path.addDistance(edge.getDistance());
-                path.addTime(weighting.calcMillis(edge, reverse, NO_EDGE));
+                path.addTime(weighting.calcEdgeMillis(edge, reverse));
                 path.addEdge(edge.getEdge());
             }
         }, false);

--- a/core/src/main/java/com/graphhopper/routing/ch/PrepareCHEdgeIteratorImpl.java
+++ b/core/src/main/java/com/graphhopper/routing/ch/PrepareCHEdgeIteratorImpl.java
@@ -101,7 +101,7 @@ public class PrepareCHEdgeIteratorImpl implements PrepareCHEdgeExplorer, Prepare
         if (!needWeight) {
             return 0;
         }
-        return weighting.calcWeight(chIterator, reverse, EdgeIterator.NO_EDGE);
+        return weighting.calcEdgeWeight(chIterator, reverse);
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/lm/LandmarkStorage.java
+++ b/core/src/main/java/com/graphhopper/routing/lm/LandmarkStorage.java
@@ -583,7 +583,7 @@ public class LandmarkStorage implements Storable<LandmarkStorage> {
     }
 
     int calcWeight(EdgeIteratorState edge, boolean reverse) {
-        return (int) (weighting.calcWeight(edge, reverse, EdgeIterator.NO_EDGE) / factor);
+        return (int) (weighting.calcEdgeWeight(edge, reverse) / factor);
     }
 
     // From all available landmarks pick just a few active ones

--- a/core/src/main/java/com/graphhopper/routing/util/AbstractFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/AbstractFlagEncoder.java
@@ -23,7 +23,6 @@ import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.reader.osm.conditional.ConditionalOSMTagInspector;
 import com.graphhopper.reader.osm.conditional.DateRangeParser;
 import com.graphhopper.routing.profiles.*;
-import com.graphhopper.routing.weighting.TurnWeighting;
 import com.graphhopper.storage.IntsRef;
 import com.graphhopper.util.*;
 import org.slf4j.Logger;
@@ -495,10 +494,12 @@ public abstract class AbstractFlagEncoder implements FlagEncoder {
     }
 
     @Override
-    public boolean supports(Class<?> feature) {
-        if (TurnWeighting.class.isAssignableFrom(feature))
-            return maxTurnCosts > 0;
+    public boolean supportsTurnCosts() {
+        return maxTurnCosts > 0;
+    }
 
+    @Override
+    public boolean supports(Class<?> feature) {
         return false;
     }
 

--- a/core/src/main/java/com/graphhopper/routing/util/EncodingManager.java
+++ b/core/src/main/java/com/graphhopper/routing/util/EncodingManager.java
@@ -24,7 +24,6 @@ import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.reader.osm.conditional.DateRangeParser;
 import com.graphhopper.routing.profiles.*;
 import com.graphhopper.routing.util.parsers.*;
-import com.graphhopper.routing.weighting.TurnWeighting;
 import com.graphhopper.storage.*;
 import com.graphhopper.util.EdgeIteratorState;
 import com.graphhopper.util.Helper;
@@ -352,7 +351,7 @@ public class EncodingManager implements EncodedValueLookup {
 
             // FlagEncoder can demand TurnCostParsers => add them after the explicitly added ones
             for (AbstractFlagEncoder encoder : flagEncoderList) {
-                if (encoder.supports(TurnWeighting.class) && !em.turnCostParsers.containsKey(encoder.toString()))
+                if (encoder.supportsTurnCosts() && !em.turnCostParsers.containsKey(encoder.toString()))
                     _addTurnCostParser(new OSMTurnRelationParser(encoder.toString(), encoder.getMaxTurnCosts()));
             }
 
@@ -736,7 +735,7 @@ public class EncodingManager implements EncodedValueLookup {
 
     public boolean needsTurnCostsSupport() {
         for (FlagEncoder encoder : edgeEncoders) {
-            if (encoder.supports(TurnWeighting.class))
+            if (encoder.supportsTurnCosts())
                 return true;
         }
         return false;

--- a/core/src/main/java/com/graphhopper/routing/util/FlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/FlagEncoder.java
@@ -50,6 +50,8 @@ public interface FlagEncoder extends EncodedValueLookup {
      */
     DecimalEncodedValue getAverageSpeedEnc();
 
+    boolean supportsTurnCosts();
+
     /**
      * Returns true if the feature class is supported like TurnWeighting or PriorityWeighting.
      * Use support(String) instead.

--- a/core/src/main/java/com/graphhopper/routing/util/FlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/FlagEncoder.java
@@ -17,13 +17,9 @@
  */
 package com.graphhopper.routing.util;
 
-import com.graphhopper.reader.OSMTurnRelation;
 import com.graphhopper.routing.profiles.BooleanEncodedValue;
 import com.graphhopper.routing.profiles.DecimalEncodedValue;
 import com.graphhopper.routing.profiles.EncodedValueLookup;
-import com.graphhopper.storage.IntsRef;
-import com.graphhopper.util.InstructionAnnotation;
-import com.graphhopper.util.Translation;
 
 /**
  * This class provides methods to define how a value (like speed or direction) converts to a flag

--- a/core/src/main/java/com/graphhopper/routing/util/TestAlgoCollector.java
+++ b/core/src/main/java/com/graphhopper/routing/util/TestAlgoCollector.java
@@ -51,7 +51,7 @@ public class TestAlgoCollector {
         QueryGraph queryGraph = QueryGraph.lookup(algoEntry.getForQueryGraph(), queryList);
         AlgorithmOptions opts = algoEntry.getAlgorithmOptions();
         FlagEncoder encoder = opts.getWeighting().getFlagEncoder();
-        if (encoder.supports(TurnWeighting.class)) {
+        if (encoder.supportsTurnCosts()) {
             if (!opts.getTraversalMode().isEdgeBased()) {
                 errors.add("Cannot use TurnWeighting with node based traversal");
                 return this;

--- a/core/src/main/java/com/graphhopper/routing/weighting/AbstractAdjustedWeighting.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/AbstractAdjustedWeighting.java
@@ -21,6 +21,8 @@ import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.routing.util.HintsMap;
 import com.graphhopper.util.EdgeIteratorState;
 
+import static com.graphhopper.util.EdgeIterator.NO_EDGE;
+
 /**
  * The AdjustedWeighting wraps another Weighting.
  *
@@ -33,6 +35,16 @@ public abstract class AbstractAdjustedWeighting implements Weighting {
         if (superWeighting == null)
             throw new IllegalArgumentException("No super weighting set");
         this.superWeighting = superWeighting;
+    }
+
+    @Override
+    public final double calcEdgeWeight(EdgeIteratorState edgeState, boolean reverse) {
+        return calcWeight(edgeState, reverse, NO_EDGE);
+    }
+
+    @Override
+    public final long calcEdgeMillis(EdgeIteratorState edgeState, boolean reverse) {
+        return calcMillis(edgeState, reverse, NO_EDGE);
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/weighting/AbstractWeighting.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/AbstractWeighting.java
@@ -23,6 +23,7 @@ import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.routing.util.HintsMap;
 import com.graphhopper.util.EdgeIteratorState;
 
+import static com.graphhopper.util.EdgeIterator.NO_EDGE;
 import static com.graphhopper.util.Helper.toLowerCase;
 
 /**
@@ -42,6 +43,16 @@ public abstract class AbstractWeighting implements Weighting {
 
         avSpeedEnc = encoder.getAverageSpeedEnc();
         accessEnc = encoder.getAccessEnc();
+    }
+
+    @Override
+    public final double calcEdgeWeight(EdgeIteratorState edgeState, boolean reverse) {
+        return calcWeight(edgeState, reverse, NO_EDGE);
+    }
+
+    @Override
+    public final long calcEdgeMillis(EdgeIteratorState edgeState, boolean reverse) {
+        return calcMillis(edgeState, reverse, NO_EDGE);
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/weighting/AbstractWeighting.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/AbstractWeighting.java
@@ -106,7 +106,7 @@ public abstract class AbstractWeighting implements Weighting {
         return toString().equals(other.toString());
     }
 
-    static final boolean isValidName(String name) {
+    static boolean isValidName(String name) {
         if (name == null || name.isEmpty())
             return false;
 

--- a/core/src/main/java/com/graphhopper/routing/weighting/TurnWeighting.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/TurnWeighting.java
@@ -28,6 +28,7 @@ import com.graphhopper.util.EdgeIteratorState;
 
 import static com.graphhopper.routing.profiles.TurnCost.EV_SUFFIX;
 import static com.graphhopper.routing.util.EncodingManager.getKey;
+import static com.graphhopper.util.EdgeIterator.NO_EDGE;
 
 /**
  * Provides methods to retrieve turn costs for a specific turn.
@@ -76,6 +77,11 @@ public class TurnWeighting implements Weighting {
     }
 
     @Override
+    public final double calcEdgeWeight(EdgeIteratorState edgeState, boolean reverse) {
+        return calcWeight(edgeState, reverse, NO_EDGE);
+    }
+
+    @Override
     public double calcWeight(EdgeIteratorState edgeState, boolean reverse, int prevOrNextEdgeId) {
         double weight = superWeighting.calcWeight(edgeState, reverse, prevOrNextEdgeId);
         if (!EdgeIterator.Edge.isValid(prevOrNextEdgeId))
@@ -86,6 +92,11 @@ public class TurnWeighting implements Weighting {
                 ? calcTurnWeight(origEdgeId, edgeState.getBaseNode(), prevOrNextEdgeId)
                 : calcTurnWeight(prevOrNextEdgeId, edgeState.getBaseNode(), origEdgeId);
         return weight + turnCosts;
+    }
+
+    @Override
+    public final long calcEdgeMillis(EdgeIteratorState edgeState, boolean reverse) {
+        return calcMillis(edgeState, reverse, NO_EDGE);
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/weighting/TurnWeighting.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/TurnWeighting.java
@@ -36,7 +36,6 @@ import static com.graphhopper.routing.util.EncodingManager.getKey;
  * @author Peter Karich
  */
 public class TurnWeighting implements Weighting {
-    public static final int INFINITE_U_TURN_COSTS = -1;
     private final DecimalEncodedValue turnCostEnc;
     private final TurnCostStorage turnCostStorage;
     private final Weighting superWeighting;

--- a/core/src/main/java/com/graphhopper/routing/weighting/Weighting.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/Weighting.java
@@ -39,30 +39,40 @@ public interface Weighting {
      */
     double getMinWeight(double distance);
 
-    double calcEdgeWeight(EdgeIteratorState edgeState, boolean reverse);
-
     /**
-     * This method calculates the weighting a certain edgeState should be associated. E.g. a high
-     * value indicates that the edge should be avoided. Make sure that this method is very fast and
-     * optimized as this is called potentially millions of times for one route or a lot more for
-     * nearly any preprocessing phase.
+     * This method calculates the weight of a given {@link EdgeIteratorState}. E.g. a high value indicates that the edge
+     * should be avoided during shortest path search. Make sure that this method is very fast and optimized as this is
+     * called potentially millions of times for one route or a lot more for nearly any preprocessing phase. This
+     * method does not include any turn costs like {@link #calcWeight}.
      *
-     * @param edgeState        the edge for which the weight should be calculated
-     * @param reverse          if the specified edge is specified in reverse direction e.g. from the reverse
-     *                         case of a bidirectional search.
-     * @param prevOrNextEdgeId if reverse is false this has to be the previous edgeId, if true it
-     *                         has to be the next edgeId in the direction from start to end.
+     * @param edgeState the edge for which the weight should be calculated
+     * @param reverse   if the specified edge is specified in reverse direction e.g. from the reverse
+     *                  case of a bidirectional search.
      * @return the calculated weight with the specified velocity has to be in the range of 0 and
      * +Infinity. Make sure your method does not return NaN which can e.g. occur for 0/0.
      */
+    double calcEdgeWeight(EdgeIteratorState edgeState, boolean reverse);
+
+    /**
+     * Calculates the weight of a given edge like {@link #calcEdgeWeight}, but potentially also adds the transition
+     * cost (the turn weight) associated with transitioning from/to the edge with ID prevOrNextEdgeId.
+     *
+     * @param prevOrNextEdgeId if reverse is false this has to be the previous edgeId, if true it
+     *                         has to be the next edgeId in the direction from start to end.
+     */
     double calcWeight(EdgeIteratorState edgeState, boolean reverse, int prevOrNextEdgeId);
 
+    /**
+     * This method calculates the time taken (in milli seconds) to travel along the specified edgeState.
+     * It is typically used for post-processing and on only a few thousand edges.
+     */
     long calcEdgeMillis(EdgeIteratorState edgeState, boolean reverse);
 
     /**
-     * This method calculates the time taken (in milli seconds) for the specified edgeState and
-     * optionally include the turn costs (in seconds) of the previous (or next) edgeId via
-     * prevOrNextEdgeId. Typically used for post-processing and on only a few thousand edges.
+     * Like {@link #calcEdgeMillis}, but potentially also includes the turn costs (in seconds) needed for the transition
+     * between the previous (or next) edgeId and this edge via prevOrNextEdgeId.
+     *
+     * @see #calcWeight
      */
     long calcMillis(EdgeIteratorState edgeState, boolean reverse, int prevOrNextEdgeId);
 

--- a/core/src/main/java/com/graphhopper/routing/weighting/Weighting.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/Weighting.java
@@ -39,6 +39,8 @@ public interface Weighting {
      */
     double getMinWeight(double distance);
 
+    double calcEdgeWeight(EdgeIteratorState edgeState, boolean reverse);
+
     /**
      * This method calculates the weighting a certain edgeState should be associated. E.g. a high
      * value indicates that the edge should be avoided. Make sure that this method is very fast and
@@ -54,6 +56,8 @@ public interface Weighting {
      * +Infinity. Make sure your method does not return NaN which can e.g. occur for 0/0.
      */
     double calcWeight(EdgeIteratorState edgeState, boolean reverse, int prevOrNextEdgeId);
+
+    long calcEdgeMillis(EdgeIteratorState edgeState, boolean reverse);
 
     /**
      * This method calculates the time taken (in milli seconds) for the specified edgeState and

--- a/core/src/main/java/com/graphhopper/routing/weighting/Weighting.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/Weighting.java
@@ -29,6 +29,8 @@ import com.graphhopper.util.EdgeIteratorState;
  */
 public interface Weighting {
 
+    int INFINITE_U_TURN_COSTS = -1;
+
     /**
      * Used only for the heuristic estimation in A*
      *

--- a/core/src/main/java/com/graphhopper/storage/CHProfile.java
+++ b/core/src/main/java/com/graphhopper/storage/CHProfile.java
@@ -2,7 +2,6 @@ package com.graphhopper.storage;
 
 import com.graphhopper.routing.util.TraversalMode;
 import com.graphhopper.routing.weighting.AbstractWeighting;
-import com.graphhopper.routing.weighting.TurnWeighting;
 import com.graphhopper.routing.weighting.Weighting;
 
 import java.util.ArrayList;
@@ -10,7 +9,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 
-import static com.graphhopper.routing.weighting.TurnWeighting.INFINITE_U_TURN_COSTS;
+import static com.graphhopper.routing.weighting.Weighting.INFINITE_U_TURN_COSTS;
 
 /**
  * Specifies all properties of a CH routing profile. Generally these properties cannot be changed after the CH
@@ -44,7 +43,7 @@ public class CHProfile {
     }
 
     /**
-     * @param uTurnCosts the costs of a u-turn in seconds, for {@link TurnWeighting#INFINITE_U_TURN_COSTS} the u-turn costs
+     * @param uTurnCosts the costs of a u-turn in seconds, for {@link Weighting#INFINITE_U_TURN_COSTS} the u-turn costs
      *                   will be infinite
      */
     public CHProfile(Weighting weighting, boolean edgeBased, int uTurnCosts) {

--- a/core/src/test/java/com/graphhopper/routing/CHQueryWithTurnCostsTest.java
+++ b/core/src/test/java/com/graphhopper/routing/CHQueryWithTurnCostsTest.java
@@ -42,7 +42,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 
-import static com.graphhopper.routing.weighting.TurnWeighting.INFINITE_U_TURN_COSTS;
+import static com.graphhopper.routing.weighting.Weighting.INFINITE_U_TURN_COSTS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 

--- a/core/src/test/java/com/graphhopper/routing/RandomCHRoutingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/RandomCHRoutingTest.java
@@ -26,7 +26,7 @@ import org.junit.runners.Parameterized;
 
 import java.util.*;
 
-import static com.graphhopper.routing.weighting.TurnWeighting.INFINITE_U_TURN_COSTS;
+import static com.graphhopper.routing.weighting.Weighting.INFINITE_U_TURN_COSTS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 

--- a/core/src/test/java/com/graphhopper/routing/RoutingAlgorithmTest.java
+++ b/core/src/test/java/com/graphhopper/routing/RoutingAlgorithmTest.java
@@ -50,6 +50,7 @@ import java.util.Random;
 
 import static com.graphhopper.routing.util.TraversalMode.EDGE_BASED;
 import static com.graphhopper.routing.util.TraversalMode.NODE_BASED;
+import static com.graphhopper.util.EdgeIterator.NO_EDGE;
 import static com.graphhopper.util.GHUtility.updateDistancesFor;
 import static com.graphhopper.util.Helper.DIST_EARTH;
 import static com.graphhopper.util.Parameters.Algorithms.ASTAR_BI;
@@ -817,6 +818,11 @@ public class RoutingAlgorithmTest {
             }
 
             @Override
+            public final double calcEdgeWeight(EdgeIteratorState edgeState, boolean reverse) {
+                return calcWeight(edgeState, reverse, NO_EDGE);
+            }
+
+            @Override
             public double calcWeight(EdgeIteratorState edgeState, boolean reverse, int prevOrNextEdgeId) {
                 int adj = edgeState.getAdjNode();
                 int base = edgeState.getBaseNode();
@@ -835,6 +841,11 @@ public class RoutingAlgorithmTest {
                     return 2 * edgeState.getDistance();
 
                 return edgeState.getDistance() * 0.8;
+            }
+
+            @Override
+            public final long calcEdgeMillis(EdgeIteratorState edgeState, boolean reverse) {
+                return calcMillis(edgeState, reverse, NO_EDGE);
             }
 
             @Override

--- a/core/src/test/java/com/graphhopper/routing/RoutingAlgorithmTest.java
+++ b/core/src/test/java/com/graphhopper/routing/RoutingAlgorithmTest.java
@@ -987,7 +987,7 @@ public class RoutingAlgorithmTest {
     private GraphHopperStorage createGHStorage(boolean is3D, Weighting... weightings) {
         CHProfile[] chProfiles = new CHProfile[weightings.length];
         for (int i = 0; i < weightings.length; i++) {
-            chProfiles[i] = new CHProfile(weightings[i], traversalMode, TurnWeighting.INFINITE_U_TURN_COSTS);
+            chProfiles[i] = new CHProfile(weightings[i], traversalMode, Weighting.INFINITE_U_TURN_COSTS);
         }
         return new GraphBuilder(encodingManager).set3D(is3D)
                 .setCHProfiles(chProfiles)
@@ -1140,7 +1140,7 @@ public class RoutingAlgorithmTest {
     private static abstract class CHCalculator implements PathCalculator {
         @Override
         public Path calcPath(GraphHopperStorage graph, Weighting weighting, TraversalMode traversalMode, int maxVisitedNodes, int from, int to) {
-            CHProfile chProfile = new CHProfile(weighting, traversalMode, TurnWeighting.INFINITE_U_TURN_COSTS);
+            CHProfile chProfile = new CHProfile(weighting, traversalMode, Weighting.INFINITE_U_TURN_COSTS);
             PrepareContractionHierarchies pch = PrepareContractionHierarchies.fromGraphHopperStorage(graph, chProfile);
             CHGraph chGraph = graph.getCHGraph(chProfile);
             if (chGraph.getEdges() == chGraph.getOriginalEdges()) {
@@ -1166,7 +1166,7 @@ public class RoutingAlgorithmTest {
 
         @Override
         public Path calcPath(GraphHopperStorage graph, Weighting weighting, TraversalMode traversalMode, int maxVisitedNodes, QueryResult from, QueryResult to) {
-            CHProfile chProfile = new CHProfile(weighting, traversalMode, TurnWeighting.INFINITE_U_TURN_COSTS);
+            CHProfile chProfile = new CHProfile(weighting, traversalMode, Weighting.INFINITE_U_TURN_COSTS);
             PrepareContractionHierarchies pch = PrepareContractionHierarchies.fromGraphHopperStorage(graph, chProfile);
             CHGraph chGraph = graph.getCHGraph(chProfile);
             if (chGraph.getEdges() == chGraph.getOriginalEdges()) {

--- a/core/src/test/java/com/graphhopper/routing/ch/CHProfileSelectorTest.java
+++ b/core/src/test/java/com/graphhopper/routing/ch/CHProfileSelectorTest.java
@@ -33,7 +33,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static com.graphhopper.routing.weighting.TurnWeighting.INFINITE_U_TURN_COSTS;
+import static com.graphhopper.routing.weighting.Weighting.INFINITE_U_TURN_COSTS;
 import static org.junit.Assert.*;
 
 public class CHProfileSelectorTest {

--- a/core/src/test/java/com/graphhopper/routing/ch/CHTurnCostTest.java
+++ b/core/src/test/java/com/graphhopper/routing/ch/CHTurnCostTest.java
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
 import java.util.*;
 
 import static com.graphhopper.routing.ch.CHParameters.*;
-import static com.graphhopper.routing.weighting.TurnWeighting.INFINITE_U_TURN_COSTS;
+import static com.graphhopper.routing.weighting.Weighting.INFINITE_U_TURN_COSTS;
 import static com.graphhopper.util.GHUtility.updateDistancesFor;
 import static org.junit.Assert.*;
 

--- a/core/src/test/java/com/graphhopper/routing/ch/EdgeBasedNodeContractorTest.java
+++ b/core/src/test/java/com/graphhopper/routing/ch/EdgeBasedNodeContractorTest.java
@@ -43,7 +43,7 @@ import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 
-import static com.graphhopper.routing.weighting.TurnWeighting.INFINITE_U_TURN_COSTS;
+import static com.graphhopper.routing.weighting.Weighting.INFINITE_U_TURN_COSTS;
 import static org.junit.Assert.*;
 
 /**

--- a/core/src/test/java/com/graphhopper/routing/ch/EdgeBasedWitnessPathSearcherTest.java
+++ b/core/src/test/java/com/graphhopper/routing/ch/EdgeBasedWitnessPathSearcherTest.java
@@ -29,7 +29,7 @@ import com.graphhopper.util.PMap;
 import org.junit.Before;
 import org.junit.Test;
 
-import static com.graphhopper.routing.weighting.TurnWeighting.INFINITE_U_TURN_COSTS;
+import static com.graphhopper.routing.weighting.Weighting.INFINITE_U_TURN_COSTS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 

--- a/core/src/test/java/com/graphhopper/routing/ch/NodeBasedNodeContractorTest.java
+++ b/core/src/test/java/com/graphhopper/routing/ch/NodeBasedNodeContractorTest.java
@@ -32,7 +32,6 @@ import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.*;
 import com.graphhopper.storage.index.LocationIndexTree;
 import com.graphhopper.util.CHEdgeIteratorState;
-import com.graphhopper.util.EdgeIterator;
 import com.graphhopper.util.EdgeIteratorState;
 import com.graphhopper.util.PMap;
 import org.junit.Test;
@@ -519,7 +518,7 @@ public class NodeBasedNodeContractorTest {
         if (edge instanceof CHEdgeIteratorState) {
             return ((CHEdgeIteratorState) edge).getWeight();
         } else {
-            return weighting.calcWeight(edge, false, EdgeIterator.NO_EDGE);
+            return weighting.calcEdgeWeight(edge, false);
         }
     }
 

--- a/core/src/test/java/com/graphhopper/routing/ch/Path4CHTest.java
+++ b/core/src/test/java/com/graphhopper/routing/ch/Path4CHTest.java
@@ -19,7 +19,7 @@ import com.graphhopper.util.EdgeIteratorState;
 import org.junit.Before;
 import org.junit.Test;
 
-import static com.graphhopper.routing.weighting.TurnWeighting.INFINITE_U_TURN_COSTS;
+import static com.graphhopper.routing.weighting.Weighting.INFINITE_U_TURN_COSTS;
 import static com.graphhopper.util.GHUtility.getEdge;
 import static org.junit.Assert.assertEquals;
 

--- a/core/src/test/java/com/graphhopper/routing/ch/PrepareContractionHierarchiesTest.java
+++ b/core/src/test/java/com/graphhopper/routing/ch/PrepareContractionHierarchiesTest.java
@@ -287,24 +287,23 @@ public class PrepareContractionHierarchiesTest {
 
         int tmpEdgeId = edgeState01.getEdge();
         g.freeze();
-        int x = EdgeIterator.NO_EDGE;
-        double weight = w.calcWeight(edgeState01, false, x) + w.calcWeight(edgeState12, false, x);
-        int sc0_2 = lg.shortcut(0, 2, oneDirFlags, w.calcWeight(edgeState01, false, x) + w.calcWeight(edgeState12, false, x), tmpEdgeId, edgeState12.getEdge());
+        double weight = w.calcEdgeWeight(edgeState01, false) + w.calcEdgeWeight(edgeState12, false);
+        int sc0_2 = lg.shortcut(0, 2, oneDirFlags, w.calcEdgeWeight(edgeState01, false) + w.calcEdgeWeight(edgeState12, false), tmpEdgeId, edgeState12.getEdge());
 
         tmpEdgeId = sc0_2;
-        weight += w.calcWeight(edgeState23, false, x);
+        weight += w.calcEdgeWeight(edgeState23, false);
         int sc0_3 = lg.shortcut(0, 3, oneDirFlags, weight, tmpEdgeId, edgeState23.getEdge());
 
         tmpEdgeId = sc0_3;
-        weight += w.calcWeight(edgeState34, false, x);
+        weight += w.calcEdgeWeight(edgeState34, false);
         int sc0_4 = lg.shortcut(0, 4, oneDirFlags, weight, tmpEdgeId, edgeState34.getEdge());
 
         tmpEdgeId = sc0_4;
-        weight += w.calcWeight(edgeState45, false, x);
+        weight += w.calcEdgeWeight(edgeState45, false);
         int sc0_5 = lg.shortcut(0, 5, oneDirFlags, weight, tmpEdgeId, edgeState45.getEdge());
 
         tmpEdgeId = sc0_5;
-        weight += w.calcWeight(edgeState56, false, x);
+        weight += w.calcEdgeWeight(edgeState56, false);
         int sc0_6 = lg.shortcut(0, 6, oneDirFlags, weight, tmpEdgeId, edgeState56.getEdge());
 
         lg.setLevel(0, 10);
@@ -486,7 +485,7 @@ public class PrepareContractionHierarchiesTest {
     }
 
     private double getWeight(Graph graph, Weighting w, int from, int to, boolean incoming) {
-        return w.calcWeight(getEdge(graph, from, to, false), incoming, -1);
+        return w.calcEdgeWeight(getEdge(graph, from, to, false), incoming);
     }
 
     private EdgeIteratorState getEdge(Graph graph, int from, int to, boolean incoming) {

--- a/core/src/test/java/com/graphhopper/routing/util/CarFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/CarFlagEncoderTest.java
@@ -23,7 +23,6 @@ import com.graphhopper.routing.profiles.BooleanEncodedValue;
 import com.graphhopper.routing.profiles.DecimalEncodedValue;
 import com.graphhopper.routing.profiles.EncodedValue;
 import com.graphhopper.routing.profiles.Roundabout;
-import com.graphhopper.routing.util.parsers.OSMRoadAccessParser;
 import com.graphhopper.routing.weighting.FastestWeighting;
 import com.graphhopper.storage.IntsRef;
 import com.graphhopper.util.GHUtility;
@@ -227,11 +226,11 @@ public class CarFlagEncoderTest {
         EncodingManager.AcceptWay acceptWay = new EncodingManager.AcceptWay();
         assertTrue(em.acceptWay(way, acceptWay));
         IntsRef edgeFlags = em.handleWayTags(way, acceptWay, relFlags);
-        assertEquals(60, weighting.calcWeight(GHUtility.createMockedEdgeIteratorState(1000, edgeFlags), false, -1), 0.1);
+        assertEquals(60, weighting.calcEdgeWeight(GHUtility.createMockedEdgeIteratorState(1000, edgeFlags), false), 0.1);
 
         way.setTag("vehicle", "destination");
         edgeFlags = em.handleWayTags(way, acceptWay, relFlags);
-        assertEquals(600, weighting.calcWeight(GHUtility.createMockedEdgeIteratorState(1000, edgeFlags), false, -1), 0.1);
+        assertEquals(600, weighting.calcEdgeWeight(GHUtility.createMockedEdgeIteratorState(1000, edgeFlags), false), 0.1);
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/routing/util/DefaultEdgeFilterTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/DefaultEdgeFilterTest.java
@@ -30,7 +30,7 @@ import com.graphhopper.util.CHEdgeExplorer;
 import com.graphhopper.util.CHEdgeIterator;
 import org.junit.Test;
 
-import static com.graphhopper.routing.weighting.TurnWeighting.INFINITE_U_TURN_COSTS;
+import static com.graphhopper.routing.weighting.Weighting.INFINITE_U_TURN_COSTS;
 import static org.junit.Assert.assertEquals;
 
 public class DefaultEdgeFilterTest {

--- a/core/src/test/java/com/graphhopper/routing/weighting/BidirectionalRoutingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/BidirectionalRoutingTest.java
@@ -92,7 +92,7 @@ public class BidirectionalRoutingTest {
         encoder = new CarFlagEncoder(5, 5, 1);
         encodingManager = EncodingManager.create(encoder);
         weighting = new FastestWeighting(encoder);
-        chProfiles = Arrays.asList(CHProfile.nodeBased(weighting), CHProfile.edgeBased(weighting, TurnWeighting.INFINITE_U_TURN_COSTS));
+        chProfiles = Arrays.asList(CHProfile.nodeBased(weighting), CHProfile.edgeBased(weighting, Weighting.INFINITE_U_TURN_COSTS));
         graph = createGraph();
     }
 

--- a/core/src/test/java/com/graphhopper/routing/weighting/BidirectionalRoutingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/BidirectionalRoutingTest.java
@@ -26,6 +26,7 @@ import java.util.*;
 
 import static com.graphhopper.routing.util.TraversalMode.EDGE_BASED;
 import static com.graphhopper.routing.util.TraversalMode.NODE_BASED;
+import static com.graphhopper.routing.weighting.Weighting.INFINITE_U_TURN_COSTS;
 import static com.graphhopper.util.Parameters.Algorithms.ASTAR_BI;
 import static com.graphhopper.util.Parameters.Algorithms.DIJKSTRA_BI;
 import static org.junit.Assert.assertEquals;
@@ -92,7 +93,7 @@ public class BidirectionalRoutingTest {
         encoder = new CarFlagEncoder(5, 5, 1);
         encodingManager = EncodingManager.create(encoder);
         weighting = new FastestWeighting(encoder);
-        chProfiles = Arrays.asList(CHProfile.nodeBased(weighting), CHProfile.edgeBased(weighting, Weighting.INFINITE_U_TURN_COSTS));
+        chProfiles = Arrays.asList(CHProfile.nodeBased(weighting), CHProfile.edgeBased(weighting, INFINITE_U_TURN_COSTS));
         graph = createGraph();
     }
 

--- a/core/src/test/java/com/graphhopper/routing/weighting/BlockAreaWeightingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/BlockAreaWeightingTest.java
@@ -6,7 +6,6 @@ import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.storage.Graph;
 import com.graphhopper.storage.GraphBuilder;
 import com.graphhopper.storage.GraphEdgeIdFinder;
-import com.graphhopper.util.EdgeIterator;
 import com.graphhopper.util.EdgeIteratorState;
 import com.graphhopper.util.shapes.Circle;
 import org.junit.Before;
@@ -39,11 +38,11 @@ public class BlockAreaWeightingTest {
         GraphEdgeIdFinder.BlockArea bArea = new GraphEdgeIdFinder.BlockArea(graph);
         EdgeIteratorState edge = graph.getEdgeIteratorState(0, 1);
         BlockAreaWeighting instance = new BlockAreaWeighting(new FastestWeighting(encoder), bArea);
-        assertEquals(94.35, instance.calcWeight(edge, false, EdgeIterator.NO_EDGE), .01);
+        assertEquals(94.35, instance.calcEdgeWeight(edge, false), .01);
 
         bArea.add(0);
         instance = new BlockAreaWeighting(new FastestWeighting(encoder), bArea);
-        assertEquals(Double.POSITIVE_INFINITY, instance.calcWeight(edge, false, EdgeIterator.NO_EDGE), .01);
+        assertEquals(Double.POSITIVE_INFINITY, instance.calcEdgeWeight(edge, false), .01);
     }
 
     @Test
@@ -51,16 +50,16 @@ public class BlockAreaWeightingTest {
         EdgeIteratorState edge = graph.getEdgeIteratorState(0, 1);
         GraphEdgeIdFinder.BlockArea bArea = new GraphEdgeIdFinder.BlockArea(graph);
         BlockAreaWeighting instance = new BlockAreaWeighting(new FastestWeighting(encoder), bArea);
-        assertEquals(94.35, instance.calcWeight(edge, false, EdgeIterator.NO_EDGE), 0.01);
+        assertEquals(94.35, instance.calcEdgeWeight(edge, false), 0.01);
 
         bArea.add(new Circle(0.01, 0.01, 100));
-        assertEquals(Double.POSITIVE_INFINITY, instance.calcWeight(edge, false, EdgeIterator.NO_EDGE), .01);
+        assertEquals(Double.POSITIVE_INFINITY, instance.calcEdgeWeight(edge, false), .01);
 
         bArea = new GraphEdgeIdFinder.BlockArea(graph);
         instance = new BlockAreaWeighting(new FastestWeighting(encoder), bArea);
         // Do not match 1,1 of edge
         bArea.add(new Circle(0.1, 0.1, 100));
-        assertEquals(94.35, instance.calcWeight(edge, false, EdgeIterator.NO_EDGE), .01);
+        assertEquals(94.35, instance.calcEdgeWeight(edge, false), .01);
     }
 
 

--- a/core/src/test/java/com/graphhopper/routing/weighting/DirectedRoutingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/DirectedRoutingTest.java
@@ -25,7 +25,7 @@ import org.junit.runners.Parameterized;
 
 import java.util.*;
 
-import static com.graphhopper.routing.weighting.TurnWeighting.INFINITE_U_TURN_COSTS;
+import static com.graphhopper.routing.weighting.Weighting.INFINITE_U_TURN_COSTS;
 import static com.graphhopper.util.EdgeIterator.ANY_EDGE;
 import static com.graphhopper.util.EdgeIterator.NO_EDGE;
 import static com.graphhopper.util.Parameters.Algorithms.ASTAR_BI;

--- a/core/src/test/java/com/graphhopper/routing/weighting/FastestWeightingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/FastestWeightingTest.java
@@ -42,7 +42,7 @@ public class FastestWeightingTest {
     public void testMinWeightHasSameUnitAs_getWeight() {
         Weighting instance = new FastestWeighting(encoder);
         IntsRef flags = GHUtility.setProperties(encodingManager.createEdgeFlags(), encoder, encoder.getMaxSpeed(), true, false);
-        assertEquals(instance.getMinWeight(10), instance.calcWeight(createMockedEdgeIteratorState(10, flags), false, EdgeIterator.NO_EDGE), 1e-8);
+        assertEquals(instance.getMinWeight(10), instance.calcEdgeWeight(createMockedEdgeIteratorState(10, flags), false), 1e-8);
     }
 
     @Test
@@ -52,22 +52,22 @@ public class FastestWeightingTest {
 
         VirtualEdgeIteratorState virtEdge = new VirtualEdgeIteratorState(0, 1, 1, 2, 10,
                 GHUtility.setProperties(encodingManager.createEdgeFlags(), encoder, 10, true, false), "test", Helper.createPointList(51, 0, 51, 1), false);
-        double time = instance.calcWeight(virtEdge, false, 0);
+        double time = instance.calcEdgeWeight(virtEdge, false);
 
         virtEdge.setUnfavored(true);
         // heading penalty on edge
-        assertEquals(time + 100, instance.calcWeight(virtEdge, false, 0), 1e-8);
+        assertEquals(time + 100, instance.calcEdgeWeight(virtEdge, false), 1e-8);
         // only after setting it
         virtEdge.setUnfavored(true);
-        assertEquals(time + 100, instance.calcWeight(virtEdge, true, 0), 1e-8);
+        assertEquals(time + 100, instance.calcEdgeWeight(virtEdge, true), 1e-8);
         // but not after releasing it
         virtEdge.setUnfavored(false);
-        assertEquals(time, instance.calcWeight(virtEdge, true, 0), 1e-8);
+        assertEquals(time, instance.calcEdgeWeight(virtEdge, true), 1e-8);
 
         // test default penalty
         virtEdge.setUnfavored(true);
         instance = new FastestWeighting(encoder);
-        assertEquals(time + Routing.DEFAULT_HEADING_PENALTY, instance.calcWeight(virtEdge, false, 0), 1e-8);
+        assertEquals(time + Routing.DEFAULT_HEADING_PENALTY, instance.calcEdgeWeight(virtEdge, false), 1e-8);
     }
 
     @Test
@@ -75,12 +75,10 @@ public class FastestWeightingTest {
         Weighting instance = new FastestWeighting(encoder);
         IntsRef edgeFlags = encodingManager.createEdgeFlags();
         encoder.getAverageSpeedEnc().setDecimal(false, edgeFlags, 0);
-        assertEquals(1.0 / 0, instance.calcWeight(createMockedEdgeIteratorState(10, edgeFlags),
-                false, EdgeIterator.NO_EDGE), 1e-8);
+        assertEquals(1.0 / 0, instance.calcEdgeWeight(createMockedEdgeIteratorState(10, edgeFlags), false), 1e-8);
 
         // 0 / 0 returns NaN but calcWeight should not return NaN!
-        assertEquals(1.0 / 0, instance.calcWeight(createMockedEdgeIteratorState(0, edgeFlags),
-                false, EdgeIterator.NO_EDGE), 1e-8);
+        assertEquals(1.0 / 0, instance.calcEdgeWeight(createMockedEdgeIteratorState(0, edgeFlags), false), 1e-8);
     }
 
     @Test
@@ -94,8 +92,8 @@ public class FastestWeightingTest {
 
         EdgeIteratorState edge = GHUtility.createMockedEdgeIteratorState(100000, edgeFlags);
 
-        assertEquals(375 * 60 * 1000, w.calcMillis(edge, false, EdgeIterator.NO_EDGE));
-        assertEquals(600 * 60 * 1000, w.calcMillis(edge, true, EdgeIterator.NO_EDGE));
+        assertEquals(375 * 60 * 1000, w.calcEdgeMillis(edge, false));
+        assertEquals(600 * 60 * 1000, w.calcEdgeMillis(edge, true));
 
         g.close();
     }

--- a/core/src/test/java/com/graphhopper/routing/weighting/ShortFastestWeightingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/ShortFastestWeightingTest.java
@@ -19,7 +19,6 @@ package com.graphhopper.routing.weighting;
 
 import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.routing.util.FlagEncoder;
-import com.graphhopper.util.EdgeIterator;
 import com.graphhopper.util.EdgeIteratorState;
 import com.graphhopper.util.GHUtility;
 import com.graphhopper.util.PMap;
@@ -40,11 +39,11 @@ public class ShortFastestWeightingTest {
     public void testShort() {
         EdgeIteratorState edge = createMockedEdgeIteratorState(10, GHUtility.setProperties(encodingManager.createEdgeFlags(), encoder, 50, true, false));
         Weighting instance = new ShortFastestWeighting(encoder, 0.03);
-        assertEquals(1.02, instance.calcWeight(edge, false, EdgeIterator.NO_EDGE), 1e-8);
+        assertEquals(1.02, instance.calcEdgeWeight(edge, false), 1e-8);
 
         // more influence from distance
         instance = new ShortFastestWeighting(encoder, 0.1);
-        assertEquals(1.72, instance.calcWeight(edge, false, EdgeIterator.NO_EDGE), 1e-8);
+        assertEquals(1.72, instance.calcEdgeWeight(edge, false), 1e-8);
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/storage/GraphHopperStorageCHTest.java
+++ b/core/src/test/java/com/graphhopper/storage/GraphHopperStorageCHTest.java
@@ -36,7 +36,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static com.graphhopper.routing.ch.NodeBasedNodeContractorTest.SC_ACCESS;
-import static com.graphhopper.routing.weighting.TurnWeighting.INFINITE_U_TURN_COSTS;
+import static com.graphhopper.routing.weighting.Weighting.INFINITE_U_TURN_COSTS;
 import static com.graphhopper.util.EdgeIterator.NO_EDGE;
 import static org.junit.Assert.*;
 

--- a/core/src/test/java/com/graphhopper/storage/ShortcutUnpackerTest.java
+++ b/core/src/test/java/com/graphhopper/storage/ShortcutUnpackerTest.java
@@ -18,7 +18,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import static com.graphhopper.routing.weighting.TurnWeighting.INFINITE_U_TURN_COSTS;
+import static com.graphhopper.routing.weighting.Weighting.INFINITE_U_TURN_COSTS;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(Parameterized.class)

--- a/reader-gtfs/src/main/java/com/graphhopper/reader/gtfs/GraphExplorer.java
+++ b/reader-gtfs/src/main/java/com/graphhopper/reader/gtfs/GraphExplorer.java
@@ -113,7 +113,8 @@ public final class GraphExplorer {
         GtfsStorage.EdgeType edgeType = edge.get(flagEncoder.getTypeEnc());
         switch (edgeType) {
             case HIGHWAY:
-                return (long) (accessEgressWeighting.calcMillis(edge, reverse, -1) * (5.0 / walkSpeedKmH));
+                // todonow: why do we not account for turn times here ?
+                return (long) (accessEgressWeighting.calcEdgeMillis(edge, reverse) * (5.0 / walkSpeedKmH));
             case ENTER_TIME_EXPANDED_NETWORK:
                 if (reverse) {
                     return 0;

--- a/reader-osm/src/test/java/com/graphhopper/routing/TrafficChangeWithNodeOrderingReusingTest.java
+++ b/reader-osm/src/test/java/com/graphhopper/routing/TrafficChangeWithNodeOrderingReusingTest.java
@@ -188,7 +188,7 @@ public class TrafficChangeWithNodeOrderingReusingTest {
 
         @Override
         public double calcWeight(EdgeIteratorState edgeState, boolean reverse, int prevOrNextEdgeId) {
-            double baseWeight = this.baseWeighting.calcWeight(edgeState, reverse, prevOrNextEdgeId);
+            double baseWeight = baseWeighting.calcWeight(edgeState, reverse, prevOrNextEdgeId);
             if (edgeState instanceof CHEdgeIteratorState) {
                 // important! we may not change weights of shortcuts (the deviations are already included in their weight)
                 if (((CHEdgeIteratorState) edgeState).isShortcut()) {

--- a/tools/src/main/java/com/graphhopper/tools/CHMeasurement.java
+++ b/tools/src/main/java/com/graphhopper/tools/CHMeasurement.java
@@ -35,7 +35,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 import static com.graphhopper.routing.ch.CHParameters.*;
-import static com.graphhopper.routing.weighting.TurnWeighting.INFINITE_U_TURN_COSTS;
+import static com.graphhopper.routing.weighting.Weighting.INFINITE_U_TURN_COSTS;
 import static com.graphhopper.util.Parameters.Algorithms.ASTAR_BI;
 import static com.graphhopper.util.Parameters.Algorithms.DIJKSTRA_BI;
 import static java.lang.System.nanoTime;

--- a/web-bundle/src/main/java/com/graphhopper/resources/InfoResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/InfoResource.java
@@ -17,7 +17,6 @@
  */
 package com.graphhopper.resources;
 
-import com.graphhopper.routing.weighting.TurnWeighting;
 import com.graphhopper.storage.GraphHopperStorage;
 import com.graphhopper.util.CmdArgs;
 import com.graphhopper.util.Constants;
@@ -78,7 +77,7 @@ public class InfoResource {
         for (String v : info.supported_vehicles) {
             Info.PerVehicle perVehicleJson = new Info.PerVehicle();
             perVehicleJson.elevation = hasElevation;
-            perVehicleJson.turn_costs = storage.getEncodingManager().getEncoder(v).supports(TurnWeighting.class);
+            perVehicleJson.turn_costs = storage.getEncodingManager().getEncoder(v).supportsTurnCosts();
             info.features.put(v, perVehicleJson);
         }
         if (config.has("gtfs.file")) {


### PR DESCRIPTION
This is some preliminary work for #1820, mainly to reduce the diff when we actually fix #1820.

1) (trivial) move the `INFINITE_U_TURN_COSTS` constant into `Weighting`. 
2) add `Weighting#calcEdgeWeight/Millis`. For now this is a pure convenience method that just calls `calcWeight` with `prevOrNext=-1`. For #1820 this will be the other way around: In `AbstractWeighting` we will have `calcWeight` which uses `calcEdgeWeight` and adds `calcTurnWeight`. Subclasses will then only override `calcEdgeWeight/Millis` and leave the turn cost calculation to `AbstractWeighting`. The turn cost calculation can then be adjusted by changing the `TurnCostProvider` implementation which is passed to `AbstractWeighting` via its constructor (at least this is what I currently think we should do).
3) replace `FlagEncoder#supports(TurnWeighting.class)` with `FlagEncoder#supportsTurnCosts()`. Note that this it what it was like before 0.4 according to the changelog

The actual work for #1820 is happening here: https://github.com/graphhopper/graphhopper/tree/remove_turn_weighting, but its not in (near) a mergeable state yet.

Any thoughts ?
