### PR TITLE
Remove unused maxRetries mechanism in GraphHopper#calcPaths

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/template/AlternativeRoutingTemplate.java
+++ b/core/src/main/java/com/graphhopper/routing/template/AlternativeRoutingTemplate.java
@@ -67,7 +67,7 @@ final public class AlternativeRoutingTemplate extends ViaRoutingTemplate {
     }
 
     @Override
-    public boolean isReady(PathMerger pathMerger, Translation tr) {
+    public void finish(PathMerger pathMerger, Translation tr) {
         if (pathList.isEmpty())
             throw new RuntimeException("Empty paths for alternative route calculation not expected");
 
@@ -82,6 +82,5 @@ final public class AlternativeRoutingTemplate extends ViaRoutingTemplate {
             ghResponse.add(tmpAltRsp);
             pathMerger.doWork(tmpAltRsp, Collections.singletonList(pathList.get(index)), encodingManager, tr);
         }
-        return true;
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/template/RoundTripRoutingTemplate.java
+++ b/core/src/main/java/com/graphhopper/routing/template/RoundTripRoutingTemplate.java
@@ -154,13 +154,11 @@ public class RoundTripRoutingTemplate extends AbstractRoutingTemplate implements
     }
 
     @Override
-    public boolean isReady(PathMerger pathMerger, Translation tr) {
+    public void finish(PathMerger pathMerger, Translation tr) {
         altResponse = new PathWrapper();
         altResponse.setWaypoints(getWaypoints());
         ghResponse.add(altResponse);
         pathMerger.doWork(altResponse, pathList, encodingManager, tr);
-        // with potentially retrying, including generating new route points, for now disabled
-        return true;
     }
 
     private QueryResult generateValidPoint(GHPoint from, double distanceInMeters, double heading,
@@ -180,9 +178,4 @@ public class RoundTripRoutingTemplate extends AbstractRoutingTemplate implements
         }
     }
 
-    @Override
-    public int getMaxRetries() {
-        // with potentially retrying, including generating new route points, for now disabled
-        return 1;
-    }
 }

--- a/core/src/main/java/com/graphhopper/routing/template/RoutingTemplate.java
+++ b/core/src/main/java/com/graphhopper/routing/template/RoutingTemplate.java
@@ -51,10 +51,6 @@ public interface RoutingTemplate {
      * This method merges the returned paths appropriately e.g. all paths from the list into one
      * PathWrapper of GHResponse or multiple (via / round trip).
      */
-    boolean isReady(PathMerger pathMerger, Translation tr);
+    void finish(PathMerger pathMerger, Translation tr);
 
-    /**
-     * This method returns the maximum number of full retries of these 3 steps
-     */
-    int getMaxRetries();
 }

--- a/core/src/main/java/com/graphhopper/routing/template/ViaRoutingTemplate.java
+++ b/core/src/main/java/com/graphhopper/routing/template/ViaRoutingTemplate.java
@@ -216,19 +216,13 @@ public class ViaRoutingTemplate extends AbstractRoutingTemplate implements Routi
     }
 
     @Override
-    public boolean isReady(PathMerger pathMerger, Translation tr) {
+    public void finish(PathMerger pathMerger, Translation tr) {
         if (ghRequest.getPoints().size() - 1 != pathList.size())
             throw new RuntimeException("There should be exactly one more points than paths. points:" + ghRequest.getPoints().size() + ", paths:" + pathList.size());
 
         altResponse.setWaypoints(getWaypoints());
         ghResponse.add(altResponse);
         pathMerger.doWork(altResponse, pathList, encodingManager, tr);
-        return true;
-    }
-
-    @Override
-    public int getMaxRetries() {
-        return 1;
     }
 
 }


### PR DESCRIPTION
It looks like `maxRetries` was intended to be used with round trip calculation. But its disabled anyway, so I removed it (in hope of reducing some (but not a lot) complexity in `GraphHopper`).