### PR TITLE
Add flag to reactivate transfer between stops connected to same OSM n…

### DIFF
--- a/reader-gtfs/src/main/java/com/graphhopper/reader/gtfs/GraphHopperGtfs.java
+++ b/reader-gtfs/src/main/java/com/graphhopper/reader/gtfs/GraphHopperGtfs.java
@@ -131,9 +131,17 @@ public class GraphHopperGtfs extends GraphHopperOSM {
                     throw new RuntimeException(e);
                 }
             }
+
+            //When set a transfer edge will be created between stops connected to same OSM node. This is to keep previous behavior before
+            //this commit https://github.com/graphhopper/graphhopper/commit/31ae1e1534849099f24e45d53c96340a7c6a5197.
+            boolean createTransferStopsConnectSameOsmNode = ghConfig.has("gtfs.create_transfers_stops_same_osm_node") &&
+                                                            ghConfig.getBool("gtfs.create_transfers_stops_same_osm_node", false);
+
+
             LocationIndex streetNetworkIndex = getLocationIndex();
             getGtfsStorage().getGtfsFeeds().forEach((id, gtfsFeed) -> {
                 GtfsReader gtfsReader = new GtfsReader(id, graphHopperStorage, graphHopperStorage.getEncodingManager(), getGtfsStorage(), streetNetworkIndex);
+                gtfsReader.setCreateTransferStopsConnectSameOsmNode(createTransferStopsConnectSameOsmNode);
                 gtfsReader.connectStopsToStreetNetwork();
                 getType0TransferWithTimes(gtfsFeed)
                         .forEach(t -> {

--- a/reader-gtfs/src/main/java/com/graphhopper/reader/gtfs/GtfsReader.java
+++ b/reader-gtfs/src/main/java/com/graphhopper/reader/gtfs/GtfsReader.java
@@ -89,6 +89,7 @@ class GtfsReader {
     private final BooleanEncodedValue accessEnc;
     private final IntEncodedValue timeEnc;
     private final IntEncodedValue validityIdEnc;
+    private boolean createTransferStopsConnectSameOsmNode = false;
 
     GtfsReader(String id, Graph graph, EncodingManager encodingManager, GtfsStorageI gtfsStorage, LocationIndex walkNetworkIndex) {
         this.id = id;
@@ -105,6 +106,10 @@ class GtfsReader {
         this.i = graph.getNodes();
         this.startDate = feed.getStartDate();
         this.endDate = feed.getEndDate();
+    }
+
+    void setCreateTransferStopsConnectSameOsmNode(boolean createTransfer) {
+        this.createTransferStopsConnectSameOsmNode = createTransfer;
     }
 
     void connectStopsToStreetNetwork() {
@@ -212,7 +217,7 @@ class GtfsReader {
             while (i.next()) {
                 if (i.get(ptEncodedValues.getTypeEnc()) == GtfsStorage.EdgeType.EXIT_PT) {
                     GtfsStorageI.PlatformDescriptor fromPlatformDescriptor = gtfsStorage.getPlatformDescriptorByEdge().get(i.getEdge());
-                    if (fromPlatformDescriptor.stop_id.equals(transfer.from_stop_id) &&
+                    if ((createTransferStopsConnectSameOsmNode || fromPlatformDescriptor.stop_id.equals(transfer.from_stop_id)) &&
                             (transfer.from_route_id == null && fromPlatformDescriptor instanceof GtfsStorageI.RouteTypePlatform || transfer.from_route_id != null && GtfsStorageI.PlatformDescriptor.route(transfer.from_stop_id, transfer.from_route_id).equals(fromPlatformDescriptor))) {
                         LOGGER.debug("  Creating transfers from stop {}, platform {}", transfer.from_stop_id, fromPlatformDescriptor);
                         EdgeIterator j = graph.createEdgeExplorer().setBaseNode(i.getAdjNode());


### PR DESCRIPTION
https://github.com/graphhopper/graphhopper/issues/2007

Add flag to allow previous transfer edge between stops connected to same OSM node behaviour.

To activate transfer edge creation just set the following flag in the config.yml file : 

`graphhopper.gtfs.create_transfers_stops_same_osm_node: true`
