### PR TITLE
CustomWeighting: ensure Map is ordered

### DIFF
--- a/core/files/changelog.txt
+++ b/core/files/changelog.txt
@@ -1,4 +1,5 @@
 3.0
+    CustomWeighting requires LinkedHashMap throw exception if this is not provided
     removed Dockerfile
     the second argument of the VirtualEdgeIteratorState constructor is now an edge key (was an edge id before)
 

--- a/core/src/main/java/com/graphhopper/routing/util/CustomModel.java
+++ b/core/src/main/java/com/graphhopper/routing/util/CustomModel.java
@@ -20,10 +20,7 @@ package com.graphhopper.routing.util;
 import com.graphhopper.json.geo.JsonFeature;
 import com.graphhopper.util.Parameters;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * This class is used in combination with CustomProfile.
@@ -38,9 +35,9 @@ public class CustomModel {
     private Double headingPenalty = Parameters.Routing.DEFAULT_HEADING_PENALTY;
     // default value derived from the cost for time e.g. 25€/hour and for distance 0.5€/km, for trucks this is usually larger
     private double distanceInfluence = DEFAULT_D_I;
-    private Map<String, Object> speedFactorMap = new HashMap<>();
-    private Map<String, Object> maxSpeedMap = new HashMap<>();
-    private Map<String, Object> priorityMap = new HashMap<>();
+    private Map<String, Object> speedFactorMap = new LinkedHashMap<>();
+    private Map<String, Object> maxSpeedMap = new LinkedHashMap<>();
+    private Map<String, Object> priorityMap = new LinkedHashMap<>();
     private Map<String, JsonFeature> areas = new HashMap<>();
 
     public CustomModel() {
@@ -66,7 +63,8 @@ public class CustomModel {
             }
             return (T) newList;
         } else if (originalObject instanceof Map) {
-            Map copy = new HashMap<>(((Map) originalObject).size());
+            Map copy = originalObject instanceof LinkedHashMap ? new LinkedHashMap<>(((Map) originalObject).size()) :
+                    new HashMap<>(((Map) originalObject).size());
             for (Object o : ((Map) originalObject).entrySet()) {
                 Map.Entry entry = (Map.Entry) o;
                 copy.put(entry.getKey(), deepCopy(entry.getValue()));

--- a/core/src/main/java/com/graphhopper/routing/weighting/custom/PriorityCalculator.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/custom/PriorityCalculator.java
@@ -24,6 +24,7 @@ import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.prep.PreparedGeometryFactory;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -45,8 +46,8 @@ final class PriorityCalculator {
                 priorityList.add(GeoToValueEntry.create(priorityKey, new PreparedGeometryFactory().create(geometry),
                         (Number) value, 1, 0, 1));
             } else {
-                if (!(value instanceof Map))
-                    throw new IllegalArgumentException(priorityKey + ": non-root entries require a map but was: " + value.getClass().getSimpleName());
+                if (!(value instanceof LinkedHashMap))
+                    throw new IllegalArgumentException(priorityKey + ": non-root entries require a sorted map (LinkedHashMap) but was: " + value.getClass().getSimpleName());
                 final double defaultPriority = 1, minPriority = 0, maxPriority = 1;
                 EncodedValue encodedValue = getEV(lookup, "priority", key);
                 if (encodedValue instanceof EnumEncodedValue) {

--- a/core/src/main/java/com/graphhopper/routing/weighting/custom/SpeedCalculator.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/custom/SpeedCalculator.java
@@ -100,7 +100,7 @@ final class SpeedCalculator {
                         (Number) value, 1, 0, 1));
             } else {
                 if (!(value instanceof LinkedHashMap))
-                    throw new IllegalArgumentException(speedFactorKey + ": non-root entries require a map (LinkedHashMap), but was: " + value.getClass().getSimpleName());
+                    throw new IllegalArgumentException(speedFactorKey + ": non-root entries require a sorted map (LinkedHashMap), but was: " + value.getClass().getSimpleName());
                 final double defaultSpeedFactor = 1, minSpeedFactor = 0, maxSpeedFactor = 1;
                 EncodedValue encodedValue = getEV(lookup, "speed_factor", key);
                 if (encodedValue instanceof EnumEncodedValue) {

--- a/core/src/main/java/com/graphhopper/routing/weighting/custom/SpeedCalculator.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/custom/SpeedCalculator.java
@@ -24,6 +24,7 @@ import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.prep.PreparedGeometryFactory;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -60,8 +61,8 @@ final class SpeedCalculator {
                 maxSpeedList.add(GeoToValueEntry.create(maxSpeedKey, new PreparedGeometryFactory().create(geometry),
                         (Number) value, maxSpeed, 0, maxSpeed));
             } else {
-                if (!(value instanceof Map))
-                    throw new IllegalArgumentException(maxSpeedKey + ": non-root entries require a map but was: " + value.getClass().getSimpleName());
+                if (!(value instanceof LinkedHashMap))
+                    throw new IllegalArgumentException(maxSpeedKey + ": non-root entries require a sorted map (LinkedHashMap), but was: " + value.getClass().getSimpleName());
                 final double defaultMaxSpeed = maxSpeed, minMaxSpeed = 0, maxMaxSpeed = maxSpeed;
                 EncodedValue encodedValue = getEV(lookup, "max_speed", key);
                 if (encodedValue instanceof EnumEncodedValue) {
@@ -98,8 +99,8 @@ final class SpeedCalculator {
                 speedFactorList.add(GeoToValueEntry.create(speedFactorKey, new PreparedGeometryFactory().create(geometry),
                         (Number) value, 1, 0, 1));
             } else {
-                if (!(value instanceof Map))
-                    throw new IllegalArgumentException(speedFactorKey + ": non-root entries require a map but was: " + value.getClass().getSimpleName());
+                if (!(value instanceof LinkedHashMap))
+                    throw new IllegalArgumentException(speedFactorKey + ": non-root entries require a map (LinkedHashMap), but was: " + value.getClass().getSimpleName());
                 final double defaultSpeedFactor = 1, minSpeedFactor = 0, maxSpeedFactor = 1;
                 EncodedValue encodedValue = getEV(lookup, "speed_factor", key);
                 if (encodedValue instanceof EnumEncodedValue) {

--- a/core/src/test/java/com/graphhopper/routing/util/CustomModelTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/CustomModelTest.java
@@ -52,31 +52,19 @@ public class CustomModelTest {
         assertNull(getValue(car, "max_weight"));
 
         assertEquals("<3.0", getValue(CustomModel.merge(car, truck), "max_width"));
-        try {
-            CustomModel.merge(truck, car);
-            fail("car is incompatible to truck (base)");
-        } catch (Exception ex) {
-            assertTrue(ex.getMessage().contains("max_width: only use a comparison key with a bigger value than 3.0 but was 2.0"), ex.getMessage());
-        }
+        Exception ex = assertThrows(IllegalArgumentException.class, () -> CustomModel.merge(truck, car));
+        assertTrue(ex.getMessage().contains("max_width: only use a comparison key with a bigger value than 3.0 but was 2.0"), ex.getMessage());
 
         CustomModel car2 = setValue(new CustomModel(), ">", "max_width", 2);
-        try {
-            CustomModel.merge(truck, car2);
-            fail("car is incompatible to car2 (base)");
-        } catch (Exception ex) {
-            assertTrue(ex.getMessage().contains("max_width: comparison keys must match but did not: "), ex.getMessage());
-        }
+        ex = assertThrows(IllegalArgumentException.class, () -> CustomModel.merge(truck, car2));
+        assertTrue(ex.getMessage().contains("max_width: comparison keys must match but did not: "), ex.getMessage());
 
         Map<String, Object> map = new HashMap<>();
         map.put("<2.0", 0.5);
         CustomModel customModel = new CustomModel();
         customModel.getPriority().put("max_width", map);
-        try {
-            CustomModel.merge(customModel, customModel);
-            fail("models are incompatible");
-        } catch (Exception ex) {
-            assertTrue(ex.getMessage().contains("only blocking comparisons are allowed, but query was 0.5 and server side: 0.5"), ex.getMessage());
-        }
+        ex = assertThrows(IllegalArgumentException.class, () -> CustomModel.merge(customModel, customModel));
+        assertTrue(ex.getMessage().contains("only blocking comparisons are allowed, but query was 0.5 and server side: 0.5"), ex.getMessage());
     }
 
     @Test
@@ -110,11 +98,7 @@ public class CustomModelTest {
         assertEquals(1.5, (Double) ((Map) truck.getPriority().get("road_class")).get("primary"), .1);
 
         truck.getPriority().put("road_class", createMap("primary", "incompatible"));
-        try {
-            CustomModel.merge(car, truck);
-            fail("we cannot merge this");
-        } catch (Exception ex) {
-        }
+        assertThrows(IllegalArgumentException.class, () -> CustomModel.merge(car, truck));
     }
 
     Map createMap(Object... objects) {

--- a/core/src/test/java/com/graphhopper/routing/weighting/CustomWeightingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/CustomWeightingTest.java
@@ -36,6 +36,7 @@ import org.locationtech.jts.geom.GeometryFactory;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static com.graphhopper.routing.ev.RoadClass.*;
@@ -85,7 +86,7 @@ public class CustomWeightingTest {
         assertEquals(72, new FastestWeighting(carFE, NO_TURN_COST_PROVIDER).calcEdgeWeight(medium, false), .1);
         assertEquals(36, new FastestWeighting(carFE, NO_TURN_COST_PROVIDER).calcEdgeWeight(fast, false), .1);
 
-        Map<String, Object> map = new HashMap<>();
+        Map<String, Object> map = new LinkedHashMap<>();
         CustomModel model = new CustomModel().setDistanceInfluence(0);
         assertEquals(144, createWeighting(model).calcEdgeWeight(slow, false), .1);
         assertEquals(72, createWeighting(model).calcEdgeWeight(medium, false), .1);
@@ -128,7 +129,7 @@ public class CustomWeightingTest {
                 set(roadClassEnc, SECONDARY).set(avSpeedEnc, 70);
 
         CustomModel vehicleModel = new CustomModel();
-        Map map = new HashMap();
+        Map map = new LinkedHashMap();
 
         map.put(PRIMARY.toString(), 1.0);
         map.put(CustomWeighting.CATCH_ALL, 0.5);
@@ -158,7 +159,7 @@ public class CustomWeightingTest {
         assertEquals(1.15, createWeighting(vehicleModel).calcEdgeWeight(primary, false), 0.01);
 
         // now reduce speed for road class 'primary' -> the weight increases
-        Map map = new HashMap();
+        Map map = new LinkedHashMap();
         map.put(PRIMARY.toString(), 60);
         vehicleModel.getMaxSpeed().put(KEY, map);
         assertEquals(1.3, createWeighting(vehicleModel).calcEdgeWeight(primary, false), 0.01);
@@ -170,7 +171,7 @@ public class CustomWeightingTest {
         CustomModel vehicleModel = new CustomModel();
         assertEquals(3.1, createWeighting(vehicleModel).calcEdgeWeight(edge, false), 0.01);
         // here we increase weight for edges that are road class links
-        Map map = new HashMap<>();
+        Map map = new LinkedHashMap<>();
         map.put("true", 0.5);
         vehicleModel.getPriority().put(RoadClassLink.KEY, map);
         CustomWeighting weighting = createWeighting(vehicleModel);
@@ -183,7 +184,7 @@ public class CustomWeightingTest {
     public void testPriority() {
         CustomModel vehicleModel = new CustomModel();
 
-        Map map = new HashMap();
+        Map map = new LinkedHashMap();
         map.put(MOTORWAY.toString(), 0.1);
         vehicleModel.getPriority().put(KEY, map);
         CustomWeighting weighting = createWeighting(vehicleModel);
@@ -207,7 +208,7 @@ public class CustomWeightingTest {
         assertEquals(3.10, weighting.calcEdgeWeight(slowEdge, false), 0.01);
         assertEquals(1.30, weighting.calcEdgeWeight(fastEdge, false), 0.01);
 
-        Map map = new HashMap();
+        Map map = new LinkedHashMap();
         map.put(">69", 0.2);
         CustomModel vehicleModel = new CustomModel();
         vehicleModel.getPriority().put("max_speed", map);
@@ -216,7 +217,7 @@ public class CustomWeightingTest {
         assertEquals(3.70, weighting.calcEdgeWeight(fastEdge, false), 0.01);
 
         // this is currently a bit hidden feature as only the shared encoded values are suggested in the UI
-        map = new HashMap();
+        map = new LinkedHashMap();
         map.put(">50", 0.2);
         vehicleModel = new CustomModel();
         vehicleModel.getPriority().put(EncodingManager.getKey("car", "average_speed"), map);
@@ -234,13 +235,26 @@ public class CustomWeightingTest {
         assertEquals(3.10, weighting.calcEdgeWeight(slowEdge, false), 0.01);
         assertEquals(1.30, weighting.calcEdgeWeight(fastEdge, false), 0.01);
 
-        Map map = new HashMap();
+        Map map = new LinkedHashMap();
         map.put(" > 1.5", 0.2); // allow decimal values in range even for int encoded value
         CustomModel vehicleModel = new CustomModel();
         vehicleModel.getPriority().put("lanes", map);
         weighting = createWeighting(vehicleModel);
         assertEquals(3.10, weighting.calcEdgeWeight(slowEdge, false), 0.01);
         assertEquals(3.70, weighting.calcEdgeWeight(fastEdge, false), 0.01);
+    }
+
+    @Test
+    public void unorderedMapShouldFail() {
+        Map map = new HashMap<>();
+        map.put(" > 1.5", 0.2); // allow decimal values in range even for int encoded value
+        CustomModel vehicleModel = new CustomModel();
+        vehicleModel.getPriority().put("lanes", map);
+        try {
+            createWeighting(vehicleModel);
+            assertTrue(false);
+        } catch (Exception ex) {
+        }
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/routing/weighting/CustomWeightingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/CustomWeightingTest.java
@@ -41,8 +41,7 @@ import java.util.Map;
 
 import static com.graphhopper.routing.ev.RoadClass.*;
 import static com.graphhopper.routing.weighting.TurnCostProvider.NO_TURN_COST_PROVIDER;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class CustomWeightingTest {
 
@@ -250,11 +249,7 @@ public class CustomWeightingTest {
         map.put(" > 1.5", 0.2); // allow decimal values in range even for int encoded value
         CustomModel vehicleModel = new CustomModel();
         vehicleModel.getPriority().put("lanes", map);
-        try {
-            createWeighting(vehicleModel);
-            assertTrue(false);
-        } catch (Exception ex) {
-        }
+        assertThrows(IllegalArgumentException.class, () -> createWeighting(vehicleModel));
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/routing/weighting/custom/PriorityCalculatorTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/custom/PriorityCalculatorTest.java
@@ -26,6 +26,7 @@ import com.graphhopper.util.EdgeIteratorState;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -45,7 +46,7 @@ class PriorityCalculatorTest {
     @Test
     public void priority() {
         CustomModel model = new CustomModel();
-        Map<String, Object> map = new HashMap<>();
+        Map<String, Object> map = new LinkedHashMap<>();
         map.put("*", 0.3);
         model.getPriority().put(RoadClass.KEY, map);
         assertEquals(0.3, calcPriority(edge, model));
@@ -63,7 +64,7 @@ class PriorityCalculatorTest {
     @Test
     public void invalidPriority() {
         CustomModel model = new CustomModel();
-        Map<String, Object> map = new HashMap<>();
+        Map<String, Object> map = new LinkedHashMap<>();
         map.put("*", 1.1);
         model.getPriority().put(RoadClass.KEY, map);
         try {
@@ -88,9 +89,9 @@ class PriorityCalculatorTest {
         EnumEncodedValue<RoadEnvironment> roadEnvironment = em.getEnumEncodedValue(RoadEnvironment.KEY, RoadEnvironment.class);
         edge.set(roadClass, RoadClass.PRIMARY);
         edge.set(roadEnvironment, RoadEnvironment.BRIDGE);
-        Map<String, Object> roadClassMap = new HashMap<>();
+        Map<String, Object> roadClassMap = new LinkedHashMap<>();
         roadClassMap.put(RoadClass.PRIMARY.toString(), 0.7);
-        Map<String, Object> roadEnvironmentMap = new HashMap<>();
+        Map<String, Object> roadEnvironmentMap = new LinkedHashMap<>();
         roadEnvironmentMap.put(RoadEnvironment.BRIDGE.toString(), 0.5);
         CustomModel model = new CustomModel();
         model.getPriority().put(RoadClass.KEY, roadClassMap);
@@ -106,7 +107,7 @@ class PriorityCalculatorTest {
         edge.set(maxSpeedEnc, 110);
         edge.setReverse(maxSpeedEnc, 50);
 
-        Map<String, Object> maxSpeedMap = new HashMap<>();
+        Map<String, Object> maxSpeedMap = new LinkedHashMap<>();
         maxSpeedMap.put("<100", 0.5);
 
         CustomModel model = new CustomModel();

--- a/core/src/test/java/com/graphhopper/routing/weighting/custom/SpeedCalculatorTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/custom/SpeedCalculatorTest.java
@@ -29,6 +29,7 @@ import com.graphhopper.util.EdgeIteratorState;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -57,7 +58,7 @@ class SpeedCalculatorTest {
     public void maxSpeed() {
         // here we use max_speed to limit speed
         CustomModel model = new CustomModel();
-        Map<String, Object> map = new HashMap<>();
+        Map<String, Object> map = new LinkedHashMap<>();
         map.put("*", 25);
         model.getMaxSpeed().put(RoadClass.KEY, map);
         assertEquals(25, calcSpeed(edge, model));
@@ -78,7 +79,7 @@ class SpeedCalculatorTest {
     @Test
     public void invalidMaxSpeed() {
         CustomModel model = new CustomModel();
-        Map<String, Object> map = new HashMap<>();
+        Map<String, Object> map = new LinkedHashMap<>();
         map.put("*", 300);
         model.getMaxSpeed().put(RoadClass.KEY, map);
         try {
@@ -103,9 +104,9 @@ class SpeedCalculatorTest {
         EnumEncodedValue<RoadEnvironment> roadEnvironment = em.getEnumEncodedValue(RoadEnvironment.KEY, RoadEnvironment.class);
         edge.set(roadClass, RoadClass.PRIMARY);
         edge.set(roadEnvironment, RoadEnvironment.BRIDGE);
-        Map<String, Object> roadClassMap = new HashMap<>();
+        Map<String, Object> roadClassMap = new LinkedHashMap<>();
         roadClassMap.put(RoadClass.PRIMARY.toString(), 40);
-        Map<String, Object> roadEnvironmentMap = new HashMap<>();
+        Map<String, Object> roadEnvironmentMap = new LinkedHashMap<>();
         roadEnvironmentMap.put(RoadEnvironment.BRIDGE.toString(), 20);
         CustomModel model = new CustomModel();
         model.getMaxSpeed().put(RoadClass.KEY, roadClassMap);
@@ -118,7 +119,7 @@ class SpeedCalculatorTest {
     public void speedFactor() {
         // here we use speed_factor to adjust speed
         CustomModel model = new CustomModel();
-        Map<String, Object> map = new HashMap<>();
+        Map<String, Object> map = new LinkedHashMap<>();
         map.put("*", 0.1);
         model.getSpeedFactor().put(RoadClass.KEY, map);
         assertEquals(6, calcSpeed(edge, model));
@@ -136,7 +137,7 @@ class SpeedCalculatorTest {
     @Test
     public void invalidSpeedFactor() {
         CustomModel model = new CustomModel();
-        Map<String, Object> map = new HashMap<>();
+        Map<String, Object> map = new LinkedHashMap<>();
         map.put("*", 1.1);
         model.getSpeedFactor().put(RoadClass.KEY, map);
         try {
@@ -154,9 +155,9 @@ class SpeedCalculatorTest {
         EnumEncodedValue<RoadEnvironment> roadEnvironment = em.getEnumEncodedValue(RoadEnvironment.KEY, RoadEnvironment.class);
         edge.set(roadClass, RoadClass.PRIMARY);
         edge.set(roadEnvironment, RoadEnvironment.BRIDGE);
-        Map<String, Object> roadClassMap = new HashMap<>();
+        Map<String, Object> roadClassMap = new LinkedHashMap<>();
         roadClassMap.put(RoadClass.PRIMARY.toString(), 0.7);
-        Map<String, Object> roadEnvironmentMap = new HashMap<>();
+        Map<String, Object> roadEnvironmentMap = new LinkedHashMap<>();
         roadEnvironmentMap.put(RoadEnvironment.BRIDGE.toString(), 0.5);
         CustomModel model = new CustomModel();
         model.getSpeedFactor().put(RoadClass.KEY, roadClassMap);

--- a/example/src/main/java/com/graphhopper/example/RoutingExample.java
+++ b/example/src/main/java/com/graphhopper/example/RoutingExample.java
@@ -93,7 +93,7 @@ public class RoutingExample {
                 addPoint(new GHPoint(42.508774, 1.535414)).addPoint(new GHPoint(42.506595, 1.528795)).
                 setHeadings(Arrays.asList(180d, 90d)).
                 // use flexible mode (i.e. disable contraction hierarchies) to make heading and pass_through working
-                        putHint(Parameters.CH.DISABLE, true);
+                putHint(Parameters.CH.DISABLE, true);
         // if you have via points you can avoid U-turns there with
         // req.getHints().putObject(Parameters.Routing.PASS_THROUGH, true);
         GHResponse res = hopper.route(req);


### PR DESCRIPTION
There is a bug which could occur for Java or the API when using multiple encoded values and/or multiple cases for one encoded value. The next goal should be to make CustomModel.getPriority/getSpeedFactor/getMaxSpeed type safe which we might reach when we limit the language to only "clause" as key and number as value (which is a next but much bigger step).