### PR TITLE
Remove memory mx bean

### DIFF
--- a/api/src/main/java/com/graphhopper/util/Helper.java
+++ b/api/src/main/java/com/graphhopper/util/Helper.java
@@ -174,13 +174,6 @@ public class Helper {
         return "totalMB:" + getTotalMB() + ", usedMB:" + getUsedMB();
     }
 
-    public static int getUsedMBAfterGC() {
-        gcAndWait();
-        long result = (ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed() +
-                ManagementFactory.getMemoryMXBean().getNonHeapMemoryUsage().getUsed()) / (1024 * 1024);
-        return (int) result;
-    }
-
     public static void gcAndWait() {
         long before = getTotalGcCount();
         // trigger gc

--- a/web-bundle/src/main/java/com/graphhopper/http/GraphHopperBundle.java
+++ b/web-bundle/src/main/java/com/graphhopper/http/GraphHopperBundle.java
@@ -50,6 +50,7 @@ import org.glassfish.hk2.utilities.binding.AbstractBinder;
 
 import javax.inject.Inject;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Collectors;
 
 public class GraphHopperBundle implements ConfiguredBundle<GraphHopperBundleConfiguration> {
@@ -206,7 +207,8 @@ public class GraphHopperBundle implements ConfiguredBundle<GraphHopperBundleConf
             if (k instanceof String && ((String) k).startsWith("graphhopper."))
                 throw new IllegalArgumentException("You need to prefix system parameters with '-Ddw.graphhopper.' instead of '-Dgraphhopper.' see #1879 and #1897");
         }
-
+        // Make sure Jersey's Error Messages are in english
+        Locale.setDefault( new Locale("en"));
         // When Dropwizard's Hibernate Validation misvalidates a query parameter,
         // a JerseyViolationException is thrown.
         // With this mapper, we use our custom format for that (backwards compatibility),

--- a/web-bundle/src/main/java/com/graphhopper/http/GraphHopperBundle.java
+++ b/web-bundle/src/main/java/com/graphhopper/http/GraphHopperBundle.java
@@ -50,7 +50,6 @@ import org.glassfish.hk2.utilities.binding.AbstractBinder;
 
 import javax.inject.Inject;
 import java.util.List;
-import java.util.Locale;
 import java.util.stream.Collectors;
 
 public class GraphHopperBundle implements ConfiguredBundle<GraphHopperBundleConfiguration> {
@@ -207,8 +206,7 @@ public class GraphHopperBundle implements ConfiguredBundle<GraphHopperBundleConf
             if (k instanceof String && ((String) k).startsWith("graphhopper."))
                 throw new IllegalArgumentException("You need to prefix system parameters with '-Ddw.graphhopper.' instead of '-Dgraphhopper.' see #1879 and #1897");
         }
-        // Make sure Jersey's Error Messages are in english
-        Locale.setDefault( new Locale("en"));
+
         // When Dropwizard's Hibernate Validation misvalidates a query parameter,
         // a JerseyViolationException is thrown.
         // With this mapper, we use our custom format for that (backwards compatibility),


### PR DESCRIPTION
While looking into porting to iOS I discovered that the problematic method `getUsedMBAfterGC` isn't used anywhere. Proposing to remove it.