### PR TITLE
No longer enable CH by default in GraphHopper class

### DIFF
--- a/core/files/changelog.txt
+++ b/core/files/changelog.txt
@@ -1,5 +1,5 @@
 1.0
-    GraphHopper class no longer enables CH by default
+    GraphHopper class no longer enables CH by default, #1914
     replaced command line arguments -Dgraphhopper.. with -Ddw.graphhopper.. due to #1879, see also #1897
     GraphHopper.init(CmdArgs)->GraphHopper.init(GraphHopperConfig), see #1879
     remove TurnWeighting, see #1863

--- a/core/files/changelog.txt
+++ b/core/files/changelog.txt
@@ -1,6 +1,9 @@
 1.0
+    GraphHopper class no longer enables CH by default
     replaced command line arguments -Dgraphhopper.. with -Ddw.graphhopper.. due to #1879, see also #1897
     GraphHopper.init(CmdArgs)->GraphHopper.init(GraphHopperConfig), see #1879
+    remove TurnWeighting, see #1863
+    speed up path simplification with path details/instructions, see #1802
     revert compression of landmark preparation data, see #1749 and #1376
     removed GenericWeighting and DataFlagEncoder as a normal CarFlagEncoder does the job too
     add required EncodedValues like road_class to EncodingManager if not added from user

