### PR TITLE
Interpolate Ferry Elevation for Skadi Elevation Provider

### DIFF
--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -970,8 +970,15 @@ public class GraphHopper implements GraphHopperAPI {
             float tunnel = sw.stop().getSeconds();
             sw = new StopWatch().start();
             new EdgeElevationInterpolator(ghStorage, roadEnvEnc, RoadEnvironment.BRIDGE).execute();
+            float bridge = sw.stop().getSeconds();
+            float ferry = -1;
+            if (eleProvider instanceof SkadiProvider) {
+                sw = new StopWatch().start();
+                new EdgeElevationInterpolator(ghStorage, roadEnvEnc, RoadEnvironment.FERRY).execute();
+                ferry = sw.stop().getSeconds();
+            }
             ghStorage.getProperties().put(INTERPOLATION_KEY, true);
-            logger.info("Bridge interpolation " + (int) sw.stop().getSeconds() + "s, " + "tunnel interpolation " + (int) tunnel + "s");
+            logger.info("Bridge interpolation " + (int) bridge + "s, " + "tunnel interpolation " + (int) tunnel + "s, ferry interpolation " + (int) ferry);
         }
     }
 


### PR DESCRIPTION
This PR fixes #2098. For now I set it up to only interpolate ferries if the SkadiElevationProvider is used. For the other providers this is probably not necessary.

Another improvement on top of this would be to not even lookup the elevation for any ferries (except for tower nodes) and then interpolate the elevation for the ferries. This might speed up the overall import, since no elevation file lookup needs to be done.

If found a nice example in Denmark: http://localhost:8989/maps/?point=57.437455%2C10.538464&point=57.295185%2C10.92041&locale=de-DE&elevation=true&profile=car&use_miles=false&layer=Omniscale

Before:
![Screenshot from 2020-07-30 14-18-01](https://user-images.githubusercontent.com/1553525/88922950-332dd300-d271-11ea-9f39-37373f83096f.png)
After:
![Screenshot from 2020-07-30 14-18-10](https://user-images.githubusercontent.com/1553525/88922940-30cb7900-d271-11ea-9862-471e12caf174.png)
