### PR TITLE
Use LMProfile instead of just Weighting for Landmark preparations

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/ch/CHPreparationHandler.java
+++ b/core/src/main/java/com/graphhopper/routing/ch/CHPreparationHandler.java
@@ -79,19 +79,19 @@ public class CHPreparationHandler {
 
         if ("no".equals(chWeightingsStr) || "false".equals(chWeightingsStr)) {
             // default is fastest and we need to clear this explicitly
-            chProfileStrings.clear();
+            setCHProfilesAsStrings(Collections.<String>emptyList());
         } else if (!chWeightingsStr.isEmpty()) {
             setCHProfilesAsStrings(Arrays.asList(chWeightingsStr.split(",")));
         }
 
-        boolean enableThis = !chProfileStrings.isEmpty();
+        boolean enableThis = !getCHProfileStrings().isEmpty();
         setEnabled(enableThis);
         if (enableThis)
             setDisablingAllowed(ghConfig.getBool(CH.INIT_DISABLING_ALLOWED, isDisablingAllowed()));
 
         String edgeBasedCHStr = ghConfig.get(CH.PREPARE + "edge_based", "off").trim();
         edgeBasedCHStr = edgeBasedCHStr.equals("false") ? "off" : edgeBasedCHStr;
-        edgeBasedCHMode = EdgeBasedCHMode.valueOf(edgeBasedCHStr.toUpperCase(Locale.ROOT));
+        setEdgeBasedCHMode(EdgeBasedCHMode.valueOf(edgeBasedCHStr.toUpperCase(Locale.ROOT)));
 
         pMap = ghConfig.asPMap();
     }
@@ -185,9 +185,6 @@ public class CHPreparationHandler {
     }
 
     public List<String> getCHProfileStrings() {
-        if (chProfileStrings.isEmpty())
-            throw new IllegalStateException("Potential bug: chProfileStrings is empty");
-
         return new ArrayList<>(chProfileStrings);
     }
 
