### PR TITLE
no need to explicitely list the snake case methods

### DIFF
--- a/client-hc/src/main/java/com/graphhopper/api/GraphHopperWeb.java
+++ b/client-hc/src/main/java/com/graphhopper/api/GraphHopperWeb.java
@@ -111,7 +111,7 @@ public class GraphHopperWeb implements GraphHopperAPI {
         ignoreSet.add("points_encoded");
         ignoreSet.add("pointsencoded");
         ignoreSet.add("type");
-        objectMapper = Jackson.newObjectMapper();
+        objectMapper = Jackson.initObjectMapperWithSnake(new ObjectMapper());
     }
 
     public GraphHopperWeb setDownloader(OkHttpClient downloader) {

--- a/client-hc/src/main/java/com/graphhopper/api/GraphHopperWeb.java
+++ b/client-hc/src/main/java/com/graphhopper/api/GraphHopperWeb.java
@@ -111,7 +111,7 @@ public class GraphHopperWeb implements GraphHopperAPI {
         ignoreSet.add("points_encoded");
         ignoreSet.add("pointsencoded");
         ignoreSet.add("type");
-        objectMapper = Jackson.initObjectMapperWithSnake(new ObjectMapper());
+        objectMapper = Jackson.newObjectMapper();
     }
 
     public GraphHopperWeb setDownloader(OkHttpClient downloader) {

--- a/config-example.yml
+++ b/config-example.yml
@@ -1,12 +1,14 @@
 graphhopper:
 
-  # OpenStreetMap input file
-  # datareader.file: some.pbf
+  # OpenStreetMap input file PBF or XML, can be changed via command line -Ddw.graphhopper.datareader.file=some.pbf
+  datareader.file: ""
+  # Local folder used by graphhopper to store its data
+  graph.location: graph-cache
 
   ##### Vehicles #####
 
 
-  # More options: foot,bike,bike2,mtb,racingbike,motorcycle (comma separated)
+  # More options: foot,hike,bike,bike2,mtb,racingbike,motorcycle,car4wd,wheelchair (comma separated)
   # bike2 takes elevation data into account (like up-hill is slower than down-hill) and requires enabling graph.elevation.provider below.
   graph.flag_encoders: car
 
@@ -151,28 +153,28 @@ graphhopper:
 
 # Dropwizard server configuration
 server:
-  applicationConnectors:
+  application_connectors:
   - type: http
     port: 8989
     # for security reasons bind to localhost
-    bindHost: localhost
-  requestLog:
+    bind_host: localhost
+  request_log:
       appenders: []
-  adminConnectors:
+  admin_connectors:
   - type: http
     port: 8990
-    bindHost: localhost
+    bind_host: localhost
 # See https://www.dropwizard.io/1.3.8/docs/manual/configuration.html#logging
 logging:
   appenders:
   - type: file
-    timeZone: UTC
-    currentLogFilename: logs/graphhopper.log
-    logFormat: "%d{YYYY-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"
+    time_zone: UTC
+    current_log_filename: logs/graphhopper.log
+    log_format: "%d{YYYY-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"
     archive: true
-    archivedLogFilenamePattern: ./logs/graphhopper-%d.log.gz
-    archivedFileCount: 30
-    neverBlock: true
+    archived_log_filename_pattern: ./logs/graphhopper-%d.log.gz
+    archived_file_count: 30
+    never_block: true
   - type: console
-    timeZone: UTC
-    logFormat: "%d{YYYY-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"
+    time_zone: UTC
+    log_format: "%d{YYYY-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"

--- a/core/files/changelog.txt
+++ b/core/files/changelog.txt
@@ -1,5 +1,5 @@
 1.0
-    Properties in config.yml have to follow the snake_case, #1918
+    Properties in config.yml have to follow the snake_case, #1918, easy convert via https://github.com/karussell/snake_case
     GraphHopper class no longer enables CH by default, #1914
     replaced command line arguments -Dgraphhopper.. with -Ddw.graphhopper.. due to #1879, see also #1897
     GraphHopper.init(CmdArgs)->GraphHopper.init(GraphHopperConfig), see #1879

--- a/core/files/changelog.txt
+++ b/core/files/changelog.txt
@@ -1,4 +1,5 @@
 1.0
+    Properties in config.yml have to follow the snake_case, #1918
     GraphHopper class no longer enables CH by default, #1914
     replaced command line arguments -Dgraphhopper.. with -Ddw.graphhopper.. due to #1879, see also #1897
     GraphHopper.init(CmdArgs)->GraphHopper.init(GraphHopperConfig), see #1879

--- a/web-api/src/main/java/com/graphhopper/jackson/GHRequestMixIn.java
+++ b/web-api/src/main/java/com/graphhopper/jackson/GHRequestMixIn.java
@@ -28,7 +28,6 @@ import java.util.List;
 /**
  * With this approach we avoid the jackson annotations dependency in core
  */
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 interface GHRequestMixIn {
 
     // a good trick to serialize unknown properties into the HintsMap

--- a/web-api/src/main/java/com/graphhopper/jackson/GHRequestMixIn.java
+++ b/web-api/src/main/java/com/graphhopper/jackson/GHRequestMixIn.java
@@ -19,8 +19,6 @@ package com.graphhopper.jackson;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.graphhopper.GHRequest;
 
 import java.util.List;

--- a/web-api/src/main/java/com/graphhopper/jackson/GHRequestMixIn.java
+++ b/web-api/src/main/java/com/graphhopper/jackson/GHRequestMixIn.java
@@ -19,6 +19,8 @@ package com.graphhopper.jackson;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.graphhopper.GHRequest;
 
 import java.util.List;
@@ -26,21 +28,13 @@ import java.util.List;
 /**
  * With this approach we avoid the jackson annotations dependency in core
  */
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 interface GHRequestMixIn {
 
     // a good trick to serialize unknown properties into the HintsMap
     @JsonAnySetter
     void putHint(String fieldName, Object value);
 
-    @JsonProperty("point_hints")
-    GHRequest setPointHints(List<String> pointHints);
-
-    @JsonProperty("snap_preventions")
-    GHRequest setSnapPreventions(List<String> snapPreventions);
-
     @JsonProperty("details")
     GHRequest setPathDetails(List<String> pathDetails);
-
-    @JsonProperty("curbsides")
-    GHRequest setCurbsides(List<String> curbsides);
 }

--- a/web-api/src/main/java/com/graphhopper/jackson/Jackson.java
+++ b/web-api/src/main/java/com/graphhopper/jackson/Jackson.java
@@ -20,11 +20,16 @@ package com.graphhopper.jackson;
 import com.bedatadriven.jackson.datatype.jts.JtsModule;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 
 public class Jackson {
 
     public static ObjectMapper newObjectMapper() {
         return initObjectMapper(new ObjectMapper());
+    }
+
+    public static ObjectMapper initObjectMapperWithSnake(ObjectMapper objectMapper) {
+        return initObjectMapper(objectMapper.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE));
     }
 
     public static ObjectMapper initObjectMapper(ObjectMapper objectMapper) {

--- a/web-api/src/main/java/com/graphhopper/jackson/Jackson.java
+++ b/web-api/src/main/java/com/graphhopper/jackson/Jackson.java
@@ -28,13 +28,10 @@ public class Jackson {
         return initObjectMapper(new ObjectMapper());
     }
 
-    public static ObjectMapper initObjectMapperWithSnake(ObjectMapper objectMapper) {
-        return initObjectMapper(objectMapper.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE));
-    }
-
     public static ObjectMapper initObjectMapper(ObjectMapper objectMapper) {
         objectMapper.registerModule(new GraphHopperModule());
         objectMapper.registerModule(new JtsModule());
+        objectMapper.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
         objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         return objectMapper;
     }

--- a/web-bundle/src/main/java/com/graphhopper/http/GraphHopperBundle.java
+++ b/web-bundle/src/main/java/com/graphhopper/http/GraphHopperBundle.java
@@ -20,6 +20,7 @@ package com.graphhopper.http;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.SerializationConfig;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
@@ -157,6 +158,8 @@ public class GraphHopperBundle implements ConfiguredBundle<GraphHopperBundleConf
 
         Jackson.initObjectMapper(bootstrap.getObjectMapper());
         bootstrap.getObjectMapper().setDateFormat(new StdDateFormat());
+        // See https://github.com/dropwizard/dropwizard/issues/1558
+        bootstrap.getObjectMapper().enable(MapperFeature.ALLOW_EXPLICIT_PROPERTY_RENAMING);
         // Because VirtualEdgeIteratorState has getters which throw Exceptions.
         // http://stackoverflow.com/questions/35359430/how-to-make-jackson-ignore-properties-if-the-getters-throw-exceptions
         bootstrap.getObjectMapper().registerModule(new SimpleModule().setSerializerModifier(new BeanSerializerModifier() {


### PR DESCRIPTION
of GHRequest in GHRequestMixIn.

Unfortunately there seems to be no lowerCamelCase naming strategy. With such a strategy we could enable it globally and annotate only GraphHopperConfigMixIn (or should we create something like this?)