### PR TITLE
Isochrones just by weight (rather than time or distance)

### DIFF
--- a/isochrone/src/main/java/com/graphhopper/isochrone/algorithm/ShortestPathTree.java
+++ b/isochrone/src/main/java/com/graphhopper/isochrone/algorithm/ShortestPathTree.java
@@ -31,8 +31,7 @@ import com.graphhopper.util.GHUtility;
 import java.util.PriorityQueue;
 import java.util.function.Consumer;
 
-import static com.graphhopper.isochrone.algorithm.ShortestPathTree.ExploreType.DISTANCE;
-import static com.graphhopper.isochrone.algorithm.ShortestPathTree.ExploreType.TIME;
+import static com.graphhopper.isochrone.algorithm.ShortestPathTree.ExploreType.*;
 import static java.util.Comparator.comparingDouble;
 import static java.util.Comparator.comparingLong;
 
@@ -47,7 +46,7 @@ import static java.util.Comparator.comparingLong;
  */
 public class ShortestPathTree extends AbstractRoutingAlgorithm {
 
-    enum ExploreType {TIME, DISTANCE}
+    enum ExploreType {TIME, DISTANCE, WEIGHT}
 
     public static class IsoLabel {
 
@@ -118,6 +117,12 @@ public class ShortestPathTree extends AbstractRoutingAlgorithm {
         this.queueByZ = new PriorityQueue<>(1000, comparingDouble(l -> l.distance));
     }
 
+    public void setWeightLimit(double limit) {
+        exploreType = WEIGHT;
+        this.limit = limit;
+        this.queueByZ = new PriorityQueue<>(1000, comparingDouble(l -> l.weight));
+    }
+
     public void search(int from, final Consumer<IsoLabel> consumer) {
         checkAlreadyRun();
         IsoLabel currentLabel = new IsoLabel(from, -1, 0, 0, 0, null);
@@ -173,7 +178,8 @@ public class ShortestPathTree extends AbstractRoutingAlgorithm {
     private double getExploreValue(IsoLabel label) {
         if (exploreType == TIME)
             return label.time;
-        // if(exploreType == DISTANCE)
+        if (exploreType == WEIGHT)
+            return label.weight;
         return label.distance;
     }
 

--- a/web-bundle/src/main/java/com/graphhopper/resources/IsochroneResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/IsochroneResource.java
@@ -79,7 +79,9 @@ public class IsochroneResource {
             @QueryParam("reverse_flow") @DefaultValue("false") boolean reverseFlow,
             @QueryParam("point") @NotNull GHPointParam point,
             @QueryParam("time_limit") @DefaultValue("600") LongParam timeLimitInSeconds,
-            @QueryParam("distance_limit") @DefaultValue("-1") LongParam distanceInMeter,
+            @QueryParam("distance_limit") @DefaultValue("-1") LongParam distanceLimitInMeter,
+            @QueryParam("weight_limit") @DefaultValue("-1") LongParam weightLimit,
+            @QueryParam("weight_limit_offset") @DefaultValue("0") LongParam weightLimitOffset,
             @QueryParam("type") @DefaultValue("json") ResponseType respType) {
         StopWatch sw = new StopWatch().start();
 
@@ -116,8 +118,16 @@ public class IsochroneResource {
         ShortestPathTree shortestPathTree = new ShortestPathTree(queryGraph, weighting, reverseFlow, traversalMode);
 
         double limit;
-        if (distanceInMeter.get() > 0) {
-            limit = distanceInMeter.get();
+        if (weightLimit.get() > 0){
+            limit = weightLimit.get();
+            // Since weight can be generic, we should make the offset configurable
+            long offset = 0;
+            if(weightLimitOffset.get() > 0){
+                offset = weightLimitOffset.get();
+            }
+            shortestPathTree.setWeightLimit(limit+ Math.max(limit * 0.14, offset));
+        } else if (distanceLimitInMeter.get() > 0) {
+            limit = distanceLimitInMeter.get();
             shortestPathTree.setDistanceLimit(limit + Math.max(limit * 0.14, 2_000));
         } else {
             limit = timeLimitInSeconds.get() * 1000;
@@ -132,7 +142,9 @@ public class IsochroneResource {
         Collection<ConstraintVertex> sites = new ArrayList<>();
         shortestPathTree.search(qr.getClosestNode(), label -> {
             double exploreValue;
-            if (distanceInMeter.get() > 0) {
+            if (weightLimit.get() > 0){
+                exploreValue = label.weight;
+            } else if (distanceLimitInMeter.get() > 0) {
                 exploreValue = label.distance;
             } else {
                 exploreValue = label.time;


### PR DESCRIPTION
This PR adds the ability to limit isochrones by weight as well.

Since weight can be any number, I also made the "offset" configurable as well. Probably offset is not the correct word. Maybe search limit? 

Related to #1979 and #1607 