### PR TITLE
Add 100m radius restriction to point hint matches

### DIFF
--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -1168,9 +1168,9 @@ public class GraphHopper implements GraphHopperAPI {
         if (ROUND_TRIP.equalsIgnoreCase(algoStr))
             routingTemplate = new RoundTripRoutingTemplate(request, ghRsp, locationIndex, encodingManager, weighting, routingConfig.getMaxRoundTripRetries());
         else if (ALT_ROUTE.equalsIgnoreCase(algoStr))
-            routingTemplate = new AlternativeRoutingTemplate(request, ghRsp, locationIndex, encodingManager, weighting);
+            routingTemplate = new AlternativeRoutingTemplate(request, ghRsp, locationIndex, ghStorage.getNodeAccess(), encodingManager, weighting);
         else
-            routingTemplate = new ViaRoutingTemplate(request, ghRsp, locationIndex, encodingManager, weighting);
+            routingTemplate = new ViaRoutingTemplate(request, ghRsp, locationIndex, ghStorage.getNodeAccess(), encodingManager, weighting);
         return routingTemplate;
     }
 

--- a/core/src/main/java/com/graphhopper/routing/template/AlternativeRoutingTemplate.java
+++ b/core/src/main/java/com/graphhopper/routing/template/AlternativeRoutingTemplate.java
@@ -26,6 +26,7 @@ import com.graphhopper.routing.RoutingAlgorithmFactory;
 import com.graphhopper.routing.profiles.EncodedValueLookup;
 import com.graphhopper.routing.querygraph.QueryGraph;
 import com.graphhopper.routing.weighting.Weighting;
+import com.graphhopper.storage.NodeAccess;
 import com.graphhopper.storage.index.LocationIndex;
 import com.graphhopper.storage.index.QueryResult;
 import com.graphhopper.util.Parameters.Routing;
