### PR TITLE
Disable rezooming on intermediate point addition

### DIFF
--- a/web/src/main/resources/assets/js/main-template.js
+++ b/web/src/main/resources/assets/js/main-template.js
@@ -397,6 +397,7 @@ function setIntermediateCoord(e) {
     });
     var index = routeManipulation.getIntermediatePointIndex(routeSegments, e.latlng);
     ghRequest.route.add(e.latlng.wrap(), index);
+    ghRequest.do_zoom = false;
     resolveIndex(index);
     routeIfAllResolved();
 }


### PR DESCRIPTION
This PR prevents the automatic-rezoom features that takes place when the user adds an intermediate destination (which can be very annoying when fine tuning very-very long tracks).

It is a simplified version of the commit removed from https://github.com/graphhopper/graphhopper/pull/1856
