### PR TITLE
include npm as part of the maven cycle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ debug.sh
 /web/src/main/resources/assets/js/main.js
 /web/src/main/resources/assets/js/config/options_prod.js
 /web/dependency-reduced-pom.xml
+/web/node
 *.pbf
 !/reader-osm/src/test/resources/com/graphhopper/reader/osm/*.pbf
 *.dem

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,10 +35,9 @@ before_script:
   - _JAVA_OPTIONS=
   - "mvn --version"
   - "if [ -z \"$API_KEY\" ]; then API_KEY=78da6e9a-273e-43d1-bdda-8f24e007a1fa; fi" # change in GraphHopperWebIT too
-  - cd web && npm install && BROWSERIFYSWAP_ENV='development' npm run bundleProduction && cd ..
 
 script:
-  - "mvn -Dkey=$API_KEY clean install -B"
+  - "mvn -Pinclude-web-ui -Dkey=$API_KEY clean install -B"
 
 after_success:
   # often spotbugs etc take long to be compatible with a future JDK version so skip them

--- a/config-example.yml
+++ b/config-example.yml
@@ -176,7 +176,7 @@ graphhopper:
 #
 # assets:
 #  overrides:
-#    /maps: web/src/main/resources/assets/
+#    /maps: web/target/classes/assets/
 
 # Dropwizard server configuration
 server:

--- a/core/files/changelog.txt
+++ b/core/files/changelog.txt
@@ -1,15 +1,19 @@
 1.0
+    changes to config.yml:
+      properties have to follow the snake_case, #1918, easy convert via https://github.com/karussell/snake_case
+      all routing profiles have to be configured when setting up GraphHopper, #1958, #1922
+      for developing with JavaScript, npm and the web UI it is important to change your assets overrides to web/target/classes/assets/, see #2041
+    moved SPTEntry and ShortcutUnpacker to com.graphhopper.routing(.ch)
+    renamed PathWrapper to ResponsePath
     moved package from core/src/test/java/com/graphhopper/routing/profiles to ev
     removed HintsMap
     removed /change endpoint
     removed vehicle,weighting and edge_based from GraphHopper class, replaced with new profile parameter, #1958
-    all routing profiles have to be configured when setting up GraphHopper, #1958
     there no longer is a default vehicle, not setting the vehicle now only works if there is exactly one profile that matches the other parameters. anyway you should use the new profile rather than the vehicle parameter.
     removed IPFilter. Use a firewall instead.
     PMap refactored. It is recommended to use putObject(String, Object) instead of put, #1956
     removed UnsafeDataAccess as not maintained, see #1620
     add profiles parameter and replace prepare.ch/lm.weightings and prepare.ch.edge_based with profiles_ch/lm config parameters, #1922
-    Properties in config.yml have to follow the snake_case, #1918, easy convert via https://github.com/karussell/snake_case
     GraphHopper class no longer enables CH by default, #1914
     replaced command line arguments -Dgraphhopper.. with -Ddw.graphhopper.. due to #1879, see also #1897
     GraphHopper.init(CmdArgs)->GraphHopper.init(GraphHopperConfig), see #1879

--- a/docs/core/quickstart-from-source.md
+++ b/docs/core/quickstart-from-source.md
@@ -14,9 +14,7 @@ Then do:
 
 ```bash
 git clone git://github.com/graphhopper/graphhopper.git
-cd graphhopper; git checkout 0.13
-# fetches main.js, can be omitted if no UI is needed
-cd web/src/main/resources/ && ZFILE=/tmp/gh.jar && wget -O $ZFILE "https://repository.sonatype.org/service/local/artifact/maven/redirect?r=central-proxy&g=com.graphhopper&a=graphhopper-web&v=LATEST" && unzip $ZFILE assets/js/main.js && rm $ZFILE && cd ../../../..
+cd graphhopper; git checkout 1.0
 ./graphhopper.sh -a web -i europe_germany_berlin.pbf
 # now go to http://localhost:8989/ and you should see something similar to GraphHopper Maps: https://graphhopper.com/maps/
 ```
@@ -143,12 +141,11 @@ npm run lint
 # see the package.json where more scripts are defined
 ```
 
-### Experimental
+You can also avoid installing npm and build the main.js via maven:
 
-If you need **offline** routing in the browser like for smaller areas or hybrid routing solution
-then there is a highly experimental version of GraphHopper using TeaVM. 
-Have a look into this [blog post](http://karussell.wordpress.com/2014/05/04/graphhopper-in-the-browser-teavm-makes-offline-routing-via-openstreetmap-possible-in-javascript/) 
-for a demo and more information.
+```
+mvn -Pinclude-web-ui install
+```
 
 ### Android Usage
  

--- a/docs/core/quickstart-from-source.md
+++ b/docs/core/quickstart-from-source.md
@@ -141,12 +141,6 @@ npm run lint
 # see the package.json where more scripts are defined
 ```
 
-You can also avoid installing npm and build the main.js via maven:
-
-```
-mvn -Pinclude-web-ui install
-```
-
 ### Android Usage
  
 For details on Android-usage have a look into this [Android site](../android/index.md)

--- a/graphhopper.sh
+++ b/graphhopper.sh
@@ -171,7 +171,7 @@ function packageJar {
   if [ ! -f "$JAR" ]; then
     echo "## building graphhopper jar: $JAR"
     echo "## using maven at $MAVEN_HOME"
-    execMvn -Pinclude-web-ui --projects web -am -DskipTests=true package
+    execMvn --projects web -am -DskipTests=true package
   else
     echo "## existing jar found $JAR"
   fi

--- a/graphhopper.sh
+++ b/graphhopper.sh
@@ -171,7 +171,7 @@ function packageJar {
   if [ ! -f "$JAR" ]; then
     echo "## building graphhopper jar: $JAR"
     echo "## using maven at $MAVEN_HOME"
-    execMvn --projects web -am -DskipTests=true package
+    execMvn -Pinclude-web-ui --projects web -am -DskipTests=true package
   else
     echo "## existing jar found $JAR"
   fi
@@ -188,17 +188,6 @@ elif [ "$ACTION" = "build" ]; then
  packageJar
  exit
 
-elif [ "$ACTION" = "web" ]; then
- # remove once #1700 is implemented
- if [ ! -f "web/src/main/resources/assets/js/main.js" ]; then
-   rm -rf ./*/target # force rebuilding the jar as overrides is likely not enabled for assets in config.yml
-   cd web
-   npm install
-   BROWSERIFYSWAP_ENV='development' npm run bundleProduction
-   cd ..
- else
-   echo "## existing main.js found $JAR"
- fi
 fi
  
 if [ "$FILE" = "" ]; then

