### PR TITLE
Clean up TarjanSCC's single-node component handling

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/subnetwork/PrepareRoutingSubnetworks.java
+++ b/core/src/main/java/com/graphhopper/routing/subnetwork/PrepareRoutingSubnetworks.java
@@ -200,7 +200,7 @@ public class PrepareRoutingSubnetworks {
         final EdgeFilter outFilter = DefaultEdgeFilter.outEdges(bothFilter.getAccessEnc());
 
         // partition graph into strongly connected components using Tarjan's algorithm        
-        TarjansSCCAlgorithm tarjan = new TarjansSCCAlgorithm(ghStorage, outFilter, true);
+        TarjansSCCAlgorithm tarjan = new TarjansSCCAlgorithm(ghStorage, outFilter, false);
         List<IntArrayList> components = tarjan.findComponents();
         logger.info(sw.stop() + ", size:" + components.size());
 


### PR DESCRIPTION
When we are calculating strongly connected components there are very many components with only a single node, especially when multiple vehicles are used. For this reason it has an option to 'ignore' single-node components and before this fix: e6783acb1760c5ffff07c569244fefc97946f5e1 this significantly reduced the time it took to calculate the connected components. However, after this fix this is no longer faster and in fact its a bit slower, because to 'detect' the single-node components also all nodes were traversed. Moreover, the implementation had a bug: Even when using the `ignoreSingleEntries` option the `findComponents` method returned (some) components with a single-entry (which were **also**) added to the `ignoreSet`. So the `ignoreSet` (which is supposed to contain the single node components) and the result of `findComponents` was not even disjoint. I have now cleaned up these issues and the algorithm now runs faster even when including the single node components in the result (depending on the `excludeSingleNodeComponents` the single node components are either returned by the `findComponents()` or not). 

I am not sure if we even need to keep the flag, because now that we can obtain the single-node components using Tarjan there should not be need to run the 'second' (BFS) subnetwork search anymore, but I am trying to tackle the (apparently many) issues related to subnetwork removal one by one atm :)