### PR TITLE
Set OSMReader#process methods public

### DIFF
--- a/reader-osm/src/main/java/com/graphhopper/reader/osm/OSMReader.java
+++ b/reader-osm/src/main/java/com/graphhopper/reader/osm/OSMReader.java
@@ -311,7 +311,7 @@ public class OSMReader implements DataReader, TurnCostParser.ExternalInternalMap
     /**
      * Process properties, encode flags and create edges for the way.
      */
-    void processWay(ReaderWay way) {
+    public void processWay(ReaderWay way) {
         if (way.getNodes().size() < 2)
             return;
 
@@ -479,7 +479,7 @@ public class OSMReader implements DataReader, TurnCostParser.ExternalInternalMap
             return Double.NaN;
     }
 
-    private void processNode(ReaderNode node) {
+    protected void processNode(ReaderNode node) {
         if (isInBounds(node)) {
             addNode(node);
 

--- a/reader-osm/src/main/java/com/graphhopper/reader/osm/OSMReader.java
+++ b/reader-osm/src/main/java/com/graphhopper/reader/osm/OSMReader.java
@@ -414,7 +414,7 @@ public class OSMReader implements DataReader, TurnCostParser.ExternalInternalMap
         }
     }
 
-    public void processRelation(ReaderRelation relation) {
+    protected void processRelation(ReaderRelation relation) {
         if (tcs != null && relation.hasTag("type", "restriction"))
             storeTurnRelation(createTurnRelations(relation));
     }

--- a/reader-osm/src/main/java/com/graphhopper/reader/osm/OSMReader.java
+++ b/reader-osm/src/main/java/com/graphhopper/reader/osm/OSMReader.java
@@ -479,7 +479,7 @@ public class OSMReader implements DataReader, TurnCostParser.ExternalInternalMap
             return Double.NaN;
     }
 
-    protected void processNode(ReaderNode node) {
+    public void processNode(ReaderNode node) {
         if (isInBounds(node)) {
             addNode(node);
 

--- a/reader-osm/src/main/java/com/graphhopper/reader/osm/OSMReader.java
+++ b/reader-osm/src/main/java/com/graphhopper/reader/osm/OSMReader.java
@@ -311,7 +311,7 @@ public class OSMReader implements DataReader, TurnCostParser.ExternalInternalMap
     /**
      * Process properties, encode flags and create edges for the way.
      */
-    public void processWay(ReaderWay way) {
+    protected void processWay(ReaderWay way) {
         if (way.getNodes().size() < 2)
             return;
 
@@ -479,7 +479,7 @@ public class OSMReader implements DataReader, TurnCostParser.ExternalInternalMap
             return Double.NaN;
     }
 
-    public void processNode(ReaderNode node) {
+    protected void processNode(ReaderNode node) {
         if (isInBounds(node)) {
             addNode(node);
 


### PR DESCRIPTION
I was browsing through the OSMReader and saw that the three methods:

- processRelation
- processWay
- processNode

Have three different visibility. In one project I am already using the processRelation method to add a hook. Now I wanted to use the processNode method as well and saw that this is not easily possible. I think there are good use-cases to extend all three methods.

WDYT? Would it make sense to set all 3 methods public? Personally I could very well live with setting them protected, but that way at least there is a way to modify it. 