--- a/pom.xml
+++ b/pom.xml
@@ -235,23 +235,6 @@
                 </configuration>
             </plugin>
 
-	    <!--
-            <plugin>
-                <groupId>com.github.spotbugs</groupId>
-                <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>3.1.11</version>
-                <configuration>
-                    <maxRank>4</maxRank>
-                    <failOnError>true</failOnError>
-                    <excludeFilterFile>core/files/spotbugs-exclude.xml</excludeFilterFile>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-pmd-plugin</artifactId>
-                <version>3.12.0</version>
-            </plugin>
-            -->
             <plugin>
                 <groupId>de.thetaphi</groupId>
                 <artifactId>forbiddenapis</artifactId>

--- a/web/package.json
+++ b/web/package.json
@@ -6,10 +6,10 @@
   "license": "Apache-2.0",
   "main": "main.js",
   "scripts": {
-    "watch": "watchify src/main/resources/assets/js/main-template.js -o src/main/resources/assets/js/main.js --debug --verbose",
-    "bundle": "browserify src/main/resources/assets/js/main-template.js -o src/main/resources/assets/js/main.js",
-    "bundleDebug": "browserify src/main/resources/assets/js/main-template.js --debug -o src/main/resources/assets/js/main.js",
-    "bundleProduction": "browserify -g uglifyify src/main/resources/assets/js/main-template.js -o src/main/resources/assets/js/main.js",
+    "watch": "watchify src/main/resources/assets/js/main-template.js -o target/classes/assets/js/main.js --debug --verbose",
+    "bundle": "browserify src/main/resources/assets/js/main-template.js -o target/classes/assets/js/main.js",
+    "bundleDebug": "browserify src/main/resources/assets/js/main-template.js --debug -o target/classes/assets/js/main.js",
+    "bundleProduction": "browserify -g uglifyify src/main/resources/assets/js/main-template.js -o target/classes/assets/js/main.js",
     "test": "JASMINE_CONFIG_PATH=src/test/resources/assets/spec/jasmine.json jasmine",
     "lint": "jshint src/main/resources/assets/js/"
   },

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -95,7 +95,56 @@
 
         </plugins>
     </build>
