### PR TITLE
introduce lazy removal from PriorityQueue for all routing algorithms

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/AStarBidirection.java
+++ b/core/src/main/java/com/graphhopper/routing/AStarBidirection.java
@@ -93,13 +93,6 @@ public class AStarBidirection extends AbstractNonCHBidirAlgo {
         return entry;
     }
 
-    @Override
-    protected double calcWeight(EdgeIteratorState iter, SPTEntry currEdge, boolean reverse) {
-        // TODO performance: check if the node is already existent in the opposite direction
-        // then we could avoid the approximation as we already know the exact complete path!
-        return super.calcWeight(iter, currEdge, reverse);
-    }
-
     public WeightApproximator getApproximation() {
         return weightApprox.getApproximation();
     }

--- a/core/src/main/java/com/graphhopper/routing/AStarBidirection.java
+++ b/core/src/main/java/com/graphhopper/routing/AStarBidirection.java
@@ -94,14 +94,6 @@ public class AStarBidirection extends AbstractNonCHBidirAlgo {
     }
 
     @Override
-    protected void updateEntry(SPTEntry entry, EdgeIteratorState edge, double weight, SPTEntry parent, boolean reverse) {
-        entry.edge = edge.getEdge();
-        entry.weight = weight + weightApprox.approximate(edge.getAdjNode(), reverse);
-        ((AStarEntry) entry).weightOfVisitedPath = weight;
-        entry.parent = parent;
-    }
-
-    @Override
     protected double calcWeight(EdgeIteratorState iter, SPTEntry currEdge, boolean reverse) {
         // TODO performance: check if the node is already existent in the opposite direction
         // then we could avoid the approximation as we already know the exact complete path!

--- a/core/src/main/java/com/graphhopper/routing/AStarBidirectionCH.java
+++ b/core/src/main/java/com/graphhopper/routing/AStarBidirectionCH.java
@@ -59,13 +59,6 @@ public class AStarBidirectionCH extends AbstractBidirCHAlgo {
         return entry;
     }
 
-    @Override
-    protected double calcWeight(RoutingCHEdgeIteratorState iter, SPTEntry currEdge, boolean reverse) {
-        // TODO performance: check if the node is already existent in the opposite direction
-        // then we could avoid the approximation as we already know the exact complete path!
-        return super.calcWeight(iter, currEdge, reverse);
-    }
-
     public WeightApproximator getApproximation() {
         return weightApprox.getApproximation();
     }

--- a/core/src/main/java/com/graphhopper/routing/AStarBidirectionCH.java
+++ b/core/src/main/java/com/graphhopper/routing/AStarBidirectionCH.java
@@ -60,14 +60,6 @@ public class AStarBidirectionCH extends AbstractBidirCHAlgo {
     }
 
     @Override
-    protected void updateEntry(SPTEntry entry, int edge, int adjNode, int incEdge, double weight, SPTEntry parent, boolean reverse) {
-        entry.edge = edge;
-        entry.weight = weight + weightApprox.approximate(adjNode, reverse);
-        ((AStar.AStarEntry) entry).weightOfVisitedPath = weight;
-        entry.parent = parent;
-    }
-
-    @Override
     protected double calcWeight(RoutingCHEdgeIteratorState iter, SPTEntry currEdge, boolean reverse) {
         // TODO performance: check if the node is already existent in the opposite direction
         // then we could avoid the approximation as we already know the exact complete path!

--- a/core/src/main/java/com/graphhopper/routing/AStarBidirectionEdgeCHNoSOD.java
+++ b/core/src/main/java/com/graphhopper/routing/AStarBidirectionEdgeCHNoSOD.java
@@ -66,15 +66,6 @@ public class AStarBidirectionEdgeCHNoSOD extends AbstractBidirectionEdgeCHNoSOD 
         return entry;
     }
 
-    @Override
-    protected void updateEntry(SPTEntry entry, int edge, int adjNode, int incEdge, double weight, SPTEntry parent, boolean reverse) {
-        entry.edge = edge;
-        ((AStarCHEntry) entry).incEdge = incEdge;
-        entry.weight = getHeapWeight(adjNode, reverse, weight);
-        ((AStarCHEntry) entry).weightOfVisitedPath = weight;
-        entry.parent = parent;
-    }
-
     public WeightApproximator getApproximation() {
         return weightApprox.getApproximation();
     }

--- a/core/src/main/java/com/graphhopper/routing/AbstractBidirAlgo.java
+++ b/core/src/main/java/com/graphhopper/routing/AbstractBidirAlgo.java
@@ -58,12 +58,14 @@ public abstract class AbstractBidirAlgo implements BidirRoutingAlgorithm {
         toInEdge = ANY_EDGE;
     }
 
-    protected void initCollections(int size) {
-        pqOpenSetFrom = new PriorityQueue<>(size);
-        bestWeightMapFrom = new GHIntObjectHashMap<>(size);
+    protected void initCollections(int queueSize, int mapSize) {
+        mapSize = Math.max(mapSize, 50);
+        queueSize = Math.max(queueSize, 10);
+        pqOpenSetFrom = new PriorityQueue<>(queueSize);
+        bestWeightMapFrom = new GHIntObjectHashMap<>(mapSize);
 
-        pqOpenSetTo = new PriorityQueue<>(size);
-        bestWeightMapTo = new GHIntObjectHashMap<>(size);
+        pqOpenSetTo = new PriorityQueue<>(queueSize);
+        bestWeightMapTo = new GHIntObjectHashMap<>(mapSize);
     }
 
     /**

--- a/core/src/main/java/com/graphhopper/routing/AbstractBidirCHAlgo.java
+++ b/core/src/main/java/com/graphhopper/routing/AbstractBidirCHAlgo.java
@@ -191,8 +191,6 @@ public abstract class AbstractBidirCHAlgo extends AbstractBidirAlgo implements B
                 bestWeightMap.put(traversalId, entry);
                 prioQueue.add(entry);
             } else if (entry.getWeightOfVisitedPath() > weight) {
-                // this call might return false, ignore this: see #2104
-                prioQueue.remove(entry);
                 entry.deleted = true;
                 entry = createEntry(iter.getEdge(), iter.getAdjNode(), origEdgeId, weight, currEdge, reverse);
                 bestWeightMap.put(traversalId, entry);

--- a/core/src/main/java/com/graphhopper/routing/AbstractBidirCHAlgo.java
+++ b/core/src/main/java/com/graphhopper/routing/AbstractBidirCHAlgo.java
@@ -134,10 +134,12 @@ public abstract class AbstractBidirCHAlgo extends AbstractBidirAlgo implements B
 
     @Override
     boolean fillEdgesFrom() {
-        if (pqOpenSetFrom.isEmpty()) {
-            return false;
-        }
-        currFrom = pqOpenSetFrom.poll();
+        do {
+            if (pqOpenSetFrom.isEmpty())
+                return false;
+            currFrom = pqOpenSetFrom.poll();
+        } while (currFrom.deleted);
+
         visitedCountFrom++;
         if (fromEntryCanBeSkipped()) {
             return true;
@@ -152,10 +154,12 @@ public abstract class AbstractBidirCHAlgo extends AbstractBidirAlgo implements B
 
     @Override
     boolean fillEdgesTo() {
-        if (pqOpenSetTo.isEmpty()) {
-            return false;
-        }
-        currTo = pqOpenSetTo.poll();
+        do {
+            if (pqOpenSetTo.isEmpty())
+                return false;
+            currTo = pqOpenSetTo.poll();
+        } while (currTo.deleted);
+
         visitedCountTo++;
         if (toEntryCanBeSkipped()) {
             return true;
@@ -187,8 +191,10 @@ public abstract class AbstractBidirCHAlgo extends AbstractBidirAlgo implements B
                 bestWeightMap.put(traversalId, entry);
                 prioQueue.add(entry);
             } else if (entry.getWeightOfVisitedPath() > weight) {
+                // this call might return false, ignore this: see #2104
                 prioQueue.remove(entry);
-                updateEntry(entry, iter.getEdge(), iter.getAdjNode(), origEdgeId, weight, currEdge, reverse);
+                entry = createEntry(iter.getEdge(), iter.getAdjNode(), origEdgeId, weight, currEdge, reverse);
+                bestWeightMap.put(traversalId, entry);
                 prioQueue.add(entry);
             } else
                 continue;
@@ -207,12 +213,6 @@ public abstract class AbstractBidirCHAlgo extends AbstractBidirAlgo implements B
                 ? graph.getTurnWeight(origEdgeId, edgeState.getBaseNode(), prevOrNextEdgeId)
                 : graph.getTurnWeight(prevOrNextEdgeId, edgeState.getBaseNode(), origEdgeId);
         return edgeWeight + turnCosts;
-    }
-
-    protected void updateEntry(SPTEntry entry, int edge, int adjNode, int incEdge, double weight, SPTEntry parent, boolean reverse) {
-        entry.edge = edge;
-        entry.weight = weight;
-        entry.parent = parent;
     }
 
     protected boolean accept(RoutingCHEdgeIteratorState edge, SPTEntry currEdge, boolean reverse) {

--- a/core/src/main/java/com/graphhopper/routing/AbstractBidirCHAlgo.java
+++ b/core/src/main/java/com/graphhopper/routing/AbstractBidirCHAlgo.java
@@ -50,13 +50,13 @@ public abstract class AbstractBidirCHAlgo extends AbstractBidirAlgo implements B
         outEdgeExplorer = graph.createOutEdgeExplorer();
         inEdgeExplorer = graph.createInEdgeExplorer();
         levelEdgeFilter = new CHLevelEdgeFilter(graph);
-        int size = Math.min(Math.max(200, graph.getNodes() / 10), 150_000);
-        initCollections(size);
+        int size = Math.min(graph.getNodes() / 10, 2_000);
+        initCollections(size / 10, size);
     }
 
     @Override
-    protected void initCollections(int size) {
-        super.initCollections(Math.min(size, 2000));
+    protected void initCollections(int queueSize, int mapSize) {
+        super.initCollections(Math.min(queueSize, 200), Math.min(mapSize, 2000));
     }
 
     /**

--- a/core/src/main/java/com/graphhopper/routing/AbstractBidirCHAlgo.java
+++ b/core/src/main/java/com/graphhopper/routing/AbstractBidirCHAlgo.java
@@ -193,6 +193,7 @@ public abstract class AbstractBidirCHAlgo extends AbstractBidirAlgo implements B
             } else if (entry.getWeightOfVisitedPath() > weight) {
                 // this call might return false, ignore this: see #2104
                 prioQueue.remove(entry);
+                entry.deleted = true;
                 entry = createEntry(iter.getEdge(), iter.getAdjNode(), origEdgeId, weight, currEdge, reverse);
                 bestWeightMap.put(traversalId, entry);
                 prioQueue.add(entry);

--- a/core/src/main/java/com/graphhopper/routing/AbstractNonCHBidirAlgo.java
+++ b/core/src/main/java/com/graphhopper/routing/AbstractNonCHBidirAlgo.java
@@ -182,8 +182,6 @@ public abstract class AbstractNonCHBidirAlgo extends AbstractBidirAlgo implement
                 bestWeightMap.put(traversalId, entry);
                 prioQueue.add(entry);
             } else if (entry.getWeightOfVisitedPath() > weight) {
-                // this call might return false, ignore this: see #2104
-                prioQueue.remove(entry);
                 entry.deleted = true;
                 entry = createEntry(iter, weight, currEdge, reverse);
                 bestWeightMap.put(traversalId, entry);

--- a/core/src/main/java/com/graphhopper/routing/AbstractNonCHBidirAlgo.java
+++ b/core/src/main/java/com/graphhopper/routing/AbstractNonCHBidirAlgo.java
@@ -184,6 +184,7 @@ public abstract class AbstractNonCHBidirAlgo extends AbstractBidirAlgo implement
             } else if (entry.getWeightOfVisitedPath() > weight) {
                 // this call might return false, ignore this: see #2104
                 prioQueue.remove(entry);
+                entry.deleted = true;
                 entry = createEntry(iter, weight, currEdge, reverse);
                 bestWeightMap.put(traversalId, entry);
                 prioQueue.add(entry);

--- a/core/src/main/java/com/graphhopper/routing/AbstractNonCHBidirAlgo.java
+++ b/core/src/main/java/com/graphhopper/routing/AbstractNonCHBidirAlgo.java
@@ -127,10 +127,12 @@ public abstract class AbstractNonCHBidirAlgo extends AbstractBidirAlgo implement
 
     @Override
     boolean fillEdgesFrom() {
-        if (pqOpenSetFrom.isEmpty()) {
-            return false;
-        }
-        currFrom = pqOpenSetFrom.poll();
+        do {
+            if (pqOpenSetFrom.isEmpty())
+                return false;
+            currFrom = pqOpenSetFrom.poll();
+        } while (currFrom.deleted);
+
         visitedCountFrom++;
         if (fromEntryCanBeSkipped()) {
             return true;
@@ -145,10 +147,12 @@ public abstract class AbstractNonCHBidirAlgo extends AbstractBidirAlgo implement
 
     @Override
     boolean fillEdgesTo() {
-        if (pqOpenSetTo.isEmpty()) {
-            return false;
-        }
-        currTo = pqOpenSetTo.poll();
+        do {
+            if (pqOpenSetTo.isEmpty())
+                return false;
+            currTo = pqOpenSetTo.poll();
+        } while (currTo.deleted);
+
         visitedCountTo++;
         if (toEntryCanBeSkipped()) {
             return true;
@@ -178,8 +182,10 @@ public abstract class AbstractNonCHBidirAlgo extends AbstractBidirAlgo implement
                 bestWeightMap.put(traversalId, entry);
                 prioQueue.add(entry);
             } else if (entry.getWeightOfVisitedPath() > weight) {
+                // this call might return false, ignore this: see #2104
                 prioQueue.remove(entry);
-                updateEntry(entry, iter, weight, currEdge, reverse);
+                entry = createEntry(iter, weight, currEdge, reverse);
+                bestWeightMap.put(traversalId, entry);
                 prioQueue.add(entry);
             } else
                 continue;
@@ -192,12 +198,6 @@ public abstract class AbstractNonCHBidirAlgo extends AbstractBidirAlgo implement
                 updateBestPath(edgeWeight, entry, EdgeIterator.NO_EDGE, traversalId, reverse);
             }
         }
-    }
-
-    protected void updateEntry(SPTEntry entry, EdgeIteratorState edge, double weight, SPTEntry parent, boolean reverse) {
-        entry.edge = edge.getEdge();
-        entry.weight = weight;
-        entry.parent = parent;
     }
 
     protected double calcWeight(EdgeIteratorState iter, SPTEntry currEdge, boolean reverse) {

--- a/core/src/main/java/com/graphhopper/routing/AbstractNonCHBidirAlgo.java
+++ b/core/src/main/java/com/graphhopper/routing/AbstractNonCHBidirAlgo.java
@@ -62,8 +62,8 @@ public abstract class AbstractNonCHBidirAlgo extends AbstractBidirAlgo implement
         edgeExplorer = graph.createEdgeExplorer();
         outEdgeFilter = DefaultEdgeFilter.outEdges(flagEncoder.getAccessEnc());
         inEdgeFilter = DefaultEdgeFilter.inEdges(flagEncoder.getAccessEnc());
-        int size = Math.min(Math.max(200, graph.getNodes() / 10), 150_000);
-        initCollections(size);
+        int mapSize = Math.min(graph.getNodes() / 10, 250_000);
+        initCollections(mapSize / 50, mapSize);
     }
 
     /**

--- a/core/src/main/java/com/graphhopper/routing/DijkstraBidirectionEdgeCHNoSOD.java
+++ b/core/src/main/java/com/graphhopper/routing/DijkstraBidirectionEdgeCHNoSOD.java
@@ -41,14 +41,6 @@ public class DijkstraBidirectionEdgeCHNoSOD extends AbstractBidirectionEdgeCHNoS
     }
 
     @Override
-    protected void updateEntry(SPTEntry entry, int edge, int adjNode, int incEdge, double weight, SPTEntry parent, boolean reverse) {
-        entry.edge = edge;
-        ((CHEntry) entry).incEdge = incEdge;
-        entry.weight = weight;
-        entry.parent = parent;
-    }
-
-    @Override
     public String getName() {
         return "dijkstrabi|ch|edge_based|no_sod";
     }

--- a/core/src/main/java/com/graphhopper/routing/SPTEntry.java
+++ b/core/src/main/java/com/graphhopper/routing/SPTEntry.java
@@ -30,6 +30,7 @@ public class SPTEntry implements Cloneable, Comparable<SPTEntry> {
     public int adjNode;
     public double weight;
     public SPTEntry parent;
+    public boolean deleted;
 
     public SPTEntry(int edgeId, int adjNode, double weight) {
         this.edge = edgeId;


### PR DESCRIPTION
Related to #489 and #2092.

Minor speed up. Picked point 2 from below performance investigations over the last weeks:

1. the GHPriorityQueue that has an additional `double[]` array speeds up pure A* (max values are decreased), but speed is slower for LM and CH routing. Still the LM preparation is faster. See the [branch priority_queue_faster](https://github.com/graphhopper/graphhopper/tree/priority_queue_faster). (CH preparation is slightly slower, nearly not significant, for bigger maps)

2. when we remove the `priorityQueue.remove` call and allow stale SPTEntries we can have some speed ups although not so strong. But the advantage is that LM routing is also ~10% faster, the max values are reduced too and no changes for CH. This finding is interesting as when I tried this some years ago it reduced speed slightly.

3. when implementing a faster `priorityQueue.update` method (that does remove and insert into the heap at the same time) I did not measure a difference for GHPriorityQueue (might be different for java's PriorityQueue).

4. replacing our custom queue implementation in PreparationContractionHierarchies (GHTreeMapComposed) with a standard PriorityQueue then CH prep gets much slower. I'm sure I did something wrong but I couldn't find the problem. Another trial for PreparationContractionHierarchies could be to use [the LongPriorityQueue from lucene](https://github.com/graphhopper/graphhopper/commit/27165ba876bd1692eb03065f48e2560c6b7a57ef), so that we can store key and value into the `long[]` array and avoid object creation.

5. Combining 1 and 2 results in no changes for LM (i.e. an advantage over 1 alone) and significant speed up (35%!) for LM preparation (advantage over 1 and 2) but still slow CH routing (disadvantage over 2 alone).

6. This does not speed up the algorithm: check if the traversalId is already existent in the opposite direction then we could avoid the approximation as we already know the exact complete path! We can even avoid calculating the weight for edge-based traversal.