### PR TITLE
Make alternatives for CH faster

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/AlternativeRouteCH.java
+++ b/core/src/main/java/com/graphhopper/routing/AlternativeRouteCH.java
@@ -75,9 +75,10 @@ public class AlternativeRouteCH extends DijkstraBidirectionCHNoSOD {
                 if (fromSPTEntry.getWeightOfVisitedPath() + toSPTEntry.getWeightOfVisitedPath() > maxWeight)
                     return true;
 
-                // The path s -> v -> t is not the shortest path. Only s -> v and v -> t are.
-                // We still use this preliminary path to filter for shared path length with other alternatives,
-                // so we don't have to work so much.
+                // This gives us a path s -> v -> t, but since we are using contraction hierarchies,
+                // s -> v and v -> t need not be shortest paths (see ).
+                // In fact, they can sometimes be pretty strange. We still use this preliminary path to filter
+                // for shared path length with other alternatives, so we don't have to work so much.
 //                Path preliminaryRoute = createPathExtractor(graph, weighting).extract(fromSPTEntry, toSPTEntry, fromSPTEntry.getWeightOfVisitedPath() + toSPTEntry.getWeightOfVisitedPath());
 //                double preliminaryShare = calculateShare(preliminaryRoute);
 //                if (preliminaryShare > maxShareFactor) {

--- a/core/src/main/java/com/graphhopper/routing/AlternativeRouteCH.java
+++ b/core/src/main/java/com/graphhopper/routing/AlternativeRouteCH.java
@@ -22,7 +22,6 @@ import com.carrotsearch.hppc.IntIndexedContainer;
 import com.carrotsearch.hppc.predicates.IntObjectPredicate;
 import com.graphhopper.routing.ch.CHWeighting;
 import com.graphhopper.routing.ch.NodeBasedCHBidirPathExtractor;
-import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.Graph;
 import com.graphhopper.storage.SPTEntry;
 import com.graphhopper.util.EdgeIteratorState;
@@ -46,7 +45,7 @@ public class AlternativeRouteCH extends DijkstraBidirectionCHNoSOD {
     private double maxShareFactor = 0.7;
     public static final double T = 10000.0;
 
-    public AlternativeRouteCH(Graph graph, Weighting weighting) {
+    public AlternativeRouteCH(Graph graph, CHWeighting weighting) {
         super(graph, weighting);
     }
 
@@ -159,7 +158,7 @@ public class AlternativeRouteCH extends DijkstraBidirectionCHNoSOD {
                 List<EdgeIteratorState> edges = path.calcEdges();
                 int fromNode = getPreviousNodeTMetersAway(edges, vIndex);
                 int toNode = getNextNodeTMetersAway(edges, vIndex);
-                DijkstraBidirectionCHNoSOD tRouter = new DijkstraBidirectionCHNoSOD(graph, new CHWeighting(weighting));
+                DijkstraBidirectionCHNoSOD tRouter = new DijkstraBidirectionCHNoSOD(graph, weighting);
                 tRouter.setEdgeFilter(additionalEdgeFilter);
                 Path tPath = tRouter.calcPath(fromNode, toNode);
                 IntIndexedContainer tNodes = tPath.calcNodes();

--- a/core/src/main/java/com/graphhopper/routing/AlternativeRouteCH.java
+++ b/core/src/main/java/com/graphhopper/routing/AlternativeRouteCH.java
@@ -78,7 +78,6 @@ public class AlternativeRouteCH extends DijkstraBidirectionCHNoSOD {
                 // s -> v and v -> t need not be shortest paths (see ).
                 // In fact, they can sometimes be pretty strange. We still use this preliminary path to filter
                 // for shared path length with other alternatives, so we don't have to work so much.
-                // this reduces alternative rate from 2.0 to 1.6 but makes algorithm roughly 3x faster
                 final List<SPTEntry> sptEntries = calcSPEList(fromSPTEntry, toSPTEntry);
                 double preliminaryShare = calculateShare(sptEntries) / (fromSPTEntry.getWeightOfVisitedPath() + toSPTEntry.getWeightOfVisitedPath());
                 if (preliminaryShare > maxShareFactor) {
@@ -101,8 +100,8 @@ public class AlternativeRouteCH extends DijkstraBidirectionCHNoSOD {
                 path.setFromNode(svNodes.get(0));
                 for (EdgeIteratorState edge : svPath.calcEdges()) {
                     path.addEdge(edge.getEdge());
-                    // TODO should we better calculate the weight here instead of edge.getDistance?
-                    // Then we would also need to use "share/path.getWeight" below
+                    // TODO we should better calculate the weight here instead of edge.getDistance.
+                    // Then we would also need to use "share/path.getWeight" below.
                     sptEntries.add(new SPTEntry(edge.getAdjNode(), edge.getDistance()));
                 }
                 for (EdgeIteratorState edge : vtPath.calcEdges()) {
@@ -162,6 +161,7 @@ public class AlternativeRouteCH extends DijkstraBidirectionCHNoSOD {
                 tRouter.setEdgeFilter(additionalEdgeFilter);
                 Path tPath = tRouter.calcPath(fromNode, toNode);
                 IntIndexedContainer tNodes = tPath.calcNodes();
+                // TODO path.calcNodes is duplicate work as we already have "edges"
                 return tNodes.contains(path.calcNodes().get(vIndex));
             }
 

--- a/core/src/main/java/com/graphhopper/routing/BidirPathExtractor.java
+++ b/core/src/main/java/com/graphhopper/routing/BidirPathExtractor.java
@@ -87,7 +87,7 @@ public class BidirPathExtractor {
         SPTEntry currEntry = sptEntry;
         SPTEntry parentEntry = currEntry.parent;
         while (EdgeIterator.Edge.isValid(currEntry.edge)) {
-            onEdge(currEntry.edge, currEntry.adjNode, reverse, getIncEdge(parentEntry));
+            onEdge(currEntry, currEntry.edge, currEntry.adjNode, reverse, getIncEdge(parentEntry));
             currEntry = parentEntry;
             parentEntry = currEntry.parent;
         }
@@ -110,7 +110,7 @@ public class BidirPathExtractor {
         path.setEndNode(node);
     }
 
-    protected void onEdge(int edge, int adjNode, boolean reverse, int prevOrNextEdge) {
+    protected void onEdge(SPTEntry entry, int edge, int adjNode, boolean reverse, int prevOrNextEdge) {
         EdgeIteratorState edgeState = graph.getEdgeIteratorState(edge, adjNode);
         path.addDistance(edgeState.getDistance());
         path.addTime(weighting.calcMillis(edgeState, reverse, prevOrNextEdge));

--- a/core/src/main/java/com/graphhopper/routing/ch/EdgeBasedCHBidirPathExtractor.java
+++ b/core/src/main/java/com/graphhopper/routing/ch/EdgeBasedCHBidirPathExtractor.java
@@ -41,7 +41,7 @@ public class EdgeBasedCHBidirPathExtractor extends BidirPathExtractor {
     }
 
     @Override
-    public void onEdge(int edge, int adjNode, boolean reverse, int prevOrNextEdge) {
+    public void onEdge(SPTEntry entry, int edge, int adjNode, boolean reverse, int prevOrNextEdge) {
         if (reverse) {
             shortcutUnpacker.visitOriginalEdgesBwd(edge, adjNode, true, prevOrNextEdge);
         } else {

--- a/core/src/main/java/com/graphhopper/routing/ch/NodeBasedCHBidirPathExtractor.java
+++ b/core/src/main/java/com/graphhopper/routing/ch/NodeBasedCHBidirPathExtractor.java
@@ -21,6 +21,7 @@ package com.graphhopper.routing.ch;
 import com.graphhopper.routing.BidirPathExtractor;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.Graph;
+import com.graphhopper.storage.SPTEntry;
 import com.graphhopper.storage.ShortcutUnpacker;
 import com.graphhopper.util.EdgeIteratorState;
 
@@ -35,7 +36,7 @@ public class NodeBasedCHBidirPathExtractor extends BidirPathExtractor {
     }
 
     @Override
-    public void onEdge(int edge, int adjNode, boolean reverse, int prevOrNextEdge) {
+    public void onEdge(SPTEntry entry, int edge, int adjNode, boolean reverse, int prevOrNextEdge) {
         if (reverse) {
             shortcutUnpacker.visitOriginalEdgesBwd(edge, adjNode, true, prevOrNextEdge);
         } else {


### PR DESCRIPTION
This makes the CH route requests with alternatives much faster. It is still 3 to 8 times slower compared to raw "routingCH" speed (slower for longer routes).

The only required change is to add a parameter `SPTEntry entry` to BidirPathExtractor.onEdge. Not sure if this is nice @easbar?