### PR TITLE
Fix problems with block_area

### DIFF
--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -1073,6 +1073,9 @@ public class GraphHopper implements GraphHopperAPI {
                 return Collections.emptyList();
 
             QueryGraph queryGraph = QueryGraph.lookup(graph, qResults);
+            if (weighting instanceof BlockAreaWeighting)
+                ((BlockAreaWeighting) weighting).setQueryGraph(queryGraph);
+
             int maxVisitedNodesForRequest = hints.getInt(Routing.MAX_VISITED_NODES, routingConfig.getMaxVisitedNodes());
             if (maxVisitedNodesForRequest > routingConfig.getMaxVisitedNodes())
                 throw new IllegalArgumentException("The max_visited_nodes parameter has to be below or equal to:" + routingConfig.getMaxVisitedNodes());

--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -1020,6 +1020,9 @@ public class GraphHopper implements GraphHopperAPI {
             Graph graph = ghStorage;
             if (chPreparationHandler.isEnabled() && !disableCH) {
                 if (algorithmFactory instanceof CHRoutingAlgorithmFactory) {
+                    if (hints.has(Routing.BLOCK_AREA))
+                        throw new IllegalArgumentException("When CH is enabled the " + Parameters.Routing.BLOCK_AREA + " cannot be specified");
+
                     CHProfile chProfile = ((CHRoutingAlgorithmFactory) algorithmFactory).getCHProfile();
                     weighting = chProfile.getWeighting();
                     graph = ghStorage.getCHGraph(chProfile);
@@ -1030,7 +1033,8 @@ public class GraphHopper implements GraphHopperAPI {
                 checkNonChMaxWaypointDistance(points);
                 weighting = createWeighting(hints, encoder, turnCostProvider);
                 if (hints.has(Routing.BLOCK_AREA))
-                    weighting = new BlockAreaWeighting(weighting, createBlockArea(points, hints, DefaultEdgeFilter.allEdges(encoder)));
+                    weighting = new BlockAreaWeighting(weighting, GraphEdgeIdFinder.createBlockArea(ghStorage, locationIndex,
+                            points, hints, DefaultEdgeFilter.allEdges(encoder)));
             }
             ghRsp.addDebugInfo("tmode:" + tMode.toString());
 
@@ -1113,17 +1117,6 @@ public class GraphHopper implements GraphHopperAPI {
 
     protected ChangeGraphHelper createChangeGraphHelper(Graph graph, LocationIndex locationIndex) {
         return new ChangeGraphHelper(graph, locationIndex);
-    }
-
-    private GraphEdgeIdFinder.BlockArea createBlockArea(List<GHPoint> points, HintsMap hints, EdgeFilter edgeFilter) {
-        String blockAreaStr = hints.get(Parameters.Routing.BLOCK_AREA, "");
-        GraphEdgeIdFinder.BlockArea blockArea = new GraphEdgeIdFinder(ghStorage, locationIndex).
-                parseBlockArea(blockAreaStr, edgeFilter, hints.getDouble(Routing.BLOCK_AREA + ".edge_id_max_area", 1000 * 1000));
-        for (GHPoint p : points) {
-            if (blockArea.contains(p))
-                throw new IllegalArgumentException("Request with " + Routing.BLOCK_AREA + " contained query point " + p + ". This is not allowed.");
-        }
-        return blockArea;
     }
 
     private void checkIfPointsAreInBounds(List<GHPoint> points) {

--- a/core/src/main/java/com/graphhopper/routing/weighting/BlockAreaWeighting.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/BlockAreaWeighting.java
@@ -1,5 +1,6 @@
 package com.graphhopper.routing.weighting;
 
+import com.graphhopper.storage.Graph;
 import com.graphhopper.storage.GraphEdgeIdFinder;
 import com.graphhopper.util.EdgeIteratorState;
 
@@ -13,6 +14,11 @@ public class BlockAreaWeighting extends AbstractAdjustedWeighting {
     public BlockAreaWeighting(Weighting superWeighting, GraphEdgeIdFinder.BlockArea blockArea) {
         super(superWeighting);
         this.blockArea = blockArea;
+    }
+
+    public BlockAreaWeighting setQueryGraph(Graph queryGraph) {
+        blockArea.setGraph(queryGraph);
+        return this;
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/storage/GraphEdgeIdFinder.java
+++ b/core/src/main/java/com/graphhopper/storage/GraphEdgeIdFinder.java
@@ -17,13 +17,10 @@
  */
 package com.graphhopper.storage;
 
-import com.graphhopper.coll.GHBitSet;
+import com.carrotsearch.hppc.cursors.IntCursor;
 import com.graphhopper.coll.GHIntHashSet;
-import com.graphhopper.coll.GHTBitSet;
 import com.graphhopper.routing.util.EdgeFilter;
 import com.graphhopper.storage.index.LocationIndex;
-import com.graphhopper.storage.index.QueryResult;
-import com.graphhopper.util.BreadthFirstSearch;
 import com.graphhopper.util.EdgeIteratorState;
 import com.graphhopper.util.PointList;
 import com.graphhopper.util.shapes.Polygon;
@@ -32,6 +29,7 @@ import org.locationtech.jts.algorithm.RectangleLineIntersector;
 import org.locationtech.jts.geom.*;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static com.graphhopper.util.shapes.BBox.toEnvelope;
@@ -43,6 +41,7 @@ import static com.graphhopper.util.shapes.BBox.toEnvelope;
  */
 public class GraphEdgeIdFinder {
 
+    private final static int P_RADIUS = 5;
     private final Graph graph;
     private final LocationIndex locationIndex;
 
@@ -52,92 +51,36 @@ public class GraphEdgeIdFinder {
     }
 
     /**
-     * This method fills the edgeIds hash with edgeIds found close (exact match) to the specified point
-     */
-    public void findClosestEdgeToPoint(GHIntHashSet edgeIds, GHPoint point, EdgeFilter filter) {
-        findClosestEdge(edgeIds, point.getLat(), point.getLon(), filter);
-    }
-
-    /**
-     * This method fills the edgeIds hash with edgeIds found close (exact match) to the specified lat,lon
-     */
-    public void findClosestEdge(GHIntHashSet edgeIds, double lat, double lon, EdgeFilter filter) {
-        QueryResult qr = locationIndex.findClosest(lat, lon, filter);
-        if (qr.isValid())
-            edgeIds.add(qr.getClosestEdge().getEdge());
-    }
-
-    /**
      * This method fills the edgeIds hash with edgeIds found inside the specified shape
      */
     public void findEdgesInShape(final GHIntHashSet edgeIds, final Shape shape, EdgeFilter filter) {
-        GHPoint center = shape.getCenter();
-        QueryResult qr = locationIndex.findClosest(center.getLat(), center.getLon(), filter);
-        // TODO: this is suboptimal and will be fixed in #1324
-        if (!qr.isValid())
-            throw new IllegalArgumentException("Shape '" + shape + "' does not cover graph. Center: " + center);
-
-        if (shape.contains(qr.getSnappedPoint().lat, qr.getSnappedPoint().lon))
-            edgeIds.add(qr.getClosestEdge().getEdge());
-
-        final boolean isPolygon = shape instanceof Polygon;
-
-        BreadthFirstSearch bfs = new BreadthFirstSearch() {
-            final NodeAccess na = graph.getNodeAccess();
-            final Shape localShape = shape;
-
+        locationIndex.query(shape.getBounds(), new LocationIndex.EdgeVisitor(graph.createEdgeExplorer(filter)) {
             @Override
-            protected GHBitSet createBitSet() {
-                return new GHTBitSet();
-            }
-
-            @Override
-            protected boolean goFurther(int nodeId) {
-                if (isPolygon) return isInsideBBox(nodeId);
-
-                return localShape.contains(na.getLatitude(nodeId), na.getLongitude(nodeId));
-            }
-
-            @Override
-            protected boolean checkAdjacent(EdgeIteratorState edge) {
-                int adjNodeId = edge.getAdjNode();
-
-                if (localShape.contains(na.getLatitude(adjNodeId), na.getLongitude(adjNodeId))) {
+            public void onEdge(EdgeIteratorState edge, int nodeA, int nodeB) {
+                if (shape.intersects(edge.fetchWayGeometry(3).makeImmutable()))
                     edgeIds.add(edge.getEdge());
-                    return true;
-                }
-                return isPolygon && isInsideBBox(adjNodeId);
             }
-
-            private boolean isInsideBBox(int nodeId) {
-                BBox bbox = localShape.getBounds();
-                double lat = na.getLatitude(nodeId);
-                double lon = na.getLongitude(nodeId);
-                return lat <= bbox.maxLat && lat >= bbox.minLat && lon <= bbox.maxLon && lon >= bbox.minLon;
-            }
-        };
-        bfs.start(graph.createEdgeExplorer(filter), qr.getClosestNode());
+        });
     }
 
     /**
      * This method fills the edgeIds hash with edgeIds found inside the specified geometry
      */
-    public void fillEdgeIDs(GHIntHashSet edgeIds, Geometry geometry, EdgeFilter filter) {
+    public void fillEdgeIDs(final GHIntHashSet edgeIds, final Geometry geometry, EdgeFilter filter) {
         if (geometry instanceof Point) {
-            GHPoint point = GHPoint.create((Point) geometry);
-            findClosestEdgeToPoint(edgeIds, point, filter);
+            Point p = (Point) geometry;
+            findEdgesInShape(edgeIds, new Circle(p.getY(), p.getX(), P_RADIUS), filter);
         } else if (geometry instanceof LineString) {
-            PointList pl = PointList.fromLineString((LineString) geometry);
-            // TODO do map matching or routing
-            int lastIdx = pl.size() - 1;
-            if (pl.size() >= 2) {
-                double meanLat = (pl.getLatitude(0) + pl.getLatitude(lastIdx)) / 2;
-                double meanLon = (pl.getLongitude(0) + pl.getLongitude(lastIdx)) / 2;
-                findClosestEdge(edgeIds, meanLat, meanLon, filter);
-            }
+            locationIndex.query(BBox.fromEnvelope(geometry.getEnvelopeInternal()), new LocationIndex.EdgeVisitor(graph.createEdgeExplorer(filter)) {
+                @Override
+                public void onEdge(EdgeIteratorState edge, int nodeA, int nodeB) {
+                    if (geometry.intersects(edge.fetchWayGeometry(3).toLineString(false)))
+                        edgeIds.add(edge.getEdge());
+                }
+            });
         } else if (geometry instanceof MultiPoint) {
             for (Coordinate coordinate : geometry.getCoordinates()) {
-                findClosestEdge(edgeIds, coordinate.y, coordinate.x, filter);
+                findEdgesInShape(edgeIds, new Circle(coordinate.y, coordinate.x, P_RADIUS), filter);
             }
         }
     }
@@ -162,9 +105,9 @@ public class GraphEdgeIdFinder {
                 // always add the shape as we'll need this for virtual edges and for debugging.
                 if (splittedObject.length > 4) {
                     final Polygon polygon = Polygon.parsePoints(objectAsString);
-                    blockArea.add(polygon);
+                    GHIntHashSet blockedEdges = blockArea.add(polygon);
                     if (polygon.calculateArea() <= useEdgeIdsUntilAreaSize)
-                        findEdgesInShape(blockArea.blockedEdges, polygon, filter);
+                        findEdgesInShape(blockedEdges, polygon, filter);
                 } else if (splittedObject.length == 4) {
                     final BBox bbox = BBox.parseTwoPoints(objectAsString);
                     final RectangleLineIntersector cachedIntersector = new RectangleLineIntersector(toEnvelope(bbox));
@@ -174,22 +117,24 @@ public class GraphEdgeIdFinder {
                             return BBox.intersects(cachedIntersector, pointList);
                         }
                     };
-                    blockArea.add(preparedBBox);
+                    GHIntHashSet blockedEdges = blockArea.add(preparedBBox);
                     if (bbox.calculateArea() <= useEdgeIdsUntilAreaSize)
-                        findEdgesInShape(blockArea.blockedEdges, preparedBBox, filter);
+                        findEdgesInShape(blockedEdges, preparedBBox, filter);
                 } else if (splittedObject.length == 3) {
                     double lat = Double.parseDouble(splittedObject[0]);
                     double lon = Double.parseDouble(splittedObject[1]);
                     int radius = Integer.parseInt(splittedObject[2]);
                     Circle circle = new Circle(lat, lon, radius);
-                    blockArea.add(circle);
+                    GHIntHashSet blockedEdges = blockArea.add(circle);
                     if (circle.calculateArea() <= useEdgeIdsUntilAreaSize)
-                        findEdgesInShape(blockArea.blockedEdges, circle, filter);
+                        findEdgesInShape(blockedEdges, circle, filter);
 
                 } else if (splittedObject.length == 2) {
                     double lat = Double.parseDouble(splittedObject[0]);
                     double lon = Double.parseDouble(splittedObject[1]);
-                    findClosestEdge(blockArea.blockedEdges, lat, lon, filter);
+                    Circle circle = new Circle(lat, lon, P_RADIUS);
+                    GHIntHashSet blockedEdges = blockArea.add(circle);
+                    findEdgesInShape(blockedEdges, circle, filter);
                 } else {
                     throw new IllegalArgumentException(objectAsString + " at index " + i + " need to be defined as lat,lon "
                             + "or as a circle lat,lon,radius or rectangular lat1,lon1,lat2,lon2");
@@ -203,8 +148,8 @@ public class GraphEdgeIdFinder {
      * This class handles edges and areas where access should be blocked.
      */
     public static class BlockArea {
-        final GHIntHashSet blockedEdges = new GHIntHashSet();
-        final List<Shape> blockedShapes = new ArrayList<>();
+        private final List<GHIntHashSet> edgesList = new ArrayList<>();
+        private final List<Shape> blockedShapes = new ArrayList<>();
         private NodeAccess na;
         private final int baseEdgeCount;
         private boolean prepared;
@@ -214,15 +159,24 @@ public class GraphEdgeIdFinder {
             na = g.getNodeAccess();
         }
 
-        public void add(int edgeId) {
-            if (edgeId >= baseEdgeCount)
-                throw new IllegalStateException("Virtual edges are not expected to be added to the edge cache");
-
-            blockedEdges.add(edgeId);
+        public boolean hasCachedEdgeIds(int shapeIndex) {
+            return !edgesList.get(shapeIndex).isEmpty();
         }
 
-        public void add(Shape shape) {
+        public String toString(int shapeIndex) {
+            List<Integer> returnList = new ArrayList<>();
+            for (IntCursor intCursor : edgesList.get(shapeIndex)) {
+                returnList.add(intCursor.value);
+            }
+            Collections.sort(returnList);
+            return returnList.toString();
+        }
+
+        public GHIntHashSet add(Shape shape) {
             blockedShapes.add(shape);
+            GHIntHashSet set = new GHIntHashSet();
+            edgesList.add(set);
+            return set;
         }
 
         public final boolean contains(GHPoint point) {
@@ -237,15 +191,19 @@ public class GraphEdgeIdFinder {
          * @return true if the specified edgeState is part of this BlockArea
          */
         public final boolean intersects(EdgeIteratorState edgeState) {
-            // blockedEdges acts as cache that is only useful when filled and for non-virtual edges
-            if (!blockedEdges.isEmpty() && edgeState.getEdge() < baseEdgeCount && blockedEdges.contains(edgeState.getEdge()))
-                return true;
-
-            // compromise: mostly avoid expensive fetchWayGeometry which isn't yet fast for being used in Weighting.calc
-            BBox bbox = BBox.fromPoints(na.getLatitude(edgeState.getBaseNode()), na.getLongitude(edgeState.getBaseNode()),
-                    na.getLatitude(edgeState.getAdjNode()), na.getLongitude(edgeState.getAdjNode()));
             PointList pointList = null;
-            for (Shape shape : blockedShapes) {
+            for (int shapeIdx = 0; shapeIdx < blockedShapes.size(); shapeIdx++) {
+                GHIntHashSet blockedEdges = edgesList.get(shapeIdx);
+                // blockedEdges acts as cache that is only useful when filled and for non-virtual edges
+                if (!blockedEdges.isEmpty() && edgeState.getEdge() < baseEdgeCount) {
+                    if (blockedEdges.contains(edgeState.getEdge()))
+                        return true;
+                    continue;
+                }
+
+                // compromise: mostly avoid expensive fetchWayGeometry which isn't yet fast for being used in Weighting.calc
+                BBox bbox = createBBox(na, edgeState);
+                Shape shape = blockedShapes.get(shapeIdx);
                 if (shape.getBounds().intersects(bbox)) {
                     if (pointList == null)
                         pointList = edgeState.fetchWayGeometry(3).makeImmutable();
@@ -264,5 +222,10 @@ public class GraphEdgeIdFinder {
             na = queryGraph.getNodeAccess();
             return this;
         }
+    }
+
+    private static BBox createBBox(NodeAccess na, EdgeIteratorState edgeState) {
+        return BBox.fromPoints(na.getLatitude(edgeState.getBaseNode()), na.getLongitude(edgeState.getBaseNode()),
+                na.getLatitude(edgeState.getAdjNode()), na.getLongitude(edgeState.getAdjNode()));
     }
 }

--- a/core/src/main/java/com/graphhopper/storage/GraphEdgeIdFinder.java
+++ b/core/src/main/java/com/graphhopper/storage/GraphEdgeIdFinder.java
@@ -21,8 +21,10 @@ import com.carrotsearch.hppc.cursors.IntCursor;
 import com.graphhopper.coll.GHIntHashSet;
 import com.graphhopper.routing.querygraph.QueryGraph;
 import com.graphhopper.routing.util.EdgeFilter;
+import com.graphhopper.routing.util.HintsMap;
 import com.graphhopper.storage.index.LocationIndex;
 import com.graphhopper.util.EdgeIteratorState;
+import com.graphhopper.util.Parameters;
 import com.graphhopper.util.PointList;
 import com.graphhopper.util.shapes.Polygon;
 import com.graphhopper.util.shapes.*;
@@ -84,6 +86,18 @@ public class GraphEdgeIdFinder {
                 findEdgesInShape(edgeIds, new Circle(coordinate.y, coordinate.x, P_RADIUS), filter);
             }
         }
+    }
+
+    public static GraphEdgeIdFinder.BlockArea createBlockArea(Graph graph, LocationIndex locationIndex,
+                                                              List<GHPoint> points, HintsMap hints, EdgeFilter edgeFilter) {
+        String blockAreaStr = hints.get(Parameters.Routing.BLOCK_AREA, "");
+        GraphEdgeIdFinder.BlockArea blockArea = new GraphEdgeIdFinder(graph, locationIndex).
+                parseBlockArea(blockAreaStr, edgeFilter, hints.getDouble(Parameters.Routing.BLOCK_AREA + ".edge_id_max_area", 1000 * 1000));
+        for (GHPoint p : points) {
+            if (blockArea.contains(p))
+                throw new IllegalArgumentException("Request with " + Parameters.Routing.BLOCK_AREA + " contained query point " + p + ". This is not allowed.");
+        }
+        return blockArea;
     }
 
     /**

--- a/core/src/test/java/com/graphhopper/routing/weighting/BlockAreaWeightingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/BlockAreaWeightingTest.java
@@ -1,11 +1,17 @@
 package com.graphhopper.routing.weighting;
 
+import com.graphhopper.routing.querygraph.QueryGraph;
 import com.graphhopper.routing.util.CarFlagEncoder;
+import com.graphhopper.routing.util.EdgeFilter;
 import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.routing.util.FlagEncoder;
-import com.graphhopper.storage.Graph;
 import com.graphhopper.storage.GraphBuilder;
 import com.graphhopper.storage.GraphEdgeIdFinder;
+import com.graphhopper.storage.GraphHopperStorage;
+import com.graphhopper.storage.index.LocationIndex;
+import com.graphhopper.storage.index.LocationIndexTree;
+import com.graphhopper.storage.index.QueryResult;
+import com.graphhopper.util.EdgeIterator;
 import com.graphhopper.util.EdgeIteratorState;
 import com.graphhopper.util.shapes.Circle;
 import org.junit.Before;
@@ -20,7 +26,7 @@ public class BlockAreaWeightingTest {
 
     private FlagEncoder encoder = new CarFlagEncoder();
     private EncodingManager em;
-    private Graph graph;
+    private GraphHopperStorage graph;
 
     @Before
     public void setUp() {
@@ -62,10 +68,27 @@ public class BlockAreaWeightingTest {
         assertEquals(94.35, instance.calcEdgeWeight(edge, false), .01);
     }
 
-
     @Test
-    public void testNullGraph() {
-        // TODO is there an equivalent to check?
-        // BlockAreaWeighting weighting = new BlockAreaWeighting(new FastestWeighting(encoder));
+    public void testBlockVirtualEdges_QueryGraph() {
+        GraphEdgeIdFinder.BlockArea bArea = new GraphEdgeIdFinder.BlockArea(graph);
+        // add base graph edge to fill caches and trigger edgeId cache search (without virtual edges)
+        bArea.add(0);
+        bArea.add(new Circle(0.0025, 0.0025, 1));
+
+        LocationIndex index = new LocationIndexTree(graph, graph.getDirectory()).prepareIndex();
+        QueryResult qr = index.findClosest(0.005, 0.005, EdgeFilter.ALL_EDGES);
+        QueryGraph queryGraph = QueryGraph.lookup(graph, qr);
+        bArea.setGraph(queryGraph);
+
+        BlockAreaWeighting instance = new BlockAreaWeighting(new FastestWeighting(encoder), bArea);
+        EdgeIterator iter = queryGraph.createEdgeExplorer().setBaseNode(qr.getClosestNode());
+        int blockedEdges = 0, totalEdges = 0;
+        while (iter.next()) {
+            if (Double.isInfinite(instance.calcEdgeWeight(iter, false)))
+                blockedEdges++;
+            totalEdges++;
+        }
+        assertEquals(1, blockedEdges);
+        assertEquals(2, totalEdges);
     }
 }

--- a/core/src/test/java/com/graphhopper/routing/weighting/BlockAreaWeightingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/BlockAreaWeightingTest.java
@@ -1,5 +1,6 @@
 package com.graphhopper.routing.weighting;
 
+import com.graphhopper.coll.GHIntHashSet;
 import com.graphhopper.routing.querygraph.QueryGraph;
 import com.graphhopper.routing.util.CarFlagEncoder;
 import com.graphhopper.routing.util.EdgeFilter;
@@ -46,7 +47,8 @@ public class BlockAreaWeightingTest {
         BlockAreaWeighting instance = new BlockAreaWeighting(new FastestWeighting(encoder), bArea);
         assertEquals(94.35, instance.calcEdgeWeight(edge, false), .01);
 
-        bArea.add(0);
+        GHIntHashSet set = bArea.add(null);
+        set.add(0);
         instance = new BlockAreaWeighting(new FastestWeighting(encoder), bArea);
         assertEquals(Double.POSITIVE_INFINITY, instance.calcEdgeWeight(edge, false), .01);
     }
@@ -72,8 +74,8 @@ public class BlockAreaWeightingTest {
     public void testBlockVirtualEdges_QueryGraph() {
         GraphEdgeIdFinder.BlockArea bArea = new GraphEdgeIdFinder.BlockArea(graph);
         // add base graph edge to fill caches and trigger edgeId cache search (without virtual edges)
-        bArea.add(0);
-        bArea.add(new Circle(0.0025, 0.0025, 1));
+        GHIntHashSet set = bArea.add(new Circle(0.0025, 0.0025, 1));
+        set.add(0);
 
         LocationIndex index = new LocationIndexTree(graph, graph.getDirectory()).prepareIndex();
         QueryResult qr = index.findClosest(0.005, 0.005, EdgeFilter.ALL_EDGES);

--- a/core/src/test/java/com/graphhopper/storage/change/ChangeGraphHelperTest.java
+++ b/core/src/test/java/com/graphhopper/storage/change/ChangeGraphHelperTest.java
@@ -72,7 +72,7 @@ public class ChangeGraphHelperTest {
         ChangeGraphHelper instance = new ChangeGraphHelper(graph, locationIndex);
         JsonFeatureCollection collection = Jackson.newObjectMapper().readValue(reader, JsonFeatureCollection.class);
         long updates = instance.applyChanges(encodingManager, collection.getFeatures());
-        assertEquals(2, updates);
+        assertEquals(3, updates);
 
         // assert changed speed and access
         double newSpeed = GHUtility.getEdge(graph, 0, 1).get(avSpeedEnc);

--- a/core/src/test/resources/com/graphhopper/storage/change/overlaydata1.json
+++ b/core/src/test/resources/com/graphhopper/storage/change/overlaydata1.json
@@ -17,7 +17,7 @@
         {
             "id": "2",
             "type": "Feature",
-            "bbox": [-0.01, -0.01, 0.015, 0.005],
+            "bbox": [-0.01, -0.01, 0.005, 0.005],
             "properties": {
                 "access": false,
                 "assert_nodes": [3, 4]

--- a/reader-osm/src/test/java/com/graphhopper/GraphHopperIT.java
+++ b/reader-osm/src/test/java/com/graphhopper/GraphHopperIT.java
@@ -447,12 +447,10 @@ public class GraphHopperIT {
         assertFalse(rsp.getErrors().toString(), rsp.hasErrors());
         assertEquals(12173, rsp.getBest().getDistance(), 1);
 
-        // TODO after #1324 this will work and should block both roads and return 12173m, currently it still routes
-        //  through one of the roads due to "disconnected" roads
-        req.getHints().put(Routing.BLOCK_AREA, "49.981502,11.51762,80");
+        req.getHints().put(Routing.BLOCK_AREA, "49.980868,11.516397,150");
         rsp = tmpHopper.route(req);
         assertFalse(rsp.getErrors().toString(), rsp.hasErrors());
-        assertEquals(7383, rsp.getBest().getDistance(), 1);
+        assertEquals(12173, rsp.getBest().getDistance(), 1);
 
         // block by edge IDs -> i.e. use small rectangular area
         req.getHints().put(Routing.BLOCK_AREA, "49.981875,11.515818,49.979522,11.521407");
@@ -467,8 +465,7 @@ public class GraphHopperIT {
         assertFalse(rsp.getErrors().toString(), rsp.hasErrors());
         assertEquals(1807, rsp.getBest().getDistance(), 1);
 
-        // block point 49.985759,11.50687
-        req.getHints().put(Routing.BLOCK_AREA, "50.018274,11.492558");
+        req.getHints().put(Routing.BLOCK_AREA, "50.018277,11.492336");
         rsp = tmpHopper.route(req);
         assertFalse(rsp.getErrors().toString(), rsp.hasErrors());
         assertEquals(3363, rsp.getBest().getDistance(), 1);

--- a/web-bundle/src/main/java/com/graphhopper/resources/SPTResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/SPTResource.java
@@ -5,8 +5,10 @@ import com.graphhopper.isochrone.algorithm.Isochrone;
 import com.graphhopper.routing.profiles.*;
 import com.graphhopper.routing.querygraph.QueryGraph;
 import com.graphhopper.routing.util.*;
+import com.graphhopper.routing.weighting.BlockAreaWeighting;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.Graph;
+import com.graphhopper.storage.GraphEdgeIdFinder;
 import com.graphhopper.storage.index.LocationIndex;
 import com.graphhopper.storage.index.QueryResult;
 import com.graphhopper.util.*;
@@ -24,10 +26,7 @@ import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static com.graphhopper.routing.weighting.TurnCostProvider.NO_TURN_COST_PROVIDER;
 
@@ -81,6 +80,10 @@ public class SPTResource {
 
         // todo: /spt with turn costs ?
         Weighting weighting = graphHopper.createWeighting(hintsMap, encoder, NO_TURN_COST_PROVIDER);
+        if (hintsMap.has(Parameters.Routing.BLOCK_AREA))
+            weighting = new BlockAreaWeighting(weighting, GraphEdgeIdFinder.createBlockArea(graph, locationIndex,
+                    Collections.singletonList(point), hintsMap, DefaultEdgeFilter.allEdges(encoder)));
+
         Isochrone isochrone = new Isochrone(queryGraph, weighting, reverseFlow);
 
         if (distanceInMeter > 0) {


### PR DESCRIPTION
This PR fixes #1324.

There were a couple of bugs with the block_area feature that are fixed within this PR:

 * virtual edges are handled now, see #1127
 * bread first search is replaced with locationIndex lookup, which avoids several problems documented in #1324
 * edgeId cache is properly used (return early!), which should lead to a speed up
 * multiple block areas are properly used
 * fixes #1905