### PR TITLE
Use AStar by default for edge-based CH

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/AStarBidirectionEdgeCHNoSOD.java
+++ b/core/src/main/java/com/graphhopper/routing/AStarBidirectionEdgeCHNoSOD.java
@@ -107,7 +107,6 @@ public class AStarBidirectionEdgeCHNoSOD extends AbstractBidirectionEdgeCHNoSOD 
         return currTo.weight + weightApprox.approximate(currTo.adjNode, true);
     }
 
-
     @Override
     public String getName() {
         return "astarbi|ch|edge_based|no_sod";

--- a/core/src/main/java/com/graphhopper/routing/Router.java
+++ b/core/src/main/java/com/graphhopper/routing/Router.java
@@ -49,7 +49,8 @@ import java.util.*;
 
 import static com.graphhopper.routing.weighting.Weighting.INFINITE_U_TURN_COSTS;
 import static com.graphhopper.util.Helper.DIST_EARTH;
-import static com.graphhopper.util.Parameters.Algorithms.*;
+import static com.graphhopper.util.Parameters.Algorithms.ALT_ROUTE;
+import static com.graphhopper.util.Parameters.Algorithms.ROUND_TRIP;
 import static com.graphhopper.util.Parameters.Routing.CURBSIDE;
 import static com.graphhopper.util.Parameters.Routing.POINT_HINT;
 
@@ -133,10 +134,7 @@ public class Router {
             }
             ghRsp.addDebugInfo("tmode:" + tMode.toString());
 
-            String algoStr = request.getAlgorithm();
-            if (algoStr.isEmpty())
-                algoStr = chEnabled && !disableCH ? DIJKSTRA_BI : ASTAR_BI;
-            RoutingTemplate routingTemplate = createRoutingTemplate(request, ghRsp, algoStr, weighting);
+            RoutingTemplate routingTemplate = createRoutingTemplate(request, ghRsp, request.getAlgorithm(), weighting);
 
             StopWatch sw = new StopWatch().start();
             List<QueryResult> qResults = routingTemplate.lookup(request.getPoints());
@@ -150,7 +148,7 @@ public class Router {
                 throw new IllegalArgumentException("The max_visited_nodes parameter has to be below or equal to:" + routerConfig.getMaxVisitedNodes());
 
             AlgorithmOptions algoOpts = AlgorithmOptions.start().
-                    algorithm(algoStr).
+                    algorithm(request.getAlgorithm()).
                     traversalMode(tMode).
                     weighting(weighting).
                     maxVisitedNodes(maxVisitedNodesForRequest).

--- a/core/src/main/java/com/graphhopper/routing/RoutingAlgorithmFactorySimple.java
+++ b/core/src/main/java/com/graphhopper/routing/RoutingAlgorithmFactorySimple.java
@@ -44,7 +44,7 @@ public class RoutingAlgorithmFactorySimple implements RoutingAlgorithmFactory {
         } else if (DIJKSTRA.equalsIgnoreCase(algoStr)) {
             ra = new Dijkstra(g, weighting, opts.getTraversalMode());
 
-        } else if (ASTAR_BI.equalsIgnoreCase(algoStr)) {
+        } else if (ASTAR_BI.equalsIgnoreCase(algoStr) || Helper.isEmpty(opts.getAlgorithm())) {
             AStarBidirection aStarBi = new AStarBidirection(g, weighting,
                     opts.getTraversalMode());
             aStarBi.setApproximation(getApproximation(ASTAR_BI, opts, g.getNodeAccess()));

--- a/core/src/main/java/com/graphhopper/routing/lm/LMRoutingAlgorithmFactory.java
+++ b/core/src/main/java/com/graphhopper/routing/lm/LMRoutingAlgorithmFactory.java
@@ -22,6 +22,7 @@ import com.graphhopper.routing.AStar;
 import com.graphhopper.routing.*;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.Graph;
+import com.graphhopper.util.Helper;
 import com.graphhopper.util.Parameters;
 
 import static com.graphhopper.util.Parameters.Algorithms.*;
@@ -58,7 +59,7 @@ public class LMRoutingAlgorithmFactory implements RoutingAlgorithmFactory {
             algo.setApproximation(getApproximator(g, activeLM, epsilon));
             algo.setMaxVisitedNodes(opts.getMaxVisitedNodes());
             return algo;
-        } else if (ASTAR_BI.equalsIgnoreCase(algoStr)) {
+        } else if (ASTAR_BI.equalsIgnoreCase(algoStr) || Helper.isEmpty(opts.getAlgorithm())) {
             double epsilon = opts.getHints().getDouble(Parameters.Algorithms.AStarBi.EPSILON, 1);
             AStarBidirection algo = new AStarBidirection(g, weighting, opts.getTraversalMode());
             algo.setApproximation(getApproximator(g, activeLM, epsilon));


### PR DESCRIPTION
For some reason I did not realize earlier that edge-based CH is using Dijkstra by default, even though AStar is significantly faster. The default algorithm is now chosen by the different algo factories and the default algorithm for edge-based CH is now AStar. For the Bavaria map this improves the average routing time from `4.9ms` to `3.3ms`  (-33%). For comparison: With node-based CH we get around `1.4ms`. Edge-based CH is x2.4 slower now.