### PR TITLE
Make test more stable by using JSONAssert equals

### DIFF
--- a/web-api/pom.xml
+++ b/web-api/pom.xml
@@ -43,6 +43,12 @@
             <version>${dropwizard.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.skyscreamer</groupId>
+            <artifactId>jsonassert</artifactId>
+            <version>1.5.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/web-api/src/test/java/com/graphhopper/util/InstructionListRepresentationTest.java
+++ b/web-api/src/test/java/com/graphhopper/util/InstructionListRepresentationTest.java
@@ -2,17 +2,27 @@ package com.graphhopper.util;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.graphhopper.jackson.Jackson;
+import org.skyscreamer.jsonassert.JSONAssert;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Locale;
 import java.util.Map;
+import org.json.JSONException;
 
 import static io.dropwizard.testing.FixtureHelpers.fixture;
 import static org.junit.Assert.assertEquals;
 
 public class InstructionListRepresentationTest {
+
+    private void assertJsonEqualsNonStrict(String json1, String json2) {
+        try {
+            JSONAssert.assertEquals(json1, json2, false);
+        } catch (JSONException jse) {
+            throw new IllegalArgumentException(jse.getMessage());
+        }
+    }
 
     @Test
     public void testRoundaboutJsonIntegrity() throws IOException {
@@ -30,7 +40,7 @@ public class InstructionListRepresentationTest {
                 .setExitNumber(2)
                 .setExited();
         il.add(instr);
-        assertEquals(objectMapper.readTree(fixture("fixtures/roundabout1.json")).toString(), objectMapper.valueToTree(il).toString());
+        assertJsonEqualsNonStrict(objectMapper.readTree(fixture("fixtures/roundabout1.json")).toString(), objectMapper.valueToTree(il).toString());
     }
 
 


### PR DESCRIPTION
Test in `web-api/src/test/java/com/graphhopper/util/InstructionListRepresentationTest.java` uses jackson to serialize objects into json and assert the serialized results with several hard-coded strings. However, the order of serialized json is not guaranteed so tests may fail if the order is different. So tests may fail or pass without any changes made to the source code and cannot serve as good regression tests.

This PR proposes to use JSONAssert and modify the corresponding json test assertions
