### PR TITLE
Make virtual edge IDs consecutive

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/querygraph/EdgeChangeBuilder.java
+++ b/core/src/main/java/com/graphhopper/routing/querygraph/EdgeChangeBuilder.java
@@ -66,7 +66,7 @@ class EdgeChangeBuilder {
         //    these adjacent real nodes so we can use them in the next step
         for (int i = 0; i < getNumVirtualNodes(); i++) {
             // base node
-            EdgeIteratorState baseRevEdge = getVirtualEdge(i * 4 + VE_BASE_REV);
+            EdgeIteratorState baseRevEdge = getVirtualEdge(i * 4 + SNAP_BASE);
             int towerNode = baseRevEdge.getAdjNode();
             if (!isVirtualNode(towerNode)) {
                 towerNodesToChange.add(towerNode);
@@ -74,7 +74,7 @@ class EdgeChangeBuilder {
             }
 
             // adj node
-            EdgeIteratorState adjEdge = getVirtualEdge(i * 4 + VE_ADJ);
+            EdgeIteratorState adjEdge = getVirtualEdge(i * 4 + SNAP_ADJ);
             towerNode = adjEdge.getAdjNode();
             if (!isVirtualNode(towerNode)) {
                 towerNodesToChange.add(towerNode);
@@ -101,8 +101,8 @@ class EdgeChangeBuilder {
             edgeChangesAtRealNodes.put(node, edgeChanges);
         }
         EdgeIteratorState edge = base
-                ? getVirtualEdge(virtNode * 4 + VE_BASE)
-                : getVirtualEdge(virtNode * 4 + VE_ADJ_REV);
+                ? getVirtualEdge(virtNode * 4 + BASE_SNAP)
+                : getVirtualEdge(virtNode * 4 + ADJ_SNAP);
         edgeChanges.getAdditionalEdges().add(edge);
     }
 

--- a/core/src/main/java/com/graphhopper/routing/querygraph/QueryGraph.java
+++ b/core/src/main/java/com/graphhopper/routing/querygraph/QueryGraph.java
@@ -219,7 +219,7 @@ public class QueryGraph implements Graph {
     }
 
     private int getInternalVirtualEdgeId(int origEdgeId) {
-        return origEdgeId - mainEdges;
+        return 2 * (origEdgeId - mainEdges);
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/querygraph/QueryGraph.java
+++ b/core/src/main/java/com/graphhopper/routing/querygraph/QueryGraph.java
@@ -52,7 +52,7 @@ import java.util.*;
  * @author Peter Karich
  */
 public class QueryGraph implements Graph {
-    static final int VE_BASE = 0, VE_BASE_REV = 1, VE_ADJ = 2, VE_ADJ_REV = 3;
+    static final int BASE_SNAP = 0, SNAP_BASE = 1, SNAP_ADJ = 2, ADJ_SNAP = 3;
     private final Graph mainGraph;
     private final int mainNodes;
     private final int mainEdges;
@@ -266,13 +266,12 @@ public class QueryGraph implements Graph {
 
     private List<List<EdgeIteratorState>> buildVirtualEdgesAtVirtualNodes() {
         final List<List<EdgeIteratorState>> virtualEdgesAtVirtualNodes = new ArrayList<>();
-        final int[] vEdges = {VE_BASE_REV, VE_ADJ};
         for (int i = 0; i < queryOverlay.getVirtualNodes().size(); i++) {
-            List<EdgeIteratorState> filteredEdges = new ArrayList<>(2);
-            for (int vEdge : vEdges) {
-                filteredEdges.add(queryOverlay.getVirtualEdge(i * 4 + vEdge));
-            }
-            virtualEdgesAtVirtualNodes.add(filteredEdges);
+            List<EdgeIteratorState> virtualEdges = Arrays.<EdgeIteratorState>asList(
+                    queryOverlay.getVirtualEdge(i * 4 + SNAP_BASE),
+                    queryOverlay.getVirtualEdge(i * 4 + SNAP_ADJ)
+            );
+            virtualEdgesAtVirtualNodes.add(virtualEdges);
         }
         return virtualEdgesAtVirtualNodes;
     }

--- a/core/src/main/java/com/graphhopper/routing/querygraph/QueryOverlayBuilder.java
+++ b/core/src/main/java/com/graphhopper/routing/querygraph/QueryOverlayBuilder.java
@@ -221,7 +221,7 @@ class QueryOverlayBuilder {
 
         PointList baseReversePoints = basePoints.clone(true);
         double baseDistance = basePoints.calcDistance(Helper.DIST_PLANE);
-        int virtEdgeId = firstVirtualEdgeId + queryOverlay.getNumVirtualEdges();
+        int virtEdgeId = firstVirtualEdgeId + queryOverlay.getNumVirtualEdges() / 2;
 
         boolean reverse = closestEdge.get(EdgeIteratorState.REVERSE_STATE);
         // edges between base and snapped point

--- a/core/src/main/java/com/graphhopper/routing/querygraph/VirtualEdgeIteratorState.java
+++ b/core/src/main/java/com/graphhopper/routing/querygraph/VirtualEdgeIteratorState.java
@@ -249,6 +249,7 @@ public class VirtualEdgeIteratorState implements EdgeIteratorState, CHEdgeIterat
     @Override
     public String toString() {
         return baseNode + "->" + adjNode;
+//        return edgeId + ": " + baseNode + "->" + adjNode + " @ " + hashCode();
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/querygraph/VirtualEdgeIteratorState.java
+++ b/core/src/main/java/com/graphhopper/routing/querygraph/VirtualEdgeIteratorState.java
@@ -249,7 +249,6 @@ public class VirtualEdgeIteratorState implements EdgeIteratorState, CHEdgeIterat
     @Override
     public String toString() {
         return baseNode + "->" + adjNode;
-//        return edgeId + ": " + baseNode + "->" + adjNode + " @ " + hashCode();
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/weighting/QueryGraphWeighting.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/QueryGraphWeighting.java
@@ -115,7 +115,7 @@ public class QueryGraphWeighting implements Weighting {
     }
 
     private int getOriginalEdge(int edge) {
-        return closestEdges.get((edge - firstVirtualEdgeId) / 4);
+        return closestEdges.get((edge - firstVirtualEdgeId) / 2);
     }
 
     private boolean isVirtualNode(int node) {

--- a/core/src/test/java/com/graphhopper/routing/HeadingResolverTest.java
+++ b/core/src/test/java/com/graphhopper/routing/HeadingResolverTest.java
@@ -118,8 +118,8 @@ class HeadingResolverTest {
         assertEquals(IntArrayList.from(1), resolver.getEdgesWithDifferentHeading(2, 90));
 
         // if the heading points West we get the Eastern edge 2->1
-        assertEquals("2->1", queryGraph.getEdgeIteratorState(3, Integer.MIN_VALUE).toString());
-        assertEquals(IntArrayList.from(3), resolver.getEdgesWithDifferentHeading(2, 270));
+        assertEquals("2->1", queryGraph.getEdgeIteratorState(2, Integer.MIN_VALUE).toString());
+        assertEquals(IntArrayList.from(2), resolver.getEdgesWithDifferentHeading(2, 270));
     }
 
     private QueryResult createQR(EdgeIteratorState closestEdge, double lat, double lon, int wayIndex) {

--- a/core/src/test/java/com/graphhopper/routing/querygraph/QueryGraphTest.java
+++ b/core/src/test/java/com/graphhopper/routing/querygraph/QueryGraphTest.java
@@ -601,8 +601,8 @@ public class QueryGraphTest {
         queryGraph.unfavorVirtualEdges(unfavoredEdges);
         // test penalized south
         expect = true;
-        assertEquals(expect, isAvoidEdge(queryGraph.getVirtualEdges().get(QueryGraph.VE_ADJ)));
-        assertEquals(expect, isAvoidEdge(queryGraph.getVirtualEdges().get(QueryGraph.VE_ADJ_REV)));
+        assertEquals(expect, isAvoidEdge(queryGraph.getEdgeIteratorState(2, 1)));
+        assertEquals(expect, isAvoidEdge(queryGraph.getEdgeIteratorState(2, 2)));
 
         queryGraph.clearUnfavoredStatus();
         // enforce south
@@ -611,8 +611,8 @@ public class QueryGraphTest {
 
         // test penalized north
         expect = true;
-        assertEquals(expect, isAvoidEdge(queryGraph.getVirtualEdges().get(QueryGraph.VE_BASE)));
-        assertEquals(expect, isAvoidEdge(queryGraph.getVirtualEdges().get(QueryGraph.VE_BASE_REV)));
+        assertEquals(expect, isAvoidEdge(queryGraph.getEdgeIteratorState(1, 0)));
+        assertEquals(expect, isAvoidEdge(queryGraph.getEdgeIteratorState(1, 2)));
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/routing/querygraph/QueryGraphTest.java
+++ b/core/src/test/java/com/graphhopper/routing/querygraph/QueryGraphTest.java
@@ -844,7 +844,7 @@ public class QueryGraphTest {
         assertSame(queryGraph.getVirtualEdges().get(3), queryGraph.getEdgeIteratorState(2, 2));
 
         try {
-            queryGraph.getEdgeIteratorState(4, 0);
+            queryGraph.getEdgeIteratorState(3, 2);
             fail("there should be an error");
         } catch (IndexOutOfBoundsException e) {
             // ok

--- a/core/src/test/java/com/graphhopper/routing/querygraph/QueryGraphTest.java
+++ b/core/src/test/java/com/graphhopper/routing/querygraph/QueryGraphTest.java
@@ -842,6 +842,13 @@ public class QueryGraphTest {
         assertSame(queryGraph.getVirtualEdges().get(1), queryGraph.getEdgeIteratorState(1, 0));
         assertSame(queryGraph.getVirtualEdges().get(2), queryGraph.getEdgeIteratorState(2, 1));
         assertSame(queryGraph.getVirtualEdges().get(3), queryGraph.getEdgeIteratorState(2, 2));
+
+        try {
+            queryGraph.getEdgeIteratorState(4, 0);
+            fail("there should be an error");
+        } catch (IndexOutOfBoundsException e) {
+            // ok
+        }
     }
 
     private QueryGraph lookup(QueryResult res) {

--- a/web/src/test/java/com/graphhopper/http/resources/SPTResourceTest.java
+++ b/web/src/test/java/com/graphhopper/http/resources/SPTResourceTest.java
@@ -98,7 +98,7 @@ public class SPTResourceTest {
         assertTrue(lines.length > 500);
         assertEquals("prev_node_id,edge_id,node_id,time,distance", lines[0]);
         assertEquals("-1,-1,1884,0,0", lines[1]);
-        assertEquals("1884,2274,1324,3817,74", lines[2]);
+        assertEquals("1884,2273,1324,3817,74", lines[2]);
         assertEquals("1884,2272,263,13496,262", lines[3]);
     }
 


### PR DESCRIPTION
When we insert a virtual node between two nodes, like nodes 0 and 1 here: 

```
0-x-1
```

four `VirtualEdgeIteratorState`s get created. Two are visible for the edge explorer at the virtual node and one is visible from each of the real nodes (0 and 1). However, these edge states only represent the two directions of the two edges 0-x and x-1 and in fact `edgeState.getEdge()` returns the same number for each pair. Also the virtual edge IDs were not consecutive before this PR. So if 0-1 was the only edge with ID 0 we would get two virtual edge states with ID 1 and two with ID 3. IDs 2 and 4 could still be used to *obtain* the virtual edge states using `graph.getEdgeIteratorState(2,x)` but the returned edge state would still not have edge ID 2 (in this case it would be `edgeState.getEdge()==1` instead).

With this PR the virtual edge IDs will just be 1 and 2 (the same for both directions of the edges just as we do for non-virtual edges as well) and `getEdgeIteratorState(3, x)` will an error.