### PR TITLE
fix country rule ordering

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/profiles/Country.java
+++ b/core/src/main/java/com/graphhopper/routing/profiles/Country.java
@@ -30,6 +30,10 @@ public enum Country {
         this.name = name;
     }
 
+    public static EnumEncodedValue<Country> create() {
+        return new EnumEncodedValue<>(Country.KEY, Country.class);
+    }
+
     @Override
     public String toString() {
         return name;

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/DefaultTagParserFactory.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/DefaultTagParserFactory.java
@@ -64,6 +64,9 @@ public class DefaultTagParserFactory implements TagParserFactory {
             return new OSMHazmatTunnelParser();
         else if (name.equals(HazmatWater.KEY))
             return new OSMHazmatWaterParser();
+        else if (name.equals(Country.KEY))
+            throw new IllegalArgumentException("The property countries.borders_directory is required in the configuration when using 'country'");
+
         throw new IllegalArgumentException("entry in encoder list not supported " + name);
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/DefaultTagParserFactory.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/DefaultTagParserFactory.java
@@ -65,7 +65,8 @@ public class DefaultTagParserFactory implements TagParserFactory {
         else if (name.equals(HazmatWater.KEY))
             return new OSMHazmatWaterParser();
         else if (name.equals(Country.KEY))
-            throw new IllegalArgumentException("The property countries.borders_directory is required in the configuration when using 'country'");
+            throw new IllegalArgumentException("The property spatial_rules.borders_directory is required in the configuration " +
+                    "when using 'country' in encoded_values");
 
         throw new IllegalArgumentException("entry in encoder list not supported " + name);
     }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/SpatialRuleParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/SpatialRuleParser.java
@@ -34,10 +34,6 @@ public class SpatialRuleParser implements TagParser {
     private final IntEncodedValue spatialRuleEnc;
     private SpatialRuleLookup spatialRuleLookup;
 
-    public SpatialRuleParser(SpatialRuleLookup spatialRuleLookup) {
-        this(spatialRuleLookup, new EnumEncodedValue<>(Country.KEY, Country.class));
-    }
-
     public SpatialRuleParser(SpatialRuleLookup spatialRuleLookup, IntEncodedValue spatialRuleEnc) {
         this.spatialRuleLookup = spatialRuleLookup;
         this.spatialRuleEnc = spatialRuleEnc;

--- a/core/src/main/java/com/graphhopper/routing/util/spatialrules/CountriesSpatialRuleFactory.java
+++ b/core/src/main/java/com/graphhopper/routing/util/spatialrules/CountriesSpatialRuleFactory.java
@@ -1,25 +1,33 @@
 package com.graphhopper.routing.util.spatialrules;
 
+import com.graphhopper.routing.profiles.Country;
 import com.graphhopper.routing.util.spatialrules.countries.AustriaSpatialRule;
 import com.graphhopper.routing.util.spatialrules.countries.GermanySpatialRule;
+import org.locationtech.jts.geom.Polygon;
 
 import java.util.List;
 
-import org.locationtech.jts.geom.Polygon;
+import static com.graphhopper.util.Helper.toUpperCase;
 
 public class CountriesSpatialRuleFactory implements SpatialRuleLookupBuilder.SpatialRuleFactory {
+
     @Override
     public SpatialRule createSpatialRule(String id, List<Polygon> polygons) {
-        switch (id) {
-            case "AUT":
-                AustriaSpatialRule austriaSpatialRule = new AustriaSpatialRule();
-                austriaSpatialRule.setBorders(polygons);
-                return austriaSpatialRule;
-            case "DEU":
-                GermanySpatialRule germanySpatialRule = new GermanySpatialRule();
-                germanySpatialRule.setBorders(polygons);
-                return germanySpatialRule;
+        try {
+            Country country = Country.valueOf(toUpperCase(id));
+            switch (country) {
+                case AUT:
+                    AustriaSpatialRule austriaSpatialRule = new AustriaSpatialRule();
+                    austriaSpatialRule.setBorders(polygons);
+                    return austriaSpatialRule;
+                case DEU:
+                    GermanySpatialRule germanySpatialRule = new GermanySpatialRule();
+                    germanySpatialRule.setBorders(polygons);
+                    return germanySpatialRule;
+            }
+        } catch (Exception ex) {
         }
+
         return SpatialRule.EMPTY;
     }
 }

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/SpatialRuleParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/SpatialRuleParserTest.java
@@ -10,7 +10,7 @@ public class SpatialRuleParserTest {
 
     @Test
     public void testMixParserAdding() {
-        EncodingManager em = new EncodingManager.Builder().add(new SpatialRuleParser(null)).build();
+        EncodingManager em = new EncodingManager.Builder().add(new SpatialRuleParser(null, Country.create())).build();
         assertTrue(em.hasEncodedValue(Country.KEY));
     }
 }

--- a/core/src/test/java/com/graphhopper/routing/util/spatialrules/SpatialRuleLookupBuilderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/spatialrules/SpatialRuleLookupBuilderTest.java
@@ -166,7 +166,7 @@ public class SpatialRuleLookupBuilderTest {
             }
         };
 
-        EncodingManager em = new EncodingManager.Builder().add(new SpatialRuleParser(index)).add(new CarFlagEncoder(new PMap())).build();
+        EncodingManager em = new EncodingManager.Builder().add(new SpatialRuleParser(index, Country.create())).add(new CarFlagEncoder(new PMap())).build();
         IntEncodedValue countrySpatialIdEnc = em.getIntEncodedValue(Country.KEY);
         EnumEncodedValue<RoadAccess> tmpRoadAccessEnc = em.getEnumEncodedValue(RoadAccess.KEY, RoadAccess.class);
         DecimalEncodedValue tmpCarMaxSpeedEnc = em.getDecimalEncodedValue(MaxSpeed.KEY);
@@ -184,13 +184,13 @@ public class SpatialRuleLookupBuilderTest {
 
         IntsRef relFlags = em.createRelationFlags();
         EncodingManager.AcceptWay map = new EncodingManager.AcceptWay().put("car", EncodingManager.Access.WAY);
-        ReaderWay way = new ReaderWay(27l);
+        ReaderWay way = new ReaderWay(27L);
         way.setTag("highway", "track");
         way.setTag("estimated_center", new GHPoint(0.005, 0.005));
         e1.setFlags(em.handleWayTags(way, map, relFlags));
         assertEquals(RoadAccess.DESTINATION, e1.get(tmpRoadAccessEnc));
 
-        ReaderWay way2 = new ReaderWay(28l);
+        ReaderWay way2 = new ReaderWay(28L);
         way2.setTag("highway", "track");
         way2.setTag("estimated_center", new GHPoint(-0.005, -0.005));
         e2.setFlags(em.handleWayTags(way2, map, relFlags));
@@ -199,13 +199,13 @@ public class SpatialRuleLookupBuilderTest {
         assertEquals(index.getSpatialId(new GermanySpatialRule()), e1.get(countrySpatialIdEnc));
         assertEquals(index.getSpatialId(SpatialRule.EMPTY), e2.get(countrySpatialIdEnc));
 
-        ReaderWay livingStreet = new ReaderWay(29l);
+        ReaderWay livingStreet = new ReaderWay(29L);
         livingStreet.setTag("highway", "living_street");
         livingStreet.setTag("estimated_center", new GHPoint(0.005, 0.005));
         e3.setFlags(em.handleWayTags(livingStreet, map, relFlags));
         assertEquals(5, e3.get(tmpCarMaxSpeedEnc), .1);
 
-        ReaderWay livingStreet2 = new ReaderWay(30l);
+        ReaderWay livingStreet2 = new ReaderWay(30L);
         livingStreet2.setTag("highway", "living_street");
         livingStreet2.setTag("estimated_center", new GHPoint(-0.005, -0.005));
         e4.setFlags(em.handleWayTags(livingStreet2, map, relFlags));

--- a/core/src/test/java/com/graphhopper/routing/util/spatialrules/SpatialRuleLookupHelperTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/spatialrules/SpatialRuleLookupHelperTest.java
@@ -1,0 +1,35 @@
+package com.graphhopper.routing.util.spatialrules;
+
+import com.graphhopper.json.geo.JsonFeature;
+import com.graphhopper.json.geo.JsonFeatureCollection;
+import org.junit.Test;
+
+import java.util.*;
+
+import static com.graphhopper.routing.util.spatialrules.SpatialRuleLookupHelper.JSON_ID_FIELD;
+import static com.graphhopper.routing.util.spatialrules.SpatialRuleLookupHelper.reorder;
+import static org.junit.Assert.assertEquals;
+
+public class SpatialRuleLookupHelperTest {
+
+    static JsonFeatureCollection createJsonFeatureCollection(String key) {
+        JsonFeatureCollection coll = new JsonFeatureCollection();
+        Map<String, Object> map = new HashMap<>();
+        map.put(JSON_ID_FIELD, key);
+        coll.getFeatures().add(new JsonFeature(null, null, null, null, map));
+        return coll;
+    }
+
+    @Test
+    public void testReorder() {
+        List<JsonFeatureCollection> allFeatureList = new ArrayList<>();
+        allFeatureList.add(createJsonFeatureCollection("first_country"));
+        allFeatureList.add(createJsonFeatureCollection("sec_country"));
+        allFeatureList.add(createJsonFeatureCollection("3rd_country"));
+
+        List<JsonFeatureCollection> result = reorder(allFeatureList, Arrays.asList("3rd_country", "sec_country"));
+        assertEquals(1, result.size());
+        assertEquals("3rd_country", result.get(0).getFeatures().get(0).getProperties().get(JSON_ID_FIELD));
+        assertEquals("sec_country", result.get(0).getFeatures().get(1).getProperties().get(JSON_ID_FIELD));
+    }
+}

--- a/reader-osm/src/main/java/com/graphhopper/reader/osm/GraphHopperOSM.java
+++ b/reader-osm/src/main/java/com/graphhopper/reader/osm/GraphHopperOSM.java
@@ -73,17 +73,18 @@ public class GraphHopperOSM extends GraphHopper {
             return;
 
         if (landmarkSplittingFeatureCollection != null && !landmarkSplittingFeatureCollection.getFeatures().isEmpty()) {
-            SpatialRuleLookup ruleLookup = SpatialRuleLookupBuilder.buildIndex(Collections.singletonList(landmarkSplittingFeatureCollection), "area", new SpatialRuleLookupBuilder.SpatialRuleFactory() {
-                @Override
-                public SpatialRule createSpatialRule(final String id, List<Polygon> polygons) {
-                    return new DefaultSpatialRule() {
+            SpatialRuleLookup ruleLookup = SpatialRuleLookupBuilder.buildIndex(
+                    Collections.singletonList(landmarkSplittingFeatureCollection), "area", new SpatialRuleLookupBuilder.SpatialRuleFactory() {
                         @Override
-                        public String getId() {
-                            return id;
+                        public SpatialRule createSpatialRule(final String id, List<Polygon> polygons) {
+                            return new DefaultSpatialRule() {
+                                @Override
+                                public String getId() {
+                                    return id;
+                                }
+                            }.setBorders(polygons);
                         }
-                    }.setBorders(polygons);
-                }
-            });
+                    });
             for (PrepareLandmarks prep : getLMPreparationHandler().getPreparations()) {
                 // the ruleLookup splits certain areas from each other but avoids making this a permanent change so that other algorithms still can route through these regions.
                 if (ruleLookup != null && ruleLookup.size() > 0) {

--- a/web-bundle/src/main/java/com/graphhopper/http/GraphHopperManaged.java
+++ b/web-bundle/src/main/java/com/graphhopper/http/GraphHopperManaged.java
@@ -67,11 +67,11 @@ public class GraphHopperManaged implements Managed {
             graphHopper = new GraphHopperOSM(landmarkSplittingFeatureCollection).forServer();
         }
         if (!configuration.get("spatial_rules.location", "").isEmpty()) {
-            throw new RuntimeException("spatial_rules.location has been deprecated. Please use countries.borders_directory instead.");
+            throw new RuntimeException("spatial_rules.location has been deprecated. Please use spatial_rules.borders_directory instead.");
         }
-        String spatialRuleBordersDirLocation = configuration.get("countries.borders_directory", "");
+        String spatialRuleBordersDirLocation = configuration.get("spatial_rules.borders_directory", "");
         if (!spatialRuleBordersDirLocation.isEmpty()) {
-            final BBox maxBounds = BBox.parseBBoxString(configuration.get("countries.max_bbox", "-180, 180, -90, 90"));
+            final BBox maxBounds = BBox.parseBBoxString(configuration.get("spatial_rules.max_bbox", "-180, 180, -90, 90"));
             final Path bordersDirectory = Paths.get(spatialRuleBordersDirLocation);
             List<JsonFeatureCollection> jsonFeatureCollections = new ArrayList<>();
             try (DirectoryStream<Path> stream = Files.newDirectoryStream(bordersDirectory, "*.{geojson,json}")) {

--- a/web-bundle/src/main/java/com/graphhopper/http/GraphHopperManaged.java
+++ b/web-bundle/src/main/java/com/graphhopper/http/GraphHopperManaged.java
@@ -67,11 +67,11 @@ public class GraphHopperManaged implements Managed {
             graphHopper = new GraphHopperOSM(landmarkSplittingFeatureCollection).forServer();
         }
         if (!configuration.get("spatial_rules.location", "").isEmpty()) {
-            throw new RuntimeException("spatial_rules.location has been deprecated. Please use spatial_rules.borders_directory instead.");
+            throw new RuntimeException("spatial_rules.location has been deprecated. Please use countries.borders_directory instead.");
         }
-        String spatialRuleBordersDirLocation = configuration.get("spatial_rules.borders_directory", "");
+        String spatialRuleBordersDirLocation = configuration.get("countries.borders_directory", "");
         if (!spatialRuleBordersDirLocation.isEmpty()) {
-            final BBox maxBounds = BBox.parseBBoxString(configuration.get("spatial_rules.max_bbox", "-180, 180, -90, 90"));
+            final BBox maxBounds = BBox.parseBBoxString(configuration.get("countries.max_bbox", "-180, 180, -90, 90"));
             final Path bordersDirectory = Paths.get(spatialRuleBordersDirLocation);
             List<JsonFeatureCollection> jsonFeatureCollections = new ArrayList<>();
             try (DirectoryStream<Path> stream = Files.newDirectoryStream(bordersDirectory, "*.{geojson,json}")) {
@@ -84,7 +84,8 @@ public class GraphHopperManaged implements Managed {
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
-            SpatialRuleLookupHelper.buildAndInjectSpatialRuleIntoGH(graphHopper, new Envelope(maxBounds.minLon, maxBounds.maxLon, maxBounds.minLat, maxBounds.maxLat), jsonFeatureCollections);
+            SpatialRuleLookupHelper.buildAndInjectCountrySpatialRules(graphHopper,
+                    new Envelope(maxBounds.minLon, maxBounds.maxLon, maxBounds.minLat, maxBounds.maxLat), jsonFeatureCollections);
         }
         graphHopper.init(configuration);
     }
@@ -93,9 +94,9 @@ public class GraphHopperManaged implements Managed {
     public void start() {
         graphHopper.importOrLoad();
         logger.info("loaded graph at:{}, data_reader_file:{}, encoded values:{}, {}",
-                        graphHopper.getGraphHopperLocation(), graphHopper.getDataReaderFile(),
-                        graphHopper.getEncodingManager().toEncodedValuesAsString(),
-                        graphHopper.getGraphHopperStorage().toDetailsString());
+                graphHopper.getGraphHopperLocation(), graphHopper.getDataReaderFile(),
+                graphHopper.getEncodingManager().toEncodedValuesAsString(),
+                graphHopper.getGraphHopperStorage().toDetailsString());
     }
 
     public GraphHopper getGraphHopper() {

--- a/web/src/test/java/com/graphhopper/http/SpatialRulesTest.java
+++ b/web/src/test/java/com/graphhopper/http/SpatialRulesTest.java
@@ -46,8 +46,8 @@ public class SpatialRulesTest {
                 put("graph.flag_encoders", "car").
                 put("graph.encoded_values", "country,road_environment,road_class,road_access,max_speed").
                 put("prepare.ch.weightings", "no").
-                put("spatial_rules.borders_directory", "../core/files/spatialrules").
-                put("spatial_rules.max_bbox", "11.4,11.7,49.9,50.1").
+                put("countries.borders_directory", "../core/files/spatialrules").
+                put("countries.max_bbox", "11.4,11.7,49.9,50.1").
                 put("datareader.file", "../core/files/north-bayreuth.osm.gz").
                 put("graph.location", DIR);
     }

--- a/web/src/test/java/com/graphhopper/http/SpatialRulesTest.java
+++ b/web/src/test/java/com/graphhopper/http/SpatialRulesTest.java
@@ -46,8 +46,8 @@ public class SpatialRulesTest {
                 put("graph.flag_encoders", "car").
                 put("graph.encoded_values", "country,road_environment,road_class,road_access,max_speed").
                 put("prepare.ch.weightings", "no").
-                put("countries.borders_directory", "../core/files/spatialrules").
-                put("countries.max_bbox", "11.4,11.7,49.9,50.1").
+                put("spatial_rules.borders_directory", "../core/files/spatialrules").
+                put("spatial_rules.max_bbox", "11.4,11.7,49.9,50.1").
                 put("datareader.file", "../core/files/north-bayreuth.osm.gz").
                 put("graph.location", DIR);
     }


### PR DESCRIPTION
fixes #1875

As we currently already sort the strings https://github.com/graphhopper/graphhopper/blob/master/core/src/main/java/com/graphhopper/routing/util/spatialrules/SpatialRuleLookupBuilder.java#L86

the only required change for #1875 would be to reorder the Country enum (AUT should come before DEU).

But as this is too error-prone I decided for a better & special handling when using the Country enum in combination with the SpatialRuleFactory. This is currently done in SpatialRuleLookupHelper.buildAndInjectSpatialRuleIntoGH. I have renamed this to a more Country-specific name as it is nothing generic. ~~Also `spatial_rules.borders_directory` is renamed to `country.borders_directory` to make usage more clear~~. To avoid mixing this in the future I have removed the SpatialRuleParser constructor the with enum-Country default.