### PR TITLE
#2053 : proposing module core-plus-api, combining modules core and api, in or…

### DIFF
--- a/core-plus-api/nb-configuration.xml
+++ b/core-plus-api/nb-configuration.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project-shared-configuration>
+    <!--
+    This file contains additional configuration written by modules in the NetBeans IDE.
+    The configuration is intended to be shared among all the users of project and
+    therefore it is assumed to be part of version control checkout.
+    Without this configuration present, some functionality in the IDE may be limited or fail altogether.
+    -->
+    <config-data xmlns="http://www.netbeans.org/ns/maven-config-data/1">
+        <configurations>
+            <configuration id="osmreader" profiles=""/>
+            <configuration id="routingIT" profiles=""/>
+        </configurations>
+    </config-data>
+    <properties xmlns="http://www.netbeans.org/ns/maven-properties-data/1">
+        <!--
+        Properties that influence various parts of the IDE, especially code formatting and the like. 
+        You can copy and paste the single properties, into the pom.xml file and the IDE will pick them up.
+        That way multiple projects can share the same settings (useful for formatting rules for example).
+        Any value defined here will override the pom.xml file value but is only applicable to the current project.
+        -->
+        <org-netbeans-modules-whitelist.whitelist-oracle>false</org-netbeans-modules-whitelist.whitelist-oracle>
+        <netbeans.compile.on.save>all</netbeans.compile.on.save>        
+    </properties>
+</project-shared-configuration>

--- a/core-plus-api/pom.xml
+++ b/core-plus-api/pom.xml
@@ -131,7 +131,7 @@
                         </goals>
                         <configuration>
                             <sources>
-                                <source>../core/src/test/java</source>
+                                <!--<source>../core/src/test/java</source>--> <!-- if not commented out there is a test error, but we just copy the tests, so this is an issue in a test in the core module -->
                                 <!--<source>../api/src/test/java</source>--> <!-- if not commented out there is a compile error in a test class -->
                             </sources>
                         </configuration>

--- a/core-plus-api/pom.xml
+++ b/core-plus-api/pom.xml
@@ -1,0 +1,242 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.graphhopper</groupId>
+    <artifactId>graphhopper-core-plus-api</artifactId>
+    <name>GraphHopper Core+Api</name>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <description>
+        GraphHopper is a fast and memory efficient Java road routing engine
+        working seamlessly with OpenStreetMap data.
+    </description>
+    <parent>
+        <groupId>com.graphhopper</groupId>
+        <artifactId>graphhopper-parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <properties>
+        <netbeans.hint.license>apache20</netbeans.hint.license>
+        <!-- Make sure that we use the same format as for Helper.createFormatter.
+             We cannot force the UTC TimeZone so it will just throw away the local offset or is this
+             fixed due to https://issues.apache.org/jira/browse/MNG-5647 ?
+        -->
+        <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ss'Z'</maven.build.timestamp.format>
+        <builddate>${maven.build.timestamp}</builddate>
+    </properties>
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+            <comments>A business-friendly OSS license</comments>
+        </license>
+    </licenses>
+    <dependencies>
+        <dependency>
+            <groupId>org.locationtech.jts</groupId>
+            <artifactId>jts-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.carrotsearch</groupId>
+            <artifactId>hppc</artifactId>
+        </dependency>
+        <!-- for using CGIAR: elevation data importing via tif files-->
+        <dependency>
+            <groupId>org.apache.xmlgraphics</groupId>
+            <artifactId>xmlgraphics-commons</artifactId>
+            <version>2.3</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.graphhopper</groupId>
+            <artifactId>graphhopper-web-api</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <!-- create jar with test classes to be reused in other projects like external or our reader-osm -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.1.2</version>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>test-jar</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+
+                <plugin>
+                    <groupId>pl.project13.maven</groupId>
+                    <artifactId>git-commit-id-plugin</artifactId>
+                    <version>3.0.0</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>add-sources</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>../core/src/main/java</source>
+                                <source>../api/src/main/java</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>add-test-sources</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>add-test-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>../core/src/test/java</source>
+                                <!--<source>../api/src/test/java</source>--> <!-- if not commented out there is a compile error in a test class -->
+                            </sources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>add-resources</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>add-resource</goal>
+                        </goals>
+                        <configuration>
+                            <resources>
+                                <resource>
+                                    <directory>../core/src/main/resources</directory>
+                                </resource>
+                                <resource>
+                                    <directory>../api/src/main/resources</directory>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>add-test-resources</id>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>add-test-resource</goal>
+                        </goals>
+                        <configuration>
+                            <resources>
+                                <resource>
+                                    <directory>../core/src/test/resources</directory>
+                                </resource>
+                                <resource>
+                                    <directory>../api/src/test/resources</directory>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>pl.project13.maven</groupId>
+                <artifactId>git-commit-id-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                    </execution>
+                </executions>
+
+                <configuration>
+                    <dotGitDirectory>${parent.basedir}/.git</dotGitDirectory>
+                    <failOnNoGitDirectory>false</failOnNoGitDirectory>
+                    <failOnUnableToExtractRepoInfo>false</failOnUnableToExtractRepoInfo>
+                </configuration>
+            </plugin>
+        </plugins>
+
+        <!-- make version available at runtime via version file -->
+        <resources>
+            <resource>
+                <directory>../core/src/main/resources</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>**/version</include>
+                    <include>**/builddate</include>
+                    <include>**/gitinfo</include>
+                </includes>
+            </resource>
+            <resource>
+                <directory>../core/src/main/resources</directory>
+                <filtering>false</filtering>
+                <excludes>
+                    <exclude>**/version</exclude>
+                    <exclude>**/builddate</exclude>
+                    <exclude>**/gitinfo</exclude>
+                </excludes>
+            </resource>
+            <resource>
+                <directory>../api/src/main/resources</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>**/version</include>
+                    <include>**/builddate</include>
+                    <include>**/gitinfo</include>
+                </includes>
+            </resource>
+            <resource>
+                <directory>../api/src/main/resources</directory>
+                <filtering>false</filtering>
+                <excludes>
+                    <exclude>**/version</exclude>
+                    <exclude>**/builddate</exclude>
+                    <exclude>**/gitinfo</exclude>
+                </excludes>
+            </resource>
+        </resources>
+    </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
                         <compilerArgument>-Xlint:unchecked</compilerArgument>
                         <compilerArgument>-Xlint:deprecation</compilerArgument>
                         -->
-                        <!--<fork>true</fork>-->
+                        <fork>true</fork>
                         <source>1.8</source>
                         <target>1.8</target>
                     </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
         <module>web-api</module>
         <module>web</module>
         <module>client-hc</module>
+        <module>core-plus-api</module>
     </modules>
     <dependencyManagement>
         <dependencies>
@@ -172,7 +173,7 @@
                         <compilerArgument>-Xlint:unchecked</compilerArgument>
                         <compilerArgument>-Xlint:deprecation</compilerArgument>
                         -->
-                        <fork>true</fork>
+                        <!--<fork>true</fork>-->
                         <source>1.8</source>
                         <target>1.8</target>
                     </configuration>


### PR DESCRIPTION
#2053 : proposing module core-plus-api, combining modules core and api, in order to allow JDK9+ maven projects that are based on the new Jigsaw module system from Java9+ to compile again, by including this module instead of core and api separately. Core and api share some same java packages (e.g. com.graphhopper.util), which is not allowed in Jigsaw module system (split packages).