-
+    <profiles>
+        <profile>
+            <id>include-web-ui</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.github.eirslett</groupId>
+                        <artifactId>frontend-maven-plugin</artifactId>
+                        <version>1.10.0</version>
+                        <executions>
+                            <execution>
+                                <id>install node and npm</id>
+                                <goals>
+                                    <goal>install-node-and-npm</goal>
+                                </goals>
+                                <configuration>
+                                    <nodeVersion>v12.3.1</nodeVersion>
+                                    <npmVersion>6.14.5</npmVersion>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>npm install</id>
+                                <goals>
+                                    <goal>npm</goal>
+                                </goals>
+                                <configuration>
+                                    <arguments>install</arguments>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>npm run bundleProduction</id>
+                                <goals>
+                                    <goal>npm</goal>
+                                </goals>
+                                <configuration>
+                                    <arguments>run bundleProduction</arguments>
+                                    <environmentVariables>
+                                        <BROWSERIFYSWAP_ENV>development</BROWSERIFYSWAP_ENV>
+                                    </environmentVariables>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>
 
 

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -57,6 +57,45 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>com.github.eirslett</groupId>
+                <artifactId>frontend-maven-plugin</artifactId>
+                <version>1.10.0</version>
+                <executions>
+                    <execution>
+                        <id>install node and npm</id>
+                        <goals>
+                            <goal>install-node-and-npm</goal>
+                        </goals>
+                        <configuration>
+                            <nodeVersion>v12.3.1</nodeVersion>
+                            <npmVersion>6.14.5</npmVersion>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>npm install</id>
+                        <goals>
+                            <goal>npm</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>install</arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>npm run bundleProduction</id>
+                        <goals>
+                            <goal>npm</goal>
+                        </goals>
+                        <phase>generate-resources</phase>
+                        <configuration>
+                            <arguments>run bundleProduction</arguments>
+                            <environmentVariables>
+                                <BROWSERIFYSWAP_ENV>development</BROWSERIFYSWAP_ENV>
+                            </environmentVariables>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>3.2.1</version>
@@ -95,56 +134,6 @@
 
         </plugins>
     </build>
-    <profiles>
-        <profile>
-            <id>include-web-ui</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>com.github.eirslett</groupId>
-                        <artifactId>frontend-maven-plugin</artifactId>
-                        <version>1.10.0</version>
-                        <executions>
-                            <execution>
-                                <id>install node and npm</id>
-                                <goals>
-                                    <goal>install-node-and-npm</goal>
-                                </goals>
-                                <configuration>
-                                    <nodeVersion>v12.3.1</nodeVersion>
-                                    <npmVersion>6.14.5</npmVersion>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>npm install</id>
-                                <goals>
-                                    <goal>npm</goal>
-                                </goals>
-                                <configuration>
-                                    <arguments>install</arguments>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>npm run bundleProduction</id>
-                                <goals>
-                                    <goal>npm</goal>
-                                </goals>
-                                <configuration>
-                                    <arguments>run bundleProduction</arguments>
-                                    <environmentVariables>
-                                        <BROWSERIFYSWAP_ENV>development</BROWSERIFYSWAP_ENV>
-                                    </environmentVariables>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>
 
 


### PR DESCRIPTION
This fixes #1700.

Setting up npm is not required for users that only need the API (no web UI), Android or Desktop. But we should still include it in the maven cycle. So I decided to give it a try via a maven profile and the plugin seems to work properly.

The npm_modules are duplicated in web/node/npm_modules in parallel to the "normal" web/npm_modules. Is this bad? (IMO this is fine as we have the maven node&npm stuff and the other is the real locally installed node&npm. But it could also be confusing?)

TODO:

 - [x] adapt javascript docs
 - [x] remove main.js for `mvn clean`

You might want to have a look into this change @easbar @michaz @Nakaner