@@ -200,9 +197,6 @@ public class CHPreparationHandler {
      * @see #addCHProfileAsString(String)
      */
     public CHPreparationHandler setCHProfilesAsStrings(List<String> profileStrings) {
-        if (profileStrings.isEmpty())
-            throw new IllegalArgumentException("It is not allowed to pass an empty list of CH profile strings");
-
         chProfileStrings.clear();
         for (String profileString : profileStrings) {
             profileString = toLowerCase(profileString);

--- a/core/src/main/java/com/graphhopper/routing/lm/LMProfile.java
+++ b/core/src/main/java/com/graphhopper/routing/lm/LMProfile.java
@@ -1,0 +1,64 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.graphhopper.routing.lm;
+
+import com.graphhopper.routing.weighting.AbstractWeighting;
+import com.graphhopper.routing.weighting.Weighting;
+
+import java.util.Objects;
+
+public class LMProfile {
+    private final String profileName;
+    private final Weighting weighting;
+
+    public LMProfile(Weighting weighting) {
+        this(AbstractWeighting.weightingToFileName(weighting), weighting);
+    }
+
+    public LMProfile(String profileName, Weighting weighting) {
+        this.profileName = profileName;
+        this.weighting = weighting;
+    }
+
+    public String getName() {
+        return profileName;
+    }
+
+    public Weighting getWeighting() {
+        return weighting;
+    }
+
+    @Override
+    public String toString() {
+        return profileName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        LMProfile lmProfile = (LMProfile) o;
+        return Objects.equals(profileName, lmProfile.profileName);
+    }
+
+    @Override
+    public int hashCode() {
+        return profileName.hashCode();
+    }
+}

--- a/core/src/main/java/com/graphhopper/routing/lm/PrepareLandmarks.java
+++ b/core/src/main/java/com/graphhopper/routing/lm/PrepareLandmarks.java
@@ -44,19 +44,19 @@ public class PrepareLandmarks extends AbstractAlgoPreparation {
     private static final Logger LOGGER = LoggerFactory.getLogger(PrepareLandmarks.class);
     private final Graph graph;
     private final LandmarkStorage lms;
-    private final Weighting weighting;
+    private final LMProfile lmProfile;
     private int defaultActiveLandmarks;
 
-    public PrepareLandmarks(Directory dir, GraphHopperStorage graph, Weighting weighting,
+    public PrepareLandmarks(Directory dir, GraphHopperStorage graph, LMProfile lmProfile,
                             int landmarks, int activeLandmarks) {
         if (activeLandmarks > landmarks)
             throw new IllegalArgumentException("Default value for active landmarks " + activeLandmarks
                     + " should be less or equal to landmark count of " + landmarks);
         this.graph = graph;
         this.defaultActiveLandmarks = activeLandmarks;
-        this.weighting = weighting;
+        this.lmProfile = lmProfile;
 
-        lms = new LandmarkStorage(graph, dir, weighting, landmarks);
+        lms = new LandmarkStorage(graph, dir, lmProfile, landmarks);
     }
 
     /**
@@ -113,8 +113,8 @@ public class PrepareLandmarks extends AbstractAlgoPreparation {
         return lms.getSubnetworksWithLandmarks();
     }
 
-    public Weighting getWeighting() {
-        return weighting;
+    public LMProfile getLMProfile() {
+        return lmProfile;
     }
 
     public boolean loadExisting() {
@@ -143,7 +143,7 @@ public class PrepareLandmarks extends AbstractAlgoPreparation {
 
             double epsilon = opts.getHints().getDouble(Parameters.Algorithms.AStar.EPSILON, 1);
             AStar astar = (AStar) algo;
-            astar.setApproximation(new LMApproximator(qGraph, weighting, this.graph.getNodes(), lms, activeLM, lms.getFactor(), false).
+            astar.setApproximation(new LMApproximator(qGraph, lmProfile.getWeighting(), this.graph.getNodes(), lms, activeLM, lms.getFactor(), false).
                     setEpsilon(epsilon));
             return algo;
         } else if (algo instanceof AStarBidirection) {
@@ -152,7 +152,7 @@ public class PrepareLandmarks extends AbstractAlgoPreparation {
 
             double epsilon = opts.getHints().getDouble(Parameters.Algorithms.AStarBi.EPSILON, 1);
             AStarBidirection astarbi = (AStarBidirection) algo;
-            astarbi.setApproximation(new LMApproximator(qGraph, weighting, this.graph.getNodes(), lms, activeLM, lms.getFactor(), false).
+            astarbi.setApproximation(new LMApproximator(qGraph, lmProfile.getWeighting(), this.graph.getNodes(), lms, activeLM, lms.getFactor(), false).
                     setEpsilon(epsilon));
             return algo;
         } else if (algo instanceof AlternativeRoute) {
@@ -161,7 +161,7 @@ public class PrepareLandmarks extends AbstractAlgoPreparation {
 
             double epsilon = opts.getHints().getDouble(Parameters.Algorithms.AStarBi.EPSILON, 1);
             AlternativeRoute altRoute = (AlternativeRoute) algo;
-            altRoute.setApproximation(new LMApproximator(qGraph, weighting, this.graph.getNodes(), lms, activeLM, lms.getFactor(), false).
+            altRoute.setApproximation(new LMApproximator(qGraph, lmProfile.getWeighting(), this.graph.getNodes(), lms, activeLM, lms.getFactor(), false).
                     setEpsilon(epsilon));
             // landmark algorithm follows good compromise between fast response and exploring 'interesting' paths so we
             // can decrease this exploration factor further (1->dijkstra, 0.8->bidir. A*)

--- a/core/src/test/java/com/graphhopper/routing/lm/LMApproximatorTest.java
+++ b/core/src/test/java/com/graphhopper/routing/lm/LMApproximatorTest.java
@@ -69,7 +69,7 @@ public class LMApproximatorTest {
 
         Weighting weighting = new FastestWeighting(encoder);
 
-        PrepareLandmarks lm = new PrepareLandmarks(dir, graph, weighting, 16, 8);
+        PrepareLandmarks lm = new PrepareLandmarks(dir, graph, new LMProfile(weighting), 16, 8);
         lm.setMaximumWeight(10000);
         lm.doWork();
         LandmarkStorage landmarkStorage = lm.getLandmarkStorage();

--- a/core/src/test/java/com/graphhopper/routing/lm/LMPreparationHandlerTest.java
+++ b/core/src/test/java/com/graphhopper/routing/lm/LMPreparationHandlerTest.java
@@ -22,18 +22,18 @@ public class LMPreparationHandlerTest {
     public void addWeighting() {
         LMPreparationHandler handler = new LMPreparationHandler();
         handler.setEnabled(true);
-        handler.addWeighting("fastest");
-        assertEquals(Arrays.asList("fastest"), handler.getWeightingsAsStrings());
+        handler.addLMProfileAsString("fastest");
+        assertEquals(Arrays.asList("fastest"), handler.getLMProfileStrings());
 
         // special parameters like the maximum weight
         handler = new LMPreparationHandler().setEnabled(true);
-        handler.addWeighting("fastest|maximum=65000");
-        handler.addWeighting("shortest|maximum=20000");
-        assertEquals(Arrays.asList("fastest", "shortest"), handler.getWeightingsAsStrings());
+        handler.addLMProfileAsString("fastest|maximum=65000");
+        handler.addLMProfileAsString("shortest|maximum=20000");
+        assertEquals(Arrays.asList("fastest", "shortest"), handler.getLMProfileStrings());
 
         FlagEncoder car = new CarFlagEncoder();
         EncodingManager em = EncodingManager.create(car);
-        handler.addWeighting(new FastestWeighting(car)).addWeighting(new ShortestWeighting(car));
+        handler.addLMProfile(new LMProfile(new FastestWeighting(car))).addLMProfile(new LMProfile(new ShortestWeighting(car)));
         handler.createPreparations(new GraphHopperStorage(new RAMDirectory(), em, false), null);
         assertEquals(1, handler.getPreparations().get(0).getLandmarkStorage().getFactor(), .1);
         assertEquals(0.3, handler.getPreparations().get(1).getLandmarkStorage().getFactor(), .1);

--- a/core/src/test/java/com/graphhopper/routing/lm/LandmarkStorageTest.java
+++ b/core/src/test/java/com/graphhopper/routing/lm/LandmarkStorageTest.java
@@ -65,24 +65,24 @@ public class LandmarkStorageTest {
     }
 
     @Test
-    public void testInfinitWeight() {
+    public void testInfiniteWeight() {
         Directory dir = new RAMDirectory();
         EdgeIteratorState edge = ghStorage.edge(0, 1);
-        int res = new LandmarkStorage(ghStorage, dir, new FastestWeighting(encoder) {
+        int res = new LandmarkStorage(ghStorage, dir, new LMProfile(new FastestWeighting(encoder) {
             @Override
             public double calcEdgeWeight(EdgeIteratorState edgeState, boolean reverse) {
                 return Integer.MAX_VALUE * 2L;
             }
-        }, 8).setMaximumWeight(LandmarkStorage.PRECISION).calcWeight(edge, false);
+        }), 8).setMaximumWeight(LandmarkStorage.PRECISION).calcWeight(edge, false);
         assertEquals(Integer.MAX_VALUE, res);
 
         dir = new RAMDirectory();
-        res = new LandmarkStorage(ghStorage, dir, new FastestWeighting(encoder) {
+        res = new LandmarkStorage(ghStorage, dir, new LMProfile(new FastestWeighting(encoder) {
             @Override
             public double calcEdgeWeight(EdgeIteratorState edgeState, boolean reverse) {
                 return Double.POSITIVE_INFINITY;
             }
-        }, 8).setMaximumWeight(LandmarkStorage.PRECISION).calcWeight(edge, false);
+        }), 8).setMaximumWeight(LandmarkStorage.PRECISION).calcWeight(edge, false);
         assertEquals(Integer.MAX_VALUE, res);
     }
 
@@ -93,7 +93,7 @@ public class LandmarkStorageTest {
         DataAccess da = dir.find("landmarks_fastest_car");
         da.create(2000);
 
-        LandmarkStorage lms = new LandmarkStorage(ghStorage, dir, new FastestWeighting(encoder), 4).
+        LandmarkStorage lms = new LandmarkStorage(ghStorage, dir, new LMProfile(new FastestWeighting(encoder)), 4).
                 setMaximumWeight(LandmarkStorage.PRECISION);
         // 2^16=65536, use -1 for infinity and -2 for maximum
         lms.setWeight(0, 65536);
@@ -122,7 +122,7 @@ public class LandmarkStorageTest {
         ghStorage.edge(4, 5, 10, true);
         ghStorage.edge(5, 6, 10, false);
 
-        LandmarkStorage storage = new LandmarkStorage(ghStorage, new RAMDirectory(), new FastestWeighting(encoder), 2);
+        LandmarkStorage storage = new LandmarkStorage(ghStorage, new RAMDirectory(), new LMProfile(new FastestWeighting(encoder)), 2);
         storage.setMinimumNodes(2);
         storage.createLandmarks();
         assertEquals(3, storage.getSubnetworksWithLandmarks());
@@ -140,7 +140,7 @@ public class LandmarkStorageTest {
         ghStorage.edge(3, 2, 10, false);
         ghStorage.edge(3, 4, 10, true);
 
-        LandmarkStorage storage = new LandmarkStorage(ghStorage, new RAMDirectory(), new FastestWeighting(encoder), 2);
+        LandmarkStorage storage = new LandmarkStorage(ghStorage, new RAMDirectory(), new LMProfile(new FastestWeighting(encoder)), 2);
         storage.setMinimumNodes(3);
         storage.createLandmarks();
         assertEquals(2, storage.getSubnetworksWithLandmarks());
@@ -158,7 +158,7 @@ public class LandmarkStorageTest {
         ghStorage.edge(4, 5, 10, true);
         ghStorage.edge(5, 2, 10, false);
 
-        LandmarkStorage storage = new LandmarkStorage(ghStorage, new RAMDirectory(), new FastestWeighting(encoder), 2);
+        LandmarkStorage storage = new LandmarkStorage(ghStorage, new RAMDirectory(), new LMProfile(new FastestWeighting(encoder)), 2);
         storage.setMinimumNodes(2);
         storage.createLandmarks();
 
@@ -173,7 +173,7 @@ public class LandmarkStorageTest {
         GHUtility.setProperties(ghStorage.edge(1, 2).setDistance(10), encoder, 0.9, true, true);
         ghStorage.edge(2, 3, 10, true);
 
-        LandmarkStorage storage = new LandmarkStorage(ghStorage, new RAMDirectory(), new FastestWeighting(encoder), 2);
+        LandmarkStorage storage = new LandmarkStorage(ghStorage, new RAMDirectory(), new LMProfile(new FastestWeighting(encoder)), 2);
         storage.setMinimumNodes(2);
         storage.createLandmarks();
 
@@ -185,7 +185,7 @@ public class LandmarkStorageTest {
     public void testWithBorderBlocking() {
         RoutingAlgorithmTest.initBiGraph(ghStorage);
 
-        LandmarkStorage storage = new LandmarkStorage(ghStorage, new RAMDirectory(), new FastestWeighting(encoder), 2);
+        LandmarkStorage storage = new LandmarkStorage(ghStorage, new RAMDirectory(), new LMProfile(new FastestWeighting(encoder)), 2);
         final SpatialRule ruleRight = new DefaultSpatialRule() {
             @Override
             public String getId() {

--- a/core/src/test/java/com/graphhopper/routing/lm/PrepareLandmarksTest.java
+++ b/core/src/test/java/com/graphhopper/routing/lm/PrepareLandmarksTest.java
@@ -96,7 +96,8 @@ public class PrepareLandmarksTest {
 
         int lm = 5, activeLM = 2;
         Weighting weighting = new FastestWeighting(encoder);
-        LandmarkStorage store = new LandmarkStorage(graph, dir, weighting, lm);
+        LMProfile lmProfile = new LMProfile(weighting);
+        LandmarkStorage store = new LandmarkStorage(graph, dir, lmProfile, lm);
         store.setMinimumNodes(2);
         store.createLandmarks();
 
@@ -135,7 +136,7 @@ public class PrepareLandmarksTest {
         AlgorithmOptions opts = AlgorithmOptions.start().weighting(weighting).traversalMode(tm).
                 build();
 
-        PrepareLandmarks prepare = new PrepareLandmarks(new RAMDirectory(), graph, weighting, 4, 2);
+        PrepareLandmarks prepare = new PrepareLandmarks(new RAMDirectory(), graph, lmProfile, 4, 2);
         prepare.setMinimumNodes(2);
         prepare.doWork();
 
@@ -184,7 +185,8 @@ public class PrepareLandmarksTest {
 
         Directory dir = new RAMDirectory(fileStr, true).create();
         Weighting weighting = new FastestWeighting(encoder);
-        PrepareLandmarks plm = new PrepareLandmarks(dir, graph, weighting, 2, 2);
+        LMProfile lmProfile = new LMProfile(weighting);
+        PrepareLandmarks plm = new PrepareLandmarks(dir, graph, lmProfile, 2, 2);
         plm.setMinimumNodes(2);
         plm.doWork();
 
@@ -196,7 +198,7 @@ public class PrepareLandmarksTest {
         assertEquals(4791, Math.round(plm.getLandmarkStorage().getFromWeight(0, 1) * expectedFactor));
 
         dir = new RAMDirectory(fileStr, true);
-        plm = new PrepareLandmarks(dir, graph, weighting, 2, 2);
+        plm = new PrepareLandmarks(dir, graph, lmProfile, 2, 2);
         assertTrue(plm.loadExisting());
         assertEquals(expectedFactor, plm.getLandmarkStorage().getFactor(), 1e-6);
         assertEquals(Arrays.toString(new int[]{

--- a/core/src/test/java/com/graphhopper/routing/weighting/DirectedRoutingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/DirectedRoutingTest.java
@@ -4,6 +4,7 @@ import com.graphhopper.Repeat;
 import com.graphhopper.RepeatRule;
 import com.graphhopper.routing.*;
 import com.graphhopper.routing.ch.PrepareContractionHierarchies;
+import com.graphhopper.routing.lm.LMProfile;
 import com.graphhopper.routing.lm.PrepareLandmarks;
 import com.graphhopper.routing.querygraph.QueryGraph;
 import com.graphhopper.routing.util.*;
@@ -50,6 +51,7 @@ public class DirectedRoutingTest {
     private Directory dir;
     private GraphHopperStorage graph;
     private CHProfile chProfile;
+    private LMProfile lmProfile;
     private CHGraph chGraph;
     private CarFlagEncoder encoder;
     private TurnCostStorage turnCostStorage;
@@ -104,6 +106,7 @@ public class DirectedRoutingTest {
         turnCostStorage = graph.getTurnCostStorage();
         weighting = new FastestWeighting(encoder, new DefaultTurnCostProvider(encoder, turnCostStorage, uTurnCosts));
         chProfile = CHProfile.edgeBased(weighting);
+        lmProfile = new LMProfile(weighting);
         graph.addCHGraph(chProfile);
         graph.create(1000);
     }
@@ -119,7 +122,7 @@ public class DirectedRoutingTest {
             chGraph = graph.getCHGraph(chProfile);
         }
         if (prepareLM) {
-            lm = new PrepareLandmarks(dir, graph, weighting, 16, 8);
+            lm = new PrepareLandmarks(dir, graph, lmProfile, 16, 8);
             lm.setMaximumWeight(1000);
             lm.doWork();
         }

--- a/core/src/test/java/com/graphhopper/routing/weighting/RandomizedRoutingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/RandomizedRoutingTest.java
@@ -6,6 +6,7 @@ import com.graphhopper.Repeat;
 import com.graphhopper.RepeatRule;
 import com.graphhopper.routing.*;
 import com.graphhopper.routing.ch.PrepareContractionHierarchies;
+import com.graphhopper.routing.lm.LMProfile;
 import com.graphhopper.routing.lm.PerfectApproximator;
 import com.graphhopper.routing.lm.PrepareLandmarks;
 import com.graphhopper.routing.profiles.DecimalEncodedValue;
@@ -120,7 +121,7 @@ public class RandomizedRoutingTest {
             chGraph = graph.getCHGraph(chProfile);
         }
         if (prepareLM) {
-            lm = new PrepareLandmarks(dir, graph, weighting, 16, 8);
+            lm = new PrepareLandmarks(dir, graph, new LMProfile(weighting), 16, 8);
             lm.setMaximumWeight(10000);
             lm.doWork();
         }

--- a/core/src/test/java/com/graphhopper/storage/GraphHopperStorageLMTest.java
+++ b/core/src/test/java/com/graphhopper/storage/GraphHopperStorageLMTest.java
@@ -49,7 +49,7 @@ public class GraphHopperStorageLMTest {
         graph.close();
 
         GraphHopper hopper = new GraphHopper().setGraphHopperLocation(defaultGraphLoc).setCHEnabled(false);
-        hopper.getLMPreparationHandler().setEnabled(true).setWeightingsAsStrings(Arrays.asList("fastest"));
+        hopper.getLMPreparationHandler().setEnabled(true).setLMProfileStrings(Arrays.asList("fastest"));
         // does lm preparation
         hopper.importOrLoad();
         EncodingManager em = hopper.getEncodingManager();
@@ -58,7 +58,7 @@ public class GraphHopperStorageLMTest {
         assertEquals(16, hopper.getLMPreparationHandler().getLandmarks());
 
         hopper = new GraphHopper().setGraphHopperLocation(defaultGraphLoc).setCHEnabled(false);
-        hopper.getLMPreparationHandler().setEnabled(true).setWeightingsAsStrings(Arrays.asList("fastest"));
+        hopper.getLMPreparationHandler().setEnabled(true).setLMProfileStrings(Arrays.asList("fastest"));
         // just loads the LM data
         hopper.importOrLoad();
         assertEquals(1, em.fetchEdgeEncoders().size());

--- a/reader-osm/src/test/java/com/graphhopper/GraphHopperIT.java
+++ b/reader-osm/src/test/java/com/graphhopper/GraphHopperIT.java
@@ -191,7 +191,7 @@ public class GraphHopperIT {
         if (lm) {
             tmpHopper.getLMPreparationHandler().
                     setEnabled(true).
-                    setWeightingsAsStrings(Collections.singletonList(weightCalcStr)).
+                    setLMProfileStrings(Collections.singletonList(weightCalcStr)).
                     setDisablingAllowed(true);
         }
         tmpHopper.importAndClose();
@@ -206,7 +206,7 @@ public class GraphHopperIT {
         if (lm) {
             tmpHopper.getLMPreparationHandler().
                     setEnabled(true).
-                    setWeightingsAsStrings(Collections.singletonList(weightCalcStr)).
+                    setLMProfileStrings(Collections.singletonList(weightCalcStr)).
                     setDisablingAllowed(true);
         }
         tmpHopper.importOrLoad();
@@ -1095,7 +1095,7 @@ public class GraphHopperIT {
                 setDisablingAllowed(true);
 
         tmpHopper.getLMPreparationHandler().setEnabled(true).
-                setWeightingsAsStrings(Collections.singletonList("fastest|maximum=2000")).
+                setLMProfileStrings(Collections.singletonList("fastest|maximum=2000")).
                 setDisablingAllowed(true);
 
         tmpHopper.importOrLoad();
@@ -1152,7 +1152,7 @@ public class GraphHopperIT {
                 setDisablingAllowed(true);
 
         hopper.getLMPreparationHandler().setEnabled(true).
-                setWeightingsAsStrings(Collections.singletonList("fastest|maximum=2000")).
+                setLMProfileStrings(Collections.singletonList("fastest|maximum=2000")).
                 setDisablingAllowed(true);
 
         hopper.importOrLoad();
@@ -1193,7 +1193,7 @@ public class GraphHopperIT {
                 setGraphHopperLocation(tmpGraphFile);
         hopper.getCHPreparationHandler().setEnabled(false);
         hopper.getLMPreparationHandler().setEnabled(true).
-                setWeightingsAsStrings(Collections.singletonList("fastest|maximum=2000")).
+                setLMProfileStrings(Collections.singletonList("fastest|maximum=2000")).
                 setDisablingAllowed(true);
         hopper.importOrLoad();
 

--- a/reader-osm/src/test/java/com/graphhopper/reader/osm/GraphHopperOSMTest.java
+++ b/reader-osm/src/test/java/com/graphhopper/reader/osm/GraphHopperOSMTest.java
@@ -28,7 +28,6 @@ import com.graphhopper.routing.ch.CHRoutingAlgorithmFactory;
 import com.graphhopper.routing.ch.PrepareContractionHierarchies;
 import com.graphhopper.routing.lm.PrepareLandmarks;
 import com.graphhopper.routing.util.*;
-import com.graphhopper.routing.weighting.AbstractWeighting;
 import com.graphhopper.routing.weighting.FastestWeighting;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.CHProfile;
@@ -884,7 +883,7 @@ public class GraphHopperOSMTest {
                     setGraphHopperLocation(ghLoc).
                     setDataReaderFile(testOsm);
             tmpGH.getLMPreparationHandler().
-                    addWeighting("fastest").
+                    addLMProfileAsString("fastest").
                     setEnabled(true).
                     setPreparationThreads(threadCount);
 
@@ -894,7 +893,7 @@ public class GraphHopperOSMTest {
             for (PrepareLandmarks prepLM : tmpGH.getLMPreparationHandler().getPreparations()) {
                 assertTrue("Preparation wasn't run! [" + threadCount + "]", prepLM.isPrepared());
 
-                String name = AbstractWeighting.weightingToFileName(prepLM.getWeighting());
+                String name = prepLM.getLMProfile().getName();
                 Integer singleThreadShortcutCount = landmarkCount.get(name);
                 if (singleThreadShortcutCount == null)
                     landmarkCount.put(name, prepLM.getSubnetworksWithLandmarks());

--- a/reader-osm/src/test/java/com/graphhopper/routing/RoutingAlgorithmWithOSMIT.java
+++ b/reader-osm/src/test/java/com/graphhopper/routing/RoutingAlgorithmWithOSMIT.java
@@ -563,7 +563,7 @@ public class RoutingAlgorithmWithOSMIT {
             hopper.setWayPointMaxDistance(0);
 
             // always enable landmarks
-            hopper.getLMPreparationHandler().addWeighting(weightStr).
+            hopper.getLMPreparationHandler().addLMProfileAsString(weightStr).
                     setEnabled(true).setDisablingAllowed(true);
 
             if (withCH)


### PR DESCRIPTION
Here we maintain a pair of a profile name and a `Weighting` (=`LMProfile`) instead of just the `Weighting` for every LM preparation. This will be used to select an LM preparation by name similar to `CHProfile`. For now simply use default names `AbstractWeighting.weightingToFileName` so everything should work as before.