### PR TITLE
Refactor edge key

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/AStarBidirectionCH.java
+++ b/core/src/main/java/com/graphhopper/routing/AStarBidirectionCH.java
@@ -68,6 +68,11 @@ public class AStarBidirectionCH extends AbstractBidirCHAlgo {
     }
 
     @Override
+    protected int getTraversalId(RoutingCHEdgeIteratorState edge, int origEdgeId, boolean reverse) {
+        return edge.getAdjNode();
+    }
+
+    @Override
     protected double calcWeight(RoutingCHEdgeIteratorState iter, SPTEntry currEdge, boolean reverse) {
         // TODO performance: check if the node is already existent in the opposite direction
         // then we could avoid the approximation as we already know the exact complete path!

--- a/core/src/main/java/com/graphhopper/routing/AStarBidirectionEdgeCHNoSOD.java
+++ b/core/src/main/java/com/graphhopper/routing/AStarBidirectionEdgeCHNoSOD.java
@@ -21,8 +21,10 @@ import com.graphhopper.routing.ch.AStarCHEntry;
 import com.graphhopper.routing.weighting.BalancedWeightApproximator;
 import com.graphhopper.routing.weighting.BeelineWeightApproximator;
 import com.graphhopper.routing.weighting.WeightApproximator;
+import com.graphhopper.storage.RoutingCHEdgeIteratorState;
 import com.graphhopper.storage.RoutingCHGraph;
 import com.graphhopper.util.DistancePlaneProjection;
+import com.graphhopper.util.GHUtility;
 
 /**
  * @author easbar

--- a/core/src/main/java/com/graphhopper/routing/AbstractBidirCHAlgo.java
+++ b/core/src/main/java/com/graphhopper/routing/AbstractBidirCHAlgo.java
@@ -223,13 +223,7 @@ public abstract class AbstractBidirCHAlgo extends AbstractBidirAlgo implements B
         return edge.getEdge();
     }
 
-    protected int getTraversalId(RoutingCHEdgeIteratorState edge, int origEdgeId, boolean reverse) {
-        return getTraversalId(edge, reverse);
-    }
-
-    protected int getTraversalId(RoutingCHEdgeIteratorState edge, boolean reverse) {
-        return traversalMode.createTraversalId(edge.getBaseNode(), edge.getAdjNode(), edge.getEdge(), reverse);
-    }
+    protected abstract int getTraversalId(RoutingCHEdgeIteratorState edge, int origEdgeId, boolean reverse);
 
     @Override
     protected int getOtherNode(int edge, int node) {

--- a/core/src/main/java/com/graphhopper/routing/AbstractBidirectionEdgeCHNoSOD.java
+++ b/core/src/main/java/com/graphhopper/routing/AbstractBidirectionEdgeCHNoSOD.java
@@ -27,6 +27,7 @@ import com.graphhopper.storage.RoutingCHEdgeIteratorState;
 import com.graphhopper.storage.RoutingCHGraph;
 import com.graphhopper.util.EdgeExplorer;
 import com.graphhopper.util.EdgeIterator;
+import com.graphhopper.util.EdgeIteratorState;
 import com.graphhopper.util.GHUtility;
 
 import static com.graphhopper.util.EdgeIterator.ANY_EDGE;
@@ -95,7 +96,7 @@ public abstract class AbstractBidirectionEdgeCHNoSOD extends AbstractBidirCHAlgo
                 : innerOutExplorer.setBaseNode(entry.adjNode);
         while (iter.next()) {
             final int edgeId = iter.getEdge();
-            int key = GHUtility.createEdgeKey(iter.getAdjNode(), iter.getBaseNode(), edgeId, !reverse);
+            int key = iter.getEdgeKey(reverse);
             SPTEntry entryOther = bestWeightMapOther.get(key);
             if (entryOther == null) {
                 continue;
@@ -131,8 +132,8 @@ public abstract class AbstractBidirectionEdgeCHNoSOD extends AbstractBidirCHAlgo
 
     @Override
     protected int getTraversalId(RoutingCHEdgeIteratorState edge, int origEdgeId, boolean reverse) {
-        int baseNode = getOtherNode(origEdgeId, edge.getAdjNode());
-        return GHUtility.createEdgeKey(baseNode, edge.getAdjNode(), origEdgeId, reverse);
+        EdgeIteratorState origEdge = graph.getBaseGraph().getEdgeIteratorState(origEdgeId, edge.getAdjNode());
+        return origEdge.getEdgeKey(reverse);
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/DijkstraBidirectionCH.java
+++ b/core/src/main/java/com/graphhopper/routing/DijkstraBidirectionCH.java
@@ -56,7 +56,7 @@ public class DijkstraBidirectionCH extends DijkstraBidirectionCHNoSOD {
             if (iter.getEdge() == entry.edge) {
                 continue;
             }
-            int traversalId = getTraversalId(iter, reverse);
+            int traversalId = iter.getAdjNode();
             SPTEntry adjNode = bestWeightMap.get(traversalId);
             // we have to be careful because of rounded shortcut weights in combination with virtual via nodes, see #1574
             final double precision = 0.001;

--- a/core/src/main/java/com/graphhopper/routing/DijkstraBidirectionCHNoSOD.java
+++ b/core/src/main/java/com/graphhopper/routing/DijkstraBidirectionCHNoSOD.java
@@ -18,6 +18,7 @@
 package com.graphhopper.routing;
 
 import com.graphhopper.routing.util.TraversalMode;
+import com.graphhopper.storage.RoutingCHEdgeIteratorState;
 import com.graphhopper.storage.RoutingCHGraph;
 
 public class DijkstraBidirectionCHNoSOD extends AbstractBidirCHAlgo {
@@ -39,6 +40,11 @@ public class DijkstraBidirectionCHNoSOD extends AbstractBidirCHAlgo {
 
     protected SPTEntry getParent(SPTEntry entry) {
         return entry.getParent();
+    }
+
+    @Override
+    protected int getTraversalId(RoutingCHEdgeIteratorState edge, int origEdgeId, boolean reverse) {
+        return edge.getAdjNode();
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/querygraph/QueryOverlayBuilder.java
+++ b/core/src/main/java/com/graphhopper/routing/querygraph/QueryOverlayBuilder.java
@@ -146,8 +146,8 @@ class QueryOverlayBuilder {
 
                 GHPoint3D prevPoint = fullPL.get(0);
                 int adjNode = closestEdge.getAdjNode();
-                int origEdgeKey = GHUtility.createEdgeKey(baseNode, adjNode, closestEdge.getEdge(), false);
-                int origRevEdgeKey = GHUtility.createEdgeKey(baseNode, adjNode, closestEdge.getEdge(), true);
+                int origEdgeKey = closestEdge.getEdgeKey(false);
+                int origRevEdgeKey = closestEdge.getEdgeKey(true);
                 int prevWayIndex = 1;
                 int prevNodeId = baseNode;
                 int virtNodeId = queryOverlay.getVirtualNodes().getSize() + firstVirtualNodeId;

--- a/core/src/main/java/com/graphhopper/routing/querygraph/VirtualEdgeIteratorState.java
+++ b/core/src/main/java/com/graphhopper/routing/querygraph/VirtualEdgeIteratorState.java
@@ -64,7 +64,7 @@ public class VirtualEdgeIteratorState implements EdgeIteratorState {
      * This method returns the original edge via its key. I.e. also the direction is
      * already correctly encoded.
      *
-     * @see GHUtility#createEdgeKey(int, int, int, boolean)
+     * @see EdgeIteratorState#getEdgeKey(boolean) 
      */
     public int getOriginalEdgeKey() {
         return originalEdgeKey;

--- a/core/src/main/java/com/graphhopper/routing/util/TraversalMode.java
+++ b/core/src/main/java/com/graphhopper/routing/util/TraversalMode.java
@@ -70,7 +70,10 @@ public enum TraversalMode {
      * @return the identifier to access the shortest path tree
      */
     public final int createTraversalId(EdgeIteratorState iterState, boolean reverse) {
-        return createTraversalId(iterState.getBaseNode(), iterState.getAdjNode(), iterState.getEdge(), reverse);
+        if (edgeBased) {
+            return iterState.getEdgeKey(reverse);
+        }
+        return iterState.getAdjNode();
     }
 
     /**

--- a/core/src/main/java/com/graphhopper/util/EdgeIteratorState.java
+++ b/core/src/main/java/com/graphhopper/util/EdgeIteratorState.java
@@ -75,6 +75,8 @@ public interface EdgeIteratorState {
 
     default int getEdgeKey(boolean reverse) {
         return GHUtility.createEdgeKey(getBaseNode(), getAdjNode(), getEdge(), reverse);
+        // What I really want to do is:
+        // return getEdge() * 2 + (getBaseNode() != getAdjNode() && (get(EdgeIterator.REVERSE_STATE) ^ reverse) ? 0 : 1);
     }
 
     /**

--- a/core/src/main/java/com/graphhopper/util/EdgeIteratorState.java
+++ b/core/src/main/java/com/graphhopper/util/EdgeIteratorState.java
@@ -73,6 +73,10 @@ public interface EdgeIteratorState {
      */
     int getEdge();
 
+    default int getEdgeKey(boolean reverse) {
+        return GHUtility.createEdgeKey(getBaseNode(), getAdjNode(), getEdge(), reverse);
+    }
+
     /**
      * @return the edge id of the first original edge of the current edge. This is needed for shortcuts
      * in edge-based contraction hierarchies and otherwise simply returns the id of the current edge.


### PR DESCRIPTION
This is how far I got. May be of use on its own (?) because I (think I) managed to get rid of one overloaded method in the CH class hierarchy which goes back and forth a lot..

What I did:

- Put `getEdgeKey()` on `EdgeIteratorState` and implement by calling `GHUtility.createEdgeKey`
- Replace most occurances of `GHUtility.createEdgeKey` by that call

What I would ultimately want to do:

- Replace remaining 3 occurances
- Remove it
- Replace the implementation (in `EdgeIteratorState`) by the one commented-out there. Because that is the _other_ notion of edge direction that we have, and I only want us to have one (the direction that was used to create the edge):

```
    default int getEdgeKey(boolean reverse) {
        return GHUtility.createEdgeKey(getBaseNode(), getAdjNode(), getEdge(), reverse);
        // What I really want to do is:
        // return getEdge() * 2 + (getBaseNode() != getAdjNode() && (get(EdgeIterator.REVERSE_STATE) ^ reverse) ? 0 : 1);
    }
```

What's the problem:

- I'm not sure how to get rid of the occurance in `CHPreparationGraph`:

```
        @Override
        public int getOrigEdgeKeyFirst() {
            int e = graph.edgesAndFlags.get(index);
            return GHUtility.createEdgeKey(node, getAdjNode(), e >> 2, false);
        }
```

- Particularly I don't know if we could just _inline_ the call there, and then the preparation uses a different traversal id than the rest of the system. Don't know if that matters, the important tests seem to pass, and it uses a different algorithm and different graph interface anyway, so it wouldn't even be wrong, technically. But maybe it does matter.

Feel free to ignore if not useful.