### PR TITLE
Added support for OSM BB Header to OSMReader

### DIFF
--- a/reader-osm/pom.xml
+++ b/reader-osm/pom.xml
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>org.openstreetmap.osmosis</groupId>
             <artifactId>osmosis-osm-binary</artifactId>
-            <version>0.47.3</version>
+            <version>0.48.3</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/reader-osm/src/main/java/com/graphhopper/reader/osm/OSMFileHeader.java
+++ b/reader-osm/src/main/java/com/graphhopper/reader/osm/OSMFileHeader.java
@@ -18,6 +18,7 @@
 package com.graphhopper.reader.osm;
 
 import com.graphhopper.reader.ReaderElement;
+import com.graphhopper.util.shapes.BBox;
 
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
@@ -30,6 +31,8 @@ import javax.xml.stream.XMLStreamReader;
  * @author ratrun
  */
 public class OSMFileHeader extends ReaderElement {
+
+    private BBox bbox;
     public OSMFileHeader() {
         super(0, FILEHEADER);
     }
@@ -50,8 +53,19 @@ public class OSMFileHeader extends ReaderElement {
         }
     }
 
+    public BBox getBbox() {
+        return bbox;
+    }
+
+    public void setBbox(BBox bbox) {
+        this.bbox = bbox;
+    }
+
     @Override
     public String toString() {
-        return "OSM File header:" + super.toString();
+        String s = "OSM File header:" + super.toString();
+        if (bbox != null)
+            s += " BBox:" + bbox.toString();
+        return  s;
     }
 }

--- a/reader-osm/src/main/java/com/graphhopper/reader/osm/OSMReaderUtility.java
+++ b/reader-osm/src/main/java/com/graphhopper/reader/osm/OSMReaderUtility.java
@@ -27,6 +27,7 @@ import java.util.Date;
  * @author ratrun
  */
 public class OSMReaderUtility {
+    public static final double COORDINATE_SCALING_FACTOR = 0.000000001;
     // use a day somewhere within July 1970 which then makes two identical long months ala 31 days, see #588
     private final static Date STATIC_DATE = new Date((31 * 6) * 24 * 3600 * 1000);
 

--- a/reader-osm/src/main/java/com/graphhopper/reader/osm/pbf/PbfBlobDecoder.java
+++ b/reader-osm/src/main/java/com/graphhopper/reader/osm/pbf/PbfBlobDecoder.java
@@ -9,6 +9,7 @@ import com.graphhopper.reader.ReaderRelation;
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.reader.osm.OSMFileHeader;
 import com.graphhopper.util.Helper;
+import com.graphhopper.util.shapes.BBox;
 import org.openstreetmap.osmosis.osmbinary.Fileformat;
 import org.openstreetmap.osmosis.osmbinary.Osmformat;
 import org.slf4j.Logger;
@@ -18,6 +19,8 @@ import java.io.IOException;
 import java.util.*;
 import java.util.zip.DataFormatException;
 import java.util.zip.Inflater;
+
+import static com.graphhopper.reader.osm.OSMReaderUtility.COORDINATE_SCALING_FACTOR;
 
 /**
  * Converts PBF block data into decoded entities ready to be passed into an Osmosis pipeline. This
@@ -97,23 +100,16 @@ public class PbfBlobDecoder implements Runnable {
         OSMFileHeader fileheader = new OSMFileHeader();
         long milliSecondDate = header.getOsmosisReplicationTimestamp();
         fileheader.setTag("timestamp", Helper.createFormatter().format(new Date(milliSecondDate * 1000)));
-        decodedEntities.add(fileheader);
 
         // Build a new bound object which corresponds to the header.
-/*
-         Bound bound;
-         if (header.hasBbox()) {
-         HeaderBBox bbox = header.getBbox();
-         bound = new Bound(bbox.getRight() * COORDINATE_SCALING_FACTOR, bbox.getLeft() * COORDINATE_SCALING_FACTOR,
-         bbox.getTop() * COORDINATE_SCALING_FACTOR, bbox.getBottom() * COORDINATE_SCALING_FACTOR,
-         header.getSource());
-         } else {
-         bound = new Bound(header.getSource());
-         }
+        if (header.hasBbox()) {
+            Osmformat.HeaderBBox bbox = header.getBbox();
+            fileheader.setBbox(new BBox(bbox.getRight() * COORDINATE_SCALING_FACTOR, bbox.getLeft() * COORDINATE_SCALING_FACTOR,
+                    bbox.getTop() * COORDINATE_SCALING_FACTOR, bbox.getBottom() * COORDINATE_SCALING_FACTOR));
+        }
+        fileheader.setTag("hasBBox", header.hasBbox());
+        decodedEntities.add(fileheader);
 
-         // Add the bound object to the results.
-         decodedEntities.add(new BoundContainer(bound));
-         */
     }
 
     private Map<String, String> buildTags(List<Integer> keys, List<Integer> values, PbfFieldDecoder fieldDecoder) {

--- a/reader-osm/src/main/java/com/graphhopper/reader/osm/pbf/PbfFieldDecoder.java
+++ b/reader-osm/src/main/java/com/graphhopper/reader/osm/pbf/PbfFieldDecoder.java
@@ -5,6 +5,8 @@ import org.openstreetmap.osmosis.osmbinary.Osmformat;
 
 import java.util.Date;
 
+import static com.graphhopper.reader.osm.OSMReaderUtility.COORDINATE_SCALING_FACTOR;
+
 /**
  * Manages decoding of the lower level PBF data structures.
  * <p>
@@ -13,7 +15,7 @@ import java.util.Date;
  *         <p>
  */
 public class PbfFieldDecoder {
-    private static final double COORDINATE_SCALING_FACTOR = 0.000000001;
+
     private String[] strings;
     private int coordGranularity;
     private long coordLatitudeOffset;


### PR DESCRIPTION
The OSMReader is now able to use the OSM BBox Header.

I reimplemented and updated the old version that was already implemented but put in comments.
https://github.com/graphhopper/graphhopper/blob/c0aaffae8631efb8fa23c6ab5cf26e27027efd08/reader-osm/src/main/java/com/graphhopper/reader/osm/pbf/PbfBlobDecoder.java#L104-L112

This solvels #2133