### PR TITLE
Improve large route ui (show step number)

### DIFF
--- a/web/src/main/resources/assets/css/style.css
+++ b/web/src/main/resources/assets/css/style.css
@@ -462,3 +462,20 @@ td img.pic {
 .fullscreen-reverse-btn {
     background-image: url("../img/full-reverse.png");
 }
+
+#locationpoints {
+    counter-set: pointcounter -1;
+}
+
+#locationpoints>div {
+    counter-increment: pointcounter;
+}
+
+#locationpoints>div:nth-child(n+2):nth-last-child(n+3)::before {
+    content: counter(pointcounter);
+    position: absolute;
+    right: calc(100% - 1.2em);
+    text-align: right;
+    font-size: 70%;
+}
+}


### PR DESCRIPTION
This PR proposes two fine tunings to the web UI. I'm not sure whether this part should be covered by additional unit tests, and/or should be split.

A first commit uses plain CSS to put a number in front of each step in the routing (to be able to see the correspondence with the markers on the map).

~~A second commit adds a checkbox that, when checked, prevents the automatic-rezoom features that takes place when the user adds an intermediate destination (this feature is very annoying when fine tuning very long tracks).~~
