### PR TITLE
Fix step numbering in non-firefox browsers

### DIFF
--- a/web/src/main/resources/assets/css/style.css
+++ b/web/src/main/resources/assets/css/style.css
@@ -121,11 +121,7 @@ body {
     float: left;
 }
 
-#locationpoints {
-    counter-set: pointcounter -1;
-}
-
-#locationpoints>div {
+#locationpoints>div:nth-child(n+2) {
     counter-increment: pointcounter;
 }
 


### PR DESCRIPTION
Fixes the issue (firefox only feature) raised in the discussions about the PR that added step numbers in the web UI : https://github.com/graphhopper/graphhopper/pull/1856