--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -138,7 +138,7 @@ public class GraphHopper implements GraphHopperAPI {
      */
     protected GraphHopper loadGraph(GraphHopperStorage g) {
         this.ghStorage = g;
-        fullyLoaded = true;
+        setFullyLoaded();
         initLocationIndex();
         return this;
     }
@@ -300,19 +300,6 @@ public class GraphHopper implements GraphHopperAPI {
     }
 
     /**
-     * This method enabled or disables the speed mode (Contraction Hierarchies)
-     *
-     * @deprecated use {@link #setCHEnabled(boolean)} instead
-     */
-    public GraphHopper setCHEnable(boolean enable) {
-        return setCHEnabled(enable);
-    }
-
-    public final boolean isCHEnabled() {
-        return chPreparationHandler.isEnabled();
-    }
-
-    /**
      * Enables or disables contraction hierarchies (CH). This speed-up mode is enabled by default.
      */
     public GraphHopper setCHEnabled(boolean enable) {
@@ -412,7 +399,7 @@ public class GraphHopper implements GraphHopperAPI {
 
     public void setGraphHopperStorage(GraphHopperStorage ghStorage) {
         this.ghStorage = ghStorage;
-        fullyLoaded = true;
+        setFullyLoaded();
     }
 
     /**
@@ -788,7 +775,7 @@ public class GraphHopper implements GraphHopperAPI {
                 return false;
 
             postProcessing(false);
-            fullyLoaded = true;
+            setFullyLoaded();
             return true;
         } finally {
             if (lock != null)
@@ -1261,7 +1248,7 @@ public class GraphHopper implements GraphHopperAPI {
                 + getMemInfo() + ")");
         ghStorage.flush();
         logger.info("flushed graph " + getMemInfo() + ")");
-        fullyLoaded = true;
+        setFullyLoaded();
     }
 
     /**
@@ -1306,6 +1293,10 @@ public class GraphHopper implements GraphHopperAPI {
 
     public void setNonChMaxWaypointDistance(int nonChMaxWaypointDistance) {
         routingConfig.setNonChMaxWaypointDistance(nonChMaxWaypointDistance);
+    }
+
+    private void setFullyLoaded() {
+        fullyLoaded = true;
     }
 
     private static class DefaultWeightingFactory {

--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -129,8 +129,6 @@ public class GraphHopper implements GraphHopperAPI {
     private PathDetailsBuilderFactory pathBuilderFactory = new PathDetailsBuilderFactory();
 
     public GraphHopper() {
-        chPreparationHandler.setEnabled(true);
-        lmPreparationHandler.setEnabled(false);
     }
 
     /**
@@ -296,15 +294,6 @@ public class GraphHopper implements GraphHopperAPI {
     private GraphHopper setUnsafeMemory() {
         ensureNotLoaded();
         dataAccessType = DAType.UNSAFE_STORE;
-        return this;
-    }
-
-    /**
-     * Enables or disables contraction hierarchies (CH). This speed-up mode is enabled by default.
-     */
-    public GraphHopper setCHEnabled(boolean enable) {
-        ensureNotLoaded();
-        chPreparationHandler.setEnabled(enable);
         return this;
     }
 
@@ -786,10 +775,10 @@ public class GraphHopper implements GraphHopperAPI {
     public RoutingAlgorithmFactory getAlgorithmFactory(HintsMap map) {
         boolean disableCH = map.getBool(Parameters.CH.DISABLE, false);
         boolean disableLM = map.getBool(Parameters.Landmark.DISABLE, false);
-        if (disableCH && !chPreparationHandler.isDisablingAllowed()) {
+        if (chPreparationHandler.isEnabled() && disableCH && !chPreparationHandler.isDisablingAllowed()) {
             throw new IllegalArgumentException("Disabling CH is not allowed on the server side");
         }
-        if (disableLM && !lmPreparationHandler.isDisablingAllowed()) {
+        if (lmPreparationHandler.isEnabled() && disableLM && !lmPreparationHandler.isDisablingAllowed()) {
             throw new IllegalArgumentException("Disabling LM is not allowed on the server side");
         }
 
@@ -994,11 +983,11 @@ public class GraphHopper implements GraphHopperAPI {
             }
 
             boolean disableCH = hints.getBool(CH.DISABLE, false);
-            if (!chPreparationHandler.isDisablingAllowed() && disableCH)
+            if (chPreparationHandler.isEnabled() && !chPreparationHandler.isDisablingAllowed() && disableCH)
                 throw new IllegalArgumentException("Disabling CH not allowed on the server-side");
 
             boolean disableLM = hints.getBool(Landmark.DISABLE, false);
-            if (!lmPreparationHandler.isDisablingAllowed() && disableLM)
+            if (lmPreparationHandler.isEnabled() && !lmPreparationHandler.isDisablingAllowed() && disableLM)
                 throw new IllegalArgumentException("Disabling LM not allowed on the server-side");
 
             if (chPreparationHandler.isEnabled() && !disableCH) {

--- a/core/src/main/java/com/graphhopper/routing/ch/CHPreparationHandler.java
+++ b/core/src/main/java/com/graphhopper/routing/ch/CHPreparationHandler.java
@@ -49,8 +49,6 @@ public class CHPreparationHandler {
     private final List<CHProfile> chProfiles = new ArrayList<>();
     private final Set<String> chProfileStrings = new LinkedHashSet<>();
     private boolean disablingAllowed = false;
-    // for backward compatibility enable CH by default.
-    private boolean enabled = true;
     private EdgeBasedCHMode edgeBasedCHMode = EdgeBasedCHMode.OFF;
     private int preparationThreads;
     private ExecutorService threadPool;
@@ -58,8 +56,6 @@ public class CHPreparationHandler {
 
     public CHPreparationHandler() {
         setPreparationThreads(1);
-        // use fastest by default
-        setCHProfilesAsStrings(Collections.singletonList("fastest"));
     }
 
     public void init(GraphHopperConfig ghConfig) {
@@ -84,10 +80,7 @@ public class CHPreparationHandler {
             setCHProfilesAsStrings(Arrays.asList(chWeightingsStr.split(",")));
         }
 
-        boolean enableThis = !getCHProfileStrings().isEmpty();
-        setEnabled(enableThis);
-        if (enableThis)
-            setDisablingAllowed(ghConfig.getBool(CH.INIT_DISABLING_ALLOWED, isDisablingAllowed()));
+        setDisablingAllowed(ghConfig.getBool(CH.INIT_DISABLING_ALLOWED, isDisablingAllowed()));
 
         String edgeBasedCHStr = ghConfig.get(CH.PREPARE + "edge_based", "off").trim();
         edgeBasedCHStr = edgeBasedCHStr.equals("false") ? "off" : edgeBasedCHStr;
@@ -97,19 +90,11 @@ public class CHPreparationHandler {
     }
 
     public final boolean isEnabled() {
-        return enabled;
-    }
-
-    /**
-     * Enables or disables contraction hierarchies (CH). This speed-up mode is enabled by default.
-     */
-    public final CHPreparationHandler setEnabled(boolean enabled) {
-        this.enabled = enabled;
-        return this;
+        return !chProfiles.isEmpty() || !chProfileStrings.isEmpty() || !preparations.isEmpty();
     }
 
     public final boolean isDisablingAllowed() {
-        return disablingAllowed || !isEnabled();
+        return disablingAllowed;
     }
 
     /**

--- a/core/src/main/java/com/graphhopper/routing/ch/CHPreparationHandler.java
+++ b/core/src/main/java/com/graphhopper/routing/ch/CHPreparationHandler.java
@@ -74,7 +74,6 @@ public class CHPreparationHandler {
         }
 
         if ("no".equals(chWeightingsStr) || "false".equals(chWeightingsStr)) {
-            // default is fastest and we need to clear this explicitly
             setCHProfilesAsStrings(Collections.<String>emptyList());
         } else if (!chWeightingsStr.isEmpty()) {
             setCHProfilesAsStrings(Arrays.asList(chWeightingsStr.split(",")));

--- a/core/src/main/java/com/graphhopper/routing/lm/LMPreparationHandler.java
+++ b/core/src/main/java/com/graphhopper/routing/lm/LMPreparationHandler.java
@@ -58,7 +58,6 @@ public class LMPreparationHandler {
     private final List<String> lmProfileStrings = new ArrayList<>();
     private final List<LMProfile> lmProfiles = new ArrayList<>();
     private final Map<String, Double> maximumWeights = new HashMap<>();
-    private boolean enabled = false;
     private int minNodes = -1;
     private boolean disablingAllowed = false;
     private final List<String> lmSuggestionsLocations = new ArrayList<>(5);
@@ -88,10 +87,7 @@ public class LMPreparationHandler {
             setLMProfileStrings(tmpLMWeightingList);
         }
 
-        boolean enableThis = !getLMProfileStrings().isEmpty();
-        setEnabled(enableThis);
-        if (enableThis)
-            setDisablingAllowed(ghConfig.getBool(Landmark.INIT_DISABLING_ALLOWED, isDisablingAllowed()));
+        setDisablingAllowed(ghConfig.getBool(Landmark.INIT_DISABLING_ALLOWED, isDisablingAllowed()));
     }
 
     public int getLandmarks() {
@@ -107,16 +103,8 @@ public class LMPreparationHandler {
         return disablingAllowed || !isEnabled();
     }
 
-    /**
-     * Enables or disables this handler. This speed-up mode is disabled by default.
-     */
-    public final LMPreparationHandler setEnabled(boolean enabled) {
-        this.enabled = enabled;
-        return this;
-    }
-
     public final boolean isEnabled() {
-        return enabled;
+        return !lmProfileStrings.isEmpty() || !lmProfiles.isEmpty() || !preparations.isEmpty();
     }
 
     public int getPreparationThreads() {
@@ -189,10 +177,6 @@ public class LMPreparationHandler {
 
     public boolean hasLMProfiles() {
         return !lmProfiles.isEmpty();
-    }
-
-    public boolean hasPreparations() {
-        return !preparations.isEmpty();
     }
 
     public int size() {

--- a/core/src/main/java/com/graphhopper/storage/GraphHopperStorage.java
+++ b/core/src/main/java/com/graphhopper/storage/GraphHopperStorage.java
@@ -284,7 +284,7 @@ public final class GraphHopperStorage implements GraphStorage, Graph {
         List<CHProfile> configured = getCHProfiles();
         for (CHProfile chProfile : configured) {
             if (!loaded.contains(chProfile.toString())) {
-                throw new IllegalStateException("Configured CH profile: " + chProfile.toString() + " is not contained in loaded weightings for CH" + loadedStr + ".\n" +
+                throw new IllegalStateException("Configured CH profile: " + chProfile.toString() + " is not contained in loaded CH profiles: " + loadedStr + ".\n" +
                         "You configured: " + configured);
             }
         }

--- a/core/src/test/java/com/graphhopper/GraphHopperAPITest.java
+++ b/core/src/test/java/com/graphhopper/GraphHopperAPITest.java
@@ -71,7 +71,6 @@ public class GraphHopperAPITest {
 
         GraphHopper instance = createGraphHopper(vehicle).
                 setStoreOnFlush(false).
-                setCHEnabled(false).
                 loadGraph(graph);
         // 3 -> 0
         GHResponse rsp = instance.route(new GHRequest(42, 10.4, 42, 10).setVehicle(vehicle).setWeighting(weighting));
@@ -97,7 +96,6 @@ public class GraphHopperAPITest {
 
         GraphHopper instance = createGraphHopper(vehicle).
                 setStoreOnFlush(false).
-                setCHEnabled(false).
                 loadGraph(graph);
         GHResponse rsp = instance.route(new GHRequest(42, 10, 42, 10.4).setVehicle(vehicle).setWeighting(weighting));
         assertTrue(rsp.hasErrors());
@@ -133,7 +131,6 @@ public class GraphHopperAPITest {
         GraphHopper instance = createGraphHopper(vehicle)
                 .setElevation(true)
                 .setGraphHopperLocation(loc)
-                .setCHEnabled(false)
                 .loadGraph(graph);
         instance.flush();
         instance.close();
@@ -147,7 +144,7 @@ public class GraphHopperAPITest {
             }
         }
                 .setEncodingManager(encodingManager)
-                .setElevation(true).setCHEnabled(false);
+                .setElevation(true);
         instance.load(loc);
         instance.flush();
         instance.close();
@@ -161,7 +158,7 @@ public class GraphHopperAPITest {
             }
         }
                 .setEncodingManager(encodingManager)
-                .setElevation(true).setCHEnabled(false);
+                .setElevation(true);
         instance.load(loc);
         instance.flush();
         instance.close();
@@ -175,8 +172,7 @@ public class GraphHopperAPITest {
         String vehicle = "car";
         String weighting = "fastest";
         GraphHopper instance = createGraphHopper(vehicle).
-                setStoreOnFlush(false).
-                setCHEnabled(false);
+                setStoreOnFlush(false);
         try {
             instance.route(new GHRequest(42, 10.4, 42, 10).setVehicle(vehicle).setWeighting(weighting));
             fail();
@@ -225,7 +221,6 @@ public class GraphHopperAPITest {
         }
                 .setEncodingManager(encodingManager)
                 .setStoreOnFlush(false).
-                        setCHEnabled(false).
                         loadGraph(graph);
 
         GHResponse rsp = graphHopper.route(new GHRequest(42, 10.4, 42, 10).setVehicle(vehicle).setWeighting(weighting));

--- a/core/src/test/java/com/graphhopper/routing/ch/CHPreparationHandlerTest.java
+++ b/core/src/test/java/com/graphhopper/routing/ch/CHPreparationHandlerTest.java
@@ -67,10 +67,10 @@ public class CHPreparationHandlerTest {
     }
 
     @Test
-    public void testDisablingAllowed() {
-        assertFalse(instance.isDisablingAllowed());
-        instance.setEnabled(false);
-        assertTrue(instance.isDisablingAllowed());
+    public void testEnabled() {
+        assertFalse(instance.isEnabled());
+        instance.setCHProfileStrings("fastest");
+        assertTrue(instance.isEnabled());
     }
 
     @Test(expected = IllegalStateException.class)

--- a/core/src/test/java/com/graphhopper/routing/lm/LMPreparationHandlerTest.java
+++ b/core/src/test/java/com/graphhopper/routing/lm/LMPreparationHandlerTest.java
@@ -21,12 +21,11 @@ public class LMPreparationHandlerTest {
     @Test
     public void addWeighting() {
         LMPreparationHandler handler = new LMPreparationHandler();
-        handler.setEnabled(true);
         handler.addLMProfileAsString("fastest");
         assertEquals(Arrays.asList("fastest"), handler.getLMProfileStrings());
 
         // special parameters like the maximum weight
-        handler = new LMPreparationHandler().setEnabled(true);
+        handler = new LMPreparationHandler();
         handler.addLMProfileAsString("fastest|maximum=65000");
         handler.addLMProfileAsString("shortest|maximum=20000");
         assertEquals(Arrays.asList("fastest", "shortest"), handler.getLMProfileStrings());

--- a/core/src/test/java/com/graphhopper/storage/GraphHopperStorageLMTest.java
+++ b/core/src/test/java/com/graphhopper/storage/GraphHopperStorageLMTest.java
@@ -48,8 +48,8 @@ public class GraphHopperStorageLMTest {
         graph.flush();
         graph.close();
 
-        GraphHopper hopper = new GraphHopper().setGraphHopperLocation(defaultGraphLoc).setCHEnabled(false);
-        hopper.getLMPreparationHandler().setEnabled(true).setLMProfileStrings(Arrays.asList("fastest"));
+        GraphHopper hopper = new GraphHopper().setGraphHopperLocation(defaultGraphLoc);
+        hopper.getLMPreparationHandler().setLMProfileStrings(Arrays.asList("fastest"));
         // does lm preparation
         hopper.importOrLoad();
         EncodingManager em = hopper.getEncodingManager();
@@ -57,8 +57,8 @@ public class GraphHopperStorageLMTest {
         assertEquals(1, em.fetchEdgeEncoders().size());
         assertEquals(16, hopper.getLMPreparationHandler().getLandmarks());
 
-        hopper = new GraphHopper().setGraphHopperLocation(defaultGraphLoc).setCHEnabled(false);
-        hopper.getLMPreparationHandler().setEnabled(true).setLMProfileStrings(Arrays.asList("fastest"));
+        hopper = new GraphHopper().setGraphHopperLocation(defaultGraphLoc);
+        hopper.getLMPreparationHandler().setLMProfileStrings(Arrays.asList("fastest"));
         // just loads the LM data
         hopper.importOrLoad();
         assertEquals(1, em.fetchEdgeEncoders().size());

--- a/core/src/test/java/com/graphhopper/storage/GraphHopperStorageTest.java
+++ b/core/src/test/java/com/graphhopper/storage/GraphHopperStorageTest.java
@@ -303,7 +303,10 @@ public class GraphHopperStorageTest extends AbstractGraphStorageTester {
         Helper.close(graph);
 
         // load without configured FlagEncoders
-        GraphHopper hopper = new GraphHopper().setCHEnabled(ch);
+        GraphHopper hopper = new GraphHopper();
+        if (ch) {
+            hopper.getCHPreparationHandler().setCHProfileStrings("fastest");
+        }
         assertTrue(hopper.load(defaultGraphLoc));
         graph = hopper.getGraphHopperStorage();
         assertEquals(nodes, graph.getNodes());
@@ -311,7 +314,10 @@ public class GraphHopperStorageTest extends AbstractGraphStorageTester {
         Helper.close(graph);
 
         // load via explicitly configured FlagEncoders
-        hopper = new GraphHopper().setCHEnabled(ch).setEncodingManager(encodingManager);
+        hopper = new GraphHopper().setEncodingManager(encodingManager);
+        if (ch) {
+            hopper.getCHPreparationHandler().setCHProfileStrings("fastest");
+        }
         assertTrue(hopper.load(defaultGraphLoc));
         graph = hopper.getGraphHopperStorage();
         assertEquals(nodes, graph.getNodes());

--- a/docs/core/routing.md
+++ b/docs/core/routing.md
@@ -53,7 +53,7 @@ List<Map<String, Object>> iList = il.createJson();
 List<GPXEntry> list = il.createGPXList();
 ```
 
-## Speed mode vs. Hybrid mode vs. Flexibile mode
+## Speed mode vs. Hybrid mode vs. Flexible mode
 
 The default option of GraphHopper is the speed mode. If you don't want to use the speed-up mode you can disable it before the import (see
 config.yml `prepare.ch.weightings=no`) or on a per request base by adding `ch.disable=true` to the request. If you want to use the hybrid mode you have to enable it before the import 
@@ -66,7 +66,6 @@ To calculate a route you have to pick one vehicle and optionally an algorithm li
 
 ```java
 GraphHopper hopper = new GraphHopperOSM().forServer();
-hopper.setCHEnabled(false);
 hopper.setOSMFile(osmFile);
 hopper.setGraphHopperLocation(graphFolder);
 hopper.setEncodingManager(EncodingManager.create("car,bike"));

--- a/docs/web/api-doc.md
+++ b/docs/web/api-doc.md
@@ -38,7 +38,8 @@ type             | json    | Specifies the resulting format of the route, for `j
 point_hint       | -       | Optional parameter. Specifies a hint for each `point` parameter to prefer a certain street for the closest location lookup. E.g. if there is an address or house with two or more neighboring streets you can control for which street the closest location is looked up.
 snap_prevention  | -       | Optional parameter to avoid snapping to a certain road class or road environment. Current supported values: `motorway`, `trunk`, `ferry`, `tunnel`, `bridge` and `ford`. Multiple values are specified like `snap_prevention=ferry&snap_prevention=motorway`
 details          | -       | Optional parameter. You can request additional details for the route: `average_speed`, `street_name`, `edge_id`, `road_class`, `road_environment`, `max_speed` and `time` (and see which other values are configured in `graph.encoded_values`).  Multiple values are specified like `details=average_speed&details=time`. The returned format for one detail segment is `[fromRef, toRef, value]`. The `ref` references the points of the response. Value can also be `null` if the property does not exist for one detail segment.
-edge_base        | false   | Internal parameter to force edge-based algorithm.
+turn_costs       | false   | Use `true` if you want to consider turn restrictions for bike and motor vehicles. Keep in mind that the response time is roughly 2 times slower.
+edge_based       | false   | Internal parameter to force edge-based algorithm.
 curbside         | any     | Optional parameter applicable to edge-based routing only. It specifies on which side a query point should be relative to the driver when she leaves/arrives at a start/target/via point. Possible values: right, left, any. Specify for every point parameter. See similar heading parameter.
 force_curbside   | false   | True if the curbside parameters should lead to an exception if they cannot be fulfilled.
 
@@ -71,7 +72,6 @@ Parameter        | Default    | Description
 :----------------|:-----------|:-----------
 ch.disable       | `false`    | Use this parameter in combination with one or more parameters of this table
 weighting        | `fastest`  | Which kind of 'best' route calculation you need. Other option is `shortest` (e.g. for `vehicle=foot` or `bike`), `short_fastest` if time and distance is expensive (e.g. for `vehicle=truck`) and `curvature` (only for `vehicle=motorcycle`)
-edge_traversal   |`false`     | Use `true` if you want to consider turn restrictions for bike and motor vehicles. Keep in mind that the response time is roughly 2 times slower.
 algorithm        |`astarbi`   | The algorithm to calculate the route. Other options are `dijkstra`, `astar`, `astarbi`, `alternative_route` and `round_trip`
 block_area       | -          | Block road access via a point with the format `latitude,longitude` or an area defined by a circle `lat,lon,radius` or a rectangle `lat1,lon1,lat2,lon2`. Separate multiple areas with a semicolon `;`.
 heading          | NaN        | Favour a heading direction for a certain point. Specify either one heading for the start point or as many as there are points. In this case headings are associated by their order to the specific points. Headings are given as north based clockwise angle between 0 and 360 degree. This parameter also influences the tour generated with `algorithm=round_trip` and forces the initial direction.

--- a/reader-gtfs/README.md
+++ b/reader-gtfs/README.md
@@ -17,11 +17,10 @@ wget http://download.geofabrik.de/europe/germany/brandenburg-latest.osm.pbf
 # The following process will take roughly 5 minutes on a modern laptop when it is executed for the first time.
 # It imports the previously downloaded OSM data of the Brandenburg area as well as the GTFS.
 java -Xmx8g -Xms8g \
-# todonow: this is a) outdated, and b) why no CH (when in tests its enabled?)
-  -Dgraphhopper.datareader.file=brandenburg-latest.osm.pbf \
-  -Dgraphhopper.gtfs.file=gtfs-vbb.zip \
-  -Dgraphhopper.graph.flag_encoders=pt \
-  -Dgraphhopper.graph.location=./graph-cache \
+  -Ddw.graphhopper.datareader.file=brandenburg-latest.osm.pbf \
+  -Ddw.graphhopper.gtfs.file=gtfs-vbb.zip \
+  -Ddw.graphhopper.graph.flag_encoders=pt \
+  -Ddw.graphhopper.graph.location=./graph-cache \
   -jar web/target/graphhopper-web-*.jar server config.yml
 # view the web UI e.g. via:
 firefox http://localhost:8989

--- a/reader-gtfs/README.md
+++ b/reader-gtfs/README.md
@@ -17,10 +17,10 @@ wget http://download.geofabrik.de/europe/germany/brandenburg-latest.osm.pbf
 # The following process will take roughly 5 minutes on a modern laptop when it is executed for the first time.
 # It imports the previously downloaded OSM data of the Brandenburg area as well as the GTFS.
 java -Xmx8g -Xms8g \
+# todonow: this is a) outdated, and b) why no CH (when in tests its enabled?)
   -Dgraphhopper.datareader.file=brandenburg-latest.osm.pbf \
   -Dgraphhopper.gtfs.file=gtfs-vbb.zip \
   -Dgraphhopper.graph.flag_encoders=pt \
-  -Dgraphhopper.prepare.ch.weightings=no \
   -Dgraphhopper.graph.location=./graph-cache \
   -jar web/target/graphhopper-web-*.jar server config.yml
 # view the web UI e.g. via:

--- a/reader-gtfs/src/test/java/com/graphhopper/ExtendedRouteTypeIT.java
+++ b/reader-gtfs/src/test/java/com/graphhopper/ExtendedRouteTypeIT.java
@@ -48,8 +48,6 @@ public class ExtendedRouteTypeIT {
         ghConfig.put("graph.flag_encoders", "car,foot");
         ghConfig.put("graph.location", GRAPH_LOC);
         ghConfig.put("gtfs.file", "files/another-sample-feed-extended-route-type.zip");
-        // todonow: do we want the (previously by default) CH profiles here? (same question for all GraphHopperGtfs basically
-        ghConfig.put("prepare.ch.weightings", "fastest");
         Helper.removeDir(new File(GRAPH_LOC));
         graphHopperGtfs = new GraphHopperGtfs(ghConfig);
         graphHopperGtfs.init(ghConfig);

--- a/reader-gtfs/src/test/java/com/graphhopper/ExtendedRouteTypeIT.java
+++ b/reader-gtfs/src/test/java/com/graphhopper/ExtendedRouteTypeIT.java
@@ -48,6 +48,8 @@ public class ExtendedRouteTypeIT {
         ghConfig.put("graph.flag_encoders", "car,foot");
         ghConfig.put("graph.location", GRAPH_LOC);
         ghConfig.put("gtfs.file", "files/another-sample-feed-extended-route-type.zip");
+        // todonow: do we want the (previously by default) CH profiles here? (same question for all GraphHopperGtfs basically
+        ghConfig.put("prepare.ch.weightings", "fastest");
         Helper.removeDir(new File(GRAPH_LOC));
         graphHopperGtfs = new GraphHopperGtfs(ghConfig);
         graphHopperGtfs.init(ghConfig);

--- a/reader-osm/src/test/java/com/graphhopper/GraphHopperIT.java
+++ b/reader-osm/src/test/java/com/graphhopper/GraphHopperIT.java
@@ -78,7 +78,6 @@ public class GraphHopperIT {
         GraphHopper hopper = createGraphHopper(vehicle).
                 setOSMFile(MONACO).
                 setStoreOnFlush(true).
-                setCHEnabled(false).
                 importOrLoad();
 
         GHResponse rsp = hopper.route(new GHRequest(43.727687, 7.418737, 43.74958, 7.436566).
@@ -129,7 +128,6 @@ public class GraphHopperIT {
         GraphHopper hopper = createGraphHopper(vehicle).
                 setOSMFile(MONACO).
                 setStoreOnFlush(true).
-                setCHEnabled(false).
                 importOrLoad();
 
         GHRequest request = new GHRequest().setAlgorithm(ASTAR).setVehicle(vehicle).setWeighting(weighting);
@@ -151,8 +149,7 @@ public class GraphHopperIT {
         final String vehicle = "car";
         final String weighting = "shortest";
         GraphHopper hopper = createGraphHopper(vehicle).
-                setOSMFile(MONACO).
-                setCHEnabled(false);
+                setOSMFile(MONACO);
         hopper.importOrLoad();
         Translation tr = hopper.getTranslationMap().getWithFallBack(Locale.US);
 
@@ -181,28 +178,24 @@ public class GraphHopperIT {
         GraphHopper hopper = createGraphHopper(vehicle).
                 setOSMFile(MONACO).
                 setStoreOnFlush(true).
-                setCHEnabled(ch).
                 setSortGraph(sort);
         if (ch) {
             hopper.getCHPreparationHandler().setCHProfileStrings(weighting).setDisablingAllowed(true);
         }
         if (lm) {
             hopper.getLMPreparationHandler().
-                    setEnabled(true).
                     setLMProfileStrings(Collections.singletonList(weighting)).
                     setDisablingAllowed(true);
         }
         hopper.importAndClose();
         hopper = createGraphHopper(vehicle).
                 setOSMFile(MONACO).
-                setStoreOnFlush(true).
-                setCHEnabled(ch);
+                setStoreOnFlush(true);
         if (ch) {
             hopper.getCHPreparationHandler().setCHProfileStrings(weighting).setDisablingAllowed(true);
         }
         if (lm) {
             hopper.getLMPreparationHandler().
-                    setEnabled(true).
                     setLMProfileStrings(Collections.singletonList(weighting)).
                     setDisablingAllowed(true);
         }
@@ -294,7 +287,6 @@ public class GraphHopperIT {
         GraphHopper hopper = createGraphHopper(vehicle).
                 setOSMFile(MONACO).
                 setStoreOnFlush(true).
-                setCHEnabled(false).
                 importOrLoad();
 
         GHRequest req = new GHRequest(43.729057, 7.41251, 43.740298, 7.423561).
@@ -324,8 +316,7 @@ public class GraphHopperIT {
         final String weighting = "fastest";
 
         GraphHopper hopper = createGraphHopper(vehicle).
-                setOSMFile(BAYREUTH).
-                setCHEnabled(false);
+                setOSMFile(BAYREUTH);
         hopper.importOrLoad();
 
         GHRequest req = new GHRequest(50.028917, 11.496506, 49.985228, 11.600876).
@@ -349,8 +340,7 @@ public class GraphHopperIT {
         final String weighting = "fastest";
 
         GraphHopper hopper = createGraphHopper(vehicle).
-                setOSMFile(BAYREUTH).
-                setCHEnabled(false);
+                setOSMFile(BAYREUTH);
         hopper.importOrLoad();
 
         GHRequest req = new GHRequest(50.023513, 11.548862, 49.969441, 11.537876).
@@ -374,8 +364,7 @@ public class GraphHopperIT {
         final String weighting = "fastest";
 
         GraphHopper hopper = createGraphHopper(vehicle).
-                setOSMFile(LAUF).
-                setCHEnabled(false);
+                setOSMFile(LAUF);
         hopper.importOrLoad();
 
         GHRequest req = new GHRequest(49.46553, 11.154669, 49.465244, 11.152577).
@@ -410,8 +399,7 @@ public class GraphHopperIT {
         final String weighting = "fastest";
 
         GraphHopper hopper = createGraphHopper(vehicle).
-                setOSMFile(BAYREUTH).
-                setCHEnabled(false);
+                setOSMFile(BAYREUTH);
         hopper.importOrLoad();
 
         GHRequest req = new GHRequest(49.985307, 11.50628, 49.985731, 11.507465).
@@ -428,8 +416,7 @@ public class GraphHopperIT {
         final String weighting = "fastest";
 
         GraphHopper hopper = createGraphHopper(vehicle).
-                setOSMFile(BAYREUTH).
-                setCHEnabled(false);
+                setOSMFile(BAYREUTH);
         hopper.importOrLoad();
 
         GHRequest req = new GHRequest(49.985272, 11.506151, 49.986107, 11.507202).
@@ -530,7 +517,6 @@ public class GraphHopperIT {
         GraphHopper hopper = createGraphHopper(vehicle).
                 setOSMFile(MONACO).
                 setStoreOnFlush(true).
-                setCHEnabled(false).
                 importOrLoad();
 
         Translation tr = hopper.getTranslationMap().getWithFallBack(Locale.US);
@@ -612,7 +598,6 @@ public class GraphHopperIT {
         GraphHopper hopper = createGraphHopper(vehicle).
                 setOSMFile(MONACO).
                 setStoreOnFlush(true).
-                setCHEnabled(false).
                 importOrLoad();
 
         GHRequest request = new GHRequest();
@@ -642,7 +627,6 @@ public class GraphHopperIT {
         GraphHopper hopper = createGraphHopper(vehicle).
                 setOSMFile(MONACO).
                 setStoreOnFlush(true).
-                setCHEnabled(false).
                 importOrLoad();
 
         GHRequest req = new GHRequest().
@@ -664,7 +648,6 @@ public class GraphHopperIT {
         GraphHopper hopper = createGraphHopper(vehicle).
                 setOSMFile(MONACO).
                 setStoreOnFlush(true).
-                setCHEnabled(false).
                 importOrLoad();
 
         GHPoint from = new GHPoint(43.741069, 7.426854);
@@ -694,7 +677,6 @@ public class GraphHopperIT {
         GraphHopper hopper = createGraphHopper(vehicle).
                 setOSMFile(MONACO).
                 setStoreOnFlush(true).
-                setCHEnabled(false).
                 importOrLoad();
 
         GHPoint from = new GHPoint(43.741069, 7.426854);
@@ -725,7 +707,6 @@ public class GraphHopperIT {
         GraphHopper hopper = createGraphHopper(vehicle).
                 setOSMFile(MONACO).
                 setStoreOnFlush(true).
-                setCHEnabled(false).
                 importOrLoad();
 
         GHPoint from = new GHPoint(43.741069, 7.426854);
@@ -760,7 +741,6 @@ public class GraphHopperIT {
         GraphHopper hopper = createGraphHopper(vehicle).
                 setOSMFile(MONACO).
                 setStoreOnFlush(true).
-                setCHEnabled(false).
                 importOrLoad();
 
         GHRequest rq = new GHRequest().
@@ -793,8 +773,7 @@ public class GraphHopperIT {
 
         GraphHopper hopper = createGraphHopper(vehicle).
                 setOSMFile(MONACO).
-                setStoreOnFlush(true).
-                setCHEnabled(false);
+                setStoreOnFlush(true);
 
         hopper.setElevationProvider(new SRTMProvider(DIR));
         hopper.importOrLoad();
@@ -846,7 +825,6 @@ public class GraphHopperIT {
         GraphHopper hopper = new GraphHopperOSM()
                 .setOSMFile(MONACO)
                 .setStoreOnFlush(true)
-                .setCHEnabled(false)
                 .setGraphHopperLocation(GH_LOCATION)
                 .setEncodingManager(EncodingManager.start().add(new OSMRoadEnvironmentParser() {
                     @Override
@@ -883,8 +861,7 @@ public class GraphHopperIT {
 
         GraphHopper hopper = createGraphHopper("car,foot")
                 .setOSMFile(MONACO)
-                .setStoreOnFlush(true)
-                .setCHEnabled(false);
+                .setStoreOnFlush(true);
 
         hopper.setElevationProvider(new SRTMProvider(DIR));
         hopper.importOrLoad();
@@ -916,7 +893,6 @@ public class GraphHopperIT {
         GraphHopper hopper = createGraphHopper(vehicle1 + "," + vehicle2).
                 setOSMFile(KREMS).
                 setStoreOnFlush(true).
-                setCHEnabled(false).
                 importOrLoad();
 
         Translation tr = hopper.getTranslationMap().getWithFallBack(Locale.US);
@@ -1126,7 +1102,6 @@ public class GraphHopperIT {
         GraphHopper hopper = createGraphHopper(vehicle).
                 setOSMFile(MONACO).
                 setStoreOnFlush(true).
-                setCHEnabled(false).
                 importOrLoad();
 
         GHRequest rq = new GHRequest().
@@ -1151,8 +1126,7 @@ public class GraphHopperIT {
         final String weighting = "fastest";
 
         GraphHopper hopper = createGraphHopper(vehicle).
-                setOSMFile(BAYREUTH).
-                setCHEnabled(false);
+                setOSMFile(BAYREUTH);
         hopper.importOrLoad();
 
         GHRequest req = new GHRequest().
@@ -1172,8 +1146,7 @@ public class GraphHopperIT {
         final String vehicle = "car";
         final String weighting = "fastest";
         GraphHopper hopper = createGraphHopper(vehicle).
-                setOSMFile(BAYREUTH).
-                setCHEnabled(false);
+                setOSMFile(BAYREUTH);
         hopper.importOrLoad();
 
         GHRequest req = new GHRequest().
@@ -1195,11 +1168,11 @@ public class GraphHopperIT {
                 setOSMFile(MONACO).
                 setStoreOnFlush(true);
 
-        hopper.getCHPreparationHandler().setEnabled(true).
+        hopper.getCHPreparationHandler().
                 setCHProfilesAsStrings(Collections.singletonList(weighting)).
                 setDisablingAllowed(true);
 
-        hopper.getLMPreparationHandler().setEnabled(true).
+        hopper.getLMPreparationHandler().
                 setLMProfileStrings(Collections.singletonList(weighting + "|maximum=2000")).
                 setDisablingAllowed(true);
 
@@ -1255,11 +1228,11 @@ public class GraphHopperIT {
                 setOSMFile(MONACO).
                 setStoreOnFlush(true);
 
-        hopper.getCHPreparationHandler().setEnabled(true).
+        hopper.getCHPreparationHandler().
                 setCHProfilesAsStrings(Collections.singletonList(weighting)).
                 setDisablingAllowed(true);
 
-        hopper.getLMPreparationHandler().setEnabled(true).
+        hopper.getLMPreparationHandler().
                 setLMProfileStrings(Collections.singletonList(weighting + "|maximum=2000")).
                 setDisablingAllowed(true);
 
@@ -1301,8 +1274,7 @@ public class GraphHopperIT {
         GraphHopper hopper = createGraphHopper(vehicle + ",bike").
                 setOSMFile(MONACO).
                 setStoreOnFlush(true);
-        hopper.getCHPreparationHandler().setEnabled(false);
-        hopper.getLMPreparationHandler().setEnabled(true).
+        hopper.getLMPreparationHandler().
                 setLMProfileStrings(Collections.singletonList(weighting + "|maximum=2000")).
                 setDisablingAllowed(true);
         hopper.importOrLoad();
@@ -1325,8 +1297,7 @@ public class GraphHopperIT {
     public void testTurnCostsOnOff() {
         GraphHopper hopper = createGraphHopper("car|turn_costs=true").
                 setOSMFile(MOSCOW).
-                setStoreOnFlush(true).
-                setCHEnabled(false);
+                setStoreOnFlush(true);
         hopper.importOrLoad();
 
         // no edge_based parameter -> use edge-based (since encoder supports it and no CH)
@@ -1342,8 +1313,7 @@ public class GraphHopperIT {
         final String weighting = "fastest";
         GraphHopper hopper = createGraphHopper("car|turn_costs=true").
                 setOSMFile(MOSCOW).
-                setStoreOnFlush(true).
-                setCHEnabled(true);
+                setStoreOnFlush(true);
         hopper.getCHPreparationHandler().setCHProfileStrings(weighting);
         hopper.getCHPreparationHandler().setDisablingAllowed(true);
         hopper.getCHPreparationHandler().setEdgeBasedCHMode(EdgeBasedCHMode.EDGE_AND_NODE);
@@ -1362,8 +1332,7 @@ public class GraphHopperIT {
         final String weighting = "fastest";
         GraphHopper hopper = createGraphHopper("car|turn_costs=true").
                 setOSMFile(MOSCOW).
-                setStoreOnFlush(true).
-                setCHEnabled(true);
+                setStoreOnFlush(true);
         hopper.getCHPreparationHandler()
                 .setCHProfileStrings(weighting)
                 .setEdgeBasedCHMode(EdgeBasedCHMode.EDGE_OR_NODE)
@@ -1384,8 +1353,7 @@ public class GraphHopperIT {
         // before edge-based CH was added a common case was to use edge-based without CH and CH for node-based
         GraphHopper hopper = createGraphHopper("car|turn_costs=true").
                 setOSMFile(MOSCOW).
-                setStoreOnFlush(true).
-                setCHEnabled(true);
+                setStoreOnFlush(true);
         hopper.getCHPreparationHandler()
                 .setCHProfileStrings(weighting)
                 .setEdgeBasedCHMode(EdgeBasedCHMode.OFF)
@@ -1416,8 +1384,7 @@ public class GraphHopperIT {
         final String weighting = "fastest";
         GraphHopper hopper = createGraphHopper("car|turn_costs=true").
                 setOSMFile(MOSCOW).
-                setStoreOnFlush(true).
-                setCHEnabled(true);
+                setStoreOnFlush(true);
         hopper.getCHPreparationHandler().setCHProfileStrings(weighting);
         hopper.getCHPreparationHandler().setDisablingAllowed(true);
         hopper.getCHPreparationHandler().setEdgeBasedCHMode(EdgeBasedCHMode.EDGE_OR_NODE);
@@ -1465,7 +1432,6 @@ public class GraphHopperIT {
         GraphHopper hopper = createGraphHopper(vehicle).
                 setOSMFile(MONACO).
                 setStoreOnFlush(true).
-                setCHEnabled(false).
                 importOrLoad();
         GHPoint p = new GHPoint(43.727687, 7.418737);
         GHPoint q = new GHPoint(43.74958, 7.436566);
@@ -1482,8 +1448,7 @@ public class GraphHopperIT {
     public void testEncoderWithTurnCostSupport_stillAllows_nodeBasedRouting() {
         // see #1698
         GraphHopper hopper = createGraphHopper("foot,car|turn_costs=true").
-                setOSMFile(MOSCOW).
-                setCHEnabled(false);
+                setOSMFile(MOSCOW);
         hopper.importOrLoad();
         GHPoint p = new GHPoint(55.813357, 37.5958585);
         GHPoint q = new GHPoint(55.811042, 37.594689);
@@ -1496,8 +1461,7 @@ public class GraphHopperIT {
     @Test
     public void testCurbsides() {
         GraphHopper h = createGraphHopper("car|turn_costs=true").
-                setOSMFile(BAYREUTH).
-                setCHEnabled(true);
+                setOSMFile(BAYREUTH);
         h.getCHPreparationHandler()
                 .setCHProfileStrings("fastest")
                 .setEdgeBasedCHMode(EdgeBasedCHMode.EDGE_OR_NODE);
@@ -1543,8 +1507,7 @@ public class GraphHopperIT {
     @Test
     public void testForceCurbsides() {
         GraphHopper h = createGraphHopper("car|turn_costs=true").
-                setOSMFile(MONACO).
-                setCHEnabled(true);
+                setOSMFile(MONACO);
         h.getCHPreparationHandler()
                 .setCHProfileStrings("fastest")
                 .setEdgeBasedCHMode(EdgeBasedCHMode.EDGE_OR_NODE);
@@ -1608,8 +1571,7 @@ public class GraphHopperIT {
     @Test
     public void testCHWithFiniteUTurnCostsAndMissingWeighting() {
         GraphHopper h = createGraphHopper("car|turn_costs=true").
-                setOSMFile(MONACO).
-                setCHEnabled(true);
+                setOSMFile(MONACO);
         h.getCHPreparationHandler()
                 .setCHProfileStrings("fastest|u_turn_costs=40")
                 .setEdgeBasedCHMode(EdgeBasedCHMode.EDGE_OR_NODE);
@@ -1634,7 +1596,6 @@ public class GraphHopperIT {
     public void simplifyWithInstructionsAndPathDetails() {
         GraphHopper hopper = new GraphHopperOSM().
                 setOSMFile(BAYREUTH).
-                setCHEnabled(false).
                 setGraphHopperLocation(GH_LOCATION).
                 forServer();
         EncodingManager em = new EncodingManager.Builder()

--- a/reader-osm/src/test/java/com/graphhopper/reader/osm/GraphHopperOSMTest.java
+++ b/reader-osm/src/test/java/com/graphhopper/reader/osm/GraphHopperOSMTest.java
@@ -270,17 +270,20 @@ public class GraphHopperOSMTest {
         String vehicle = "car";
         GraphHopper instance1 = createGraphHopper(vehicle).
                 setStoreOnFlush(true).
+                setCHEnabled(false).
                 setGraphHopperLocation(ghLoc).
                 setDataReaderFile(testOsm);
         instance1.importOrLoad();
 
         GraphHopper instance2 = createGraphHopper(vehicle).
                 setStoreOnFlush(true).
+                setCHEnabled(false).
                 setDataReaderFile(testOsm);
         instance2.load(ghLoc);
 
         GraphHopper instance3 = createGraphHopper(vehicle).
                 setStoreOnFlush(true).
+                setCHEnabled(false).
                 setDataReaderFile(testOsm);
         instance3.load(ghLoc);
 
@@ -305,6 +308,7 @@ public class GraphHopperOSMTest {
                 return super.importData();
             }
         }.setStoreOnFlush(true).
+                setCHEnabled(false).
                 setEncodingManager(EncodingManager.create("car")).
                 setGraphHopperLocation(ghLoc).
                 setDataReaderFile(testOsm);

--- a/reader-osm/src/test/java/com/graphhopper/reader/osm/GraphHopperOSMTest.java
+++ b/reader-osm/src/test/java/com/graphhopper/reader/osm/GraphHopperOSMTest.java
@@ -125,7 +125,6 @@ public class GraphHopperOSMTest {
         final String weighting = "fastest";
         GraphHopper gh = createGraphHopper(vehicle).
                 setStoreOnFlush(true).
-                setCHEnabled(false).
                 setGraphHopperLocation(ghLoc).
                 setDataReaderFile(testOsm);
         gh.importOrLoad();
@@ -139,8 +138,7 @@ public class GraphHopperOSMTest {
 
         gh.close();
         gh = createGraphHopper(vehicle).
-                setStoreOnFlush(true).
-                setCHEnabled(false);
+                setStoreOnFlush(true);
         assertTrue(gh.load(ghLoc));
         rsp = gh.route(new GHRequest(51.2492152, 9.4317166, 51.2, 9.4)
                 .setVehicle(vehicle).setWeighting(weighting));
@@ -151,8 +149,7 @@ public class GraphHopperOSMTest {
 
         gh = createGraphHopper(vehicle).
                 setGraphHopperLocation(ghLoc).
-                setDataReaderFile(testOsm).
-                init(new GraphHopperConfig().put(Parameters.CH.PREPARE + "weightings", "no"));
+                setDataReaderFile(testOsm);
 
         assertFalse(gh.getAlgorithmFactory(new HintsMap(weighting)) instanceof CHRoutingAlgorithmFactory);
         gh.close();
@@ -162,7 +159,6 @@ public class GraphHopperOSMTest {
     public void testQueryLocationIndexWithBBox() {
         final GraphHopper gh = createGraphHopper("car").
                 setStoreOnFlush(true).
-                setCHEnabled(false).
                 setGraphHopperLocation(ghLoc).
                 setDataReaderFile("../core/files/monaco.osm.gz");
         gh.importOrLoad();
@@ -235,7 +231,7 @@ public class GraphHopperOSMTest {
         gh.close();
 
         gh = createGraphHopper(vehicle).
-                setStoreOnFlush(true).setCHEnabled(false);
+                setStoreOnFlush(true);
         gh.load(ghLoc);
         // no error
 
@@ -244,7 +240,6 @@ public class GraphHopperOSMTest {
         // without CH should not be loadable with CH enabled
         gh = createGraphHopper(vehicle).
                 setStoreOnFlush(true).
-                setCHEnabled(false).
                 setGraphHopperLocation(ghLoc).
                 setDataReaderFile(testOsm);
         gh.importOrLoad();
@@ -261,7 +256,7 @@ public class GraphHopperOSMTest {
             gh.load(ghLoc);
             fail();
         } catch (Exception ex) {
-            assertTrue(ex.getMessage(), ex.getMessage().contains("is not contained in loaded weightings"));
+            assertTrue(ex.getMessage(), ex.getMessage().contains("is not contained in loaded CH profiles"));
         }
     }
 
@@ -270,20 +265,17 @@ public class GraphHopperOSMTest {
         String vehicle = "car";
         GraphHopper instance1 = createGraphHopper(vehicle).
                 setStoreOnFlush(true).
-                setCHEnabled(false).
                 setGraphHopperLocation(ghLoc).
                 setDataReaderFile(testOsm);
         instance1.importOrLoad();
 
         GraphHopper instance2 = createGraphHopper(vehicle).
                 setStoreOnFlush(true).
-                setCHEnabled(false).
                 setDataReaderFile(testOsm);
         instance2.load(ghLoc);
 
         GraphHopper instance3 = createGraphHopper(vehicle).
                 setStoreOnFlush(true).
-                setCHEnabled(false).
                 setDataReaderFile(testOsm);
         instance3.load(ghLoc);
 
@@ -308,7 +300,6 @@ public class GraphHopperOSMTest {
                 return super.importData();
             }
         }.setStoreOnFlush(true).
-                setCHEnabled(false).
                 setEncodingManager(EncodingManager.create("car")).
                 setGraphHopperLocation(ghLoc).
                 setDataReaderFile(testOsm);
@@ -373,7 +364,6 @@ public class GraphHopperOSMTest {
         final String vehicle = "car";
         final String weighting = "fastest";
         instance = createGraphHopper(vehicle).
-                setCHEnabled(false).
                 setStoreOnFlush(false).
                 setSortGraph(true).
                 setGraphHopperLocation(ghLoc).
@@ -409,7 +399,6 @@ public class GraphHopperOSMTest {
         // now all ways are imported
         instance = createGraphHopper(vehicle1 + "," + vehicle2).
                 setStoreOnFlush(false).
-                setCHEnabled(false).
                 setGraphHopperLocation(ghLoc).
                 setDataReaderFile(testOsm3);
         instance.importOrLoad();
@@ -456,8 +445,7 @@ public class GraphHopperOSMTest {
                 new GraphHopperConfig().
                         put("datareader.file", testOsm3).
                         put("datareader.dataaccess", "RAM").
-                        put("graph.flag_encoders", "foot,car").
-                        put(Parameters.CH.PREPARE + "weightings", "no")).
+                        put("graph.flag_encoders", "foot,car")).
                 setGraphHopperLocation(ghLoc);
         instance.importOrLoad();
         assertEquals(5, instance.getGraphHopperStorage().getNodes());
@@ -469,8 +457,7 @@ public class GraphHopperOSMTest {
                     new GraphHopperConfig().
                             put("datareader.file", testOsm3).
                             put("datareader.dataaccess", "RAM").
-                            put("graph.flag_encoders", "foot").
-                            put(Parameters.CH.PREPARE + "weightings", "no")).
+                            put("graph.flag_encoders", "foot")).
                     setDataReaderFile(testOsm3);
             tmpGH.load(ghLoc);
             fail();
@@ -483,7 +470,6 @@ public class GraphHopperOSMTest {
             GraphHopper tmpGH = new GraphHopperOSM().init(new GraphHopperConfig().
                     put("datareader.file", testOsm3).
                     put("datareader.dataaccess", "RAM").
-                    put(Parameters.CH.PREPARE + "weightings", "no").
                     put("graph.flag_encoders", "car,foot")).
                     setDataReaderFile(testOsm3);
             tmpGH.load(ghLoc);
@@ -498,8 +484,7 @@ public class GraphHopperOSMTest {
                         put("datareader.file", testOsm3).
                         put("datareader.dataaccess", "RAM").
                         put("graph.encoded_values", "road_class").
-                        put("graph.flag_encoders", "foot,car").
-                        put(Parameters.CH.PREPARE + "weightings", "no")).
+                        put("graph.flag_encoders", "foot,car")).
                 setDataReaderFile(testOsm3);
         try {
             instance.load(ghLoc);
@@ -514,11 +499,9 @@ public class GraphHopperOSMTest {
             public int getVersion() {
                 return 0;
             }
-        })).init(
-                new GraphHopperConfig().
-                        put("datareader.file", testOsm3).
-                        put("datareader.dataaccess", "RAM").
-                        put(Parameters.CH.PREPARE + "weightings", "no")).
+        })).init(new GraphHopperConfig().
+                put("datareader.file", testOsm3).
+                put("datareader.dataaccess", "RAM")).
                 setDataReaderFile(testOsm3);
         try {
             instance.load(ghLoc);
@@ -534,8 +517,7 @@ public class GraphHopperOSMTest {
                 new GraphHopperConfig().
                         put("datareader.file", testOsm3).
                         put("datareader.dataaccess", "RAM").
-                        put("graph.flag_encoders", "foot,car").
-                        put(Parameters.CH.PREPARE + "weightings", "no")).
+                        put("graph.flag_encoders", "foot,car")).
                 setGraphHopperLocation(ghLoc);
         instance.importOrLoad();
         // older versions <= 0.12 did not store this property, ensure that we fail to load it
@@ -550,8 +532,7 @@ public class GraphHopperOSMTest {
                         put("datareader.file", testOsm3).
                         put("datareader.dataaccess", "RAM").
                         put("graph.encoded_values", "road_environment,road_class").
-                        put("graph.flag_encoders", "foot,car").
-                        put(Parameters.CH.PREPARE + "weightings", "no")).
+                        put("graph.flag_encoders", "foot,car")).
                 setDataReaderFile(testOsm3);
         try {
             instance.load(ghLoc);
@@ -564,7 +545,6 @@ public class GraphHopperOSMTest {
     @Test
     public void testNoNPE_ifLoadNotSuccessful() {
         instance = createGraphHopper("car").
-                setCHEnabled(false).
                 setStoreOnFlush(true);
         try {
             // loading from empty directory
@@ -579,9 +559,7 @@ public class GraphHopperOSMTest {
 
     @Test
     public void testDoesNotCreateEmptyFolderIfLoadingFromNonExistingPath() {
-        instance = createGraphHopper("car")
-                .setCHEnabled(false);
-
+        instance = createGraphHopper("car");
         assertFalse(instance.load(ghLoc));
         assertFalse(new File(ghLoc).exists());
     }
@@ -599,7 +577,6 @@ public class GraphHopperOSMTest {
         GHTmp tmp = new GHTmp();
         try {
             tmp.setDataReaderFile(testOsm);
-            tmp.setCHEnabled(false);
             tmp.importData();
             fail();
         } catch (IllegalStateException ex) {
@@ -608,7 +585,6 @@ public class GraphHopperOSMTest {
 
         // missing graph location
         instance = new GraphHopperOSM();
-        instance.setCHEnabled(false);
         try {
             instance.importOrLoad();
             fail();
@@ -619,7 +595,6 @@ public class GraphHopperOSMTest {
         // missing OSM file to import
         instance = createGraphHopper("car").
                 setStoreOnFlush(true).
-                setCHEnabled(false).
                 setGraphHopperLocation(ghLoc);
         try {
             instance.importOrLoad();
@@ -632,7 +607,6 @@ public class GraphHopperOSMTest {
         // missing encoding manager          
         instance = new GraphHopperOSM().
                 setStoreOnFlush(true).
-                setCHEnabled(false).
                 setGraphHopperLocation(ghLoc).
                 setDataReaderFile(testOsm3);
         try {
@@ -645,7 +619,6 @@ public class GraphHopperOSMTest {
         // Import is possible even if no storeOnFlush is specified BUT here we miss the OSM file
         instance = createGraphHopper("car").
                 setStoreOnFlush(false).
-                setCHEnabled(false).
                 setGraphHopperLocation(ghLoc);
         try {
             instance.importOrLoad();
@@ -869,7 +842,6 @@ public class GraphHopperOSMTest {
         g.edge(7, 8, 110, true);
 
         GraphHopper tmp = new GraphHopperOSM().
-                setCHEnabled(false).
                 setEncodingManager(encodingManager);
         tmp.setGraphHopperStorage(g);
         tmp.postProcessing();
@@ -937,13 +909,11 @@ public class GraphHopperOSMTest {
 
             GraphHopper hopper = new GraphHopperOSM().
                     setStoreOnFlush(false).
-                    setCHEnabled(false).
                     setEncodingManager(em).
                     setGraphHopperLocation(ghLoc).
                     setDataReaderFile(testOsm);
             hopper.getLMPreparationHandler().
                     addLMProfileAsString("fastest").
-                    setEnabled(true).
                     setPreparationThreads(threadCount);
 
             hopper.importOrLoad();

--- a/reader-osm/src/test/java/com/graphhopper/reader/osm/OSMReaderTest.java
+++ b/reader-osm/src/test/java/com/graphhopper/reader/osm/OSMReaderTest.java
@@ -732,6 +732,7 @@ public class OSMReaderTest {
 
         GraphHopper hopper = new GraphHopperOSM().
                 setOSMFile(getClass().getResource("test-multi-profile-turn-restrictions.xml").getFile()).
+                setCHEnabled(false).
                 setGraphHopperLocation(dir).setEncodingManager(manager).importOrLoad();
 
         DecimalEncodedValue carTCEnc = manager.getDecimalEncodedValue(TurnCost.key("car"));

--- a/reader-osm/src/test/java/com/graphhopper/reader/osm/OSMReaderTest.java
+++ b/reader-osm/src/test/java/com/graphhopper/reader/osm/OSMReaderTest.java
@@ -732,7 +732,6 @@ public class OSMReaderTest {
 
         GraphHopper hopper = new GraphHopperOSM().
                 setOSMFile(getClass().getResource("test-multi-profile-turn-restrictions.xml").getFile()).
-                setCHEnabled(false).
                 setGraphHopperLocation(dir).setEncodingManager(manager).importOrLoad();
 
         DecimalEncodedValue carTCEnc = manager.getDecimalEncodedValue(TurnCost.key("car"));
@@ -922,7 +921,6 @@ public class OSMReaderTest {
                 .setDataReaderFile(getClass().getResource(file7).getFile())
                 .setEncodingManager(EncodingManager.create("car,motorcycle"))
                 .setGraphHopperLocation(dir);
-        hopper.getCHPreparationHandler().setEnabled(false);
         hopper.importOrLoad();
         GHRequest req = new GHRequest(48.977277, 8.256896, 48.978876, 8.254884).
                 setWeighting("curvature").
@@ -947,9 +945,8 @@ public class OSMReaderTest {
                 }
             }
         }.setEncodingManager(EncodingManager.create("car,bike")).
-                setGraphHopperLocation(dir)
-                .setCHEnabled(false).
-                        importOrLoad();
+                setGraphHopperLocation(dir).
+                importOrLoad();
 
         GHResponse response = gh.route(new GHRequest(51.2492152, 9.4317166, 52.133, 9.1)
                 .setVehicle("car").setWeighting("fastest")
@@ -974,7 +971,6 @@ public class OSMReaderTest {
             setStoreOnFlush(false);
             setOSMFile(osmFile);
             setGraphHopperLocation(dir);
-            setCHEnabled(false);
 
             BikeFlagEncoder bikeEncoder;
             if (turnCosts) {

--- a/reader-osm/src/test/java/com/graphhopper/routing/RoutingAlgorithmWithOSMIT.java
+++ b/reader-osm/src/test/java/com/graphhopper/routing/RoutingAlgorithmWithOSMIT.java
@@ -556,9 +556,6 @@ public class RoutingAlgorithmWithOSMIT {
                     setGraphHopperLocation(graphFile).
                     setEncodingManager(new EncodingManager.Builder().addAll(new DefaultFlagEncoderFactory(), importVehicles).build());
 
-            if (withCH) {
-                hopper.getCHPreparationHandler().setCHProfileStrings("fastest");
-            }
             if (osmFile.contains("krautsand"))
                 hopper.setMinNetworkSize(0, 0);
             // avoid that path.getDistance is too different to path.getPoint.calcDistance

--- a/reader-osm/src/test/java/com/graphhopper/routing/RoutingAlgorithmWithOSMIT.java
+++ b/reader-osm/src/test/java/com/graphhopper/routing/RoutingAlgorithmWithOSMIT.java
@@ -552,26 +552,30 @@ public class RoutingAlgorithmWithOSMIT {
             Helper.removeDir(new File(graphFile));
             GraphHopper hopper = new GraphHopperOSM().
                     setStoreOnFlush(true).
-                    setCHEnabled(withCH).
                     setDataReaderFile(osmFile).
                     setGraphHopperLocation(graphFile).
                     setEncodingManager(new EncodingManager.Builder().addAll(new DefaultFlagEncoderFactory(), importVehicles).build());
 
+            if (withCH) {
+                hopper.getCHPreparationHandler().setCHProfileStrings("fastest");
+            }
             if (osmFile.contains("krautsand"))
                 hopper.setMinNetworkSize(0, 0);
             // avoid that path.getDistance is too different to path.getPoint.calcDistance
             hopper.setWayPointMaxDistance(0);
 
             // always enable landmarks
-            hopper.getLMPreparationHandler().addLMProfileAsString(weightStr).
-                    setEnabled(true).setDisablingAllowed(true);
+            hopper.getLMPreparationHandler().
+                    addLMProfileAsString(weightStr).
+                    setDisablingAllowed(true);
 
-            if (withCH)
+            if (withCH) {
+                assert !Helper.isEmpty(weightStr);
                 hopper.getCHPreparationHandler().
                         addCHProfileAsString(weightStr).
-                        setEnabled(true).
                         setEdgeBasedCHMode(EdgeBasedCHMode.EDGE_OR_NODE).
                         setDisablingAllowed(true);
+            }
 
             if (is3D)
                 hopper.setElevationProvider(new SRTMProvider(DIR));
@@ -620,7 +624,6 @@ public class RoutingAlgorithmWithOSMIT {
         final GraphHopper hopper = new GraphHopperOSM().
                 setStoreOnFlush(true).
                 setEncodingManager(encodingManager).
-                setCHEnabled(false).
                 setWayPointMaxDistance(0).
                 setDataReaderFile(DIR + "/monaco.osm.gz").
                 setGraphHopperLocation(graphFile).

--- a/tools/src/main/java/com/graphhopper/tools/CHMeasurement.java
+++ b/tools/src/main/java/com/graphhopper/tools/CHMeasurement.java
@@ -113,7 +113,6 @@ public class CHMeasurement {
         ghConfig.put(SETTLED_EDGES_RESET_INTERVAL, resetInterval);
 
         LMPreparationHandler lmHandler = graphHopper.getLMPreparationHandler();
-        lmHandler.setEnabled(landmarks > 0);
         lmHandler.setDisablingAllowed(true);
 
         LOGGER.info("Initializing graph hopper with args: {}", ghConfig);

--- a/web/src/test/java/com/graphhopper/http/SpatialRulesTest.java
+++ b/web/src/test/java/com/graphhopper/http/SpatialRulesTest.java
@@ -45,7 +45,6 @@ public class SpatialRulesTest {
         config.getGraphHopperConfiguration().
                 put("graph.flag_encoders", "car").
                 put("graph.encoded_values", "country,road_environment,road_class,road_access,max_speed").
-                put("prepare.ch.weightings", "no").
                 put("spatial_rules.borders_directory", "../core/files/spatialrules").
                 put("spatial_rules.max_bbox", "11.4,11.7,49.9,50.1").
                 put("datareader.file", "../core/files/north-bayreuth.osm.gz").

--- a/web/src/test/java/com/graphhopper/http/resources/ChangeGraphResourceTest.java
+++ b/web/src/test/java/com/graphhopper/http/resources/ChangeGraphResourceTest.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.graphhopper.http.GraphHopperApplication;
 import com.graphhopper.http.GraphHopperServerConfiguration;
 import com.graphhopper.util.Helper;
-import com.graphhopper.util.Parameters;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import org.junit.AfterClass;
 import org.junit.ClassRule;
@@ -43,7 +42,6 @@ public class ChangeGraphResourceTest {
 
     static {
         config.getGraphHopperConfiguration().
-                put(Parameters.CH.PREPARE + "weightings", "no").
                 put("graph.flag_encoders", "car").
                 put("web.change_graph.enabled", "true").
                 put("graph.location", DIR).

--- a/web/src/test/java/com/graphhopper/http/resources/GpxTravelTimeConsistencyTest.java
+++ b/web/src/test/java/com/graphhopper/http/resources/GpxTravelTimeConsistencyTest.java
@@ -23,8 +23,8 @@ import com.graphhopper.GraphHopper;
 import com.graphhopper.PathWrapper;
 import com.graphhopper.reader.osm.GraphHopperOSM;
 import com.graphhopper.routing.util.EncodingManager;
-import com.graphhopper.util.gpx.GPXEntry;
 import com.graphhopper.util.Helper;
+import com.graphhopper.util.gpx.GPXEntry;
 import com.graphhopper.util.gpx.GpxFromInstructions;
 import com.graphhopper.util.shapes.GHPoint;
 import org.junit.BeforeClass;
@@ -49,7 +49,6 @@ public class GpxTravelTimeConsistencyTest {
         hopper = new GraphHopperOSM().
                 setOSMFile(osmFile).
                 setStoreOnFlush(true).
-                setCHEnabled(false).
                 setGraphHopperLocation(graphFileFoot).
                 setEncodingManager(EncodingManager.create(importVehicles)).
                 importOrLoad();

--- a/web/src/test/java/com/graphhopper/http/resources/I18nResourceTest.java
+++ b/web/src/test/java/com/graphhopper/http/resources/I18nResourceTest.java
@@ -21,7 +21,6 @@ public class I18nResourceTest {
 
     static {
         config.getGraphHopperConfiguration().
-                put("prepare.ch.weightings", "no").
                 put("graph.flag_encoders", "car").
                 put("datareader.file", "../core/files/andorra.osm.pbf").
                 put("graph.location", DIR);

--- a/web/src/test/java/com/graphhopper/http/resources/IsochroneResourceTest.java
+++ b/web/src/test/java/com/graphhopper/http/resources/IsochroneResourceTest.java
@@ -45,7 +45,6 @@ public class IsochroneResourceTest {
 
     static {
         config.getGraphHopperConfiguration().
-                put("prepare.ch.weightings", "no").
                 put("graph.flag_encoders", "car").
                 put("datareader.file", "../core/files/andorra.osm.pbf").
                 put("graph.location", DIR);

--- a/web/src/test/java/com/graphhopper/http/resources/MvtResourceTest.java
+++ b/web/src/test/java/com/graphhopper/http/resources/MvtResourceTest.java
@@ -55,7 +55,6 @@ public class MvtResourceTest {
         config.getGraphHopperConfiguration().
                 put("graph.flag_encoders", "car").
                 put("graph.encoded_values", "road_class,road_environment,max_speed,surface").
-                put("prepare.ch.weightings", "no").
                 put("prepare.min_network_size", "0").
                 put("prepare.min_one_way_network_size", "0").
                 put("datareader.file", "../core/files/andorra.osm.pbf").

--- a/web/src/test/java/com/graphhopper/http/resources/NearestResourceWithEleTest.java
+++ b/web/src/test/java/com/graphhopper/http/resources/NearestResourceWithEleTest.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.graphhopper.http.GraphHopperApplication;
 import com.graphhopper.http.GraphHopperServerConfiguration;
 import com.graphhopper.util.Helper;
-import com.graphhopper.util.Parameters;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import org.junit.AfterClass;
 import org.junit.ClassRule;
@@ -45,7 +44,6 @@ public class NearestResourceWithEleTest {
         config.getGraphHopperConfiguration().
                 put("graph.elevation.provider", "srtm").
                 put("graph.elevation.cachedir", "../core/files/").
-                put(Parameters.CH.PREPARE + "weightings", "no").
                 put("prepare.min_one_way_network_size", "0").
                 put("graph.flag_encoders", "car").
                 put("datareader.file", "../core/files/monaco.osm.gz").

--- a/web/src/test/java/com/graphhopper/http/resources/RouteResourceWithEleTest.java
+++ b/web/src/test/java/com/graphhopper/http/resources/RouteResourceWithEleTest.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.graphhopper.http.GraphHopperApplication;
 import com.graphhopper.http.GraphHopperServerConfiguration;
 import com.graphhopper.util.Helper;
-import com.graphhopper.util.Parameters;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import org.junit.AfterClass;
 import org.junit.ClassRule;
@@ -44,7 +43,6 @@ public class RouteResourceWithEleTest {
         config.getGraphHopperConfiguration().
                 put("graph.elevation.provider", "srtm").
                 put("graph.elevation.cachedir", "../core/files/").
-                put(Parameters.CH.PREPARE + "weightings", "no").
                 put("prepare.min_one_way_network_size", "0").
                 put("graph.flag_encoders", "car").
                 put("datareader.file", "../core/files/monaco.osm.gz").

--- a/web/src/test/java/com/graphhopper/http/resources/SPTResourceTest.java
+++ b/web/src/test/java/com/graphhopper/http/resources/SPTResourceTest.java
@@ -42,7 +42,6 @@ public class SPTResourceTest {
 
     static {
         config.getGraphHopperConfiguration().
-                put("prepare.ch.weightings", "no").
                 put("graph.flag_encoders", "car").
                 put("graph.encoded_values", "max_speed,road_class").
                 put("datareader.file", "../core/files/andorra.osm.pbf").


### PR DESCRIPTION
So far when creating a new `GraphHopper` instance the `CHPreparationHandler` was set to be enabled and `"fastest"` was used as default weighting, resulting in a `"fastest"` CH preparation for every vehicle. In this PR I have removed this default so there no longer are any CH preparations by default. I also removed the `LMPreparationHandler#setEnabled` methods, because there are only two cases: Either some CH/LM profiles are configured (then CH/LM is enabled) or not (then CH/LM is disabled), which means `setEnabled(false)` is equivalent to setting up no `CH/LMProfile`s and `setEnabled(true)` requires setting up the profiles and is thus unnecessary. 

The usage goes like this now:

```config.yml
graphhopper:
   # nothing changed here: adding some weightings means they will be prepared using CH
   prepare.ch.weightings=fastest
   # using an empty string or setting to 'no' means the list of weightings is empty, just as before this PR
   prepare.lm.weightings=no
```

```java
// create a new GraphHopper object. note that compared to before this PR there is no CH profile
GraphHopper hopper = new GraphHopper();
// these methods are all gone
// hopper.setCHEnabled(true);
// hopper.getCHPreparationHandler().setEnabled(true);
// hopper.getLMPreparationHandler().setEnabled(false);

// to enable CH/LM we need to add the profiles
// this resembles the previous behavior (CH will be 'enabled' by adding the profile)
hopper.getCHPreparationHandler().setCHProfileStrings("fastest");
```