### PR TITLE
Use LinkedHashMap for deterministic iteratios

### DIFF
--- a/tools/src/main/java/com/graphhopper/tools/QueryTorture.java
+++ b/tools/src/main/java/com/graphhopper/tools/QueryTorture.java
@@ -240,7 +240,7 @@ public class QueryTorture {
         GHPoint end;
         long realCount;
         List<String> points = new ArrayList<>();
-        Map<String, String> params = new HashMap<>();
+        Map<String, String> params = new LinkedHashMap<>();
 
         static Query parse(String logLine) {
             String START = "GHBaseServlet - ";

--- a/tools/src/test/java/com/graphhopper/tools/QueryTortureTest.java
+++ b/tools/src/test/java/com/graphhopper/tools/QueryTortureTest.java
@@ -29,7 +29,7 @@ public class QueryTortureTest {
     @Test
     public void testGetQuery() {
         Query result = Query.parse("2016-05-04 16:37:37,647 [qtp1604002113-823] INFO  com.graphhopper.http.GHBaseServlet - point=46.444481%2C11.306992&point=46.07847%2C11.178589&locale=en_US&vehicle=car&weighting=fastest&elevation=true 127.0.0.1 en_US Directions API 195.232.147.121 [46.456721,11.258966, 46.15583,11.153478, 46.067933,11.223352, 46.456721,11.258966], took:0.008627106, , fastest, car, alternatives: 1, distance0: 146967.68084669442, time0: 112min, points0: 1507, debugInfo: idLookup:0.004824006s; , algoInit:2.6879E-5s, dijkstrabiCH-routing:5.69366E-4s, extract time:9.987E-5;, algoInit:1.6976E-5s, dijkstrabiCH-routing:3.22521E-4s, extract time:5.9076E-5;, algoInit:1.6084E-5s, dijkstrabiCH-routing:6.75566E-4s, extract time:8.2527E-5;, algoInit:2.6879E-5s, dijkstrabiCH-routing:5.69366E-4s, extract time:9.987E-5;, algoInit:1.6976E-5s, dijkstrabiCH-routing:3.22521E-4s, extract time:5.9076E-5;, algoInit:1.6084E-5s, dijkstrabiCH-routing:6.75566E-4s, extract time:8.2527E-5, simplify (1903->1507)");
-        assertEquals("point=46.444481%2C11.306992&point=46.07847%2C11.178589&elevation=true&locale=en_US&weighting=fastest&vehicle=car", result.createQueryString());
+        assertEquals("point=46.444481%2C11.306992&point=46.07847%2C11.178589&locale=en_US&vehicle=car&weighting=fastest&elevation=true", result.createQueryString());
         assertEquals(46.444481, result.start.lat, 1e-5);
         assertEquals(11.178589, result.end.lon, 1e-5);
     }


### PR DESCRIPTION
Problem:

Test `testGetQuery` in `QueryTortureTest` call `createQueryString` in `QueryTorture`, which depends on a HashMap. The test then asserts if the HashMap contains certain entries. However, the test assumes a specific iteration order of the underlying map. But HashMap does not guarantee any specific order of entries. Therefore, the assertions will fail if the iteration order differs.

Solution:

This PR proposes to change the `HashMap` to `LinkedHashMap` for a deterministic iteration order. 