### PR TITLE
TurnRestrictions use exceptions based on restrictions in FlagEncoder

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/AbstractFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/AbstractFlagEncoder.java
@@ -25,7 +25,8 @@ import com.graphhopper.reader.osm.conditional.DateRangeParser;
 import com.graphhopper.routing.ev.*;
 import com.graphhopper.routing.util.parsers.helpers.OSMValueExtractor;
 import com.graphhopper.storage.IntsRef;
-import com.graphhopper.util.*;
+import com.graphhopper.util.BitUtil;
+import com.graphhopper.util.EdgeIteratorState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -237,7 +238,7 @@ public abstract class AbstractFlagEncoder implements FlagEncoder {
 
         return maxSpeed;
     }
-    
+
     /**
      * @return <i>true</i> if the given speed is not {@link Double#NaN}
      */
@@ -442,5 +443,10 @@ public abstract class AbstractFlagEncoder implements FlagEncoder {
     @Override
     public boolean hasEncodedValue(String key) {
         return encodedValueLookup.hasEncodedValue(key);
+    }
+
+    @Override
+    public Collection<String> getRestrictions() {
+        return restrictions;
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/util/AbstractFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/AbstractFlagEncoder.java
@@ -25,8 +25,7 @@ import com.graphhopper.reader.osm.conditional.DateRangeParser;
 import com.graphhopper.routing.ev.*;
 import com.graphhopper.routing.util.parsers.helpers.OSMValueExtractor;
 import com.graphhopper.storage.IntsRef;
-import com.graphhopper.util.BitUtil;
-import com.graphhopper.util.EdgeIteratorState;
+import com.graphhopper.util.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/core/src/main/java/com/graphhopper/routing/util/EncodingManager.java
+++ b/core/src/main/java/com/graphhopper/routing/util/EncodingManager.java
@@ -356,7 +356,7 @@ public class EncodingManager implements EncodedValueLookup {
             // FlagEncoder can demand TurnCostParsers => add them after the explicitly added ones
             for (AbstractFlagEncoder encoder : flagEncoderList) {
                 if (encoder.supportsTurnCosts() && !em.turnCostParsers.containsKey(encoder.toString()))
-                    _addTurnCostParser(new OSMTurnRelationParser(encoder.toString(), encoder.getMaxTurnCosts()));
+                    _addTurnCostParser(new OSMTurnRelationParser(encoder, encoder.getMaxTurnCosts()));
             }
 
             if (em.encodedValueMap.isEmpty())

--- a/core/src/main/java/com/graphhopper/routing/util/FlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/FlagEncoder.java
@@ -22,6 +22,8 @@ import com.graphhopper.routing.ev.DecimalEncodedValue;
 import com.graphhopper.routing.ev.EncodedValueLookup;
 import com.graphhopper.routing.util.spatialrules.TransportationMode;
 
+import java.util.Collection;
+
 /**
  * This class provides methods to define how a value (like speed or direction) converts to a flag
  * (currently an integer value), which is stored in an edge.
@@ -65,4 +67,9 @@ public interface FlagEncoder extends EncodedValueLookup {
      * @return true if already registered in an EncodingManager
      */
     boolean isRegistered();
+
+    /**
+     * @return a collection of restrictions for the given profile
+     */
+    Collection<String> getRestrictions();
 }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMTurnRelationParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMTurnRelationParser.java
@@ -20,6 +20,7 @@ package com.graphhopper.routing.util.parsers;
 import com.graphhopper.reader.OSMTurnRelation;
 import com.graphhopper.routing.ev.*;
 import com.graphhopper.routing.util.DefaultEdgeFilter;
+import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.storage.Graph;
 import com.graphhopper.storage.TurnCostStorage;
 import com.graphhopper.util.EdgeExplorer;
@@ -46,27 +47,16 @@ public class OSMTurnRelationParser implements TurnCostParser {
      * @param maxTurnCosts specify the maximum value used for turn costs, if this value is reached a
      *                     turn is forbidden and results in costs of positive infinity.
      */
-    public OSMTurnRelationParser(String name, int maxTurnCosts) {
-        this(name, maxTurnCosts, Collections.<String>emptyList());
+    public OSMTurnRelationParser(FlagEncoder encoder, int maxTurnCosts) {
+        this(encoder, maxTurnCosts, Collections.<String>emptyList());
     }
 
-    public OSMTurnRelationParser(String name, int maxTurnCosts, Collection<String> restrictions) {
-        this.name = name;
+    public OSMTurnRelationParser(FlagEncoder encoder, int maxTurnCosts, Collection<String> restrictions) {
+        this.name = encoder.toString();
         this.turnCostEnc = TurnCost.create(name, maxTurnCosts);
 
         if (restrictions.isEmpty()) {
-            // https://wiki.openstreetmap.org/wiki/Key:access
-            if (name.contains("car"))
-                this.restrictions = Arrays.asList("motorcar", "motor_vehicle", "vehicle", "access");
-            else if (name.contains("motorbike") || name.contains("motorcycle"))
-                this.restrictions = Arrays.asList("motorcycle", "motor_vehicle", "vehicle", "access");
-            else if (name.contains("truck"))
-                this.restrictions = Arrays.asList("hgv", "motor_vehicle", "vehicle", "access");
-            else if (name.contains("bike") || name.contains("bicycle"))
-                this.restrictions = Arrays.asList("bicycle", "vehicle", "access");
-            else
-                // assume default is some motor_vehicle, exception is too strict
-                this.restrictions = Arrays.asList("motor_vehicle", "vehicle", "access");
+            this.restrictions = encoder.getRestrictions();
         } else {
             this.restrictions = restrictions;
         }

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMTurnRelationParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMTurnRelationParserTest.java
@@ -29,7 +29,7 @@ public class OSMTurnRelationParserTest {
         internalToOSMEdge.put(3, 3L);
         internalToOSMEdge.put(4, 4L);
 
-        OSMTurnRelationParser parser = new OSMTurnRelationParser(encoder.toString(), 1);
+        OSMTurnRelationParser parser = new OSMTurnRelationParser(encoder, 1);
         GraphHopperStorage ghStorage = new GraphBuilder(new EncodingManager.Builder().add(encoder).addTurnCostParser(parser).build()).create();
         EdgeBasedRoutingAlgorithmTest.initGraph(ghStorage);
         TurnCostParser.ExternalInternalMap map = new TurnCostParser.ExternalInternalMap() {
@@ -64,11 +64,4 @@ public class OSMTurnRelationParserTest {
         assertTrue(Double.isInfinite(tcs.get(tce, 4, 3, 3)));
     }
 
-    @Test
-    public void unknownShouldBehaveLikeMotorVehicle() {
-        OSMTurnRelationParser parser = new OSMTurnRelationParser("fatcarsomething", 1);
-        OSMTurnRelation turnRelation = new OSMTurnRelation(4, 3, 3, OSMTurnRelation.Type.NOT);
-        turnRelation.setVehicleTypeRestricted("space");
-        parser.handleTurnRelationTags(turnRelation, null, null);
-    }
 }

--- a/reader-osm/src/test/java/com/graphhopper/reader/osm/OSMReaderTest.java
+++ b/reader-osm/src/test/java/com/graphhopper/reader/osm/OSMReaderTest.java
@@ -709,6 +709,12 @@ public class OSMReaderTest {
     public void testTurnFlagCombination() {
         CarFlagEncoder car = new CarFlagEncoder(5, 5, 24);
         CarFlagEncoder truck = new CarFlagEncoder(5, 5, 24) {
+
+            @Override
+            public Collection<String> getRestrictions() {
+                return Arrays.asList("hgv", "motor_vehicle", "vehicle", "access");
+            }
+
             @Override
             public String toString() {
                 return "truck";


### PR DESCRIPTION
This PR improves the generation of TurnRestrictions.

So far, turn restrictions except parsing worked based on the name of the FlagEncoder. If the name did not match a given set of hard coded values, we assumed it's a motor vehicle and added these tags.

This PR uses the restrictions that are set in the FlagEncoder, this makes sure we actually use the right restrictions and also improves the separation of concerns, because the OSMTurnRelationParser should not have any knowledge about specific vehicle access rules. 