### PR TITLE
Avoid object creation when calling graph#getEdges()

### DIFF
--- a/core/src/main/java/com/graphhopper/storage/BaseGraph.java
+++ b/core/src/main/java/com/graphhopper/storage/BaseGraph.java
@@ -344,7 +344,7 @@ class BaseGraph implements Graph {
 
     @Override
     public int getEdges() {
-        return getAllEdges().length();
+        return edgeCount;
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/storage/CHGraphImpl.java
+++ b/core/src/main/java/com/graphhopper/storage/CHGraphImpl.java
@@ -181,7 +181,7 @@ public class CHGraphImpl implements CHGraph, Storable<CHGraph> {
 
     @Override
     public int getEdges() {
-        return getAllEdges().length();
+        return baseGraph.getEdges() + shortcutCount;
     }
 
     @Override


### PR DESCRIPTION
No real performance improvement even though this method is called frequently in query graph's `isVirtualEdge` method, but anyway no need to create an all edge iterator to find out the number of edges.