### PR TITLE
Add weighted in/out edge explorers

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/EdgeFilter.java
+++ b/core/src/main/java/com/graphhopper/routing/util/EdgeFilter.java
@@ -25,12 +25,7 @@ import com.graphhopper.util.EdgeIteratorState;
  * @author Peter Karich
  */
 public interface EdgeFilter {
-    EdgeFilter ALL_EDGES = new EdgeFilter() {
-        @Override
-        public final boolean accept(EdgeIteratorState edgeState) {
-            return true;
-        }
-    };
+    EdgeFilter ALL_EDGES = edgeState -> true;
 
     /**
      * @return true if the current edge should be processed and false otherwise.

--- a/core/src/main/java/com/graphhopper/storage/BaseGraph.java
+++ b/core/src/main/java/com/graphhopper/storage/BaseGraph.java
@@ -589,11 +589,6 @@ class BaseGraph implements Graph {
     }
 
     @Override
-    public EdgeExplorer createEdgeExplorer() {
-        return createEdgeExplorer(EdgeFilter.ALL_EDGES);
-    }
-
-    @Override
     public AllEdgesIterator getAllEdges() {
         return new AllEdgeIterator(this, edgeAccess);
     }

--- a/core/src/main/java/com/graphhopper/storage/Graph.java
+++ b/core/src/main/java/com/graphhopper/storage/Graph.java
@@ -121,8 +121,9 @@ public interface Graph {
     default EdgeExplorer createOutEdgeExplorer(Weighting weighting) {
         final BooleanEncodedValue accessEnc = weighting.getFlagEncoder().getAccessEnc();
         return createEdgeExplorer(edge -> {
-            boolean access = edge.get(accessEnc);
-            if (!access)
+            if (edge.getBaseNode() == edge.getAdjNode())
+                return edge.get(accessEnc) || edge.getReverse(accessEnc);
+            if (!edge.get(accessEnc))
                 return false;
             return Double.isFinite(weighting.calcEdgeWeight(edge, false));
         });
@@ -136,8 +137,9 @@ public interface Graph {
     default EdgeExplorer createInEdgeExplorer(Weighting weighting) {
         final BooleanEncodedValue accessEnc = weighting.getFlagEncoder().getAccessEnc();
         return createEdgeExplorer(edge -> {
-            boolean access = edge.getReverse(accessEnc);
-            if (!access)
+            if (edge.getBaseNode() == edge.getAdjNode())
+                return edge.get(accessEnc) || edge.getReverse(accessEnc);
+            if (!edge.getReverse(accessEnc))
                 return false;
             return Double.isFinite(weighting.calcEdgeWeight(edge, true));
         });

--- a/core/src/main/java/com/graphhopper/storage/GraphHopperStorage.java
+++ b/core/src/main/java/com/graphhopper/storage/GraphHopperStorage.java
@@ -433,11 +433,6 @@ public final class GraphHopperStorage implements GraphStorage, Graph {
     }
 
     @Override
-    public EdgeExplorer createEdgeExplorer() {
-        return baseGraph.createEdgeExplorer();
-    }
-
-    @Override
     public Graph copyTo(Graph g) {
         return baseGraph.copyTo(g);
     }

--- a/reader-gtfs/src/main/java/com/graphhopper/gtfs/RealtimeFeed.java
+++ b/reader-gtfs/src/main/java/com/graphhopper/gtfs/RealtimeFeed.java
@@ -232,11 +232,6 @@ public class RealtimeFeed {
             }
 
             @Override
-            public EdgeExplorer createEdgeExplorer() {
-                return graphHopperStorage.createEdgeExplorer();
-            }
-
-            @Override
             public Graph copyTo(Graph g) {
                 return null;
             }

--- a/reader-gtfs/src/main/java/com/graphhopper/gtfs/WrapperGraph.java
+++ b/reader-gtfs/src/main/java/com/graphhopper/gtfs/WrapperGraph.java
@@ -503,11 +503,6 @@ public class WrapperGraph implements Graph {
     }
 
     @Override
-    public EdgeExplorer createEdgeExplorer() {
-        return createEdgeExplorer(EdgeFilter.ALL_EDGES);
-    }
-
-    @Override
     public Graph copyTo(Graph g) {
         throw new RuntimeException();
     }


### PR DESCRIPTION
This PR adds two new `createEdgeExplorer`-like methods to `Graph`. One returns an explorer for outgoing and one an explorer for incoming edges and both take a `Weighting` as input. Basically `createOut/InEdgeExplorer(Weighting)` is a more general version of `createEdgeExplorer(DefaultEdgeFilter.out/InEdges(accessEnc))`. I am wondering if we should go in this direction.

* With the new explorers the access flags become less important, because the explorers rely on the weighting instead. The weighting can (and probably for some time will) use the access flags internally, but this way we use the weighting to ultimately decide whether or not an edge is accessible or not. For example in some custom weighting the edge weight might be infinite even though the access flags are set.

* Evaluating the weighting makes the graph iteration more expensive. This is unfortunate especially for cases where we do not need the weight and only want to check the accessibility of an edge. We could add something like `finiteEdgeWeight(EdgeIteratorState, boolean)` to `Weighting` to allow optimizing for such cases in the `Weighting` implementation.

This PR is related to #1835. I already did something similar in #1837 for CH preparation, but now I am wondering if it would not be better to have this in BaseGraph as well. Besides the possible performance related issues it seems cleaner to hide the access flags in Weighting instead of using the access flags and the weighting to determine edge access.