### PR TITLE
Set Unit public

### DIFF
--- a/navigation/src/main/java/com/graphhopper/navigation/DistanceUtils.java
+++ b/navigation/src/main/java/com/graphhopper/navigation/DistanceUtils.java
@@ -23,7 +23,7 @@ public class DistanceUtils {
     static float meterToMiles = 0.00062137f;
     static float meterToKilometer = 0.001f;
 
-    enum Unit {
+    public enum Unit {
         METRIC,
         IMPERIAL
     }


### PR DESCRIPTION
This PR addresses a minor issue. If I would like to use the method `NavigateResponseConverter#convertFromGHResponse(GHResponse ghResponse, TranslationMap translationMap, Locale locale, DistanceConfig distanceConfig)`, I need to pass a DistanceConfig. The constructor of the DistanceConfig is: `DistanceConfig(DistanceUtils.Unit unit, TranslationMap translationMap, Locale locale)`. `DistanceUtils.Unit` has only package access, so I cannot use it in a different package, therefore I cannot use the `NavigateResponseConverter` from a different package.