### PR TITLE
Add a public facing Healthcheck

### DIFF
--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -1190,6 +1190,10 @@ public class GraphHopper implements GraphHopperAPI {
         fullyLoaded = true;
     }
 
+    public boolean getFullyLoaded(){
+        return fullyLoaded;
+    }
+
     public RouterConfig getRouterConfig() {
         return routerConfig;
     }

--- a/web-bundle/src/main/java/com/graphhopper/http/GraphHopperBundle.java
+++ b/web-bundle/src/main/java/com/graphhopper/http/GraphHopperBundle.java
@@ -277,5 +277,7 @@ public class GraphHopperBundle implements ConfiguredBundle<GraphHopperBundleConf
         environment.jersey().register(I18NResource.class);
         environment.jersey().register(InfoResource.class);
         environment.healthChecks().register("graphhopper", new GraphHopperHealthCheck(graphHopper));
+        environment.jersey().register(environment.healthChecks());
+        environment.jersey().register(HealthcheckResource.class);
     }
 }

--- a/web-bundle/src/main/java/com/graphhopper/http/health/GraphHopperHealthCheck.java
+++ b/web-bundle/src/main/java/com/graphhopper/http/health/GraphHopperHealthCheck.java
@@ -20,7 +20,6 @@ package com.graphhopper.http.health;
 
 import com.codahale.metrics.health.HealthCheck;
 import com.graphhopper.GraphHopper;
-import com.graphhopper.storage.GraphHopperStorage;
 
 public class GraphHopperHealthCheck extends HealthCheck {
 
@@ -32,11 +31,12 @@ public class GraphHopperHealthCheck extends HealthCheck {
 
     @Override
     protected Result check() {
-        boolean valid = graphHopper.getGraphHopperStorage().getBounds().isValid();
-        if (valid) {
-            return Result.healthy();
-        } else {
+        if (!graphHopper.getGraphHopperStorage().getBounds().isValid()) {
             return Result.unhealthy("GraphHopperStorage has invalid bounds.");
         }
+        if (!graphHopper.getFullyLoaded()) {
+            return Result.unhealthy("GraphHopper is not fully loaded.");
+        }
+        return Result.healthy();
     }
 }

--- a/web-bundle/src/main/java/com/graphhopper/resources/HealthcheckResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/HealthcheckResource.java
@@ -1,0 +1,55 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.resources;
+
+import com.codahale.metrics.health.HealthCheck;
+import com.codahale.metrics.health.HealthCheckRegistry;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+import java.util.SortedMap;
+
+/**
+ * This is a public facing health check that runs all registered health checks.
+ * Instead of providing details like the admin health check, this only returns OK/200 or UNHEALTHY/500.
+ *
+ * @author Robin Boldt
+ */
+@Path("health")
+public class HealthcheckResource {
+
+    private HealthCheckRegistry registry;
+
+    @Inject
+    public HealthcheckResource(HealthCheckRegistry registry) {
+        this.registry = registry;
+    }
+
+    @GET
+    public Response doGet() {
+        SortedMap<String, HealthCheck.Result> results = registry.runHealthChecks();
+        for (HealthCheck.Result result : results.values()) {
+            if (!result.isHealthy()) {
+                return Response.status(500).entity("UNHEALTHY").build();
+            }
+        }
+        return Response.ok("OK").build();
+    }
+}


### PR DESCRIPTION
This PR adds a public facing health check.

Dropwizard provides a healtcheck resource on the admin port, e.g.: http://localhost:8990/healthcheck

Usually, I don't want to expose the admin port to the internet. So I added a minimal endpoint that runs the registered health checks and either returns OK/200 or UNHEALTHY/500.

I also added a health check for the fullyLoaded attribute. I am not sure if you like that? I think we need a few more health checks in the future that also check if the graph is healthy, but I don't have a good idea on how to do this right now.