### PR TITLE
Cleanup GraphHopper tests in preparation to profile parameter

### DIFF
--- a/reader-osm/src/test/java/com/graphhopper/GraphHopperIT.java
+++ b/reader-osm/src/test/java/com/graphhopper/GraphHopperIT.java
@@ -34,7 +34,9 @@ import com.graphhopper.util.details.PathDetail;
 import com.graphhopper.util.exceptions.PointDistanceExceededException;
 import com.graphhopper.util.shapes.GHPoint;
 import com.graphhopper.util.shapes.GHPoint3D;
-import org.junit.*;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
 import java.io.File;
 import java.util.*;
@@ -961,8 +963,9 @@ public class GraphHopperIT {
 
         GraphHopper hopper = createGraphHopper(vehicle + ",bike").
                 setOSMFile(MONACO).
-                setStoreOnFlush(true).
-                importOrLoad();
+                setStoreOnFlush(true);
+        hopper.getCHPreparationHandler().setCHProfileStrings(weighting);
+        hopper.importOrLoad();
 
         assertEquals(vehicle, hopper.getDefaultVehicle().toString());
 
@@ -997,8 +1000,9 @@ public class GraphHopperIT {
 
         GraphHopper hopper = createGraphHopper(vehicle + ",bike").
                 setOSMFile(BERLIN).
-                setStoreOnFlush(true).
-                importOrLoad();
+                setStoreOnFlush(true);
+        hopper.getCHPreparationHandler().setCHProfileStrings(weighting);
+        hopper.importOrLoad();
 
         assertEquals(vehicle, hopper.getDefaultVehicle().toString());
 
@@ -1017,10 +1021,12 @@ public class GraphHopperIT {
     public void testMultipleVehiclesWithCH() {
         final String vehicle1 = "bike";
         final String vehicle2 = "car";
+        final String weighting = "fastest";
         GraphHopper hopper = createGraphHopper(vehicle1 + "," + vehicle2).
                 setOSMFile(MONACO).
-                setStoreOnFlush(true).
-                importOrLoad();
+                setStoreOnFlush(true);
+        hopper.getCHPreparationHandler().setCHProfileStrings(weighting);
+                hopper.importOrLoad();
         assertEquals(vehicle1, hopper.getDefaultVehicle().toString());
         checkMultiVehiclesWithCH(hopper);
         hopper.close();
@@ -1029,8 +1035,9 @@ public class GraphHopperIT {
         // new instance, try different order, resulting only in different default vehicle
         hopper = createGraphHopper(vehicle2 + ", " + vehicle1).
                 setOSMFile(MONACO).
-                setStoreOnFlush(true).
-                importOrLoad();
+                setStoreOnFlush(true);
+        hopper.getCHPreparationHandler().setCHProfileStrings(weighting);
+        hopper.importOrLoad();
         assertEquals(vehicle2, hopper.getDefaultVehicle().toString());
         checkMultiVehiclesWithCH(hopper);
         hopper.close();
@@ -1252,7 +1259,7 @@ public class GraphHopperIT {
                 setDisablingAllowed(true);
 
         hopper.getLMPreparationHandler().setEnabled(true).
-                setLMProfileStrings(Collections.singletonList(weighting +"|maximum=2000")).
+                setLMProfileStrings(Collections.singletonList(weighting + "|maximum=2000")).
                 setDisablingAllowed(true);
 
         hopper.importOrLoad();
@@ -1331,10 +1338,12 @@ public class GraphHopperIT {
 
     @Test
     public void testTurnCostsOnOffCH() {
+        final String weighting = "fastest";
         GraphHopper hopper = createGraphHopper("car|turn_costs=true").
                 setOSMFile(MOSCOW).
                 setStoreOnFlush(true).
                 setCHEnabled(true);
+        hopper.getCHPreparationHandler().setCHProfileStrings(weighting);
         hopper.getCHPreparationHandler().setDisablingAllowed(true);
         hopper.getCHPreparationHandler().setEdgeBasedCHMode(EdgeBasedCHMode.EDGE_AND_NODE);
         hopper.importOrLoad();
@@ -1349,11 +1358,13 @@ public class GraphHopperIT {
 
     @Test
     public void testCHOnOffWithTurnCosts() {
+        final String weighting = "fastest";
         GraphHopper hopper = createGraphHopper("car|turn_costs=true").
                 setOSMFile(MOSCOW).
                 setStoreOnFlush(true).
                 setCHEnabled(true);
         hopper.getCHPreparationHandler()
+                .setCHProfileStrings(weighting)
                 .setEdgeBasedCHMode(EdgeBasedCHMode.EDGE_OR_NODE)
                 .setDisablingAllowed(true);
         hopper.importOrLoad();
@@ -1368,12 +1379,14 @@ public class GraphHopperIT {
 
     @Test
     public void testNodeBasedCHOnlyButTurnCostForNonCH() {
+        final String weighting = "fastest";
         // before edge-based CH was added a common case was to use edge-based without CH and CH for node-based
         GraphHopper hopper = createGraphHopper("car|turn_costs=true").
                 setOSMFile(MOSCOW).
                 setStoreOnFlush(true).
                 setCHEnabled(true);
         hopper.getCHPreparationHandler()
+                .setCHProfileStrings(weighting)
                 .setEdgeBasedCHMode(EdgeBasedCHMode.OFF)
                 .setDisablingAllowed(true);
         hopper.importOrLoad();
@@ -1399,10 +1412,12 @@ public class GraphHopperIT {
     public void testEdgeBasedByDefaultIfOnlyEdgeBased() {
         // when there is only one edge-based CH profile, there is no need to specify edge_based=true explicitly,
         // see #1637
+        final String weighting = "fastest";
         GraphHopper hopper = createGraphHopper("car|turn_costs=true").
                 setOSMFile(MOSCOW).
                 setStoreOnFlush(true).
                 setCHEnabled(true);
+        hopper.getCHPreparationHandler().setCHProfileStrings(weighting);
         hopper.getCHPreparationHandler().setDisablingAllowed(true);
         hopper.getCHPreparationHandler().setEdgeBasedCHMode(EdgeBasedCHMode.EDGE_OR_NODE);
         hopper.importOrLoad();
@@ -1481,6 +1496,7 @@ public class GraphHopperIT {
                 setOSMFile(BAYREUTH).
                 setCHEnabled(true);
         h.getCHPreparationHandler()
+                .setCHProfileStrings("fastest")
                 .setEdgeBasedCHMode(EdgeBasedCHMode.EDGE_OR_NODE);
         h.importOrLoad();
 
@@ -1527,6 +1543,7 @@ public class GraphHopperIT {
                 setOSMFile(MONACO).
                 setCHEnabled(true);
         h.getCHPreparationHandler()
+                .setCHProfileStrings("fastest")
                 .setEdgeBasedCHMode(EdgeBasedCHMode.EDGE_OR_NODE);
         h.importOrLoad();
 

--- a/reader-osm/src/test/java/com/graphhopper/GraphHopperIT.java
+++ b/reader-osm/src/test/java/com/graphhopper/GraphHopperIT.java
@@ -51,30 +51,33 @@ import static org.junit.Assert.*;
 public class GraphHopperIT {
 
     public static final String DIR = "../core/files";
-    private static final String graphFileFoot = "target/graphhopperIT-foot";
-    private static final String osmFile = DIR + "/monaco.osm.gz";
+    private static final String GH_LOCATION = "target/graphhopper-it-gh";
+    private static final String BAYREUTH = DIR + "/north-bayreuth.osm.gz";
+    private static final String BERLIN = DIR + "/berlin-siegessaeule.osm.gz";
+    private static final String LAUF = DIR + "/Laufamholzstrasse.osm.xml";
+    private static final String MOSCOW = DIR + "/moscow.osm.gz";
+    private static final String KREMS = DIR + "/krems.osm.gz";
+    private static final String MONACO = DIR + "/monaco.osm.gz";
     private static final String importVehicles = "foot";
-    private static final String vehicle = "foot";
-    private static final String weightCalcStr = "shortest";
     private static GraphHopper hopper;
     private final String tmpGraphFile = "target/graphhopperIT-tmp";
 
     @BeforeClass
     public static void beforeClass() {
         // make sure we are using fresh graphhopper files with correct vehicle
-        Helper.removeDir(new File(graphFileFoot));
+        Helper.removeDir(new File(GH_LOCATION));
 
         hopper = createGraphHopper(importVehicles).
-                setOSMFile(osmFile).
+                setOSMFile(MONACO).
                 setStoreOnFlush(true).
                 setCHEnabled(false).
-                setGraphHopperLocation(graphFileFoot).
+                setGraphHopperLocation(GH_LOCATION).
                 importOrLoad();
     }
 
     @AfterClass
     public static void afterClass() {
-        Helper.removeDir(new File(graphFileFoot));
+        Helper.removeDir(new File(GH_LOCATION));
     }
 
     @Before
@@ -89,8 +92,10 @@ public class GraphHopperIT {
 
     @Test
     public void testMonacoWithInstructions() {
+        final String vehicle = "foot";
+        final String weighting = "shortest";
         GHResponse rsp = hopper.route(new GHRequest(43.727687, 7.418737, 43.74958, 7.436566).
-                setAlgorithm(ASTAR).setVehicle(vehicle).setWeighting(weightCalcStr));
+                setAlgorithm(ASTAR).setVehicle(vehicle).setWeighting(weighting));
 
         // identify the number of counts to compare with CH foot route
         assertEquals(699, rsp.getHints().getLong("visited_nodes.sum", 0));
@@ -132,7 +137,9 @@ public class GraphHopperIT {
 
     @Test
     public void withoutInstructions() {
-        GHRequest request = new GHRequest().setAlgorithm(ASTAR).setVehicle(vehicle).setWeighting(weightCalcStr);
+        final String vehicle = "foot";
+        final String weighting = "shortest";
+        GHRequest request = new GHRequest().setAlgorithm(ASTAR).setVehicle(vehicle).setWeighting(weighting);
         request.addPoint(new GHPoint(43.729584, 7.410965));
         request.addPoint(new GHPoint(43.732499, 7.426758));
         request.getHints().put("instructions", true);
@@ -148,7 +155,9 @@ public class GraphHopperIT {
 
     @Test
     public void testUTurn() {
-        GraphHopper tmpHopper = createGraphHopper("car").
+        final String vehicle = "car";
+        final String weighting = "shortest";
+        GraphHopper tmpHopper = createGraphHopper(vehicle).
                 setOSMFile(DIR + "/monaco.osm.gz").
                 setCHEnabled(false).
                 setGraphHopperLocation(tmpGraphFile);
@@ -160,7 +169,7 @@ public class GraphHopperIT {
         request.addPoint(new GHPoint(43.743887, 7.431151), 200);
         request.addPoint(new GHPoint(43.744007, 7.431076));
 
-        request.setAlgorithm(ASTAR).setVehicle("car").setWeighting(weightCalcStr);
+        request.setAlgorithm(ASTAR).setVehicle(vehicle).setWeighting(weighting);
         GHResponse rsp = tmpHopper.route(request);
 
         assertFalse(rsp.hasErrors());
@@ -175,38 +184,36 @@ public class GraphHopperIT {
     }
 
     private void testImportCloseAndLoad(boolean ch, boolean lm, boolean sort) {
-
-        String tmpOsmFile = DIR + "/monaco.osm.gz";
-        String tmpImportVehicles = "foot";
-
-        GraphHopper tmpHopper = createGraphHopper(tmpImportVehicles).
-                setOSMFile(tmpOsmFile).
+        final String vehicle = "foot";
+        final String weighting = "shortest";
+        GraphHopper tmpHopper = createGraphHopper(vehicle).
+                setOSMFile(MONACO).
                 setStoreOnFlush(true).
                 setCHEnabled(ch).
                 setSortGraph(sort).
                 setGraphHopperLocation(tmpGraphFile);
         if (ch) {
-            tmpHopper.getCHPreparationHandler().setCHProfileStrings(weightCalcStr).setDisablingAllowed(true);
+            tmpHopper.getCHPreparationHandler().setCHProfileStrings(weighting).setDisablingAllowed(true);
         }
         if (lm) {
             tmpHopper.getLMPreparationHandler().
                     setEnabled(true).
-                    setLMProfileStrings(Collections.singletonList(weightCalcStr)).
+                    setLMProfileStrings(Collections.singletonList(weighting)).
                     setDisablingAllowed(true);
         }
         tmpHopper.importAndClose();
-        tmpHopper = createGraphHopper(tmpImportVehicles).
-                setOSMFile(tmpOsmFile).
+        tmpHopper = createGraphHopper(vehicle).
+                setOSMFile(MONACO).
                 setStoreOnFlush(true).
                 setCHEnabled(ch).
                 setGraphHopperLocation(tmpGraphFile);
         if (ch) {
-            tmpHopper.getCHPreparationHandler().setCHProfileStrings(weightCalcStr).setDisablingAllowed(true);
+            tmpHopper.getCHPreparationHandler().setCHProfileStrings(weighting).setDisablingAllowed(true);
         }
         if (lm) {
             tmpHopper.getLMPreparationHandler().
                     setEnabled(true).
-                    setLMProfileStrings(Collections.singletonList(weightCalcStr)).
+                    setLMProfileStrings(Collections.singletonList(weighting)).
                     setDisablingAllowed(true);
         }
         tmpHopper.importOrLoad();
@@ -216,8 +223,8 @@ public class GraphHopperIT {
 
         if (ch) {
             GHRequest req = new GHRequest(43.727687, 7.418737, 43.74958, 7.436566).
-                    setWeighting(weightCalcStr).
-                    setVehicle(tmpImportVehicles);
+                    setWeighting(weighting).
+                    setVehicle(vehicle);
             req.getHints().put(CH.DISABLE, false);
             req.getHints().put(Landmark.DISABLE, true);
             GHResponse rsp = tmpHopper.route(req);
@@ -232,8 +239,8 @@ public class GraphHopperIT {
 
         if (lm) {
             GHRequest req = new GHRequest(43.727687, 7.418737, 43.74958, 7.436566).
-                    setVehicle(tmpImportVehicles).
-                    setWeighting(weightCalcStr).
+                    setVehicle(vehicle).
+                    setWeighting(weighting).
                     setAlgorithm(Parameters.Algorithms.ASTAR_BI);
             req.getHints().put(CH.DISABLE, true);
             req.getHints().put(Landmark.DISABLE, false);
@@ -249,8 +256,8 @@ public class GraphHopperIT {
 
         // flexible
         GHRequest req = new GHRequest(43.727687, 7.418737, 43.74958, 7.436566).
-                setVehicle(tmpImportVehicles).
-                setWeighting(weightCalcStr);
+                setVehicle(vehicle).
+                setWeighting(weighting);
         req.getHints().put(CH.DISABLE, true);
         req.getHints().put(Landmark.DISABLE, true);
         GHResponse rsp = tmpHopper.route(req);
@@ -292,8 +299,10 @@ public class GraphHopperIT {
 
     @Test
     public void testAlternativeRoutes() {
+        final String vehicle = "foot";
+        final String weighting = "shortest";
         GHRequest req = new GHRequest(43.729057, 7.41251, 43.740298, 7.423561).
-                setAlgorithm(ALT_ROUTE).setVehicle(vehicle).setWeighting(weightCalcStr);
+                setAlgorithm(ALT_ROUTE).setVehicle(vehicle).setWeighting(weighting);
 
         GHResponse rsp = hopper.route(req);
         assertFalse(rsp.hasErrors());
@@ -314,16 +323,19 @@ public class GraphHopperIT {
     }
 
     @Test
-    public void testAlternativeRoutesBikeAndCar() {
+    public void testAlternativeRoutesBike() {
+        final String vehicle = "bike";
+        final String weighting = "fastest";
+
         GraphHopper tmpHopper = new GraphHopperOSM().
-                setOSMFile(DIR + "/north-bayreuth.osm.gz").
+                setOSMFile(BAYREUTH).
                 setCHEnabled(false).
                 setGraphHopperLocation(tmpGraphFile).
-                setEncodingManager(EncodingManager.create("bike, car"));
+                setEncodingManager(EncodingManager.create(vehicle));
         tmpHopper.importOrLoad();
 
         GHRequest req = new GHRequest(50.028917, 11.496506, 49.985228, 11.600876).
-                setAlgorithm(ALT_ROUTE).setVehicle("bike").setWeighting("fastest");
+                setAlgorithm(ALT_ROUTE).setVehicle(vehicle).setWeighting(weighting);
         req.getHints().put("alternative_route.max_paths", "3");
         GHResponse rsp = tmpHopper.route(req);
         assertFalse(rsp.getErrors().toString(), rsp.hasErrors());
@@ -335,11 +347,24 @@ public class GraphHopperIT {
         assertEquals(3318, rsp.getAll().get(1).getTime() / 1000);
         // via eselslohe -> theta; BTW: here smaller time as 2nd alternative due to priority influences time order
         assertEquals(3094, rsp.getAll().get(2).getTime() / 1000);
+    }
 
-        req = new GHRequest(50.023513, 11.548862, 49.969441, 11.537876).
-                setAlgorithm(ALT_ROUTE).setVehicle("car").setWeighting("fastest");
+    @Test
+    public void testAlternativeRoutesCar() {
+        final String vehicle = "car";
+        final String weighting = "fastest";
+
+        GraphHopper tmpHopper = new GraphHopperOSM().
+                setOSMFile(BAYREUTH).
+                setCHEnabled(false).
+                setGraphHopperLocation(tmpGraphFile).
+                setEncodingManager(EncodingManager.create(vehicle));
+        tmpHopper.importOrLoad();
+
+        GHRequest req = new GHRequest(50.023513, 11.548862, 49.969441, 11.537876).
+                setAlgorithm(ALT_ROUTE).setVehicle(vehicle).setWeighting(weighting);
         req.getHints().put("alternative_route.max_paths", "3");
-        rsp = tmpHopper.route(req);
+        GHResponse rsp = tmpHopper.route(req);
         assertFalse(rsp.getErrors().toString(), rsp.hasErrors());
 
         assertEquals(3, rsp.getAll().size());
@@ -353,14 +378,17 @@ public class GraphHopperIT {
 
     @Test
     public void testPointHint() {
-        GraphHopper tmpHopper = createGraphHopper("car").
-                setOSMFile(DIR + "/Laufamholzstrasse.osm.xml").
+        final String vehicle = "car";
+        final String weighting = "fastest";
+
+        GraphHopper tmpHopper = createGraphHopper(vehicle).
+                setOSMFile(LAUF).
                 setCHEnabled(false).
                 setGraphHopperLocation(tmpGraphFile);
         tmpHopper.importOrLoad();
 
         GHRequest req = new GHRequest(49.46553, 11.154669, 49.465244, 11.152577).
-                setVehicle("car").setWeighting("fastest");
+                setVehicle(vehicle).setWeighting(weighting);
 
         req.setPointHints(new ArrayList<>(asList("Laufamholzstraße, 90482, Nürnberg, Deutschland", "")));
         GHResponse rsp = tmpHopper.route(req);
@@ -387,14 +415,17 @@ public class GraphHopperIT {
 
     @Test
     public void testNorthBayreuthDestination() {
-        GraphHopper tmpHopper = createGraphHopper("car").
-                setOSMFile(DIR + "/north-bayreuth.osm.gz").
+        final String vehicle = "car";
+        final String weighting = "fastest";
+
+        GraphHopper tmpHopper = createGraphHopper(vehicle).
+                setOSMFile(BAYREUTH).
                 setCHEnabled(false).
                 setGraphHopperLocation(tmpGraphFile);
         tmpHopper.importOrLoad();
 
         GHRequest req = new GHRequest(49.985307, 11.50628, 49.985731, 11.507465).
-                setVehicle("car").setWeighting("fastest");
+                setVehicle(vehicle).setWeighting(weighting);
 
         GHResponse rsp = tmpHopper.route(req);
         assertFalse(rsp.getErrors().toString(), rsp.hasErrors());
@@ -403,13 +434,18 @@ public class GraphHopperIT {
 
     @Test
     public void testNorthBayreuthBlockedEdges() {
-        GraphHopper tmpHopper = createGraphHopper("car").
-                setOSMFile(DIR + "/north-bayreuth.osm.gz").
+        final String vehicle = "car";
+        final String weighting = "fastest";
+
+        GraphHopper tmpHopper = createGraphHopper(vehicle).
+                setOSMFile(BAYREUTH).
                 setCHEnabled(false).
                 setGraphHopperLocation(tmpGraphFile);
         tmpHopper.importOrLoad();
 
-        GHRequest req = new GHRequest(49.985272, 11.506151, 49.986107, 11.507202);
+        GHRequest req = new GHRequest(49.985272, 11.506151, 49.986107, 11.507202).
+                setVehicle(vehicle).
+                setWeighting(weighting);
 
         GHResponse rsp = tmpHopper.route(req);
         assertFalse(rsp.getErrors().toString(), rsp.hasErrors());
@@ -422,7 +458,8 @@ public class GraphHopperIT {
         assertEquals(365, rsp.getBest().getDistance(), 1);
 
         req = new GHRequest(49.975845, 11.522598, 50.026821, 11.497364).
-                setWeighting("fastest");
+                setVehicle(vehicle).
+                setWeighting(weighting);
 
         rsp = tmpHopper.route(req);
         assertFalse(rsp.getErrors().toString(), rsp.hasErrors());
@@ -462,7 +499,7 @@ public class GraphHopperIT {
 
         // blocking works for all weightings
         req = new GHRequest(50.009504, 11.490669, 50.024726, 11.496162).
-                setVehicle("car").setWeighting("fastest");
+                setVehicle(vehicle).setWeighting(weighting);
         rsp = tmpHopper.route(req);
         assertFalse(rsp.getErrors().toString(), rsp.hasErrors());
         assertEquals(1807, rsp.getBest().getDistance(), 1);
@@ -474,7 +511,9 @@ public class GraphHopperIT {
         assertEquals(3363, rsp.getBest().getDistance(), 1);
 
         // query point and snapped point are different => block snapped point only => show that block_area changes lookup
-        req = new GHRequest(49.984465, 11.507009, 49.986107, 11.507202);
+        req = new GHRequest(49.984465, 11.507009, 49.986107, 11.507202).
+                setVehicle(vehicle).
+                setWeighting(weighting);
         rsp = tmpHopper.route(req);
         assertEquals(11.506, rsp.getBest().getWaypoints().getLongitude(0), 0.001);
         assertFalse(rsp.getErrors().toString(), rsp.hasErrors());
@@ -487,7 +526,9 @@ public class GraphHopperIT {
         assertEquals(1185, rsp.getBest().getDistance(), 10);
 
         // first point is contained in block_area => error
-        req = new GHRequest(49.979, 11.516, 49.986107, 11.507202);
+        req = new GHRequest(49.979, 11.516, 49.986107, 11.507202).
+                setVehicle(vehicle).
+                setWeighting(weighting);
         req.getHints().put(Routing.BLOCK_AREA, "49.981875,11.515818,49.979522,11.521407");
         rsp = tmpHopper.route(req);
         assertTrue("expected errors", rsp.hasErrors());
@@ -495,12 +536,15 @@ public class GraphHopperIT {
 
     @Test
     public void testMonacoVia() {
+        final String vehicle = "foot";
+        final String weighting = "shortest";
+
         Translation tr = hopper.getTranslationMap().getWithFallBack(Locale.US);
         GHResponse rsp = hopper.route(new GHRequest().
                 addPoint(new GHPoint(43.727687, 7.418737)).
                 addPoint(new GHPoint(43.74958, 7.436566)).
                 addPoint(new GHPoint(43.727687, 7.418737)).
-                setAlgorithm(ASTAR).setVehicle(vehicle).setWeighting(weightCalcStr));
+                setAlgorithm(ASTAR).setVehicle(vehicle).setWeighting(weighting));
 
         PathWrapper arsp = rsp.getBest();
         assertEquals(6875.2, arsp.getDistance(), .1);
@@ -542,7 +586,7 @@ public class GraphHopperIT {
         rsp = hopper.route(new GHRequest().
                 addPoint(new GHPoint(43.727687, 7.418737)).
                 addPoint(new GHPoint(43.727687, 7.418737)).
-                setAlgorithm(ASTAR).setVehicle(vehicle).setWeighting(weightCalcStr));
+                setAlgorithm(ASTAR).setVehicle(vehicle).setWeighting(weighting));
 
         arsp = rsp.getBest();
         assertEquals(0, arsp.getDistance(), .1);
@@ -556,7 +600,7 @@ public class GraphHopperIT {
                 addPoint(new GHPoint(43.727687, 7.418737)).
                 addPoint(new GHPoint(43.727687, 7.418737)).
                 addPoint(new GHPoint(43.727687, 7.418737)).
-                setAlgorithm(ASTAR).setVehicle(vehicle).setWeighting(weightCalcStr));
+                setAlgorithm(ASTAR).setVehicle(vehicle).setWeighting(weighting));
 
         arsp = rsp.getBest();
         assertEquals(0, arsp.getDistance(), .1);
@@ -569,11 +613,14 @@ public class GraphHopperIT {
 
     @Test
     public void testMonacoPathDetails() {
+        final String vehicle = "foot";
+        final String weighting = "shortest";
+
         GHRequest request = new GHRequest();
         request.addPoint(new GHPoint(43.727687, 7.418737));
         request.addPoint(new GHPoint(43.74958, 7.436566));
         request.addPoint(new GHPoint(43.727687, 7.418737));
-        request.setAlgorithm(ASTAR).setVehicle(vehicle).setWeighting(weightCalcStr);
+        request.setAlgorithm(ASTAR).setVehicle(vehicle).setWeighting(weighting);
         request.setPathDetails(Collections.singletonList(Parameters.Details.AVERAGE_SPEED));
 
         GHResponse rsp = hopper.route(request);
@@ -591,10 +638,13 @@ public class GraphHopperIT {
 
     @Test
     public void testMonacoEnforcedDirection() {
+        final String vehicle = "foot";
+        final String weighting = "fastest";
+
         GHRequest req = new GHRequest().
                 addPoint(new GHPoint(43.741069, 7.426854), 0.).
                 addPoint(new GHPoint(43.744445, 7.429483), 190.).
-                setVehicle(vehicle).setWeighting("fastest");
+                setVehicle(vehicle).setWeighting(weighting);
         req.getHints().put(Routing.HEADING_PENALTY, "300");
         GHResponse rsp = hopper.route(req);
 
@@ -605,35 +655,41 @@ public class GraphHopperIT {
 
     @Test
     public void testMonacoMaxVisitedNodes() {
+        final String vehicle = "foot";
+        final String weighting = "fastest";
+
         GHPoint from = new GHPoint(43.741069, 7.426854);
         GHPoint to = new GHPoint(43.744445, 7.429483);
         GHRequest req = new GHRequest().
                 addPoint(from).
                 addPoint(to).
-                setVehicle(vehicle).setWeighting("fastest");
+                setVehicle(vehicle).setWeighting(weighting);
         req.getHints().put(Routing.MAX_VISITED_NODES, 5);
         GHResponse rsp = hopper.route(req);
 
-        assertTrue(rsp.hasErrors());
+        assertTrue(rsp.getErrors().toString(), rsp.hasErrors());
 
         req = new GHRequest().
                 addPoint(from).
                 addPoint(to).
-                setVehicle(vehicle).setWeighting("fastest");
+                setVehicle(vehicle).setWeighting(weighting);
         rsp = hopper.route(req);
 
-        assertFalse(rsp.hasErrors());
+        assertFalse(rsp.getErrors().toString(), rsp.hasErrors());
     }
 
     @Test
     public void testMonacoNonChMaxWaypointDistance() {
+        final String vehicle = "foot";
+        final String weighting = "fastest";
+
         GHPoint from = new GHPoint(43.741069, 7.426854);
         GHPoint to = new GHPoint(43.727697, 7.419199);
 
         GHRequest req = new GHRequest().
                 addPoint(from).
                 addPoint(to).
-                setVehicle(vehicle).setWeighting("fastest");
+                setVehicle(vehicle).setWeighting(weighting);
 
         // Fail since points are too far
         hopper.setNonChMaxWaypointDistance(1000);
@@ -645,11 +701,14 @@ public class GraphHopperIT {
         hopper.setNonChMaxWaypointDistance(Integer.MAX_VALUE);
         rsp = hopper.route(req);
 
-        assertFalse(rsp.hasErrors());
+        assertFalse(rsp.getErrors().toString(), rsp.hasErrors());
     }
 
     @Test
     public void testMonacoNonChMaxWaypointDistanceMultiplePoints() {
+        final String vehicle = "foot";
+        final String weighting = "fastest";
+
         GHPoint from = new GHPoint(43.741069, 7.426854);
         GHPoint via = new GHPoint(43.744445, 7.429483);
         GHPoint to = new GHPoint(43.727697, 7.419199);
@@ -658,7 +717,7 @@ public class GraphHopperIT {
                 addPoint(from).
                 addPoint(via).
                 addPoint(to).
-                setVehicle(vehicle).setWeighting("fastest");
+                setVehicle(vehicle).setWeighting(weighting);
 
         // Fail since points are too far
         hopper.setNonChMaxWaypointDistance(1000);
@@ -672,16 +731,19 @@ public class GraphHopperIT {
         hopper.setNonChMaxWaypointDistance(Integer.MAX_VALUE);
         rsp = hopper.route(req);
 
-        assertFalse(rsp.hasErrors());
+        assertFalse(rsp.getErrors().toString(), rsp.hasErrors());
     }
 
     @Test
     public void testMonacoStraightVia() {
+        final String vehicle = "foot";
+        final String weighting = "fastest";
+
         GHRequest rq = new GHRequest().
                 addPoint(new GHPoint(43.741069, 7.426854)).
                 addPoint(new GHPoint(43.740371, 7.426946)).
                 addPoint(new GHPoint(43.740794, 7.427294)).
-                setVehicle(vehicle).setWeighting("fastest");
+                setVehicle(vehicle).setWeighting(weighting);
         rq.getHints().put(Routing.PASS_THROUGH, true);
         GHResponse rsp = hopper.route(rq);
 
@@ -694,7 +756,7 @@ public class GraphHopperIT {
                 addPoint(new GHPoint(43.741069, 7.426854)).
                 addPoint(new GHPoint(43.741069, 7.426854)).
                 addPoint(new GHPoint(43.740371, 7.426946)).
-                setVehicle(vehicle).setWeighting("fastest");
+                setVehicle(vehicle).setWeighting(weighting);
         rq.getHints().put(Routing.PASS_THROUGH, true);
         rsp = hopper.route(rq);
         assertEquals(91, rsp.getBest().getDistance(), 5.);
@@ -702,8 +764,11 @@ public class GraphHopperIT {
 
     @Test
     public void testSRTMWithInstructions() {
-        GraphHopper tmpHopper = createGraphHopper(importVehicles).
-                setOSMFile(osmFile).
+        final String vehicle = "foot";
+        final String weighting = "shortest";
+
+        GraphHopper tmpHopper = createGraphHopper(vehicle).
+                setOSMFile(MONACO).
                 setStoreOnFlush(true).
                 setCHEnabled(false).
                 setGraphHopperLocation(tmpGraphFile);
@@ -712,7 +777,7 @@ public class GraphHopperIT {
         tmpHopper.importOrLoad();
 
         GHResponse rsp = tmpHopper.route(new GHRequest(43.730729, 7.421288, 43.727697, 7.419199).
-                setAlgorithm(ASTAR).setVehicle(vehicle).setWeighting(weightCalcStr));
+                setAlgorithm(ASTAR).setVehicle(vehicle).setWeighting(weighting));
 
         PathWrapper arsp = rsp.getBest();
         assertEquals(1625.4, arsp.getDistance(), .1);
@@ -752,7 +817,10 @@ public class GraphHopperIT {
 
     @Test
     public void testSRTMWithoutTunnelInterpolation() {
-        GraphHopper tmpHopper = new GraphHopperOSM().setOSMFile(osmFile).setStoreOnFlush(true)
+        final String vehicle = "foot";
+        final String weighting = "shortest";
+
+        GraphHopper tmpHopper = new GraphHopperOSM().setOSMFile(MONACO).setStoreOnFlush(true)
                 .setCHEnabled(false).setGraphHopperLocation(tmpGraphFile)
                 .setEncodingManager(EncodingManager.start().add(new OSMRoadEnvironmentParser() {
                     @Override
@@ -760,14 +828,14 @@ public class GraphHopperIT {
                         // do not change RoadEnvironment to avoid triggering tunnel interpolation - is this a valid use case after #TODONOW?
                         return edgeFlags;
                     }
-                }).addAll(new DefaultFlagEncoderFactory(), importVehicles).build());
+                }).addAll(new DefaultFlagEncoderFactory(), vehicle).build());
 
         tmpHopper.setElevationProvider(new SRTMProvider(DIR));
         tmpHopper.importOrLoad();
 
         GHResponse rsp = tmpHopper.route(new GHRequest(43.74056471749763, 7.4299266210693755,
                 43.73790260334179, 7.427984089259056).setAlgorithm(ASTAR)
-                .setVehicle(vehicle).setWeighting(weightCalcStr));
+                .setVehicle(vehicle).setWeighting(weighting));
         PathWrapper arsp = rsp.getBest();
         assertEquals(356.5, arsp.getDistance(), .1);
         PointList pointList = arsp.getPoints();
@@ -784,8 +852,11 @@ public class GraphHopperIT {
 
     @Test
     public void testSRTMWithTunnelInterpolation() {
+        final String vehicle = "foot";
+        final String weighting = "shortest";
+
         GraphHopper tmpHopper = createGraphHopper("car,foot")
-                .setOSMFile(osmFile).setStoreOnFlush(true)
+                .setOSMFile(MONACO).setStoreOnFlush(true)
                 .setCHEnabled(false).setGraphHopperLocation(tmpGraphFile);
 
         tmpHopper.setElevationProvider(new SRTMProvider(DIR));
@@ -793,7 +864,7 @@ public class GraphHopperIT {
 
         GHResponse rsp = tmpHopper.route(new GHRequest(43.74056471749763, 7.4299266210693755,
                 43.73790260334179, 7.427984089259056).setAlgorithm(ASTAR)
-                .setVehicle(vehicle).setWeighting(weightCalcStr));
+                .setVehicle(vehicle).setWeighting(weighting));
         PathWrapper arsp = rsp.getBest();
         // Without interpolation: 356.5
         assertEquals(351, arsp.getDistance(), .1);
@@ -811,13 +882,12 @@ public class GraphHopperIT {
 
     @Test
     public void testKremsCyclewayInstructionsWithWayTypeInfo() {
-        String tmpOsmFile = DIR + "/krems.osm.gz";
-        String tmpVehicle = "bike";
-        String tmpImportVehicles = "foot,bike";
-        String tmpWeightCalcStr = "fastest";
+        final String vehicle1 = "foot";
+        final String vehicle2 = "bike";
+        final String weighting = "fastest";
 
-        GraphHopper tmpHopper = createGraphHopper(tmpImportVehicles).
-                setOSMFile(tmpOsmFile).
+        GraphHopper tmpHopper = createGraphHopper(vehicle1 + "," + vehicle2).
+                setOSMFile(KREMS).
                 setStoreOnFlush(true).
                 setCHEnabled(false).
                 setGraphHopperLocation(tmpGraphFile).
@@ -825,7 +895,7 @@ public class GraphHopperIT {
 
         Translation tr = tmpHopper.getTranslationMap().getWithFallBack(Locale.US);
         GHResponse rsp = tmpHopper.route(new GHRequest(48.410987, 15.599492, 48.383419, 15.659294).
-                setVehicle(tmpVehicle).setWeighting(tmpWeightCalcStr));
+                setVehicle(vehicle2).setWeighting(weighting));
         assertFalse(rsp.hasErrors());
         PathWrapper arsp = rsp.getBest();
         assertEquals(6932.2, arsp.getDistance(), .1);
@@ -854,7 +924,7 @@ public class GraphHopperIT {
 
         // do not return 'get off bike' for foot
         rsp = tmpHopper.route(new GHRequest(48.410987, 15.599492, 48.411172, 15.600371).
-                setAlgorithm(ASTAR).setVehicle("foot").setWeighting(tmpWeightCalcStr));
+                setAlgorithm(ASTAR).setVehicle(vehicle1).setWeighting(weighting));
         assertFalse(rsp.hasErrors());
         il = rsp.getBest().getInstructions();
         assertEquals("continue onto Obere Landstraße", il.get(0).getTurnDescription(tr));
@@ -863,62 +933,58 @@ public class GraphHopperIT {
 
     @Test
     public void testRoundaboutInstructionsWithCH() {
-        String tmpOsmFile = DIR + "/monaco.osm.gz";
-        String tmpVehicle = "car";
-        String tmpImportVehicles = "car,bike";
-        String tmpWeightCalcStr = "fastest";
+        final String vehicle = "car";
+        final String weighting = "fastest";
 
-        GraphHopper tmpHopper = createGraphHopper(tmpImportVehicles).
-                setOSMFile(tmpOsmFile).
+        GraphHopper tmpHopper = createGraphHopper(vehicle + ",bike").
+                setOSMFile(MONACO).
                 setStoreOnFlush(true).
                 setGraphHopperLocation(tmpGraphFile).
                 importOrLoad();
 
-        assertEquals(tmpVehicle, tmpHopper.getDefaultVehicle().toString());
+        assertEquals(vehicle, tmpHopper.getDefaultVehicle().toString());
 
         assertEquals(2, tmpHopper.getCHPreparationHandler().getPreparations().size());
 
         GHResponse rsp = tmpHopper.route(new GHRequest(43.745084, 7.430513, 43.745247, 7.430347)
-                .setVehicle(tmpVehicle).setWeighting(tmpWeightCalcStr));
+                .setVehicle(vehicle).setWeighting(weighting));
 
         PathWrapper arsp = rsp.getBest();
         assertEquals(2, ((RoundaboutInstruction) arsp.getInstructions().get(1)).getExitNumber());
 
         rsp = tmpHopper.route(new GHRequest(43.745968, 7.42907, 43.745832, 7.428614)
-                .setVehicle(tmpVehicle).setWeighting(tmpWeightCalcStr));
+                .setVehicle(vehicle).setWeighting(weighting));
         arsp = rsp.getBest();
         assertEquals(2, ((RoundaboutInstruction) arsp.getInstructions().get(1)).getExitNumber());
 
         rsp = tmpHopper.route(new GHRequest(43.745948, 7.42914, 43.746173, 7.428834)
-                .setVehicle(tmpVehicle).setWeighting(tmpWeightCalcStr));
+                .setVehicle(vehicle).setWeighting(weighting));
         arsp = rsp.getBest();
         assertEquals(1, ((RoundaboutInstruction) arsp.getInstructions().get(1)).getExitNumber());
 
         rsp = tmpHopper.route(new GHRequest(43.735817, 7.417096, 43.735666, 7.416587)
-                .setVehicle(tmpVehicle).setWeighting(tmpWeightCalcStr));
+                .setVehicle(vehicle).setWeighting(weighting));
         arsp = rsp.getBest();
         assertEquals(2, ((RoundaboutInstruction) arsp.getInstructions().get(1)).getExitNumber());
     }
 
     @Test
     public void testCircularJunctionInstructionsWithCH() {
-        String tmpOsmFile = DIR + "/berlin-siegessaeule.osm.gz";
-        String tmpVehicle = "car";
-        String tmpImportVehicles = "car,bike";
-        String tmpWeightCalcStr = "fastest";
+        String vehicle = "car";
+        String weighting = "fastest";
 
-        GraphHopper tmpHopper = createGraphHopper(tmpImportVehicles).
-                setOSMFile(tmpOsmFile).
+        GraphHopper tmpHopper = createGraphHopper(vehicle + ",bike").
+                setOSMFile(BERLIN).
                 setStoreOnFlush(true).
                 setGraphHopperLocation(tmpGraphFile).
                 importOrLoad();
 
-        assertEquals(tmpVehicle, tmpHopper.getDefaultVehicle().toString());
+        assertEquals(vehicle, tmpHopper.getDefaultVehicle().toString());
 
         assertEquals(2, tmpHopper.getCHPreparationHandler().getPreparations().size());
 
         GHResponse rsp = tmpHopper.route(new GHRequest(52.513505, 13.350443, 52.513505, 13.350245)
-                .setVehicle(tmpVehicle).setWeighting(tmpWeightCalcStr));
+                .setVehicle(vehicle).setWeighting(weighting));
 
         Instruction instr = rsp.getBest().getInstructions().get(1);
         assertTrue(instr instanceof RoundaboutInstruction);
@@ -928,24 +994,25 @@ public class GraphHopperIT {
 
     @Test
     public void testMultipleVehiclesWithCH() {
-        String tmpOsmFile = DIR + "/monaco.osm.gz";
-        GraphHopper tmpHopper = createGraphHopper("bike,car").
-                setOSMFile(tmpOsmFile).
+        final String vehicle1 = "bike";
+        final String vehicle2 = "car";
+        GraphHopper tmpHopper = createGraphHopper(vehicle1 + "," + vehicle2).
+                setOSMFile(MONACO).
                 setStoreOnFlush(true).
                 setGraphHopperLocation(tmpGraphFile).
                 importOrLoad();
-        assertEquals("bike", tmpHopper.getDefaultVehicle().toString());
+        assertEquals(vehicle1, tmpHopper.getDefaultVehicle().toString());
         checkMultiVehiclesWithCH(tmpHopper);
         tmpHopper.close();
 
         tmpHopper.clean();
         // new instance, try different order, resulting only in different default vehicle
-        tmpHopper = createGraphHopper("car,bike").
-                setOSMFile(tmpOsmFile).
+        tmpHopper = createGraphHopper(vehicle2 + ", " + vehicle1).
+                setOSMFile(MONACO).
                 setStoreOnFlush(true).
                 setGraphHopperLocation(tmpGraphFile).
                 importOrLoad();
-        assertEquals("car", tmpHopper.getDefaultVehicle().toString());
+        assertEquals(vehicle2, tmpHopper.getDefaultVehicle().toString());
         checkMultiVehiclesWithCH(tmpHopper);
         tmpHopper.close();
     }
@@ -953,21 +1020,24 @@ public class GraphHopperIT {
     private void checkMultiVehiclesWithCH(GraphHopper tmpHopper) {
         String str = tmpHopper.getEncodingManager().toString();
         GHResponse rsp = tmpHopper.route(new GHRequest(43.73005, 7.415707, 43.741522, 7.42826)
-                .setVehicle("car"));
+                .setVehicle("car")
+                .setWeighting("fastest"));
         PathWrapper arsp = rsp.getBest();
         assertFalse("car routing for " + str + " should not have errors:" + rsp.getErrors(), rsp.hasErrors());
         assertEquals(207, arsp.getTime() / 1000f, 1);
         assertEquals(2838, arsp.getDistance(), 1);
 
         rsp = tmpHopper.route(new GHRequest(43.73005, 7.415707, 43.741522, 7.42826)
-                .setVehicle("bike"));
+                .setVehicle("bike")
+                .setWeighting("fastest"));
         arsp = rsp.getBest();
         assertFalse("bike routing for " + str + " should not have errors:" + rsp.getErrors(), rsp.hasErrors());
         assertEquals(494, arsp.getTime() / 1000f, 1);
         assertEquals(2192, arsp.getDistance(), 1);
 
         rsp = tmpHopper.route(new GHRequest(43.73005, 7.415707, 43.741522, 7.42826)
-                .setVehicle("foot"));
+                .setVehicle("foot")
+                .setWeighting("fastest"));
         assertTrue("only bike and car were imported. foot request should fail", rsp.hasErrors());
 
         GHRequest req = new GHRequest().
@@ -989,19 +1059,19 @@ public class GraphHopperIT {
     }
 
     private void executeCHFootRoute(boolean sort) {
-        String tmpOsmFile = DIR + "/monaco.osm.gz";
-
-        GraphHopper tmpHopper = createGraphHopper("foot").
-                setOSMFile(tmpOsmFile).
+        final String vehicle = "foot";
+        final String weighting = "shortest";
+        GraphHopper tmpHopper = createGraphHopper(vehicle).
+                setOSMFile(MONACO).
                 setStoreOnFlush(true).
                 setSortGraph(sort).
                 setGraphHopperLocation(tmpGraphFile);
-        tmpHopper.getCHPreparationHandler().setCHProfileStrings(weightCalcStr);
+        tmpHopper.getCHPreparationHandler().setCHProfileStrings(weighting);
         tmpHopper.importOrLoad();
 
         // same query as in testMonacoWithInstructions
         GHResponse rsp = tmpHopper.route(new GHRequest(43.727687, 7.418737, 43.74958, 7.436566).
-                setVehicle(vehicle));
+                setVehicle(vehicle).setWeighting(weighting));
 
         PathWrapper bestPath = rsp.getBest();
         // identify the number of counts to compare with none-CH foot route which had nearly 700 counts
@@ -1025,9 +1095,11 @@ public class GraphHopperIT {
 
     @Test
     public void testRoundTour() {
+        final String vehicle = "foot";
+        final String weighting = "fastest";
         GHRequest rq = new GHRequest().
                 addPoint(new GHPoint(43.741069, 7.426854), 50).
-                setVehicle(vehicle).setWeighting("fastest").
+                setVehicle(vehicle).setWeighting(weighting).
                 setAlgorithm(ROUND_TRIP);
         rq.getHints().put(RoundTrip.DISTANCE, 1000);
         rq.getHints().put(RoundTrip.SEED, 0);
@@ -1043,8 +1115,11 @@ public class GraphHopperIT {
 
     @Test
     public void testPathDetails1216() {
-        GraphHopper tmpHopper = createGraphHopper("car").
-                setOSMFile(DIR + "/north-bayreuth.osm.gz").
+        final String vehicle = "car";
+        final String weighting = "fastest";
+
+        GraphHopper tmpHopper = createGraphHopper(vehicle).
+                setOSMFile(BAYREUTH).
                 setCHEnabled(false).
                 setGraphHopperLocation(tmpGraphFile);
         tmpHopper.importOrLoad();
@@ -1054,18 +1129,19 @@ public class GraphHopperIT {
                 // This is exactly between two edges with different speed values
                         addPoint(new GHPoint(49.984565, 11.499188)).
                         addPoint(new GHPoint(49.9847, 11.499612)).
-                        setVehicle("car").setWeighting("fastest").
+                        setVehicle(vehicle).setWeighting(weighting).
                         setPathDetails(Collections.singletonList(Parameters.Details.AVERAGE_SPEED));
 
         GHResponse rsp = tmpHopper.route(req);
-
-        assertFalse(rsp.hasErrors());
+        assertFalse(rsp.getErrors().toString(), rsp.hasErrors());
     }
 
     @Test
     public void testPathDetailsSamePoint() {
-        GraphHopper tmpHopper = createGraphHopper("car").
-                setOSMFile(DIR + "/north-bayreuth.osm.gz").
+        final String vehicle = "car";
+        final String weighting = "fastest";
+        GraphHopper tmpHopper = createGraphHopper(vehicle).
+                setOSMFile(BAYREUTH).
                 setCHEnabled(false).
                 setGraphHopperLocation(tmpGraphFile);
         tmpHopper.importOrLoad();
@@ -1073,7 +1149,7 @@ public class GraphHopperIT {
         GHRequest req = new GHRequest().
                 addPoint(new GHPoint(49.984352, 11.498802)).
                 addPoint(new GHPoint(49.984352, 11.498802)).
-                setVehicle("car").setWeighting("fastest").
+                setVehicle(vehicle).setWeighting(weighting).
                 setPathDetails(Collections.singletonList(Parameters.Details.AVERAGE_SPEED));
 
         GHResponse rsp = tmpHopper.route(req);
@@ -1083,24 +1159,25 @@ public class GraphHopperIT {
 
     @Test
     public void testFlexMode_631() {
-        String tmpOsmFile = DIR + "/monaco.osm.gz";
-
-        GraphHopper tmpHopper = createGraphHopper("car").
-                setOSMFile(tmpOsmFile).
+        final String vehicle = "car";
+        final String weighting = "fastest";
+        GraphHopper tmpHopper = createGraphHopper(vehicle).
+                setOSMFile(MONACO).
                 setStoreOnFlush(true).
                 setGraphHopperLocation(tmpGraphFile);
 
         tmpHopper.getCHPreparationHandler().setEnabled(true).
-                setCHProfilesAsStrings(Collections.singletonList("fastest")).
+                setCHProfilesAsStrings(Collections.singletonList(weighting)).
                 setDisablingAllowed(true);
 
         tmpHopper.getLMPreparationHandler().setEnabled(true).
-                setLMProfileStrings(Collections.singletonList("fastest|maximum=2000")).
+                setLMProfileStrings(Collections.singletonList(weighting + "|maximum=2000")).
                 setDisablingAllowed(true);
 
         tmpHopper.importOrLoad();
         GHRequest req = new GHRequest(43.727687, 7.418737, 43.74958, 7.436566).
-                setVehicle("car");
+                setVehicle(vehicle).
+                setWeighting(weighting);
         req.getHints().put(Landmark.DISABLE, true);
         req.getHints().put(CH.DISABLE, false);
 
@@ -1142,23 +1219,26 @@ public class GraphHopperIT {
 
     @Test
     public void testPreparedProfileNotAvailable() {
-        GraphHopper hopper = createGraphHopper("car").
-                setOSMFile(DIR + "/monaco.osm.gz").
+        final String vehicle = "car";
+        final String weighting = "fastest";
+
+        GraphHopper hopper = createGraphHopper(vehicle).
+                setOSMFile(MONACO).
                 setStoreOnFlush(true).
                 setGraphHopperLocation(tmpGraphFile);
 
         hopper.getCHPreparationHandler().setEnabled(true).
-                setCHProfilesAsStrings(Collections.singletonList("fastest")).
+                setCHProfilesAsStrings(Collections.singletonList(weighting)).
                 setDisablingAllowed(true);
 
         hopper.getLMPreparationHandler().setEnabled(true).
-                setLMProfileStrings(Collections.singletonList("fastest|maximum=2000")).
+                setLMProfileStrings(Collections.singletonList(weighting +"|maximum=2000")).
                 setDisablingAllowed(true);
 
         hopper.importOrLoad();
         // request a weighting that was not prepared
         GHRequest req = new GHRequest(43.727687, 7.418737, 43.74958, 7.436566).
-                setVehicle("car").
+                setVehicle(vehicle).
                 setWeighting("short_fastest");
 
         // try with CH
@@ -1186,21 +1266,24 @@ public class GraphHopperIT {
     @Test
     public void testDisablingLM() {
         // setup GH with LM preparation but no CH preparation
-        String osmFile = DIR + "/monaco.osm.gz";
-        GraphHopper hopper = createGraphHopper("car,bike").
-                setOSMFile(osmFile).
+        final String vehicle = "car";
+        final String weighting = "fastest";
+        // note that the pure presence of the bike encoder leads to 'ghost' junctions with the bike network even for
+        // cars such that the number of visited nodes depends on the bike encoder added here or not, #1910
+        GraphHopper hopper = createGraphHopper(vehicle + ",bike").
+                setOSMFile(MONACO).
                 setStoreOnFlush(true).
                 setGraphHopperLocation(tmpGraphFile);
         hopper.getCHPreparationHandler().setEnabled(false);
         hopper.getLMPreparationHandler().setEnabled(true).
-                setLMProfileStrings(Collections.singletonList("fastest|maximum=2000")).
+                setLMProfileStrings(Collections.singletonList(weighting + "|maximum=2000")).
                 setDisablingAllowed(true);
         hopper.importOrLoad();
 
         // we can switch LM on/off
         GHRequest req = new GHRequest(43.727687, 7.418737, 43.74958, 7.436566).
-                setVehicle("car").
-                setWeighting("fastest");
+                setVehicle(vehicle).
+                setWeighting(weighting);
 
         req.getHints().put(Landmark.DISABLE, false);
         GHResponse res = hopper.route(req);
@@ -1214,7 +1297,7 @@ public class GraphHopperIT {
     @Test
     public void testTurnCostsOnOff() {
         GraphHopper tmpHopper = createGraphHopper("car|turn_costs=true").
-                setOSMFile(DIR + "/moscow.osm.gz").
+                setOSMFile(MOSCOW).
                 setStoreOnFlush(true).
                 setCHEnabled(false).
                 setGraphHopperLocation(tmpGraphFile);
@@ -1231,7 +1314,7 @@ public class GraphHopperIT {
     @Test
     public void testTurnCostsOnOffCH() {
         GraphHopper tmpHopper = createGraphHopper("car|turn_costs=true").
-                setOSMFile(DIR + "/moscow.osm.gz").
+                setOSMFile(MOSCOW).
                 setStoreOnFlush(true).
                 setCHEnabled(true).
                 setGraphHopperLocation(tmpGraphFile);
@@ -1250,7 +1333,7 @@ public class GraphHopperIT {
     @Test
     public void testCHOnOffWithTurnCosts() {
         GraphHopper tmpHopper = createGraphHopper("car|turn_costs=true").
-                setOSMFile(DIR + "/moscow.osm.gz").
+                setOSMFile(MOSCOW).
                 setStoreOnFlush(true).
                 setCHEnabled(true).
                 setGraphHopperLocation(tmpGraphFile);
@@ -1271,7 +1354,7 @@ public class GraphHopperIT {
     public void testNodeBasedCHOnlyButTurnCostForNonCH() {
         // before edge-based CH was added a common case was to use edge-based without CH and CH for node-based
         GraphHopper tmpHopper = createGraphHopper("car|turn_costs=true").
-                setOSMFile(DIR + "/moscow.osm.gz").
+                setOSMFile(MOSCOW).
                 setStoreOnFlush(true).
                 setCHEnabled(true).
                 setGraphHopperLocation(tmpGraphFile);
@@ -1302,7 +1385,7 @@ public class GraphHopperIT {
         // when there is only one edge-based CH profile, there is no need to specify edge_based=true explicitly,
         // see #1637
         GraphHopper tmpHopper = createGraphHopper("car|turn_costs=true").
-                setOSMFile(DIR + "/moscow.osm.gz").
+                setOSMFile(MOSCOW).
                 setStoreOnFlush(true).
                 setCHEnabled(true).
                 setGraphHopperLocation(tmpGraphFile);
@@ -1346,11 +1429,12 @@ public class GraphHopperIT {
 
     @Test
     public void testEdgeBasedRequiresTurnCostSupport() {
+        String vehicle = "foot";
         GHPoint p = new GHPoint(43.727687, 7.418737);
         GHPoint q = new GHPoint(43.74958, 7.436566);
         GHRequest req = new GHRequest(p, q);
         req.getHints().put(Routing.EDGE_BASED, true);
-        req.setVehicle("foot");
+        req.setVehicle(vehicle);
         GHResponse rsp = hopper.route(req);
         assertTrue(rsp.hasErrors());
         assertTrue("using edge-based for encoder without turncost support should be an error, but got:\n" + rsp.getErrors(),
@@ -1361,7 +1445,7 @@ public class GraphHopperIT {
     public void testEncoderWithTurnCostSupport_stillAllows_nodeBasedRouting() {
         // see #1698
         GraphHopper tmpHopper = createGraphHopper("foot,car|turn_costs=true").
-                setOSMFile(DIR + "/moscow.osm.gz").
+                setOSMFile(MOSCOW).
                 setGraphHopperLocation(tmpGraphFile).
                 setCHEnabled(false);
         tmpHopper.importOrLoad();
@@ -1376,7 +1460,7 @@ public class GraphHopperIT {
     @Test
     public void testCurbsides() {
         GraphHopper h = createGraphHopper("car|turn_costs=true").
-                setOSMFile(DIR + "/north-bayreuth.osm.gz").
+                setOSMFile(BAYREUTH).
                 setCHEnabled(true).
                 setGraphHopperLocation(tmpGraphFile);
         h.getCHPreparationHandler()
@@ -1423,7 +1507,7 @@ public class GraphHopperIT {
     @Test
     public void testForceCurbsides() {
         GraphHopper h = createGraphHopper("car|turn_costs=true").
-                setOSMFile(DIR + "/monaco.osm.gz").
+                setOSMFile(MONACO).
                 setCHEnabled(true).
                 setGraphHopperLocation(tmpGraphFile);
         h.getCHPreparationHandler()
@@ -1488,7 +1572,7 @@ public class GraphHopperIT {
     @Test
     public void testCHWithFiniteUTurnCostsAndMissingWeighting() {
         GraphHopper h = createGraphHopper("car|turn_costs=true").
-                setOSMFile(DIR + "/monaco.osm.gz").
+                setOSMFile(MONACO).
                 setCHEnabled(true).
                 setGraphHopperLocation(tmpGraphFile);
         h.getCHPreparationHandler()
@@ -1514,7 +1598,7 @@ public class GraphHopperIT {
     @Test
     public void simplifyWithInstructionsAndPathDetails() {
         GraphHopper hopper = new GraphHopperOSM().
-                setOSMFile(DIR + "/north-bayreuth.osm.gz").
+                setOSMFile(BAYREUTH).
                 setCHEnabled(false).
                 setGraphHopperLocation(tmpGraphFile).
                 forServer();

--- a/reader-osm/src/test/java/com/graphhopper/GraphHopperIT.java
+++ b/reader-osm/src/test/java/com/graphhopper/GraphHopperIT.java
@@ -76,7 +76,6 @@ public class GraphHopperIT {
                 setOSMFile(MONACO).
                 setStoreOnFlush(true).
                 setCHEnabled(false).
-                setGraphHopperLocation(GH_LOCATION).
                 importOrLoad();
 
         GHResponse rsp = hopper.route(new GHRequest(43.727687, 7.418737, 43.74958, 7.436566).
@@ -128,7 +127,6 @@ public class GraphHopperIT {
                 setOSMFile(MONACO).
                 setStoreOnFlush(true).
                 setCHEnabled(false).
-                setGraphHopperLocation(GH_LOCATION).
                 importOrLoad();
 
         GHRequest request = new GHRequest().setAlgorithm(ASTAR).setVehicle(vehicle).setWeighting(weighting);
@@ -150,9 +148,8 @@ public class GraphHopperIT {
         final String vehicle = "car";
         final String weighting = "shortest";
         GraphHopper hopper = createGraphHopper(vehicle).
-                setOSMFile(DIR + "/monaco.osm.gz").
-                setCHEnabled(false).
-                setGraphHopperLocation(GH_LOCATION);
+                setOSMFile(MONACO).
+                setCHEnabled(false);
         hopper.importOrLoad();
         Translation tr = hopper.getTranslationMap().getWithFallBack(Locale.US);
 
@@ -182,8 +179,7 @@ public class GraphHopperIT {
                 setOSMFile(MONACO).
                 setStoreOnFlush(true).
                 setCHEnabled(ch).
-                setSortGraph(sort).
-                setGraphHopperLocation(GH_LOCATION);
+                setSortGraph(sort);
         if (ch) {
             hopper.getCHPreparationHandler().setCHProfileStrings(weighting).setDisablingAllowed(true);
         }
@@ -197,8 +193,7 @@ public class GraphHopperIT {
         hopper = createGraphHopper(vehicle).
                 setOSMFile(MONACO).
                 setStoreOnFlush(true).
-                setCHEnabled(ch).
-                setGraphHopperLocation(GH_LOCATION);
+                setCHEnabled(ch);
         if (ch) {
             hopper.getCHPreparationHandler().setCHProfileStrings(weighting).setDisablingAllowed(true);
         }
@@ -297,7 +292,6 @@ public class GraphHopperIT {
                 setOSMFile(MONACO).
                 setStoreOnFlush(true).
                 setCHEnabled(false).
-                setGraphHopperLocation(GH_LOCATION).
                 importOrLoad();
 
         GHRequest req = new GHRequest(43.729057, 7.41251, 43.740298, 7.423561).
@@ -326,11 +320,9 @@ public class GraphHopperIT {
         final String vehicle = "bike";
         final String weighting = "fastest";
 
-        GraphHopper hopper = new GraphHopperOSM().
+        GraphHopper hopper = createGraphHopper(vehicle).
                 setOSMFile(BAYREUTH).
-                setCHEnabled(false).
-                setGraphHopperLocation(GH_LOCATION).
-                setEncodingManager(EncodingManager.create(vehicle));
+                setCHEnabled(false);
         hopper.importOrLoad();
 
         GHRequest req = new GHRequest(50.028917, 11.496506, 49.985228, 11.600876).
@@ -353,11 +345,9 @@ public class GraphHopperIT {
         final String vehicle = "car";
         final String weighting = "fastest";
 
-        GraphHopper hopper = new GraphHopperOSM().
+        GraphHopper hopper = createGraphHopper(vehicle).
                 setOSMFile(BAYREUTH).
-                setCHEnabled(false).
-                setGraphHopperLocation(GH_LOCATION).
-                setEncodingManager(EncodingManager.create(vehicle));
+                setCHEnabled(false);
         hopper.importOrLoad();
 
         GHRequest req = new GHRequest(50.023513, 11.548862, 49.969441, 11.537876).
@@ -382,8 +372,7 @@ public class GraphHopperIT {
 
         GraphHopper hopper = createGraphHopper(vehicle).
                 setOSMFile(LAUF).
-                setCHEnabled(false).
-                setGraphHopperLocation(GH_LOCATION);
+                setCHEnabled(false);
         hopper.importOrLoad();
 
         GHRequest req = new GHRequest(49.46553, 11.154669, 49.465244, 11.152577).
@@ -419,8 +408,7 @@ public class GraphHopperIT {
 
         GraphHopper hopper = createGraphHopper(vehicle).
                 setOSMFile(BAYREUTH).
-                setCHEnabled(false).
-                setGraphHopperLocation(GH_LOCATION);
+                setCHEnabled(false);
         hopper.importOrLoad();
 
         GHRequest req = new GHRequest(49.985307, 11.50628, 49.985731, 11.507465).
@@ -438,8 +426,7 @@ public class GraphHopperIT {
 
         GraphHopper hopper = createGraphHopper(vehicle).
                 setOSMFile(BAYREUTH).
-                setCHEnabled(false).
-                setGraphHopperLocation(GH_LOCATION);
+                setCHEnabled(false);
         hopper.importOrLoad();
 
         GHRequest req = new GHRequest(49.985272, 11.506151, 49.986107, 11.507202).
@@ -541,7 +528,6 @@ public class GraphHopperIT {
                 setOSMFile(MONACO).
                 setStoreOnFlush(true).
                 setCHEnabled(false).
-                setGraphHopperLocation(GH_LOCATION).
                 importOrLoad();
 
         Translation tr = hopper.getTranslationMap().getWithFallBack(Locale.US);
@@ -624,7 +610,6 @@ public class GraphHopperIT {
                 setOSMFile(MONACO).
                 setStoreOnFlush(true).
                 setCHEnabled(false).
-                setGraphHopperLocation(GH_LOCATION).
                 importOrLoad();
 
         GHRequest request = new GHRequest();
@@ -655,7 +640,6 @@ public class GraphHopperIT {
                 setOSMFile(MONACO).
                 setStoreOnFlush(true).
                 setCHEnabled(false).
-                setGraphHopperLocation(GH_LOCATION).
                 importOrLoad();
 
         GHRequest req = new GHRequest().
@@ -678,7 +662,6 @@ public class GraphHopperIT {
                 setOSMFile(MONACO).
                 setStoreOnFlush(true).
                 setCHEnabled(false).
-                setGraphHopperLocation(GH_LOCATION).
                 importOrLoad();
 
         GHPoint from = new GHPoint(43.741069, 7.426854);
@@ -709,7 +692,6 @@ public class GraphHopperIT {
                 setOSMFile(MONACO).
                 setStoreOnFlush(true).
                 setCHEnabled(false).
-                setGraphHopperLocation(GH_LOCATION).
                 importOrLoad();
 
         GHPoint from = new GHPoint(43.741069, 7.426854);
@@ -741,7 +723,6 @@ public class GraphHopperIT {
                 setOSMFile(MONACO).
                 setStoreOnFlush(true).
                 setCHEnabled(false).
-                setGraphHopperLocation(GH_LOCATION).
                 importOrLoad();
 
         GHPoint from = new GHPoint(43.741069, 7.426854);
@@ -777,7 +758,6 @@ public class GraphHopperIT {
                 setOSMFile(MONACO).
                 setStoreOnFlush(true).
                 setCHEnabled(false).
-                setGraphHopperLocation(GH_LOCATION).
                 importOrLoad();
 
         GHRequest rq = new GHRequest().
@@ -811,8 +791,7 @@ public class GraphHopperIT {
         GraphHopper hopper = createGraphHopper(vehicle).
                 setOSMFile(MONACO).
                 setStoreOnFlush(true).
-                setCHEnabled(false).
-                setGraphHopperLocation(GH_LOCATION);
+                setCHEnabled(false);
 
         hopper.setElevationProvider(new SRTMProvider(DIR));
         hopper.importOrLoad();
@@ -861,8 +840,11 @@ public class GraphHopperIT {
         final String vehicle = "foot";
         final String weighting = "shortest";
 
-        GraphHopper hopper = new GraphHopperOSM().setOSMFile(MONACO).setStoreOnFlush(true)
-                .setCHEnabled(false).setGraphHopperLocation(GH_LOCATION)
+        GraphHopper hopper = new GraphHopperOSM()
+                .setOSMFile(MONACO)
+                .setStoreOnFlush(true)
+                .setCHEnabled(false)
+                .setGraphHopperLocation(GH_LOCATION)
                 .setEncodingManager(EncodingManager.start().add(new OSMRoadEnvironmentParser() {
                     @Override
                     public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay readerWay, boolean ferry, IntsRef relationFlags) {
@@ -897,8 +879,9 @@ public class GraphHopperIT {
         final String weighting = "shortest";
 
         GraphHopper hopper = createGraphHopper("car,foot")
-                .setOSMFile(MONACO).setStoreOnFlush(true)
-                .setCHEnabled(false).setGraphHopperLocation(GH_LOCATION);
+                .setOSMFile(MONACO)
+                .setStoreOnFlush(true)
+                .setCHEnabled(false);
 
         hopper.setElevationProvider(new SRTMProvider(DIR));
         hopper.importOrLoad();
@@ -931,7 +914,6 @@ public class GraphHopperIT {
                 setOSMFile(KREMS).
                 setStoreOnFlush(true).
                 setCHEnabled(false).
-                setGraphHopperLocation(GH_LOCATION).
                 importOrLoad();
 
         Translation tr = hopper.getTranslationMap().getWithFallBack(Locale.US);
@@ -980,7 +962,6 @@ public class GraphHopperIT {
         GraphHopper hopper = createGraphHopper(vehicle + ",bike").
                 setOSMFile(MONACO).
                 setStoreOnFlush(true).
-                setGraphHopperLocation(GH_LOCATION).
                 importOrLoad();
 
         assertEquals(vehicle, hopper.getDefaultVehicle().toString());
@@ -1017,7 +998,6 @@ public class GraphHopperIT {
         GraphHopper hopper = createGraphHopper(vehicle + ",bike").
                 setOSMFile(BERLIN).
                 setStoreOnFlush(true).
-                setGraphHopperLocation(GH_LOCATION).
                 importOrLoad();
 
         assertEquals(vehicle, hopper.getDefaultVehicle().toString());
@@ -1040,7 +1020,6 @@ public class GraphHopperIT {
         GraphHopper hopper = createGraphHopper(vehicle1 + "," + vehicle2).
                 setOSMFile(MONACO).
                 setStoreOnFlush(true).
-                setGraphHopperLocation(GH_LOCATION).
                 importOrLoad();
         assertEquals(vehicle1, hopper.getDefaultVehicle().toString());
         checkMultiVehiclesWithCH(hopper);
@@ -1051,7 +1030,6 @@ public class GraphHopperIT {
         hopper = createGraphHopper(vehicle2 + ", " + vehicle1).
                 setOSMFile(MONACO).
                 setStoreOnFlush(true).
-                setGraphHopperLocation(GH_LOCATION).
                 importOrLoad();
         assertEquals(vehicle2, hopper.getDefaultVehicle().toString());
         checkMultiVehiclesWithCH(hopper);
@@ -1105,8 +1083,7 @@ public class GraphHopperIT {
         GraphHopper hopper = createGraphHopper(vehicle).
                 setOSMFile(MONACO).
                 setStoreOnFlush(true).
-                setSortGraph(sort).
-                setGraphHopperLocation(GH_LOCATION);
+                setSortGraph(sort);
         hopper.getCHPreparationHandler().setCHProfileStrings(weighting);
         hopper.importOrLoad();
 
@@ -1142,7 +1119,6 @@ public class GraphHopperIT {
                 setOSMFile(MONACO).
                 setStoreOnFlush(true).
                 setCHEnabled(false).
-                setGraphHopperLocation(GH_LOCATION).
                 importOrLoad();
 
         GHRequest rq = new GHRequest().
@@ -1168,8 +1144,7 @@ public class GraphHopperIT {
 
         GraphHopper hopper = createGraphHopper(vehicle).
                 setOSMFile(BAYREUTH).
-                setCHEnabled(false).
-                setGraphHopperLocation(GH_LOCATION);
+                setCHEnabled(false);
         hopper.importOrLoad();
 
         GHRequest req = new GHRequest().
@@ -1190,8 +1165,7 @@ public class GraphHopperIT {
         final String weighting = "fastest";
         GraphHopper hopper = createGraphHopper(vehicle).
                 setOSMFile(BAYREUTH).
-                setCHEnabled(false).
-                setGraphHopperLocation(GH_LOCATION);
+                setCHEnabled(false);
         hopper.importOrLoad();
 
         GHRequest req = new GHRequest().
@@ -1211,8 +1185,7 @@ public class GraphHopperIT {
         final String weighting = "fastest";
         GraphHopper hopper = createGraphHopper(vehicle).
                 setOSMFile(MONACO).
-                setStoreOnFlush(true).
-                setGraphHopperLocation(GH_LOCATION);
+                setStoreOnFlush(true);
 
         hopper.getCHPreparationHandler().setEnabled(true).
                 setCHProfilesAsStrings(Collections.singletonList(weighting)).
@@ -1272,8 +1245,7 @@ public class GraphHopperIT {
 
         GraphHopper hopper = createGraphHopper(vehicle).
                 setOSMFile(MONACO).
-                setStoreOnFlush(true).
-                setGraphHopperLocation(GH_LOCATION);
+                setStoreOnFlush(true);
 
         hopper.getCHPreparationHandler().setEnabled(true).
                 setCHProfilesAsStrings(Collections.singletonList(weighting)).
@@ -1320,8 +1292,7 @@ public class GraphHopperIT {
         // cars such that the number of visited nodes depends on the bike encoder added here or not, #1910
         GraphHopper hopper = createGraphHopper(vehicle + ",bike").
                 setOSMFile(MONACO).
-                setStoreOnFlush(true).
-                setGraphHopperLocation(GH_LOCATION);
+                setStoreOnFlush(true);
         hopper.getCHPreparationHandler().setEnabled(false);
         hopper.getLMPreparationHandler().setEnabled(true).
                 setLMProfileStrings(Collections.singletonList(weighting + "|maximum=2000")).
@@ -1347,8 +1318,7 @@ public class GraphHopperIT {
         GraphHopper hopper = createGraphHopper("car|turn_costs=true").
                 setOSMFile(MOSCOW).
                 setStoreOnFlush(true).
-                setCHEnabled(false).
-                setGraphHopperLocation(GH_LOCATION);
+                setCHEnabled(false);
         hopper.importOrLoad();
 
         // no edge_based parameter -> use edge-based (since encoder supports it and no CH)
@@ -1364,8 +1334,7 @@ public class GraphHopperIT {
         GraphHopper hopper = createGraphHopper("car|turn_costs=true").
                 setOSMFile(MOSCOW).
                 setStoreOnFlush(true).
-                setCHEnabled(true).
-                setGraphHopperLocation(GH_LOCATION);
+                setCHEnabled(true);
         hopper.getCHPreparationHandler().setDisablingAllowed(true);
         hopper.getCHPreparationHandler().setEdgeBasedCHMode(EdgeBasedCHMode.EDGE_AND_NODE);
         hopper.importOrLoad();
@@ -1383,8 +1352,7 @@ public class GraphHopperIT {
         GraphHopper hopper = createGraphHopper("car|turn_costs=true").
                 setOSMFile(MOSCOW).
                 setStoreOnFlush(true).
-                setCHEnabled(true).
-                setGraphHopperLocation(GH_LOCATION);
+                setCHEnabled(true);
         hopper.getCHPreparationHandler()
                 .setEdgeBasedCHMode(EdgeBasedCHMode.EDGE_OR_NODE)
                 .setDisablingAllowed(true);
@@ -1404,8 +1372,7 @@ public class GraphHopperIT {
         GraphHopper hopper = createGraphHopper("car|turn_costs=true").
                 setOSMFile(MOSCOW).
                 setStoreOnFlush(true).
-                setCHEnabled(true).
-                setGraphHopperLocation(GH_LOCATION);
+                setCHEnabled(true);
         hopper.getCHPreparationHandler()
                 .setEdgeBasedCHMode(EdgeBasedCHMode.OFF)
                 .setDisablingAllowed(true);
@@ -1435,8 +1402,7 @@ public class GraphHopperIT {
         GraphHopper hopper = createGraphHopper("car|turn_costs=true").
                 setOSMFile(MOSCOW).
                 setStoreOnFlush(true).
-                setCHEnabled(true).
-                setGraphHopperLocation(GH_LOCATION);
+                setCHEnabled(true);
         hopper.getCHPreparationHandler().setDisablingAllowed(true);
         hopper.getCHPreparationHandler().setEdgeBasedCHMode(EdgeBasedCHMode.EDGE_OR_NODE);
         hopper.importOrLoad();
@@ -1452,19 +1418,19 @@ public class GraphHopperIT {
                         "\nrequested:  *|car|edge_based=false|u_turn_costs=*\navailable: [fastest|car|edge_based=true|u_turn_costs=-1]"));
     }
 
-    private GHResponse assertMoscowNodeBased(GraphHopper tmpHopper, String edgeBasedParam, boolean ch) {
-        GHResponse rsp = runMoscow(tmpHopper, edgeBasedParam, ch);
+    private GHResponse assertMoscowNodeBased(GraphHopper hopper, String edgeBasedParam, boolean ch) {
+        GHResponse rsp = runMoscow(hopper, edgeBasedParam, ch);
         assertEquals(400, rsp.getBest().getDistance(), 1);
         return rsp;
     }
 
-    private GHResponse assertMoscowEdgeBased(GraphHopper tmpHopper, String edgeBasedParam, boolean ch) {
-        GHResponse rsp = runMoscow(tmpHopper, edgeBasedParam, ch);
+    private GHResponse assertMoscowEdgeBased(GraphHopper hopper, String edgeBasedParam, boolean ch) {
+        GHResponse rsp = runMoscow(hopper, edgeBasedParam, ch);
         assertEquals(1044, rsp.getBest().getDistance(), 1);
         return rsp;
     }
 
-    private GHResponse runMoscow(GraphHopper tmpHopper, String edgeBasedParam, boolean ch) {
+    private GHResponse runMoscow(GraphHopper hopper, String edgeBasedParam, boolean ch) {
         GHRequest req = new GHRequest(55.813357, 37.5958585, 55.811042, 37.594689);
         if (edgeBasedParam.equals("true") || edgeBasedParam.equals("false")) {
             req.getHints().put(Routing.EDGE_BASED, edgeBasedParam);
@@ -1472,7 +1438,7 @@ public class GraphHopperIT {
             req.getHints().remove(Routing.EDGE_BASED);
         }
         req.getHints().put(CH.DISABLE, !ch);
-        return tmpHopper.route(req);
+        return hopper.route(req);
     }
 
     @Test
@@ -1482,7 +1448,6 @@ public class GraphHopperIT {
                 setOSMFile(MONACO).
                 setStoreOnFlush(true).
                 setCHEnabled(false).
-                setGraphHopperLocation(GH_LOCATION).
                 importOrLoad();
         GHPoint p = new GHPoint(43.727687, 7.418737);
         GHPoint q = new GHPoint(43.74958, 7.436566);
@@ -1500,7 +1465,6 @@ public class GraphHopperIT {
         // see #1698
         GraphHopper hopper = createGraphHopper("foot,car|turn_costs=true").
                 setOSMFile(MOSCOW).
-                setGraphHopperLocation(GH_LOCATION).
                 setCHEnabled(false);
         hopper.importOrLoad();
         GHPoint p = new GHPoint(55.813357, 37.5958585);
@@ -1515,8 +1479,7 @@ public class GraphHopperIT {
     public void testCurbsides() {
         GraphHopper h = createGraphHopper("car|turn_costs=true").
                 setOSMFile(BAYREUTH).
-                setCHEnabled(true).
-                setGraphHopperLocation(GH_LOCATION);
+                setCHEnabled(true);
         h.getCHPreparationHandler()
                 .setEdgeBasedCHMode(EdgeBasedCHMode.EDGE_OR_NODE);
         h.importOrLoad();
@@ -1562,8 +1525,7 @@ public class GraphHopperIT {
     public void testForceCurbsides() {
         GraphHopper h = createGraphHopper("car|turn_costs=true").
                 setOSMFile(MONACO).
-                setCHEnabled(true).
-                setGraphHopperLocation(GH_LOCATION);
+                setCHEnabled(true);
         h.getCHPreparationHandler()
                 .setEdgeBasedCHMode(EdgeBasedCHMode.EDGE_OR_NODE);
         h.importOrLoad();
@@ -1627,8 +1589,7 @@ public class GraphHopperIT {
     public void testCHWithFiniteUTurnCostsAndMissingWeighting() {
         GraphHopper h = createGraphHopper("car|turn_costs=true").
                 setOSMFile(MONACO).
-                setCHEnabled(true).
-                setGraphHopperLocation(GH_LOCATION);
+                setCHEnabled(true);
         h.getCHPreparationHandler()
                 .setCHProfileStrings("fastest|u_turn_costs=40")
                 .setEdgeBasedCHMode(EdgeBasedCHMode.EDGE_OR_NODE);
@@ -1729,9 +1690,10 @@ public class GraphHopperIT {
         assertEquals(expected, detail.toString());
     }
 
-    private static GraphHopperOSM createGraphHopper(String vehicles) {
+    private static GraphHopperOSM createGraphHopper(String encodingManagerString) {
         GraphHopperOSM hopper = new GraphHopperOSM();
-        hopper.setEncodingManager(EncodingManager.create(vehicles));
+        hopper.setEncodingManager(EncodingManager.create(encodingManagerString));
+        hopper.setGraphHopperLocation(GH_LOCATION);
         return hopper;
     }
 

--- a/reader-osm/src/test/java/com/graphhopper/GraphHopperIT.java
+++ b/reader-osm/src/test/java/com/graphhopper/GraphHopperIT.java
@@ -62,11 +62,12 @@ public class GraphHopperIT {
     private static final String MONACO = DIR + "/monaco.osm.gz";
     private static final String MOSCOW = DIR + "/moscow.osm.gz";
 
+    // when creating GH instances make sure to use this as the GH location such that it will be cleaned between tests
     private static final String GH_LOCATION = "target/graphhopper-it-gh";
 
     @Before
     @After
-    public void setUp() {
+    public void setup() {
         Helper.removeDir(new File(GH_LOCATION));
     }
 
@@ -1026,7 +1027,7 @@ public class GraphHopperIT {
                 setOSMFile(MONACO).
                 setStoreOnFlush(true);
         hopper.getCHPreparationHandler().setCHProfileStrings(weighting);
-                hopper.importOrLoad();
+        hopper.importOrLoad();
         assertEquals(vehicle1, hopper.getDefaultVehicle().toString());
         checkMultiVehiclesWithCH(hopper);
         hopper.close();

--- a/reader-osm/src/test/java/com/graphhopper/GraphHopperIT.java
+++ b/reader-osm/src/test/java/com/graphhopper/GraphHopperIT.java
@@ -1404,7 +1404,7 @@ public class GraphHopperIT {
         assertEquals(1, rsp.getErrors().size());
         String expected = "Cannot find matching CH profile for your request. Please check your parameters." +
                 "\nYou can try disabling CH using ch.disable=true" +
-                "\nrequested:  *|car|edge_based=true|u_turn_costs=*\navailable: [fastest|car|edge_based=false]";
+                "\nrequested:  fastest|car|edge_based=true|u_turn_costs=*\navailable: [fastest|car|edge_based=false]";
         assertTrue("unexpected error:\n" + rsp.getErrors().toString() + "\nwhen expecting an error containing:\n" + expected,
                 rsp.getErrors().toString().contains(expected));
     }
@@ -1431,7 +1431,7 @@ public class GraphHopperIT {
         assertTrue("unexpected error: " + rsp.getErrors(), rsp.getErrors().toString().contains(
                 "Cannot find matching CH profile for your request. Please check your parameters." +
                         "\nYou can try disabling CH using ch.disable=true" +
-                        "\nrequested:  *|car|edge_based=false|u_turn_costs=*\navailable: [fastest|car|edge_based=true|u_turn_costs=-1]"));
+                        "\nrequested:  fastest|car|edge_based=false|u_turn_costs=*\navailable: [fastest|car|edge_based=true|u_turn_costs=-1]"));
     }
 
     private GHResponse assertMoscowNodeBased(GraphHopper hopper, String edgeBasedParam, boolean ch) {
@@ -1454,6 +1454,8 @@ public class GraphHopperIT {
             req.getHints().remove(Routing.EDGE_BASED);
         }
         req.getHints().put(CH.DISABLE, !ch);
+        req.setVehicle("car");
+        req.setWeighting("fastest");
         return hopper.route(req);
     }
 

--- a/reader-osm/src/test/java/com/graphhopper/reader/osm/GraphHopperOSMTest.java
+++ b/reader-osm/src/test/java/com/graphhopper/reader/osm/GraphHopperOSMTest.java
@@ -77,35 +77,42 @@ public class GraphHopperOSMTest {
 
     @Test
     public void testLoadOSM() {
-        GraphHopper closableInstance = createGraphHopper("car").
+        String vehicle = "car";
+        String weighting = "fastest";
+        GraphHopper hopper = createGraphHopper(vehicle).
                 setStoreOnFlush(true).
                 setGraphHopperLocation(ghLoc).
                 setDataReaderFile(testOsm);
-        closableInstance.importOrLoad();
-        GHResponse rsp = closableInstance.route(new GHRequest(51.2492152, 9.4317166, 51.2, 9.4));
+        hopper.getCHPreparationHandler().setCHProfileStrings(weighting);
+        hopper.importOrLoad();
+        GHResponse rsp = hopper.route(new GHRequest(51.2492152, 9.4317166, 51.2, 9.4).
+                setVehicle(vehicle).setWeighting(weighting));
         assertFalse(rsp.hasErrors());
         assertEquals(3, rsp.getBest().getPoints().getSize());
 
-        closableInstance.close();
+        hopper.close();
 
         // no encoding manager necessary
-        closableInstance = new GraphHopperOSM().
+        hopper = new GraphHopperOSM().
                 setStoreOnFlush(true);
-        assertTrue(closableInstance.load(ghLoc));
-        rsp = closableInstance.route(new GHRequest(51.2492152, 9.4317166, 51.2, 9.4));
+        hopper.getCHPreparationHandler().setCHProfileStrings(weighting);
+        assertTrue(hopper.load(ghLoc));
+        rsp = hopper.route(new GHRequest(51.2492152, 9.4317166, 51.2, 9.4).
+                setVehicle(vehicle).setWeighting(weighting));
         assertFalse(rsp.hasErrors());
         assertEquals(3, rsp.getBest().getPoints().getSize());
 
-        closableInstance.close();
+        hopper.close();
         try {
-            rsp = closableInstance.route(new GHRequest(51.2492152, 9.4317166, 51.2, 9.4));
+            rsp = hopper.route(new GHRequest(51.2492152, 9.4317166, 51.2, 9.4)
+                    .setVehicle(vehicle).setWeighting(weighting));
             fail();
         } catch (Exception ex) {
             assertEquals("You need to create a new GraphHopper instance as it is already closed", ex.getMessage());
         }
 
         try {
-            closableInstance.getLocationIndex().findClosest(51.2492152, 9.4317166, EdgeFilter.ALL_EDGES);
+            hopper.getLocationIndex().findClosest(51.2492152, 9.4317166, EdgeFilter.ALL_EDGES);
             fail();
         } catch (Exception ex) {
             assertEquals("You need to create a new LocationIndex instance as it is already closed", ex.getMessage());
@@ -114,35 +121,40 @@ public class GraphHopperOSMTest {
 
     @Test
     public void testLoadOSMNoCH() {
-        GraphHopper gh = createGraphHopper("car").
-                setStoreOnFlush(true).setCHEnabled(false).
+        final String vehicle = "car";
+        final String weighting = "fastest";
+        GraphHopper gh = createGraphHopper(vehicle).
+                setStoreOnFlush(true).
+                setCHEnabled(false).
                 setGraphHopperLocation(ghLoc).
                 setDataReaderFile(testOsm);
         gh.importOrLoad();
 
-        assertFalse(gh.getAlgorithmFactory(new HintsMap("fastest")) instanceof CHRoutingAlgorithmFactory);
+        assertFalse(gh.getAlgorithmFactory(new HintsMap(weighting)) instanceof CHRoutingAlgorithmFactory);
 
-        GHResponse rsp = gh.route(new GHRequest(51.2492152, 9.4317166, 51.2, 9.4));
+        GHResponse rsp = gh.route(new GHRequest(51.2492152, 9.4317166, 51.2, 9.4)
+                .setVehicle(vehicle).setWeighting(weighting));
         assertFalse(rsp.hasErrors());
         assertEquals(3, rsp.getBest().getPoints().getSize());
 
         gh.close();
-        gh = createGraphHopper("car").
+        gh = createGraphHopper(vehicle).
                 setStoreOnFlush(true).
                 setCHEnabled(false);
         assertTrue(gh.load(ghLoc));
-        rsp = gh.route(new GHRequest(51.2492152, 9.4317166, 51.2, 9.4));
+        rsp = gh.route(new GHRequest(51.2492152, 9.4317166, 51.2, 9.4)
+                .setVehicle(vehicle).setWeighting(weighting));
         assertFalse(rsp.hasErrors());
         assertEquals(3, rsp.getBest().getPoints().getSize());
 
         gh.close();
 
-        gh = createGraphHopper("car").
+        gh = createGraphHopper(vehicle).
                 setGraphHopperLocation(ghLoc).
                 setDataReaderFile(testOsm).
                 init(new GraphHopperConfig().put(Parameters.CH.PREPARE + "weightings", "no"));
 
-        assertFalse(gh.getAlgorithmFactory(new HintsMap("fastest")) instanceof CHRoutingAlgorithmFactory);
+        assertFalse(gh.getAlgorithmFactory(new HintsMap(weighting)) instanceof CHRoutingAlgorithmFactory);
         gh.close();
     }
 
@@ -209,17 +221,20 @@ public class GraphHopperOSMTest {
     public void testLoadingWithDifferentCHConfig_issue471_pr1488() {
         // when there is a single CH profile we can also load GraphHopper without it
         // in #471 this was forbidden, but later it was allowed again, see #1488
-        GraphHopper gh = createGraphHopper("car").
+        final String vehicle = "car";
+        final String weighting = "fastest";
+        GraphHopper gh = createGraphHopper(vehicle).
                 setStoreOnFlush(true).
                 setGraphHopperLocation(ghLoc).
                 setDataReaderFile(testOsm);
+        gh.getCHPreparationHandler().setCHProfileStrings(weighting);
         gh.importOrLoad();
         GHResponse rsp = gh.route(new GHRequest(51.2492152, 9.4317166, 51.2, 9.4));
         assertFalse(rsp.hasErrors());
         assertEquals(3, rsp.getBest().getPoints().getSize());
         gh.close();
 
-        gh = createGraphHopper("car").
+        gh = createGraphHopper(vehicle).
                 setStoreOnFlush(true).setCHEnabled(false);
         gh.load(ghLoc);
         // no error
@@ -227,8 +242,9 @@ public class GraphHopperOSMTest {
         Helper.removeDir(new File(ghLoc));
 
         // without CH should not be loadable with CH enabled
-        gh = createGraphHopper("car").
-                setStoreOnFlush(true).setCHEnabled(false).
+        gh = createGraphHopper(vehicle).
+                setStoreOnFlush(true).
+                setCHEnabled(false).
                 setGraphHopperLocation(ghLoc).
                 setDataReaderFile(testOsm);
         gh.importOrLoad();
@@ -239,6 +255,8 @@ public class GraphHopperOSMTest {
 
         gh = createGraphHopper("car").
                 setStoreOnFlush(true);
+        gh.getCHPreparationHandler().setCHProfileStrings(weighting);
+
         try {
             gh.load(ghLoc);
             fail();
@@ -249,18 +267,19 @@ public class GraphHopperOSMTest {
 
     @Test
     public void testAllowMultipleReadingInstances() {
-        GraphHopper instance1 = createGraphHopper("car").
+        String vehicle = "car";
+        GraphHopper instance1 = createGraphHopper(vehicle).
                 setStoreOnFlush(true).
                 setGraphHopperLocation(ghLoc).
                 setDataReaderFile(testOsm);
         instance1.importOrLoad();
 
-        GraphHopper instance2 = createGraphHopper("car").
+        GraphHopper instance2 = createGraphHopper(vehicle).
                 setStoreOnFlush(true).
                 setDataReaderFile(testOsm);
         instance2.load(ghLoc);
 
-        GraphHopper instance3 = createGraphHopper("car").
+        GraphHopper instance3 = createGraphHopper(vehicle).
                 setStoreOnFlush(true).
                 setDataReaderFile(testOsm);
         instance3.load(ghLoc);
@@ -328,13 +347,17 @@ public class GraphHopperOSMTest {
 
     @Test
     public void testPrepare() {
-        instance = createGraphHopper("car").
+        final String vehicle = "car";
+        final String weighting = "shortest";
+
+        instance = createGraphHopper(vehicle).
                 setStoreOnFlush(false).
                 setGraphHopperLocation(ghLoc).
                 setDataReaderFile(testOsm);
-        instance.getCHPreparationHandler().setCHProfileStrings("shortest");
+        instance.getCHPreparationHandler().setCHProfileStrings(weighting);
         instance.importOrLoad();
         GHResponse rsp = instance.route(new GHRequest(51.2492152, 9.4317166, 51.2, 9.4).
+                setVehicle(vehicle).setWeighting(weighting).
                 setAlgorithm(DIJKSTRA_BI));
         assertFalse(rsp.hasErrors());
         assertEquals(Helper.createPointList(51.249215, 9.431716, 52.0, 9.0, 51.2, 9.4), rsp.getBest().getPoints());
@@ -343,13 +366,17 @@ public class GraphHopperOSMTest {
 
     @Test
     public void testSortedGraph_noCH() {
-        instance = createGraphHopper("car").
+        final String vehicle = "car";
+        final String weighting = "fastest";
+        instance = createGraphHopper(vehicle).
                 setCHEnabled(false).
-                setStoreOnFlush(false).setSortGraph(true).
+                setStoreOnFlush(false).
+                setSortGraph(true).
                 setGraphHopperLocation(ghLoc).
                 setDataReaderFile(testOsm);
         instance.importOrLoad();
         PathWrapper rsp = instance.route(new GHRequest(51.2492152, 9.4317166, 51.2, 9.4).
+                setVehicle(vehicle).setWeighting(weighting).
                 setAlgorithm(DIJKSTRA_BI)).getBest();
         assertFalse(rsp.hasErrors());
         assertEquals(3, rsp.getPoints().getSize());
@@ -358,6 +385,7 @@ public class GraphHopperOSMTest {
         assertEquals(new GHPoint(51.199999850988384, 9.39999970197677), rsp.getPoints().get(2));
 
         GHRequest req = new GHRequest(51.2492152, 9.4317166, 51.2, 9.4);
+        req.setVehicle(vehicle).setWeighting(weighting);
         boolean old = instance.getEncodingManager().isEnableInstructions();
         req.getHints().put("instructions", true);
         instance.route(req);
@@ -370,8 +398,12 @@ public class GraphHopperOSMTest {
 
     @Test
     public void testFootAndCar() {
+        final String vehicle1 = "car";
+        final String vehicle2 = "foot";
+        final String weighting = "fastest";
+
         // now all ways are imported
-        instance = createGraphHopper("car,foot").
+        instance = createGraphHopper(vehicle1 + "," + vehicle2).
                 setStoreOnFlush(false).
                 setCHEnabled(false).
                 setGraphHopperLocation(ghLoc).
@@ -382,7 +414,7 @@ public class GraphHopperOSMTest {
         assertEquals(8, instance.getGraphHopperStorage().getEdges());
 
         // A to D
-        GHResponse grsp = instance.route(new GHRequest(11.1, 50, 11.3, 51).setVehicle("car"));
+        GHResponse grsp = instance.route(new GHRequest(11.1, 50, 11.3, 51).setVehicle(vehicle1).setWeighting(weighting));
         assertFalse(grsp.hasErrors());
         PathWrapper rsp = grsp.getBest();
         assertEquals(3, rsp.getPoints().getSize());
@@ -392,8 +424,8 @@ public class GraphHopperOSMTest {
         assertEquals(51, rsp.getPoints().getLongitude(2), 1e-3);
         assertEquals(11.3, rsp.getPoints().getLatitude(2), 1e-3);
 
-        // A to D not allowed for foot. But the location index will choose a node close to D accessible to FOOT        
-        grsp = instance.route(new GHRequest(11.1, 50, 11.3, 51).setVehicle("foot"));
+        // A to D not allowed for foot. But the location index will choose a node close to D accessible to FOOT
+        grsp = instance.route(new GHRequest(11.1, 50, 11.3, 51).setVehicle(vehicle2).setWeighting(weighting));
         assertFalse(grsp.hasErrors());
         rsp = grsp.getBest();
         assertEquals(2, rsp.getPoints().getSize());
@@ -402,13 +434,13 @@ public class GraphHopperOSMTest {
         assertEquals(50.644, rsp.getPoints().getLongitude(1), 1e-3);
 
         // A to E only for foot
-        grsp = instance.route(new GHRequest(11.1, 50, 10, 51).setVehicle("foot"));
+        grsp = instance.route(new GHRequest(11.1, 50, 10, 51).setVehicle(vehicle2).setWeighting(weighting));
         assertFalse(grsp.hasErrors());
         rsp = grsp.getBest();
         assertEquals(2, rsp.getPoints().size());
 
         // A D E for car
-        grsp = instance.route(new GHRequest(11.1, 50, 10, 51).setVehicle("car"));
+        grsp = instance.route(new GHRequest(11.1, 50, 10, 51).setVehicle(vehicle1).setWeighting(weighting));
         assertFalse(grsp.hasErrors());
         rsp = grsp.getBest();
         assertEquals(3, rsp.getPoints().getSize());
@@ -528,6 +560,7 @@ public class GraphHopperOSMTest {
     @Test
     public void testNoNPE_ifLoadNotSuccessful() {
         instance = createGraphHopper("car").
+                setCHEnabled(false).
                 setStoreOnFlush(true);
         try {
             // loading from empty directory
@@ -542,7 +575,8 @@ public class GraphHopperOSMTest {
 
     @Test
     public void testDoesNotCreateEmptyFolderIfLoadingFromNonExistingPath() {
-        instance = createGraphHopper("car");
+        instance = createGraphHopper("car")
+                .setCHEnabled(false);
 
         assertFalse(instance.load(ghLoc));
         assertFalse(new File(ghLoc).exists());
@@ -561,6 +595,7 @@ public class GraphHopperOSMTest {
         GHTmp tmp = new GHTmp();
         try {
             tmp.setDataReaderFile(testOsm);
+            tmp.setCHEnabled(false);
             tmp.importData();
             fail();
         } catch (IllegalStateException ex) {
@@ -569,6 +604,7 @@ public class GraphHopperOSMTest {
 
         // missing graph location
         instance = new GraphHopperOSM();
+        instance.setCHEnabled(false);
         try {
             instance.importOrLoad();
             fail();
@@ -579,6 +615,7 @@ public class GraphHopperOSMTest {
         // missing OSM file to import
         instance = createGraphHopper("car").
                 setStoreOnFlush(true).
+                setCHEnabled(false).
                 setGraphHopperLocation(ghLoc);
         try {
             instance.importOrLoad();
@@ -591,6 +628,7 @@ public class GraphHopperOSMTest {
         // missing encoding manager          
         instance = new GraphHopperOSM().
                 setStoreOnFlush(true).
+                setCHEnabled(false).
                 setGraphHopperLocation(ghLoc).
                 setDataReaderFile(testOsm3);
         try {
@@ -603,6 +641,7 @@ public class GraphHopperOSMTest {
         // Import is possible even if no storeOnFlush is specified BUT here we miss the OSM file
         instance = createGraphHopper("car").
                 setStoreOnFlush(false).
+                setCHEnabled(false).
                 setGraphHopperLocation(ghLoc);
         try {
             instance.importOrLoad();
@@ -616,17 +655,20 @@ public class GraphHopperOSMTest {
     @Test
     public void testFootOnly() {
         // now only footable ways are imported => no A D C and B D E => the other both ways have pillar nodes!
-        instance = createGraphHopper("foot").
+        final String vehicle = "foot";
+        final String weighting = "fastest";
+        instance = createGraphHopper(vehicle).
                 setStoreOnFlush(false).
                 setGraphHopperLocation(ghLoc).
                 setDataReaderFile(testOsm3);
+        instance.getCHPreparationHandler().setCHProfileStrings(weighting);
         instance.importOrLoad();
 
         assertEquals(2, instance.getGraphHopperStorage().getNodes());
         assertEquals(2, instance.getGraphHopperStorage().getAllEdges().length());
 
         // A to E only for foot
-        GHResponse grsp = instance.route(new GHRequest(11.1, 50, 11.19, 52).setVehicle("foot"));
+        GHResponse grsp = instance.route(new GHRequest(11.1, 50, 11.19, 52).setVehicle(vehicle).setWeighting(weighting));
         assertFalse(grsp.hasErrors());
         PathWrapper rsp = grsp.getBest();
         // the last points snaps to the edge
@@ -635,11 +677,15 @@ public class GraphHopperOSMTest {
 
     @Test
     public void testVia() {
+        final String vehicle = "car";
+        final String weighting = "fastest";
         instance = new GraphHopperOSM().setStoreOnFlush(true).
                 init(new GraphHopperConfig().
                         put("datareader.file", testOsm3).
                         put("prepare.min_network_size", "1").
-                        put("graph.flag_encoders", "car")).
+                        put("graph.flag_encoders", vehicle).
+                        put("prepare.ch.weightings", weighting)
+                ).
                 setGraphHopperLocation(ghLoc);
         instance.importOrLoad();
 
@@ -647,14 +693,14 @@ public class GraphHopperOSMTest {
         GHPoint first = new GHPoint(11.1, 50);
         GHPoint second = new GHPoint(12, 51);
         GHPoint third = new GHPoint(11.2, 51.9);
-        GHResponse rsp12 = instance.route(new GHRequest().addPoint(first).addPoint(second));
+        GHResponse rsp12 = instance.route(new GHRequest().addPoint(first).addPoint(second).setVehicle(vehicle).setWeighting(weighting));
         assertFalse("should find 1->2", rsp12.hasErrors());
         assertEquals(147930.5, rsp12.getBest().getDistance(), .1);
-        GHResponse rsp23 = instance.route(new GHRequest().addPoint(second).addPoint(third));
+        GHResponse rsp23 = instance.route(new GHRequest().addPoint(second).addPoint(third).setVehicle(vehicle).setWeighting(weighting));
         assertFalse("should find 2->3", rsp23.hasErrors());
         assertEquals(176608.9, rsp23.getBest().getDistance(), .1);
 
-        GHResponse grsp = instance.route(new GHRequest().addPoint(first).addPoint(second).addPoint(third));
+        GHResponse grsp = instance.route(new GHRequest().addPoint(first).addPoint(second).addPoint(third).setVehicle(vehicle).setWeighting(weighting));
         assertFalse("should find 1->2->3", grsp.hasErrors());
         PathWrapper rsp = grsp.getBest();
         assertEquals(rsp12.getBest().getDistance() + rsp23.getBest().getDistance(), rsp.getDistance(), 1e-6);
@@ -667,14 +713,14 @@ public class GraphHopperOSMTest {
     public void testGetPathsDirectionEnforcement1() {
         // Test enforce start direction
         // Note: This Test does not pass for CH enabled    
-        instance = createSquareGraphInstance(false);
+        instance = createSquareGraphInstance();
 
         // Start in middle of edge 4-5 
         GHPoint start = new GHPoint(0.0015, 0.002);
         // End at middle of edge 2-3
         GHPoint end = new GHPoint(0.002, 0.0005);
 
-        GHRequest req = new GHRequest().addPoint(start, 180.).addPoint(end);
+        GHRequest req = new GHRequest().addPoint(start, 180.).addPoint(end).setVehicle("car").setWeighting("fastest");
         GHResponse response = new GHResponse();
         List<Path> paths = instance.calcPaths(req, response);
         assertFalse(response.hasErrors());
@@ -684,14 +730,14 @@ public class GraphHopperOSMTest {
     @Test
     public void testGetPathsDirectionEnforcement2() {
         // Test enforce south start direction and east end direction
-        instance = createSquareGraphInstance(false);
+        instance = createSquareGraphInstance();
 
         // Start in middle of edge 4-5 
         GHPoint start = new GHPoint(0.0015, 0.002);
         // End at middle of edge 2-3
         GHPoint end = new GHPoint(0.002, 0.0005);
 
-        GHRequest req = new GHRequest().addPoint(start, 180.).addPoint(end, 90.);
+        GHRequest req = new GHRequest().addPoint(start, 180.).addPoint(end, 90.).setVehicle("car").setWeighting("fastest");
         GHResponse response = new GHResponse();
         List<Path> paths = instance.calcPaths(req, response);
         assertFalse(response.hasErrors());
@@ -707,7 +753,7 @@ public class GraphHopperOSMTest {
 
     @Test
     public void testGetPathsDirectionEnforcement3() {
-        instance = createSquareGraphInstance(false);
+        instance = createSquareGraphInstance();
 
         // Start in middle of edge 4-5 
         GHPoint start = new GHPoint(0.0015, 0.002);
@@ -716,7 +762,7 @@ public class GraphHopperOSMTest {
         // Via Point betweeen 8-7
         GHPoint via = new GHPoint(0.0005, 0.001);
 
-        GHRequest req = new GHRequest().addPoint(start).addPoint(via, 0.).addPoint(end);
+        GHRequest req = new GHRequest().addPoint(start).addPoint(via, 0.).addPoint(end).setVehicle("car").setWeighting("fastest");
         GHResponse response = new GHResponse();
         List<Path> paths = instance.calcPaths(req, response);
         assertFalse(response.hasErrors());
@@ -726,7 +772,7 @@ public class GraphHopperOSMTest {
     @Test
     public void testGetPathsDirectionEnforcement4() {
         // Test straight via routing
-        instance = createSquareGraphInstance(false);
+        instance = createSquareGraphInstance();
 
         // Start in middle of edge 4-5 
         GHPoint start = new GHPoint(0.0015, 0.002);
@@ -734,7 +780,7 @@ public class GraphHopperOSMTest {
         GHPoint end = new GHPoint(0.002, 0.0005);
         // Via Point betweeen 8-3
         GHPoint via = new GHPoint(0.0015, 0.001);
-        GHRequest req = new GHRequest().addPoint(start).addPoint(via).addPoint(end);
+        GHRequest req = new GHRequest().addPoint(start).addPoint(via).addPoint(end).setVehicle("car").setWeighting("fastest");
         req.getHints().put(Routing.PASS_THROUGH, true);
         GHResponse response = new GHResponse();
         List<Path> paths = instance.calcPaths(req, response);
@@ -747,7 +793,7 @@ public class GraphHopperOSMTest {
     @Test
     public void testGetPathsDirectionEnforcement5() {
         // Test independence of previous enforcement for subsequent pathes
-        instance = createSquareGraphInstance(false);
+        instance = createSquareGraphInstance();
 
         // Start in middle of edge 4-5 
         GHPoint start = new GHPoint(0.0015, 0.002);
@@ -755,7 +801,7 @@ public class GraphHopperOSMTest {
         GHPoint end = new GHPoint(0.002, 0.0005);
         // First go south and than come from west to via-point at 7-6. Then go back over previously punished (11)-4 edge
         GHPoint via = new GHPoint(0.000, 0.0015);
-        GHRequest req = new GHRequest().addPoint(start, 0.).addPoint(via, 3.14 / 2).addPoint(end);
+        GHRequest req = new GHRequest().addPoint(start, 0.).addPoint(via, 3.14 / 2).addPoint(end).setVehicle("car").setWeighting("fastest");
         req.getHints().put(Routing.PASS_THROUGH, true);
         GHResponse response = new GHResponse();
         List<Path> paths = instance.calcPaths(req, response);
@@ -767,14 +813,14 @@ public class GraphHopperOSMTest {
     @Test
     public void testGetPathsDirectionEnforcement6() {
         // Test if query results at tower nodes are ignored
-        instance = createSquareGraphInstance(false);
+        instance = createSquareGraphInstance();
 
         // QueryPoints directly on TowerNodes 
         GHPoint start = new GHPoint(0, 0);
         GHPoint via = new GHPoint(0.002, 0.000);
         GHPoint end = new GHPoint(0.002, 0.002);
 
-        GHRequest req = new GHRequest().addPoint(start, 90.).addPoint(via, 270.).addPoint(end, 270.);
+        GHRequest req = new GHRequest().addPoint(start, 90.).addPoint(via, 270.).addPoint(end, 270.).setVehicle("car").setWeighting("fastest");
         GHResponse response = new GHResponse();
         List<Path> paths = instance.calcPaths(req, response);
         assertFalse(response.hasErrors());
@@ -782,7 +828,7 @@ public class GraphHopperOSMTest {
         assertArrayEquals(new int[]{2, 3, 4}, paths.get(1).calcNodes().toArray());
     }
 
-    private GraphHopper createSquareGraphInstance(boolean withCH) {
+    private GraphHopper createSquareGraphInstance() {
         CarFlagEncoder carEncoder = new CarFlagEncoder();
         EncodingManager encodingManager = EncodingManager.create(carEncoder);
         Weighting weighting = new FastestWeighting(carEncoder);
@@ -819,9 +865,8 @@ public class GraphHopperOSMTest {
         g.edge(7, 8, 110, true);
 
         GraphHopper tmp = new GraphHopperOSM().
-                setCHEnabled(withCH).
+                setCHEnabled(false).
                 setEncodingManager(encodingManager);
-        tmp.getCHPreparationHandler().setCHProfileStrings("fastest");
         tmp.setGraphHopperStorage(g);
         tmp.postProcessing();
 
@@ -833,20 +878,26 @@ public class GraphHopperOSMTest {
         HashMap<String, Long> shortcutCountMap = new HashMap<>();
         // try all parallelization modes        
         for (int threadCount = 1; threadCount < 6; threadCount++) {
-            EncodingManager em = EncodingManager.create(Arrays.asList(new CarFlagEncoder(), new MotorcycleFlagEncoder(),
-                    new MountainBikeFlagEncoder(), new RacingBikeFlagEncoder(), new FootFlagEncoder()));
+            EncodingManager em = EncodingManager.create(Arrays.asList(
+                    new CarFlagEncoder(),
+                    new MotorcycleFlagEncoder(),
+                    new MountainBikeFlagEncoder(),
+                    new RacingBikeFlagEncoder(),
+                    new FootFlagEncoder()));
 
-            GraphHopper tmpGH = new GraphHopperOSM().
+            GraphHopper hopper = new GraphHopperOSM().
                     setStoreOnFlush(false).
                     setEncodingManager(em).
                     setGraphHopperLocation(ghLoc).
                     setDataReaderFile(testOsm);
-            tmpGH.getCHPreparationHandler().setPreparationThreads(threadCount);
+            hopper.getCHPreparationHandler()
+                    .setCHProfileStrings("fastest")
+                    .setPreparationThreads(threadCount);
 
-            tmpGH.importOrLoad();
+            hopper.importOrLoad();
 
-            assertEquals(5, tmpGH.getCHPreparationHandler().getPreparations().size());
-            for (PrepareContractionHierarchies pch : tmpGH.getCHPreparationHandler().getPreparations()) {
+            assertEquals(5, hopper.getCHPreparationHandler().getPreparations().size());
+            for (PrepareContractionHierarchies pch : hopper.getCHPreparationHandler().getPreparations()) {
                 assertTrue("Preparation wasn't run! [" + threadCount + "]", pch.isPrepared());
 
                 String name = pch.getCHProfile().toFileName();
@@ -857,14 +908,14 @@ public class GraphHopperOSMTest {
                     assertEquals((long) singleThreadShortcutCount, pch.getShortcuts());
 
                 String keyError = Parameters.CH.PREPARE + "error." + name;
-                String valueError = tmpGH.getGraphHopperStorage().getProperties().get(keyError);
+                String valueError = hopper.getGraphHopperStorage().getProperties().get(keyError);
                 assertTrue("Properties for " + name + " should NOT contain error " + valueError + " [" + threadCount + "]", valueError.isEmpty());
 
                 String key = Parameters.CH.PREPARE + "date." + name;
-                String value = tmpGH.getGraphHopperStorage().getProperties().get(key);
+                String value = hopper.getGraphHopperStorage().getProperties().get(key);
                 assertFalse("Properties for " + name + " did NOT contain finish date [" + threadCount + "]", value.isEmpty());
             }
-            tmpGH.close();
+            hopper.close();
         }
     }
 
@@ -873,24 +924,28 @@ public class GraphHopperOSMTest {
         HashMap<String, Integer> landmarkCount = new HashMap<>();
         // try all parallelization modes
         for (int threadCount = 1; threadCount < 6; threadCount++) {
-            EncodingManager em = EncodingManager.create(Arrays.asList(new CarFlagEncoder(), new MotorcycleFlagEncoder(),
-                    new MountainBikeFlagEncoder(), new RacingBikeFlagEncoder(), new FootFlagEncoder()));
+            EncodingManager em = EncodingManager.create(Arrays.asList(
+                    new CarFlagEncoder(),
+                    new MotorcycleFlagEncoder(),
+                    new MountainBikeFlagEncoder(),
+                    new RacingBikeFlagEncoder(),
+                    new FootFlagEncoder()));
 
-            GraphHopper tmpGH = new GraphHopperOSM().
+            GraphHopper hopper = new GraphHopperOSM().
                     setStoreOnFlush(false).
                     setCHEnabled(false).
                     setEncodingManager(em).
                     setGraphHopperLocation(ghLoc).
                     setDataReaderFile(testOsm);
-            tmpGH.getLMPreparationHandler().
+            hopper.getLMPreparationHandler().
                     addLMProfileAsString("fastest").
                     setEnabled(true).
                     setPreparationThreads(threadCount);
 
-            tmpGH.importOrLoad();
+            hopper.importOrLoad();
 
-            assertEquals(5, tmpGH.getLMPreparationHandler().getPreparations().size());
-            for (PrepareLandmarks prepLM : tmpGH.getLMPreparationHandler().getPreparations()) {
+            assertEquals(5, hopper.getLMPreparationHandler().getPreparations().size());
+            for (PrepareLandmarks prepLM : hopper.getLMPreparationHandler().getPreparations()) {
                 assertTrue("Preparation wasn't run! [" + threadCount + "]", prepLM.isPrepared());
 
                 String name = prepLM.getLMProfile().getName();
@@ -901,14 +956,14 @@ public class GraphHopperOSMTest {
                     assertEquals((int) singleThreadShortcutCount, prepLM.getSubnetworksWithLandmarks());
 
                 String keyError = Parameters.Landmark.PREPARE + "error." + name;
-                String valueError = tmpGH.getGraphHopperStorage().getProperties().get(keyError);
+                String valueError = hopper.getGraphHopperStorage().getProperties().get(keyError);
                 assertTrue("Properties for " + name + " should NOT contain error " + valueError + " [" + threadCount + "]", valueError.isEmpty());
 
                 String key = Parameters.Landmark.PREPARE + "date." + name;
-                String value = tmpGH.getGraphHopperStorage().getProperties().get(key);
+                String value = hopper.getGraphHopperStorage().getProperties().get(key);
                 assertFalse("Properties for " + name + " did NOT contain finish date [" + threadCount + "]", value.isEmpty());
             }
-            tmpGH.close();
+            hopper.close();
         }
     }
 

--- a/reader-osm/src/test/java/com/graphhopper/reader/osm/OSMReaderTest.java
+++ b/reader-osm/src/test/java/com/graphhopper/reader/osm/OSMReaderTest.java
@@ -945,16 +945,21 @@ public class OSMReaderTest {
                     throw new RuntimeException(e);
                 }
             }
-        }.setEncodingManager(new EncodingManager.Builder().add(new CarFlagEncoder()).add(new BikeFlagEncoder()).build()).
-                setGraphHopperLocation(dir).setCHEnabled(false).
-                importOrLoad();
+        }.setEncodingManager(EncodingManager.create("car,bike")).
+                setGraphHopperLocation(dir)
+                .setCHEnabled(false).
+                        importOrLoad();
 
-        GHResponse response = gh.route(new GHRequest(51.2492152, 9.4317166, 52.133, 9.1).setPathDetails(Arrays.asList(RoadClass.KEY)));
+        GHResponse response = gh.route(new GHRequest(51.2492152, 9.4317166, 52.133, 9.1)
+                .setVehicle("car").setWeighting("fastest")
+                .setPathDetails(Arrays.asList(RoadClass.KEY)));
         List<PathDetail> list = response.getBest().getPathDetails().get(RoadClass.KEY);
         assertEquals(3, list.size());
         assertEquals(RoadClass.MOTORWAY.toString(), list.get(0).getValue());
 
-        response = gh.route(new GHRequest(51.2492152, 9.4317166, 52.133, 9.1).setPathDetails(Arrays.asList(Toll.KEY)));
+        response = gh.route(new GHRequest(51.2492152, 9.4317166, 52.133, 9.1)
+                .setVehicle("car").setWeighting("fastest")
+                .setPathDetails(Arrays.asList(Toll.KEY)));
         Throwable ex = response.getErrors().get(0);
         assertTrue(ex.getMessage(), ex.getMessage().contains("You requested the details [toll]"));
     }

--- a/reader-osm/src/test/java/com/graphhopper/routing/RoutingAlgorithmWithOSMIT.java
+++ b/reader-osm/src/test/java/com/graphhopper/routing/RoutingAlgorithmWithOSMIT.java
@@ -619,7 +619,8 @@ public class RoutingAlgorithmWithOSMIT {
         final EncodingManager encodingManager = EncodingManager.create("car");
         final GraphHopper hopper = new GraphHopperOSM().
                 setStoreOnFlush(true).
-                setEncodingManager(encodingManager).setCHEnabled(false).
+                setEncodingManager(encodingManager).
+                setCHEnabled(false).
                 setWayPointMaxDistance(0).
                 setDataReaderFile(DIR + "/monaco.osm.gz").
                 setGraphHopperLocation(graphFile).


### PR DESCRIPTION
* make tests depend less on each other by removing class variables
* stop relying on default vehicle/weighting for requests
* stop relying on default CH weighting for preparation
* production code is still the same