### PR TITLE
Add a button to zoomToFit the path (as sometimes the zoom is disabled)

### DIFF
--- a/web/src/main/resources/assets/css/style.css
+++ b/web/src/main/resources/assets/css/style.css
@@ -462,10 +462,12 @@ td img.pic {
     cursor: pointer;
 }
 
-.fullscreen-reverse-btn, .fullscreen-btn {
+.fullscreen-reverse-btn, .fullscreen-btn, .zoomfit-btn {
     cursor: pointer;
     width: 30px;
     height: 30px;
+    line-height: 30px;
+    text-align: center;
     border-radius: 4px;
     background-color: white;
     background-position: 50% 50%;
@@ -474,7 +476,7 @@ td img.pic {
     border: 2px solid rgba(0, 0, 0, 0.2);
 }
 
-.fullscreen-btn {
+.fullscreen-btn, .zoomfit-btn {
     background-image: url("../img/full.png");
 }
 

--- a/web/src/main/resources/assets/js/main-template.js
+++ b/web/src/main/resources/assets/js/main-template.js
@@ -171,7 +171,7 @@ $(document).ready(function (e) {
                 }
                 metaVersionInfo = messages.extractMetaVersionInfo(json);
 
-                mapLayer.initMap(bounds, setStartCoord, setIntermediateCoord, setEndCoord, urlParams.layer, urlParams.use_miles);
+                mapLayer.initMap(bounds, setStartCoord, setIntermediateCoord, setEndCoord, urlParams.layer, urlParams.use_miles, zoomToFit);
 
                 // execute query
                 initFromParams(urlParams, true);
@@ -510,12 +510,21 @@ function flagAll() {
     }
 }
 
+var zoomFitInfo = null;
+function zoomToFit() {
+    console.log(zoomFitInfo)
+    if (zoomFitInfo !== null) {
+        mapLayer.fitMapToBounds(zoomFitInfo);
+    }
+}
+
 function routeLatLng(request, doQuery) {
     var i;
 
     // do_zoom should not show up in the URL but in the request object to avoid zooming for history change
     var doZoom = request.do_zoom;
     request.do_zoom = true;
+
 
     var urlForHistory = request.createHistoryURL() + "&layer=" + tileLayers.activeLayerName;
 
@@ -531,6 +540,7 @@ function routeLatLng(request, doQuery) {
         History.pushState(params, messages.browserTitle, urlForHistory);
         return;
     }
+
     var infoDiv = $("#info");
     infoDiv.empty();
     infoDiv.show();
@@ -728,13 +738,15 @@ function routeLatLng(request, doQuery) {
         mapLayer.adjustMapSize();
         // TODO change bounding box on click
         var firstPath = json.paths[0];
-        if (firstPath.bbox && doZoom) {
+        if (firstPath.bbox) {
             var minLon = firstPath.bbox[0];
             var minLat = firstPath.bbox[1];
             var maxLon = firstPath.bbox[2];
             var maxLat = firstPath.bbox[3];
-            var tmpB = new L.LatLngBounds(new L.LatLng(minLat, minLon), new L.LatLng(maxLat, maxLon));
-            mapLayer.fitMapToBounds(tmpB);
+            zoomFitInfo = new L.LatLngBounds(new L.LatLng(minLat, minLon), new L.LatLng(maxLat, maxLon));
+            if (doZoom) {
+                mapLayer.fitMapToBounds(zoomFitInfo);
+            }
         }
 
         $('.defaulting').each(function (index, element) {

--- a/web/src/main/resources/assets/js/map.js
+++ b/web/src/main/resources/assets/js/map.js
@@ -49,7 +49,7 @@ function adjustMapSize() {
     // somehow this does not work: map.invalidateSize();
 }
 
-function initMap(bounds, setStartCoord, setIntermediateCoord, setEndCoord, selectLayer, useMiles) {
+function initMap(bounds, setStartCoord, setIntermediateCoord, setEndCoord, selectLayer, useMiles, zoomToFit) {
     adjustMapSize();
     // console.log("init map at " + JSON.stringify(bounds));
 
@@ -111,6 +111,22 @@ function initMap(bounds, setStartCoord, setIntermediateCoord, setEndCoord, selec
         zoomInTitle: translate.tr('zoom_in'),
         zoomOutTitle: translate.tr('zoom_out')
     }).addTo(map);
+
+    L.Control.ZoomFit = L.Control.extend({
+        onAdd: function (map) {
+            var container = L.DomUtil.create('div', 'zoomfit-btn');
+            container.textContent = '🔍'
+            L.DomUtil.addClass(container, 'leaflet-control');
+            container.title = 'Zoom to Fit';
+            container.onmousedown = function(event) {
+                zoomToFit();
+            };
+
+            return container;
+        }
+    });
+    var zoomFitControl = new L.Control.ZoomFit({ position: 'topleft'}).addTo(map);
+
 
     var full = false;
     L.Control.Fullscreen = L.Control.extend({


### PR DESCRIPTION
This commit adds a button to the web UI, to fit the zoom to the track. This may become useful given that now adding an intermediate point does not automatically rezoom.

This uses the suggestion from https://github.com/graphhopper/graphhopper/issues/775

I was not sure about the icon so I put the same as the fullscreen but with a magnifying glass (character) as overlay.

firefox // chromium
![image](https://user-images.githubusercontent.com/244649/73276487-0f69d180-41e9-11ea-8978-bef8a899b5bc.png) // ![image](https://user-images.githubusercontent.com/244649/73276588-39bb8f00-41e9-11ea-9d71-477760f68175.png)