@@ -46,8 +47,8 @@ import static com.graphhopper.util.Parameters.Routing.PASS_THROUGH;
  */
 final public class AlternativeRoutingTemplate extends ViaRoutingTemplate {
     public AlternativeRoutingTemplate(GHRequest ghRequest, GHResponse ghRsp, LocationIndex locationIndex,
-                                      EncodedValueLookup lookup, Weighting weighting) {
-        super(ghRequest, ghRsp, locationIndex, lookup, weighting);
+                                      NodeAccess nodeAccess, EncodedValueLookup lookup, Weighting weighting) {
+        super(ghRequest, ghRsp, locationIndex, nodeAccess, lookup, weighting);
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/template/ViaRoutingTemplate.java
+++ b/core/src/main/java/com/graphhopper/routing/template/ViaRoutingTemplate.java
@@ -84,7 +84,7 @@ public class ViaRoutingTemplate extends AbstractRoutingTemplate implements Routi
             GHPoint point = points.get(placeIndex);
             QueryResult qr = null;
             if (ghRequest.hasPointHints())
-                qr = locationIndex.findClosest(point.lat, point.lon, new NameSimilarityEdgeFilter(strictEdgeFilter, nodeAccess, point, ghRequest.getPointHints().get(placeIndex)));
+                qr = locationIndex.findClosest(point.lat, point.lon, new NameSimilarityEdgeFilter(strictEdgeFilter, nodeAccess, point, 100, ghRequest.getPointHints().get(placeIndex)));
             else if (ghRequest.hasSnapPreventions())
                 qr = locationIndex.findClosest(point.lat, point.lon, strictEdgeFilter);
             if (qr == null || !qr.isValid())

--- a/core/src/main/java/com/graphhopper/routing/template/ViaRoutingTemplate.java
+++ b/core/src/main/java/com/graphhopper/routing/template/ViaRoutingTemplate.java
@@ -30,6 +30,7 @@ import com.graphhopper.routing.util.EdgeFilter;
 import com.graphhopper.routing.util.NameSimilarityEdgeFilter;
 import com.graphhopper.routing.util.SnapPreventionEdgeFilter;
 import com.graphhopper.routing.weighting.Weighting;
+import com.graphhopper.storage.NodeAccess;
 import com.graphhopper.storage.index.LocationIndex;
 import com.graphhopper.storage.index.QueryResult;
 import com.graphhopper.util.*;
@@ -57,13 +58,15 @@ public class ViaRoutingTemplate extends AbstractRoutingTemplate implements Routi
     // result from route
     protected List<Path> pathList;
     protected final PathWrapper altResponse = new PathWrapper();
+    private final NodeAccess nodeAccess;
     private final EnumEncodedValue<RoadClass> roadClassEnc;
     private final EnumEncodedValue<RoadEnvironment> roadEnvEnc;
 
-    public ViaRoutingTemplate(GHRequest ghRequest, GHResponse ghRsp, LocationIndex locationIndex, EncodedValueLookup lookup, final Weighting weighting) {
+    public ViaRoutingTemplate(GHRequest ghRequest, GHResponse ghRsp, LocationIndex locationIndex, NodeAccess nodeAccess, EncodedValueLookup lookup, final Weighting weighting) {
         super(locationIndex, lookup, weighting);
         this.ghRequest = ghRequest;
         this.ghResponse = ghRsp;
+        this.nodeAccess = nodeAccess;
         this.roadClassEnc = lookup.getEnumEncodedValue(RoadClass.KEY, RoadClass.class);
         this.roadEnvEnc = lookup.getEnumEncodedValue(RoadEnvironment.KEY, RoadEnvironment.class);
     }
@@ -81,7 +84,7 @@ public class ViaRoutingTemplate extends AbstractRoutingTemplate implements Routi
             GHPoint point = points.get(placeIndex);
             QueryResult qr = null;
             if (ghRequest.hasPointHints())
-                qr = locationIndex.findClosest(point.lat, point.lon, new NameSimilarityEdgeFilter(strictEdgeFilter, ghRequest.getPointHints().get(placeIndex)));
+                qr = locationIndex.findClosest(point.lat, point.lon, new NameSimilarityEdgeFilter(strictEdgeFilter, nodeAccess, point, ghRequest.getPointHints().get(placeIndex)));
             else if (ghRequest.hasSnapPreventions())
                 qr = locationIndex.findClosest(point.lat, point.lon, strictEdgeFilter);
             if (qr == null || !qr.isValid())

--- a/core/src/main/java/com/graphhopper/storage/GraphEdgeIdFinder.java
+++ b/core/src/main/java/com/graphhopper/storage/GraphEdgeIdFinder.java
@@ -239,7 +239,7 @@ public class GraphEdgeIdFinder {
         }
     }
 
-    public static BBox createBBox(NodeAccess na, EdgeIteratorState edgeState) {
+    private static BBox createBBox(NodeAccess na, EdgeIteratorState edgeState) {
         return BBox.fromPoints(na.getLatitude(edgeState.getBaseNode()), na.getLongitude(edgeState.getBaseNode()),
                 na.getLatitude(edgeState.getAdjNode()), na.getLongitude(edgeState.getAdjNode()));
     }

--- a/core/src/main/java/com/graphhopper/storage/GraphEdgeIdFinder.java
+++ b/core/src/main/java/com/graphhopper/storage/GraphEdgeIdFinder.java
@@ -239,7 +239,7 @@ public class GraphEdgeIdFinder {
         }
     }
 
-    private static BBox createBBox(NodeAccess na, EdgeIteratorState edgeState) {
+    public static BBox createBBox(NodeAccess na, EdgeIteratorState edgeState) {
         return BBox.fromPoints(na.getLatitude(edgeState.getBaseNode()), na.getLongitude(edgeState.getBaseNode()),
                 na.getLatitude(edgeState.getAdjNode()), na.getLongitude(edgeState.getAdjNode()));
     }

--- a/core/src/main/java/com/graphhopper/util/GHUtility.java
+++ b/core/src/main/java/com/graphhopper/util/GHUtility.java
@@ -896,4 +896,76 @@ public class GHUtility {
             throw new UnsupportedOperationException("Not supported. Edge is empty.");
         }
     }
+
+    /**
+     * This node access can be used in tests to mock specific iterator behaviour via overloading
+     * certain methods.
+     */
+    public static class DisabledNodeAccess implements NodeAccess {
+
+        @Override
+        public int getTurnCostIndex(int nodeId) {
+            throw new UnsupportedOperationException("Not supported.");
+        }
+
+        @Override
+        public void setTurnCostIndex(int nodeId, int additionalValue) {
+            throw new UnsupportedOperationException("Not supported.");
+        }
+
+        @Override
+        public boolean is3D() {
+            throw new UnsupportedOperationException("Not supported.");
+        }
+
+        @Override
+        public int getDimension() {
+            throw new UnsupportedOperationException("Not supported.");
+        }
+
+        @Override
+        public void ensureNode(int nodeId) {
+            throw new UnsupportedOperationException("Not supported.");
+        }
+
+        @Override
+        public void setNode(int nodeId, double lat, double lon) {
+            throw new UnsupportedOperationException("Not supported.");
+        }
+
+        @Override
+        public void setNode(int nodeId, double lat, double lon, double ele) {
+            throw new UnsupportedOperationException("Not supported.");
+        }
+
+        @Override
+        public double getLatitude(int nodeId) {
+            throw new UnsupportedOperationException("Not supported.");
+        }
+
+        @Override
+        public double getLat(int nodeId) {
+            throw new UnsupportedOperationException("Not supported.");
+        }
+
+        @Override
+        public double getLongitude(int nodeId) {
+            throw new UnsupportedOperationException("Not supported.");
+        }
+
+        @Override
+        public double getLon(int nodeId) {
+            throw new UnsupportedOperationException("Not supported.");
+        }
+
+        @Override
+        public double getElevation(int nodeId) {
+            throw new UnsupportedOperationException("Not supported.");
+        }
+
+        @Override
+        public double getEle(int nodeId) {
+            throw new UnsupportedOperationException("Not supported.");
+        }
+    }
 }

--- a/core/src/test/java/com/graphhopper/routing/util/NameSimilarityEdgeFilterTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/NameSimilarityEdgeFilterTest.java
@@ -17,8 +17,17 @@
  */
 package com.graphhopper.routing.util;
 
+import com.graphhopper.routing.querygraph.QueryGraph;
+import com.graphhopper.storage.Graph;
+import com.graphhopper.storage.GraphBuilder;
+import com.graphhopper.storage.NodeAccess;
+import com.graphhopper.storage.index.LocationIndex;
+import com.graphhopper.util.CHEdgeIterator;
+import com.graphhopper.util.EdgeIterator;
 import com.graphhopper.util.EdgeIteratorState;
 import com.graphhopper.util.GHUtility;
+import com.graphhopper.util.shapes.GHPoint;
+import org.junit.Before;
 import org.junit.Test;
 
 import static junit.framework.TestCase.assertFalse;
@@ -29,6 +38,8 @@ import static org.junit.Assert.assertTrue;
  * @author Robin Boldt
  */
 public class NameSimilarityEdgeFilterTest {
+
+    private GHPoint basePoint = new GHPoint(49.4652132,11.1435159);
 
     @Test
     public void testAccept() {
@@ -75,6 +86,34 @@ public class NameSimilarityEdgeFilterTest {
 
         edge = createTestEdgeIterator("Hauptstr.");
         assertTrue(edgeFilter.accept(edge));
+    }
+
+    @Test
+    public void testDistanceFiltering() {
+        CarFlagEncoder encoder = new CarFlagEncoder();
+        Graph g = new GraphBuilder(EncodingManager.create(encoder)).create();
+        NodeAccess na = g.getNodeAccess();
+
+        GHPoint pointFarAway = new GHPoint(49.458629, 11.146124);
+        GHPoint point25mAway = new GHPoint(49.464871, 11.143575);
+        GHPoint point200mAway = new GHPoint(49.464598, 11.149039);
+
+        int farAwayId = 0;
+        int nodeId50 = 1;
+        int nodeID200 = 2;
+
+        na.setNode(farAwayId, pointFarAway.lat, pointFarAway.lon);
+        na.setNode(nodeId50, point25mAway.lat, point25mAway.lon);
+        na.setNode(nodeID200, point200mAway.lat, point200mAway.lon);
+
+        // Check that it matches a street 50m away
+        assertTrue(createNameSimilarityEdgeFilter(na, "Wentworth Street").
+                accept(createTestEdgeIterator("Wentworth Street", nodeId50, farAwayId)));
+
+        // Check that it doesn't match streets 200m away
+        assertFalse(createNameSimilarityEdgeFilter(na, "Wentworth Street").
+                accept(createTestEdgeIterator("Wentworth Street", nodeID200, farAwayId)));
+
     }
 
     /**
@@ -192,22 +231,51 @@ public class NameSimilarityEdgeFilterTest {
 //        assertTrue(edgeFilter.accept(edge));
     }
 
+    /**
+     * Create a NameSimilarityEdgeFilter that uses the same coordinates for all nodes
+     * so distance is not used when matching
+     */
     private NameSimilarityEdgeFilter createNameSimilarityEdgeFilter(String pointHint) {
+        return createNameSimilarityEdgeFilter(new GHUtility.DisabledNodeAccess() {
+            @Override
+            public double getLatitude(int nodeId) {
+                return basePoint.lat;
+            }
+            @Override
+            public double getLongitude(int nodeId) {
+                return basePoint.lon;
+            }
+        }, pointHint);
+    }
+
+    private NameSimilarityEdgeFilter createNameSimilarityEdgeFilter(NodeAccess nodeAccess, String pointHint) {
         return new NameSimilarityEdgeFilter(new EdgeFilter() {
             @Override
             public boolean accept(EdgeIteratorState edgeState) {
                 return true;
             }
-        }, pointHint);
+        }, nodeAccess, basePoint, pointHint);
     }
 
-    private EdgeIteratorState createTestEdgeIterator(final String name) {
+    private EdgeIteratorState createTestEdgeIterator(final String name, final int baseNodeId, final int adjNodeId) {
         return new GHUtility.DisabledEdgeIterator() {
-
             @Override
             public String getName() {
                 return name;
             }
+            @Override
+            public int getBaseNode() {
+                return baseNodeId;
+            }
+            @Override
+            public int getAdjNode() {
+                return adjNodeId;
+            }
         };
     }
+
+    private EdgeIteratorState createTestEdgeIterator(final String name) {
+        return createTestEdgeIterator(name, 0, 0);
+    }
+
 }

--- a/core/src/test/java/com/graphhopper/routing/util/NameSimilarityEdgeFilterTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/NameSimilarityEdgeFilterTest.java
@@ -254,7 +254,7 @@ public class NameSimilarityEdgeFilterTest {
             public boolean accept(EdgeIteratorState edgeState) {
                 return true;
             }
-        }, nodeAccess, basePoint, pointHint);
+        }, nodeAccess, basePoint, 100, pointHint);
     }
 
     private EdgeIteratorState createTestEdgeIterator(final String name, final int baseNodeId, final int adjNodeId) {


### PR DESCRIPTION
Fixes #1828 

NameSimilarityEdgeFilter has a circle of radius 100m around the original point. It then looks up the bounding box of the edges and see if they intersect with the circle. This is to help the issue where for some reason or another, it fails to match with the correct road and ends up matching one far away.

I've added a test to make sure it only matches nearby points. For the majority of the matching tests we're only testing name similarity so I used a mock node access that gives 0 distance between the nodes and overloaded the methods.