### PR TITLE
Update core,client-hc and reader-osm to Java 8

### DIFF
--- a/client-hc/pom.xml
+++ b/client-hc/pom.xml
@@ -54,19 +54,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <compilerArgument>-XDignore.symbol.file</compilerArgument>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
-            </plugin>
-            
-        </plugins>        
-    </build>
-        
 </project>

--- a/core/files/changelog.txt
+++ b/core/files/changelog.txt
@@ -1,3 +1,10 @@
+2.0
+    use Java 8 also for core, client-hc and reader-osm modules. all modules use Java 8 now
+    removed android demo, #1940
+    added edge key path detail, #2073
+    fixed bug for turn restrictions on bridges/tunnels, #2070
+    improved resolution of elevation profiles, 3D Douglas-Peucker and long edge sampling, #1953
+
 1.0
     changes to config.yml:
       properties have to follow the snake_case, #1918, easy convert via https://github.com/karussell/snake_case

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -107,14 +107,6 @@
 
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>pl.project13.maven</groupId>
                 <artifactId>git-commit-id-plugin</artifactId>
                 <executions>

--- a/reader-osm/pom.xml
+++ b/reader-osm/pom.xml
@@ -49,17 +49,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>


### PR DESCRIPTION
Now that it has been decided that GraphHopper only fully supports Android up to GraphHopper version 1.0 we can update all modules to Java 8. Related: #1940 (I.e. GraphHopper 2.0 drops support for very old Android versions for offline routing)