### PR TITLE
Change OpenJDK download server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ matrix:
   include:
     - jdk: openjdk8
     - env: JDK='OpenJDK 14'
-      install: . ./install-jdk.sh -F 14 -C
+      install: . ./install-jdk.sh -F 14 -C --url 'https://api.adoptopenjdk.net/v3/binary/latest/14/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk'
     - env: JDK='OpenJDK 15'
-      install: . ./install-jdk.sh -F 15 -C
+      install: . ./install-jdk.sh -F 15 -C --url 'https://api.adoptopenjdk.net/v3/binary/latest/15/ea/linux/x64/jdk/hotspot/normal/adoptopenjdk'
     
 # avoid default dependency command for maven, 'true' means 'return true' and continue
 install: true


### PR DESCRIPTION
Something is wrong with jdk.java.net, e.g. we got `curl: (56) SSL read: error:0` but other errors too.

So we could switch when moving to adoptopenjdk urls.