### PR TITLE
withInstructions should be without path details

### DIFF
--- a/tools/src/main/java/com/graphhopper/tools/Measurement.java
+++ b/tools/src/main/java/com/graphhopper/tools/Measurement.java
@@ -260,12 +260,12 @@ public class Measurement {
                     printTimeOfRouteQuery(hopper, new QuerySettings("routingCH_no_instr", count, isCH, isLM).
                             sod());
                     printTimeOfRouteQuery(hopper, new QuerySettings("routingCH_full", count, isCH, isLM).
-                            withInstructions().withPointHints().sod().simplify());
+                            withInstructions().withPointHints().sod().simplifyAndPD());
                     // for some strange (jvm optimizations) reason adding these measurements reduced the measured time for routingCH_full... see #2056
                     printTimeOfRouteQuery(hopper, new QuerySettings("routingCH_via_100", count / 100, isCH, isLM).
                             withPoints(100).sod());
                     printTimeOfRouteQuery(hopper, new QuerySettings("routingCH_via_100_full", count / 100, isCH, isLM).
-                            withPoints(100).sod().withInstructions().simplify());
+                            withPoints(100).sod().withInstructions().simplifyAndPD());
                 }
                 if (!hopper.getCHPreparationHandler().getEdgeBasedCHConfigs().isEmpty()) {
                     printTimeOfRouteQuery(hopper, new QuerySettings("routingCH_edge", count, isCH, isLM).
@@ -275,12 +275,12 @@ public class Measurement {
                     printTimeOfRouteQuery(hopper, new QuerySettings("routingCH_edge_no_instr", count, isCH, isLM).
                             edgeBased());
                     printTimeOfRouteQuery(hopper, new QuerySettings("routingCH_edge_full", count, isCH, isLM).
-                            edgeBased().withInstructions().withPointHints().simplify());
+                            edgeBased().withInstructions().withPointHints().simplifyAndPD());
                     // for some strange (jvm optimizations) reason adding these measurements reduced the measured time for routingCH_edge_full... see #2056
                     printTimeOfRouteQuery(hopper, new QuerySettings("routingCH_edge_via_100", count / 100, isCH, isLM).
                             withPoints(100).edgeBased().sod());
                     printTimeOfRouteQuery(hopper, new QuerySettings("routingCH_edge_via_100_full", count / 100, isCH, isLM).
-                            withPoints(100).edgeBased().sod().withInstructions().simplify());
+                            withPoints(100).edgeBased().sod().withInstructions().simplifyAndPD());
                 }
             }
             if (!isEmpty(countryBordersDirectory)) {
@@ -363,7 +363,7 @@ public class Measurement {
         private final int count;
         final boolean ch, lm;
         int activeLandmarks = -1;
-        boolean withInstructions, withPointHints, sod, edgeBased, simplify, alternative;
+        boolean withInstructions, withPointHints, sod, edgeBased, simplifyAndPD, alternative;
         String blockArea;
         int points = 2;
 
@@ -404,8 +404,11 @@ public class Measurement {
             return this;
         }
 
-        QuerySettings simplify() {
-            this.simplify = true;
+        /**
+         * simplify and get path details
+         */
+        QuerySettings simplifyAndPD() {
+            this.simplifyAndPD = true;
             return this;
         }
 
@@ -781,10 +784,7 @@ public class Measurement {
                 if (querySettings.alternative)
                     req.setAlgorithm(ALT_ROUTE);
 
-                if (querySettings.withInstructions)
-                    req.setPathDetails(Arrays.asList(Parameters.Details.AVERAGE_SPEED));
-
-                if (querySettings.simplify) {
+                if (querySettings.simplifyAndPD) {
                     req.setPathDetails(Arrays.asList(Parameters.Details.AVERAGE_SPEED, Parameters.Details.EDGE_ID, Parameters.Details.STREET_NAME));
                 } else {
                     // disable path simplification by setting the distance to zero


### PR DESCRIPTION
@easbar do you know why we include the `average_speed` path details for instructions in Measurement?