### PR TITLE
Extend /route endpoint to also return path details in GPX format

### DIFF
--- a/web-bundle/src/main/java/com/graphhopper/resources/RouteResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/RouteResource.java
@@ -25,6 +25,7 @@ import com.graphhopper.http.GHPointParam;
 import com.graphhopper.http.WebHelper;
 import com.graphhopper.routing.ProfileResolver;
 import com.graphhopper.util.*;
+import com.graphhopper.util.details.PathDetail;
 import com.graphhopper.util.gpx.GpxFromInstructions;
 import com.graphhopper.util.shapes.GHPoint;
 import io.dropwizard.jersey.params.AbstractParam;
@@ -240,7 +241,8 @@ public class RouteResource {
 
         long time = timeString != null ? Long.parseLong(timeString) : System.currentTimeMillis();
         InstructionList instructions = ghRsp.getBest().getInstructions();
-        return Response.ok(GpxFromInstructions.createGPX(instructions, trackName, time, enableElevation, withRoute, withTrack, withWayPoints, version, instructions.getTr()), "application/gpx+xml").
+        Map<String, List<PathDetail>> pathDetails = ghRsp.getBest().getPathDetails();
+        return Response.ok(GpxFromInstructions.createGPX(instructions, trackName, time, enableElevation, withRoute, withTrack, withWayPoints, version, instructions.getTr(), pathDetails), "application/gpx+xml").
                 header("Content-Disposition", "attachment;filename=" + "GraphHopper.gpx");
     }
 


### PR DESCRIPTION
The `/route` endpoint allows to return path details in the JSON response by adding the `details` query parameter (e.g. `details=road_class`). Unfortunately the details were omitted so far in the GPX response (query parameter `type=gpx`).

This PR adds the path details to the `<extensions>` element of each `<trkpt>` element. Obviously the values apply to the segment between two track points and not to the points themselves. When reading the path details of a track point they need to be interpreted as the path details of the segment between this and the the previous track point.