### PR TITLE
Voice Instruction for Routing Requests

### DIFF
--- a/api/src/main/java/com/graphhopper/util/InstructionList.java
+++ b/api/src/main/java/com/graphhopper/util/InstructionList.java
@@ -26,6 +26,7 @@ public class InstructionList extends AbstractList<Instruction> {
 
     private final List<Instruction> instructions;
     private final Translation tr;
+    protected boolean voiceInstructionsEnabled = false;
 
     public InstructionList(Translation tr) {
         this(10, tr);
@@ -65,4 +66,9 @@ public class InstructionList extends AbstractList<Instruction> {
         return tr;
     }
 
+    public void setVoiceInstructionsEnabled(boolean voiceInstructionsEnabled) {
+        this.voiceInstructionsEnabled = voiceInstructionsEnabled;
+    }
+
+    public boolean hasVoiceInstructionsEnabled() { return voiceInstructionsEnabled; }
 }

--- a/api/src/main/java/com/graphhopper/util/Parameters.java
+++ b/api/src/main/java/com/graphhopper/util/Parameters.java
@@ -102,6 +102,11 @@ public class Parameters {
          */
         public static final String INSTRUCTIONS = "instructions";
         /**
+         * if true the response will contain turn voice instructions
+         */
+        public static final String VOICE_INSTRUCTIONS = "voice_instructions";
+        public static final String VOICE_INSTRUCTIONS_UNIT = "voice_unit";
+        /**
          * if true the response will contain a point list
          */
         public static final String CALC_POINTS = "calc_points";

--- a/api/src/main/java/com/graphhopper/util/VoiceInstruction.java
+++ b/api/src/main/java/com/graphhopper/util/VoiceInstruction.java
@@ -1,0 +1,45 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.util;
+
+public class VoiceInstruction {
+    protected String announcement;
+    protected double distanceToManeuver;
+
+    public VoiceInstruction (String announcement, double distanceToManeuver) {
+        this.announcement = announcement;
+        this.distanceToManeuver = distanceToManeuver;
+
+    }
+
+
+    public void setAnnouncement (String announcement) {
+        this.announcement = announcement;
+    }
+
+    public String getAnnouncement () {
+        return announcement;
+    }
+
+    public void setDistanceToManeuver (double distanceToManeuver) {
+        this.distanceToManeuver = distanceToManeuver;
+    }
+
+    public double getDistanceToManeuver () { return distanceToManeuver; }
+
+}

--- a/api/src/main/java/com/graphhopper/util/VoiceInstructionDistanceConfig.java
+++ b/api/src/main/java/com/graphhopper/util/VoiceInstructionDistanceConfig.java
@@ -25,6 +25,7 @@ import static com.graphhopper.util.VoiceInstructionDistanceUtils.UnitTranslation
 
 public class VoiceInstructionDistanceConfig {
     final List<VoiceInstructionConfig> voiceInstructions;
+    private final Translation translation;
 
     public VoiceInstructionDistanceConfig(VoiceInstructionDistanceUtils.Unit unit, Translation translation) {
         if (unit == VoiceInstructionDistanceUtils.Unit.METRIC) {
@@ -43,6 +44,7 @@ public class VoiceInstructionDistanceConfig {
             );
         }
 
+        this.translation = translation;
     }
 
     public List<VoiceInstructionConfig.VoiceInstructionValue> getVoiceInstructionsForDistance(double distance, String turnDescription, String thenVoiceInstruction) {
@@ -56,5 +58,8 @@ public class VoiceInstructionDistanceConfig {
         return instructionsConfigs;
     }
 
+    public Translation getTranslation() {
+        return translation;
+    }
 
 }

--- a/api/src/main/java/com/graphhopper/util/VoiceInstructionDistanceConfig.java
+++ b/api/src/main/java/com/graphhopper/util/VoiceInstructionDistanceConfig.java
@@ -15,34 +15,31 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package com.graphhopper.navigation;
-
-import com.graphhopper.util.TranslationMap;
+package com.graphhopper.util;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Locale;
 
-import static com.graphhopper.navigation.DistanceUtils.UnitTranslationKey.*;
+import static com.graphhopper.util.VoiceInstructionDistanceUtils.UnitTranslationKey.*;
 
-public class DistanceConfig {
+public class VoiceInstructionDistanceConfig {
     final List<VoiceInstructionConfig> voiceInstructions;
 
-    public DistanceConfig(DistanceUtils.Unit unit, TranslationMap translationMap, Locale locale) {
-        if (unit == DistanceUtils.Unit.METRIC) {
+    public VoiceInstructionDistanceConfig(VoiceInstructionDistanceUtils.Unit unit, Translation translation) {
+        if (unit == VoiceInstructionDistanceUtils.Unit.METRIC) {
             voiceInstructions = Arrays.asList(
-                    new InitialVoiceInstructionConfig(FOR_HIGHER_DISTANCE_PLURAL.metric, translationMap, locale, 4250, 250, unit),
-                    new FixedDistanceVoiceInstructionConfig(IN_HIGHER_DISTANCE_PLURAL.metric, translationMap, locale, 2000, 2),
-                    new FixedDistanceVoiceInstructionConfig(IN_HIGHER_DISTANCE_SINGULAR.metric, translationMap, locale, 1000, 1),
-                    new ConditionalDistanceVoiceInstructionConfig(IN_LOWER_DISTANCE_PLURAL.metric, translationMap, locale, new int[]{400, 200}, new int[]{400, 200})
+                    new InitialVoiceInstructionConfig(FOR_HIGHER_DISTANCE_PLURAL.metric, translation, 4250, 250, unit),
+                    new FixedDistanceVoiceInstructionConfig(IN_HIGHER_DISTANCE_PLURAL.metric, translation, 2000, 2),
+                    new FixedDistanceVoiceInstructionConfig(IN_HIGHER_DISTANCE_SINGULAR.metric, translation, 1000, 1),
+                    new ConditionalDistanceVoiceInstructionConfig(IN_LOWER_DISTANCE_PLURAL.metric, translation, new int[]{400, 200}, new int[]{400, 200})
             );
         } else {
             voiceInstructions = Arrays.asList(
-                    new InitialVoiceInstructionConfig(FOR_HIGHER_DISTANCE_PLURAL.metric, translationMap, locale, 4250, 250, unit),
-                    new FixedDistanceVoiceInstructionConfig(IN_HIGHER_DISTANCE_PLURAL.imperial, translationMap, locale, 3220, 2),
-                    new FixedDistanceVoiceInstructionConfig(IN_HIGHER_DISTANCE_SINGULAR.imperial, translationMap, locale, 1610, 1),
-                    new ConditionalDistanceVoiceInstructionConfig(IN_LOWER_DISTANCE_PLURAL.imperial, translationMap, locale, new int[]{400, 200}, new int[]{1300, 600})
+                    new InitialVoiceInstructionConfig(FOR_HIGHER_DISTANCE_PLURAL.metric, translation, 4250, 250, unit),
+                    new FixedDistanceVoiceInstructionConfig(IN_HIGHER_DISTANCE_PLURAL.imperial, translation, 3220, 2),
+                    new FixedDistanceVoiceInstructionConfig(IN_HIGHER_DISTANCE_SINGULAR.imperial, translation, 1610, 1),
+                    new ConditionalDistanceVoiceInstructionConfig(IN_LOWER_DISTANCE_PLURAL.imperial, translation, new int[]{400, 200}, new int[]{1300, 600})
             );
         }
 

--- a/api/src/main/java/com/graphhopper/util/VoiceInstructionDistanceUtils.java
+++ b/api/src/main/java/com/graphhopper/util/VoiceInstructionDistanceUtils.java
@@ -15,9 +15,9 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package com.graphhopper.navigation;
+package com.graphhopper.util;
 
-public class DistanceUtils {
+public class VoiceInstructionDistanceUtils {
 
     static float meterToFeet = 3.28084f;
     static float meterToMiles = 0.00062137f;

--- a/api/src/main/java/com/graphhopper/util/VoiceInstructionList.java
+++ b/api/src/main/java/com/graphhopper/util/VoiceInstructionList.java
@@ -1,0 +1,65 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.util;
+
+import java.util.AbstractList;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * List of VoiceInstructions instructions.
+ */
+public class VoiceInstructionList extends AbstractList<VoiceInstruction> {
+
+    private final List<VoiceInstruction> voiceInstructions;
+
+
+    public VoiceInstructionList() { this(3); }
+
+    public VoiceInstructionList(int cap) {
+        voiceInstructions = new ArrayList<>(cap);
+    }
+
+
+
+    @Override
+    public int size() {
+        return voiceInstructions.size();
+    }
+
+    @Override
+    public VoiceInstruction get(int index) {
+        return voiceInstructions.get(index);
+    }
+
+    @Override
+    public VoiceInstruction set(int index, VoiceInstruction element) {
+        return voiceInstructions.set(index, element);
+    }
+
+    @Override
+    public void add(int index, VoiceInstruction element) {
+        voiceInstructions.add(index, element);
+    }
+
+    @Override
+    public VoiceInstruction remove(int index) {
+        return voiceInstructions.remove(index);
+    }
+
+}

--- a/core/src/main/java/com/graphhopper/routing/Router.java
+++ b/core/src/main/java/com/graphhopper/routing/Router.java
@@ -285,6 +285,8 @@ public class Router {
 
     private PathMerger createPathMerger(GHRequest request, Weighting weighting, Graph graph) {
         boolean enableInstructions = request.getHints().getBool(Parameters.Routing.INSTRUCTIONS, encodingManager.isEnableInstructions());
+        boolean enableVoiceInstructions = request.getHints().getBool(Parameters.Routing.VOICE_INSTRUCTIONS, false);
+        String voiceUnit  = request.getHints().getString(Parameters.Routing.VOICE_INSTRUCTIONS_UNIT, "metric");
         boolean calcPoints = request.getHints().getBool(Parameters.Routing.CALC_POINTS, routerConfig.isCalcPoints());
         double wayPointMaxDistance = request.getHints().getDouble(Parameters.Routing.WAY_POINT_MAX_DISTANCE, 1d);
         double elevationWayPointMaxDistance = request.getHints().getDouble(ELEVATION_WAY_POINT_MAX_DISTANCE, routerConfig.getElevationWayPointMaxDistance());
@@ -296,6 +298,7 @@ public class Router {
                 setCalcPoints(calcPoints).
                 setDouglasPeucker(peucker).
                 setEnableInstructions(enableInstructions).
+                setEnableVoiceInstructions(enableVoiceInstructions, voiceUnit).
                 setPathDetailsBuilders(pathDetailsBuilderFactory, request.getPathDetails()).
                 setSimplifyResponse(routerConfig.isSimplifyResponse() && wayPointMaxDistance > 0);
 

--- a/core/src/main/java/com/graphhopper/util/PathMerger.java
+++ b/core/src/main/java/com/graphhopper/util/PathMerger.java
@@ -50,6 +50,9 @@ public class PathMerger {
     private final Weighting weighting;
 
     private boolean enableInstructions = true;
+    private boolean enableVoiceInstructions = false;
+    private VoiceInstructionDistanceUtils.Unit voiceInstructionsUnit;
+    private VoiceInstructionDistanceConfig voiceInstructionDistanceConfig;
     private boolean simplifyResponse = true;
     private DouglasPeucker douglasPeucker = DP;
     private boolean calcPoints = true;
@@ -85,6 +88,20 @@ public class PathMerger {
 
     public PathMerger setEnableInstructions(boolean enableInstructions) {
         this.enableInstructions = enableInstructions;
+        return this;
+    }
+
+    public PathMerger setEnableVoiceInstructions(boolean enableVoiceInstructions, String unit) {
+        this.enableVoiceInstructions = enableVoiceInstructions;
+
+        if (enableVoiceInstructions) {
+            if (unit.equals("metric")) {
+                this.voiceInstructionsUnit = VoiceInstructionDistanceUtils.Unit.METRIC;
+            } else {
+                this.voiceInstructionsUnit = VoiceInstructionDistanceUtils.Unit.IMPERIAL;
+            }
+        }
+
         return this;
     }
 
@@ -149,6 +166,10 @@ public class PathMerger {
         }
 
         if (enableInstructions) {
+            if (enableVoiceInstructions) {
+                voiceInstructionDistanceConfig = new VoiceInstructionDistanceConfig(this.voiceInstructionsUnit, tr);
+            }
+
             fullInstructions = updateInstructionsWithContext(fullInstructions);
             responsePath.setInstructions(fullInstructions);
         }
@@ -180,6 +201,8 @@ public class PathMerger {
         Instruction instruction;
         Instruction nextInstruction;
 
+        instructions.setVoiceInstructionsEnabled(enableVoiceInstructions);
+
         for (int i = 0; i < instructions.size() - 1; i++) {
             instruction = instructions.get(i);
 
@@ -210,6 +233,11 @@ public class PathMerger {
                     nextInstruction.setSign(Instruction.U_TURN_UNKNOWN);
                 }
             }
+
+            if (enableVoiceInstructions) {
+                instruction.setVoiceInstructions(instructions, i, voiceInstructionDistanceConfig);
+            }
+
         }
 
         return instructions;

--- a/core/src/test/java/com/graphhopper/util/VoiceInstructionConfigTest.java
+++ b/core/src/test/java/com/graphhopper/util/VoiceInstructionConfigTest.java
@@ -1,11 +1,10 @@
-package com.graphhopper.navigation;
+package com.graphhopper.util;
 
-import com.graphhopper.util.TranslationMap;
 import org.junit.Test;
 
 import java.util.Locale;
 
-import static com.graphhopper.navigation.DistanceUtils.UnitTranslationKey.*;
+import static com.graphhopper.util.VoiceInstructionDistanceUtils.UnitTranslationKey.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
@@ -17,12 +16,12 @@ public class VoiceInstructionConfigTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void conditionalDistanceVICShouldHaveSameImportValueSize() {
-        new ConditionalDistanceVoiceInstructionConfig(IN_LOWER_DISTANCE_PLURAL.metric, trMap, locale, new int[]{400, 200}, new int[]{400});
+        new ConditionalDistanceVoiceInstructionConfig(IN_LOWER_DISTANCE_PLURAL.metric, trMap.getWithFallBack(locale), new int[]{400, 200}, new int[]{400});
     }
 
     @Test
     public void conditionalDistanceVICShouldReturnFirstFittingMetricValues() {
-        ConditionalDistanceVoiceInstructionConfig config = new ConditionalDistanceVoiceInstructionConfig(IN_LOWER_DISTANCE_PLURAL.metric, trMap, locale, new int[]{400, 200}, new int[]{400, 200});
+        ConditionalDistanceVoiceInstructionConfig config = new ConditionalDistanceVoiceInstructionConfig(IN_LOWER_DISTANCE_PLURAL.metric, trMap.getWithFallBack(locale), new int[]{400, 200}, new int[]{400, 200});
 
         compareVoiceInstructionValues(
                 400,
@@ -60,7 +59,7 @@ public class VoiceInstructionConfigTest {
     @Test
     public void conditionalDistanceVICShouldReturnFirstFittingImperialValues() {
         ConditionalDistanceVoiceInstructionConfig config = new ConditionalDistanceVoiceInstructionConfig(IN_LOWER_DISTANCE_PLURAL.imperial,
-                trMap, locale, new int[]{400, 200}, new int[]{600, 500});
+                trMap.getWithFallBack(locale), new int[]{400, 200}, new int[]{600, 500});
 
         compareVoiceInstructionValues(
                 400,
@@ -97,8 +96,8 @@ public class VoiceInstructionConfigTest {
 
     @Test
     public void initialVICMetricTest() {
-        InitialVoiceInstructionConfig configMetric = new InitialVoiceInstructionConfig(FOR_HIGHER_DISTANCE_PLURAL.metric, trMap,
-                locale, 4250, 250, DistanceUtils.Unit.METRIC);
+        InitialVoiceInstructionConfig configMetric = new InitialVoiceInstructionConfig(FOR_HIGHER_DISTANCE_PLURAL.metric,
+                trMap.getWithFallBack(locale), 4250, 250, VoiceInstructionDistanceUtils.Unit.METRIC);
 
         compareVoiceInstructionValues(
                 4000,
@@ -115,8 +114,8 @@ public class VoiceInstructionConfigTest {
 
     @Test
     public void germanInitialVICMetricTest() {
-        InitialVoiceInstructionConfig configMetric = new InitialVoiceInstructionConfig(FOR_HIGHER_DISTANCE_PLURAL.metric, trMap,
-                Locale.GERMAN, 4250, 250, DistanceUtils.Unit.METRIC);
+        InitialVoiceInstructionConfig configMetric = new InitialVoiceInstructionConfig(FOR_HIGHER_DISTANCE_PLURAL.metric,
+                trMap.getWithFallBack(Locale.GERMAN), 4250, 250, VoiceInstructionDistanceUtils.Unit.METRIC);
 
         compareVoiceInstructionValues(
                 4000,
@@ -133,8 +132,8 @@ public class VoiceInstructionConfigTest {
 
     @Test
     public void initialVICImperialTest() {
-        InitialVoiceInstructionConfig configImperial = new InitialVoiceInstructionConfig(FOR_HIGHER_DISTANCE_PLURAL.imperial, trMap,
-                locale, 4250, 250, DistanceUtils.Unit.IMPERIAL);
+        InitialVoiceInstructionConfig configImperial = new InitialVoiceInstructionConfig(FOR_HIGHER_DISTANCE_PLURAL.imperial,
+                trMap.getWithFallBack(locale), 4250, 250, VoiceInstructionDistanceUtils.Unit.IMPERIAL);
 
         compareVoiceInstructionValues(
                 3219,
@@ -152,7 +151,7 @@ public class VoiceInstructionConfigTest {
     @Test
     public void fixedDistanceInitialVICMetricTest() {
         FixedDistanceVoiceInstructionConfig configMetric = new FixedDistanceVoiceInstructionConfig(IN_HIGHER_DISTANCE_PLURAL.metric,
-                trMap, locale, 2000, 2);
+                trMap.getWithFallBack(locale), 2000, 2);
 
         compareVoiceInstructionValues(
                 2000,
@@ -172,7 +171,7 @@ public class VoiceInstructionConfigTest {
     @Test
     public void germanFixedDistanceInitialVICMetricTest() {
         FixedDistanceVoiceInstructionConfig configMetric = new FixedDistanceVoiceInstructionConfig(IN_HIGHER_DISTANCE_PLURAL.metric,
-                trMap, Locale.GERMAN, 2000, 2);
+                trMap.getWithFallBack(Locale.GERMAN), 2000, 2);
 
         compareVoiceInstructionValues(
                 2000,
@@ -192,7 +191,7 @@ public class VoiceInstructionConfigTest {
     @Test
     public void fixedDistanceInitialVICImperialTest() {
         FixedDistanceVoiceInstructionConfig configImperial = new FixedDistanceVoiceInstructionConfig(IN_HIGHER_DISTANCE_PLURAL.imperial,
-                trMap, locale, 2000, 2);
+                trMap.getWithFallBack(locale), 2000, 2);
 
         compareVoiceInstructionValues(
                 2000,

--- a/navigation/src/main/java/com/graphhopper/navigation/NavigateResource.java
+++ b/navigation/src/main/java/com/graphhopper/navigation/NavigateResource.java
@@ -25,6 +25,8 @@ import com.graphhopper.util.Helper;
 import com.graphhopper.util.Parameters;
 import com.graphhopper.util.StopWatch;
 import com.graphhopper.util.TranslationMap;
+import com.graphhopper.util.VoiceInstructionDistanceConfig;
+import com.graphhopper.util.VoiceInstructionDistanceUtils;
 import com.graphhopper.util.shapes.GHPoint;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -113,11 +115,11 @@ public class NavigateResource {
         if (overview.equals("full"))
             minPathPrecision = 0;
 
-        DistanceUtils.Unit unit;
+        VoiceInstructionDistanceUtils.Unit unit;
         if (voiceUnits.equals("metric")) {
-            unit = DistanceUtils.Unit.METRIC;
+            unit = VoiceInstructionDistanceUtils.Unit.METRIC;
         } else {
-            unit = DistanceUtils.Unit.IMPERIAL;
+            unit = VoiceInstructionDistanceUtils.Unit.IMPERIAL;
         }
 
         String ghProfile = resolverMap.getOrDefault(mapboxProfile, mapboxProfile);
@@ -145,7 +147,7 @@ public class NavigateResource {
         String logStr = httpReq.getQueryString() + " " + infoStr + " " + requestPoints + ", took:"
                 + took + ", " + ghProfile;
         Locale locale = Helper.getLocale(localeStr);
-        DistanceConfig config = new DistanceConfig(unit, translationMap, locale);
+        VoiceInstructionDistanceConfig config = new VoiceInstructionDistanceConfig(unit, translationMap.getWithFallBack(locale));
 
         if (ghResponse.hasErrors()) {
             logger.error(logStr + ", errors:" + ghResponse.getErrors());

--- a/navigation/src/main/java/com/graphhopper/navigation/NavigateResponseConverter.java
+++ b/navigation/src/main/java/com/graphhopper/navigation/NavigateResponseConverter.java
@@ -36,7 +36,7 @@ public class NavigateResponseConverter {
     /**
      * Converts a GHResponse into a json that follows the Mapbox API specification
      */
-    public static ObjectNode convertFromGHResponse(GHResponse ghResponse, TranslationMap translationMap, Locale locale, DistanceConfig distanceConfig) {
+    public static ObjectNode convertFromGHResponse(GHResponse ghResponse, TranslationMap translationMap, Locale locale, VoiceInstructionDistanceConfig voiceInstructionDistanceConfig) {
         ObjectNode json = JsonNodeFactory.instance.objectNode();
 
         if (ghResponse.hasErrors())
@@ -52,7 +52,7 @@ public class NavigateResponseConverter {
             ResponsePath path = paths.get(i);
             ObjectNode pathJson = routesJson.addObject();
 
-            putRouteInformation(pathJson, path, i, translationMap, locale, distanceConfig);
+            putRouteInformation(pathJson, path, i, translationMap, locale, voiceInstructionDistanceConfig);
         }
 
         final ArrayNode waypointsJson = json.putArray("waypoints");
@@ -70,7 +70,7 @@ public class NavigateResponseConverter {
         return json;
     }
 
-    private static void putRouteInformation(ObjectNode pathJson, ResponsePath path, int routeNr, TranslationMap translationMap, Locale locale, DistanceConfig distanceConfig) {
+    private static void putRouteInformation(ObjectNode pathJson, ResponsePath path, int routeNr, TranslationMap translationMap, Locale locale, VoiceInstructionDistanceConfig voiceInstructionDistanceConfig) {
         InstructionList instructions = path.getInstructions();
 
         pathJson.put("geometry", WebHelper.encodePolyline(path.getPoints(), false, 1e6));
@@ -85,7 +85,7 @@ public class NavigateResponseConverter {
 
         for (int i = 0; i < instructions.size(); i++) {
             ObjectNode instructionJson = steps.addObject();
-            putInstruction(instructions, i, locale, translationMap, instructionJson, isFirstInstructionOfLeg, distanceConfig);
+            putInstruction(instructions, i, locale, translationMap, instructionJson, isFirstInstructionOfLeg, voiceInstructionDistanceConfig);
             Instruction instruction = instructions.get(i);
             time += instruction.getTime();
             distance += instruction.getDistance();
@@ -127,7 +127,7 @@ public class NavigateResponseConverter {
     }
 
     private static ObjectNode putInstruction(InstructionList instructions, int index, Locale locale, TranslationMap translationMap,
-                                             ObjectNode instructionJson, boolean isFirstInstructionOfLeg, DistanceConfig distanceConfig) {
+                                             ObjectNode instructionJson, boolean isFirstInstructionOfLeg, VoiceInstructionDistanceConfig voiceInstructionDistanceConfig) {
         Instruction instruction = instructions.get(index);
         ArrayNode intersections = instructionJson.putArray("intersections");
         ObjectNode intersection = intersections.addObject();
@@ -169,7 +169,7 @@ public class NavigateResponseConverter {
 
         // Voice and banner instructions are empty for the last element
         if (index + 1 < instructions.size()) {
-            putVoiceInstructions(instructions, distance, index, locale, translationMap, voiceInstructions, distanceConfig);
+            putVoiceInstructions(instructions, distance, index, locale, translationMap, voiceInstructions, voiceInstructionDistanceConfig);
             putBannerInstructions(instructions, distance, index, locale, translationMap, bannerInstructions);
         }
 
@@ -177,7 +177,7 @@ public class NavigateResponseConverter {
     }
 
     private static void putVoiceInstructions(InstructionList instructions, double distance, int index, Locale locale, TranslationMap translationMap,
-                                             ArrayNode voiceInstructions, DistanceConfig distanceConfig) {
+                                             ArrayNode voiceInstructions, VoiceInstructionDistanceConfig distanceConfig) {
         /*
             A VoiceInstruction Object looks like this
             {

--- a/navigation/src/test/java/com/graphhopper/navigation/NavigateResponseConverterTest.java
+++ b/navigation/src/test/java/com/graphhopper/navigation/NavigateResponseConverterTest.java
@@ -11,6 +11,8 @@ import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.util.Helper;
 import com.graphhopper.util.Parameters;
 import com.graphhopper.util.TranslationMap;
+import com.graphhopper.util.VoiceInstructionDistanceConfig;
+import com.graphhopper.util.VoiceInstructionDistanceUtils;
 import com.graphhopper.util.shapes.GHPoint;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -32,7 +34,7 @@ public class NavigateResponseConverterTest {
     private static final String profile = "my_car";
 
     private final TranslationMap trMap = hopper.getTranslationMap();
-    private final DistanceConfig distanceConfig = new DistanceConfig(DistanceUtils.Unit.METRIC, trMap, Locale.ENGLISH);
+    private final VoiceInstructionDistanceConfig voiceInstructionDistanceConfig = new VoiceInstructionDistanceConfig(VoiceInstructionDistanceUtils.Unit.METRIC, trMap.getWithFallBack(Locale.ENGLISH));
 
     @BeforeClass
     public static void beforeClass() {
@@ -59,7 +61,7 @@ public class NavigateResponseConverterTest {
         GHResponse rsp = hopper.route(new GHRequest(42.554851, 1.536198, 42.510071, 1.548128).
                 setProfile(profile));
 
-        ObjectNode json = NavigateResponseConverter.convertFromGHResponse(rsp, trMap, Locale.ENGLISH, distanceConfig);
+        ObjectNode json = NavigateResponseConverter.convertFromGHResponse(rsp, trMap, Locale.ENGLISH, voiceInstructionDistanceConfig);
 
         JsonNode route = json.get("routes").get(0);
         double routeDistance = route.get("distance").asDouble();
@@ -129,7 +131,7 @@ public class NavigateResponseConverterTest {
         GHResponse rsp = hopper.route(new GHRequest(42.554851, 1.536198, 42.510071, 1.548128).
                 setProfile(profile));
 
-        ObjectNode json = NavigateResponseConverter.convertFromGHResponse(rsp, trMap, Locale.ENGLISH, distanceConfig);
+        ObjectNode json = NavigateResponseConverter.convertFromGHResponse(rsp, trMap, Locale.ENGLISH, voiceInstructionDistanceConfig);
 
         JsonNode steps = json.get("routes").get(0).get("legs").get(0).get("steps");
 
@@ -162,7 +164,7 @@ public class NavigateResponseConverterTest {
                 setProfile(profile));
 
         ObjectNode json = NavigateResponseConverter.convertFromGHResponse(rsp, trMap, Locale.ENGLISH,
-                new DistanceConfig(DistanceUtils.Unit.IMPERIAL, trMap, Locale.ENGLISH));
+                new VoiceInstructionDistanceConfig(VoiceInstructionDistanceUtils.Unit.IMPERIAL, trMap.getWithFallBack(Locale.ENGLISH)));
 
         JsonNode steps = json.get("routes").get(0).get("legs").get(0).get("steps");
 
@@ -199,7 +201,7 @@ public class NavigateResponseConverterTest {
 
         assertEquals(2, rsp.getAll().size());
 
-        ObjectNode json = NavigateResponseConverter.convertFromGHResponse(rsp, trMap, Locale.ENGLISH, distanceConfig);
+        ObjectNode json = NavigateResponseConverter.convertFromGHResponse(rsp, trMap, Locale.ENGLISH, voiceInstructionDistanceConfig);
 
         JsonNode routes = json.get("routes");
         assertEquals(2, routes.size());
@@ -214,7 +216,7 @@ public class NavigateResponseConverterTest {
         GHResponse rsp = hopper.route(new GHRequest(42.554851, 1.536198, 42.510071, 1.548128).
                 setProfile(profile));
 
-        ObjectNode json = NavigateResponseConverter.convertFromGHResponse(rsp, trMap, Locale.ENGLISH, distanceConfig);
+        ObjectNode json = NavigateResponseConverter.convertFromGHResponse(rsp, trMap, Locale.ENGLISH, voiceInstructionDistanceConfig);
 
         JsonNode steps = json.get("routes").get(0).get("legs").get(0).get("steps");
         JsonNode voiceInstruction = steps.get(14).get("voiceInstructions").get(0);
@@ -223,7 +225,7 @@ public class NavigateResponseConverterTest {
         rsp = hopper.route(new GHRequest(42.554851, 1.536198, 42.510071, 1.548128).
                 setProfile(profile).setLocale(Locale.GERMAN));
 
-        DistanceConfig distanceConfigGerman = new DistanceConfig(DistanceUtils.Unit.METRIC, trMap, Locale.GERMAN);
+        VoiceInstructionDistanceConfig distanceConfigGerman = new VoiceInstructionDistanceConfig(VoiceInstructionDistanceUtils.Unit.METRIC, trMap.getWithFallBack(Locale.GERMAN));
 
         json = NavigateResponseConverter.convertFromGHResponse(rsp, trMap, Locale.GERMAN, distanceConfigGerman);
 
@@ -239,7 +241,7 @@ public class NavigateResponseConverterTest {
         GHResponse rsp = hopper.route(new GHRequest(42.554851, 1.536198, 42.510071, 1.548128).
                 setProfile(profile));
 
-        ObjectNode json = NavigateResponseConverter.convertFromGHResponse(rsp, trMap, Locale.ENGLISH, distanceConfig);
+        ObjectNode json = NavigateResponseConverter.convertFromGHResponse(rsp, trMap, Locale.ENGLISH, voiceInstructionDistanceConfig);
 
         JsonNode steps = json.get("routes").get(0).get("legs").get(0).get("steps");
 
@@ -265,7 +267,7 @@ public class NavigateResponseConverterTest {
 
         GHResponse rsp = hopper.route(request);
 
-        ObjectNode json = NavigateResponseConverter.convertFromGHResponse(rsp, trMap, Locale.ENGLISH, distanceConfig);
+        ObjectNode json = NavigateResponseConverter.convertFromGHResponse(rsp, trMap, Locale.ENGLISH, voiceInstructionDistanceConfig);
 
         //Check that all waypoints are there and in the right order
         JsonNode waypointsJson = json.get("waypoints");

--- a/navigation/src/test/java/com/graphhopper/navigation/NavigateResponseConverterTest.java
+++ b/navigation/src/test/java/com/graphhopper/navigation/NavigateResponseConverterTest.java
@@ -22,6 +22,8 @@ import org.junit.Test;
 import java.io.File;
 import java.util.Locale;
 
+import static com.graphhopper.util.Parameters.Routing.VOICE_INSTRUCTIONS;
+import static com.graphhopper.util.Parameters.Routing.VOICE_INSTRUCTIONS_UNIT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -34,7 +36,6 @@ public class NavigateResponseConverterTest {
     private static final String profile = "my_car";
 
     private final TranslationMap trMap = hopper.getTranslationMap();
-    private final VoiceInstructionDistanceConfig voiceInstructionDistanceConfig = new VoiceInstructionDistanceConfig(VoiceInstructionDistanceUtils.Unit.METRIC, trMap.getWithFallBack(Locale.ENGLISH));
 
     @BeforeClass
     public static void beforeClass() {
@@ -59,9 +60,9 @@ public class NavigateResponseConverterTest {
     public void basicTest() {
 
         GHResponse rsp = hopper.route(new GHRequest(42.554851, 1.536198, 42.510071, 1.548128).
-                setProfile(profile));
+                setProfile(profile).putHint(VOICE_INSTRUCTIONS, true).putHint(VOICE_INSTRUCTIONS_UNIT, "metric"));
 
-        ObjectNode json = NavigateResponseConverter.convertFromGHResponse(rsp, trMap, Locale.ENGLISH, voiceInstructionDistanceConfig);
+        ObjectNode json = NavigateResponseConverter.convertFromGHResponse(rsp, trMap, Locale.ENGLISH);
 
         JsonNode route = json.get("routes").get(0);
         double routeDistance = route.get("distance").asDouble();
@@ -129,9 +130,9 @@ public class NavigateResponseConverterTest {
     public void voiceInstructionsTest() {
 
         GHResponse rsp = hopper.route(new GHRequest(42.554851, 1.536198, 42.510071, 1.548128).
-                setProfile(profile));
+                setProfile(profile).putHint(VOICE_INSTRUCTIONS, true).putHint(VOICE_INSTRUCTIONS_UNIT, "metric"));
 
-        ObjectNode json = NavigateResponseConverter.convertFromGHResponse(rsp, trMap, Locale.ENGLISH, voiceInstructionDistanceConfig);
+        ObjectNode json = NavigateResponseConverter.convertFromGHResponse(rsp, trMap, Locale.ENGLISH);
 
         JsonNode steps = json.get("routes").get(0).get("legs").get(0).get("steps");
 
@@ -161,10 +162,9 @@ public class NavigateResponseConverterTest {
     public void voiceInstructionsImperialTest() {
 
         GHResponse rsp = hopper.route(new GHRequest(42.554851, 1.536198, 42.510071, 1.548128).
-                setProfile(profile));
+                setProfile(profile).putHint(VOICE_INSTRUCTIONS, true).putHint(VOICE_INSTRUCTIONS_UNIT, "imperial"));
 
-        ObjectNode json = NavigateResponseConverter.convertFromGHResponse(rsp, trMap, Locale.ENGLISH,
-                new VoiceInstructionDistanceConfig(VoiceInstructionDistanceUtils.Unit.IMPERIAL, trMap.getWithFallBack(Locale.ENGLISH)));
+        ObjectNode json = NavigateResponseConverter.convertFromGHResponse(rsp, trMap, Locale.ENGLISH);
 
         JsonNode steps = json.get("routes").get(0).get("legs").get(0).get("steps");
 
@@ -197,11 +197,11 @@ public class NavigateResponseConverterTest {
     public void alternativeRoutesTest() {
 
         GHResponse rsp = hopper.route(new GHRequest(42.554851, 1.536198, 42.510071, 1.548128).
-                setProfile(profile).setAlgorithm(Parameters.Algorithms.ALT_ROUTE));
+                setProfile(profile).setAlgorithm(Parameters.Algorithms.ALT_ROUTE).putHint(VOICE_INSTRUCTIONS, true).putHint(VOICE_INSTRUCTIONS_UNIT, "metric"));
 
         assertEquals(2, rsp.getAll().size());
 
-        ObjectNode json = NavigateResponseConverter.convertFromGHResponse(rsp, trMap, Locale.ENGLISH, voiceInstructionDistanceConfig);
+        ObjectNode json = NavigateResponseConverter.convertFromGHResponse(rsp, trMap, Locale.ENGLISH);
 
         JsonNode routes = json.get("routes");
         assertEquals(2, routes.size());
@@ -214,20 +214,20 @@ public class NavigateResponseConverterTest {
     public void voiceInstructionTranslationTest() {
 
         GHResponse rsp = hopper.route(new GHRequest(42.554851, 1.536198, 42.510071, 1.548128).
-                setProfile(profile));
+                setProfile(profile).putHint(VOICE_INSTRUCTIONS, true).putHint(VOICE_INSTRUCTIONS_UNIT, "metric"));
 
-        ObjectNode json = NavigateResponseConverter.convertFromGHResponse(rsp, trMap, Locale.ENGLISH, voiceInstructionDistanceConfig);
+        ObjectNode json = NavigateResponseConverter.convertFromGHResponse(rsp, trMap, Locale.ENGLISH);
 
         JsonNode steps = json.get("routes").get(0).get("legs").get(0).get("steps");
         JsonNode voiceInstruction = steps.get(14).get("voiceInstructions").get(0);
         assertEquals("In 2 kilometers keep right", voiceInstruction.get("announcement").asText());
 
         rsp = hopper.route(new GHRequest(42.554851, 1.536198, 42.510071, 1.548128).
-                setProfile(profile).setLocale(Locale.GERMAN));
+                setProfile(profile).setLocale(Locale.GERMAN).putHint(VOICE_INSTRUCTIONS, true).putHint(VOICE_INSTRUCTIONS_UNIT, "metric"));
 
         VoiceInstructionDistanceConfig distanceConfigGerman = new VoiceInstructionDistanceConfig(VoiceInstructionDistanceUtils.Unit.METRIC, trMap.getWithFallBack(Locale.GERMAN));
 
-        json = NavigateResponseConverter.convertFromGHResponse(rsp, trMap, Locale.GERMAN, distanceConfigGerman);
+        json = NavigateResponseConverter.convertFromGHResponse(rsp, trMap, Locale.GERMAN);
 
         steps = json.get("routes").get(0).get("legs").get(0).get("steps");
         voiceInstruction = steps.get(14).get("voiceInstructions").get(0);
@@ -239,9 +239,9 @@ public class NavigateResponseConverterTest {
     public void roundaboutDegreesTest() {
 
         GHResponse rsp = hopper.route(new GHRequest(42.554851, 1.536198, 42.510071, 1.548128).
-                setProfile(profile));
+                setProfile(profile).putHint(VOICE_INSTRUCTIONS, true).putHint(VOICE_INSTRUCTIONS_UNIT, "metric"));
 
-        ObjectNode json = NavigateResponseConverter.convertFromGHResponse(rsp, trMap, Locale.ENGLISH, voiceInstructionDistanceConfig);
+        ObjectNode json = NavigateResponseConverter.convertFromGHResponse(rsp, trMap, Locale.ENGLISH);
 
         JsonNode steps = json.get("routes").get(0).get("legs").get(0).get("steps");
 
@@ -264,10 +264,12 @@ public class NavigateResponseConverterTest {
         request.addPoint(new GHPoint(42.505144, 1.526113));
         request.addPoint(new GHPoint(42.50529, 1.527218));
         request.setProfile(profile);
+        request.putHint(VOICE_INSTRUCTIONS, true);
+        request.putHint(VOICE_INSTRUCTIONS_UNIT, "metric");
 
         GHResponse rsp = hopper.route(request);
 
-        ObjectNode json = NavigateResponseConverter.convertFromGHResponse(rsp, trMap, Locale.ENGLISH, voiceInstructionDistanceConfig);
+        ObjectNode json = NavigateResponseConverter.convertFromGHResponse(rsp, trMap, Locale.ENGLISH);
 
         //Check that all waypoints are there and in the right order
         JsonNode waypointsJson = json.get("waypoints");

--- a/web-api/src/main/java/com/graphhopper/jackson/InstructionListSerializer.java
+++ b/web-api/src/main/java/com/graphhopper/jackson/InstructionListSerializer.java
@@ -53,6 +53,10 @@ public class InstructionListSerializer extends JsonSerializer<InstructionList> {
             instrJson.put("sign", instruction.getSign());
             instrJson.putAll(instruction.getExtraInfoJSON());
 
+            if (instructions.hasVoiceInstructionsEnabled()) {
+                instrJson.put("voice_instructions", instruction.getVoiceInstructions());
+            }
+
             int tmpIndex = pointsIndex + instruction.getLength();
             instrJson.put("interval", Arrays.asList(pointsIndex, tmpIndex));
             pointsIndex = tmpIndex;

--- a/web-bundle/src/main/java/com/graphhopper/resources/RouteResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/RouteResource.java
@@ -88,6 +88,8 @@ public class RouteResource {
             @QueryParam(SNAP_PREVENTION) List<String> snapPreventions,
             @QueryParam(PATH_DETAILS) List<String> pathDetails,
             @QueryParam("heading") @NotNull List<Double> headings,
+            @QueryParam(VOICE_INSTRUCTIONS) @DefaultValue("false") boolean voiceInstructions,
+            @QueryParam(VOICE_INSTRUCTIONS_UNIT) @DefaultValue("metric") String voiceUnits,
             @QueryParam("gpx.route") @DefaultValue("true") boolean withRoute /* default to false for the route part in next API version, see #437 */,
             @QueryParam("gpx.track") @DefaultValue("true") boolean withTrack,
             @QueryParam("gpx.waypoints") @DefaultValue("false") boolean withWayPoints,


### PR DESCRIPTION
# Adds voice instructions to routing requests
This PR adds optional voice instructions to the `/route` and `/route-custom` endpoints via the`voice_instructions` query-param/post-data. The instructions are calculated exactly in the same way as for the `/navigate` endpoint and most of the logic has just been moved. The instructions are only calculated and added to the response if the parameter is provided.
## Why
Because the response of the `/navigate` endpoint is formatted differently than the routing responses and we want to implement more detailed voice instructions for our mobile clients.
Additionally most routing options are hardcoded for this endpoint and we needed more flexibility (eg.: disabled contraction hierachies).
## How
Two new classes have been introduced, `VoiceInstruction` and `VoiceInstructionList`, which are a representation of a single and multiple voice instructions. The `Instruction` class got a new field `voiceInstructions` which keeps track of the voice instructions relating to an instruction. Additionally all the logic previously contained in `NavigateResponseConverter.putVoiceInstructions` has been moved to `Instruction.setVoiceInstructions` and `NavigateResponseConverter.getThenVoiceInstructionpart` has been moved to `Instruction.getThenVoiceInstructionpart`. The generation of voice instructions happens within these two functions and should be exactly the same as before. 
The generation of voice instruction get triggered in `PathMerger.updateInstructionsWithContext` and i pass the state of the `voice_instructions` query-param/post-data in `Router.createPathMerger` in the same way as the `instructions` query-param/post-data.
## Changes

- Introduced `VoiceInstruction` and `VoiceInstructionList` classes
- Moved logic of `NavigateResponseConverter.putVoiceInstructions` to `Instruction.setVoiceInstructions`
- Moved `NavigateResponseConverter.getThenVoiceInstructionpart` to `Instruction.getThenVoiceInstructionpart`
- Moved graphhopper-navigation `VoiceInstructionConfig` to graphhopper-api
- Renamed graphhopper-navigation `DistanceConfig` to `VoiceInstructionDistanceConfig` and moved it to graphhopper-api
- Renamed graphhopper-navigation `DistanceUtils` to `VoiceInstructionDistanceUtils` and moved it to graphhopper-api
- Moved graphhopper-navigation `VoiceInstructionConfigTest` to graphhopper-core (would fit better in graphhopper-api but is dependend on `TranslationMap` which would trigger a circular dependency)
- Changed constructors of `VoiceInstructionConfig` and child-classes to accept a `Translation` instead of a `TranslationMap` and `Locale`
- Changed constructor of `VoiceInstructionDistanceConfig` accept a `Translation` instead of a `TranslationMap` and `Locale`
- Changed signature of `NavigateResource.calcRoute` to accept a `voiceInstructions` and `voiceUnit` parameter
- Removed `VoiceInstructionDistanceConfig` parameter from `NavigateResponseConverter.convertFromGHResponse` and subsequent functions
- Refactored `NavigateResponseConverter.putVoiceInstructions` to add the previously generated voice instructions to the response
- Added `testCustomWeightingVoiceInstructionsJson` and `testCustomWeightingVoiceInstructions` as well as extended `testCustomWeightingJson` and `testCustomWeighting` in `CustomWeightingRouteResourceLMTest`.
- Added `testVoiceInstructionsQuery` and `testVoiceInstructionsPostQuery` as well as extended `testBasicQuery` and `testBasicPostQuery` in `RouteResourceTest`

## Finishing Thoughts
I hope this feature is something that aligns with your plans and these changes would be acceptable for you. 
Also if anything could be improved please let me know.

greets