### PR TITLE
Refactor PathDetailsBuilderFactory

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/ev/BikeNetwork.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/BikeNetwork.java
@@ -1,5 +1,5 @@
 package com.graphhopper.routing.ev;
 
 public class BikeNetwork {
-    public static final String KEY = RouteNetwork.key("bike");
+    public static final String KEY = "bike" + RouteNetwork.KEY_SUFFIX;
 }

--- a/core/src/main/java/com/graphhopper/routing/ev/FootNetwork.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/FootNetwork.java
@@ -1,5 +1,5 @@
 package com.graphhopper.routing.ev;
 
 public class FootNetwork {
-    public static final String KEY = RouteNetwork.key("foot");
+    public static final String KEY = "foot" + RouteNetwork.KEY_SUFFIX;
 }

--- a/core/src/main/java/com/graphhopper/routing/ev/RouteNetwork.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/RouteNetwork.java
@@ -27,10 +27,8 @@ public enum RouteNetwork {
 
     MISSING("missing"), INTERNATIONAL("international"), NATIONAL("national"), REGIONAL("regional"),
     LOCAL("local"), OTHER("other");
-
-    public static String key(String prefix) {
-        return prefix + "_network";
-    }
+    
+    public static final String KEY_SUFFIX = "_network";
 
     private final String name;
 

--- a/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
@@ -198,7 +198,7 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
         registerNewEncodedValue.add(avgSpeedEnc = new UnsignedDecimalEncodedValue(getKey(prefix, "average_speed"), speedBits, speedFactor, speedTwoDirections));
         registerNewEncodedValue.add(priorityEnc = new UnsignedDecimalEncodedValue(getKey(prefix, "priority"), 3, PriorityCode.getFactor(1), false));
 
-        bikeRouteEnc = getEnumEncodedValue(RouteNetwork.key("bike"), RouteNetwork.class);
+        bikeRouteEnc = getEnumEncodedValue(BikeNetwork.KEY, RouteNetwork.class);
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/util/EncodingManager.java
+++ b/core/src/main/java/com/graphhopper/routing/util/EncodingManager.java
@@ -335,13 +335,13 @@ public class EncodingManager implements EncodedValueLookup {
 
             for (AbstractFlagEncoder encoder : flagEncoderList) {
                 if (encoder instanceof BikeCommonFlagEncoder) {
-                    if (!em.hasEncodedValue(RouteNetwork.key("bike")))
+                    if (!em.hasEncodedValue(BikeNetwork.KEY))
                         _addRelationTagParser(new OSMBikeNetworkTagParser());
                     if (!em.hasEncodedValue(GetOffBike.KEY))
                         _addEdgeTagParser(new OSMGetOffBikeParser(), false, false);
 
                 } else if (encoder instanceof FootFlagEncoder) {
-                    if (!em.hasEncodedValue(RouteNetwork.key("foot")))
+                    if (!em.hasEncodedValue(FootNetwork.KEY))
                         _addRelationTagParser(new OSMFootNetworkTagParser());
                 }
             }

--- a/core/src/main/java/com/graphhopper/routing/util/FootFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/FootFlagEncoder.java
@@ -156,7 +156,7 @@ public class FootFlagEncoder extends AbstractFlagEncoder {
         registerNewEncodedValue.add(avgSpeedEnc = new UnsignedDecimalEncodedValue(getKey(prefix, "average_speed"), speedBits, speedFactor, speedTwoDirections));
         registerNewEncodedValue.add(priorityWayEncoder = new UnsignedDecimalEncodedValue(getKey(prefix, "priority"), 3, PriorityCode.getFactor(1), speedTwoDirections));
 
-        footRouteEnc = getEnumEncodedValue(RouteNetwork.key("foot"), RouteNetwork.class);
+        footRouteEnc = getEnumEncodedValue(FootNetwork.KEY, RouteNetwork.class);
     }
 
     /**

--- a/core/src/main/java/com/graphhopper/util/details/PathDetailsBuilderFactory.java
+++ b/core/src/main/java/com/graphhopper/util/details/PathDetailsBuilderFactory.java
@@ -22,7 +22,9 @@ import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.routing.weighting.Weighting;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static com.graphhopper.util.Parameters.Details.*;
 
@@ -38,7 +40,11 @@ public class PathDetailsBuilderFactory {
     public List<PathDetailsBuilder> createPathDetailsBuilders(List<String> requestedPathDetails, EncodedValueLookup evl, Weighting weighting) {
         List<PathDetailsBuilder> builders = new ArrayList<>();
         
+        Set<String> uniqueDetails = new HashSet<>();
         for (String pathDetail : requestedPathDetails) {
+            if (!uniqueDetails.add(pathDetail)) {
+                throw new IllegalArgumentException("Duplicate path detail requested: " + pathDetail);
+            }
             builders.add(createPathDetailsBuilder(pathDetail, evl, weighting));
         }
 

--- a/core/src/test/java/com/graphhopper/routing/util/AbstractBikeFlagEncoderTester.java
+++ b/core/src/test/java/com/graphhopper/routing/util/AbstractBikeFlagEncoderTester.java
@@ -226,7 +226,7 @@ public abstract class AbstractBikeFlagEncoderTester {
         // Example https://www.openstreetmap.org/way/213492914 => two hike 84544, 2768803 and two bike relations 3162932, 5254650
         IntsRef relFlags = encodingManager.handleRelationTags(rel2, encodingManager.handleRelationTags(rel, encodingManager.createRelationFlags()));
         IntsRef edgeFlags = encodingManager.handleWayTags(way, new EncodingManager.AcceptWay().put(encoder.toString(), WAY), relFlags);
-        EnumEncodedValue<RouteNetwork> enc = encodingManager.getEnumEncodedValue(RouteNetwork.key("bike"), RouteNetwork.class);
+        EnumEncodedValue<RouteNetwork> enc = encodingManager.getEnumEncodedValue(BikeNetwork.KEY, RouteNetwork.class);
         assertEquals(RouteNetwork.REGIONAL, enc.getEnum(false, edgeFlags));
     }
 

--- a/core/src/test/java/com/graphhopper/routing/util/EncodingManagerTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/EncodingManagerTest.java
@@ -19,6 +19,7 @@ package com.graphhopper.routing.util;
 
 import com.graphhopper.reader.ReaderRelation;
 import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.BikeNetwork;
 import com.graphhopper.routing.ev.BooleanEncodedValue;
 import com.graphhopper.routing.ev.EnumEncodedValue;
 import com.graphhopper.routing.ev.Roundabout;
@@ -149,7 +150,7 @@ public class EncodingManagerTest {
         manager.acceptWay(osmWay, map);
         IntsRef edgeFlags = manager.handleWayTags(osmWay, map, relFlags);
 
-        EnumEncodedValue enc = manager.getEnumEncodedValue(RouteNetwork.key("bike"), RouteNetwork.class);
+        EnumEncodedValue enc = manager.getEnumEncodedValue(BikeNetwork.KEY, RouteNetwork.class);
 
         assertTrue(defaultBike.priorityEnc.getDecimal(false, edgeFlags)
                 > lessRelationCodes.priorityEnc.getDecimal(false, edgeFlags));

--- a/reader-osm/src/test/java/com/graphhopper/reader/osm/OSMReaderTest.java
+++ b/reader-osm/src/test/java/com/graphhopper/reader/osm/OSMReaderTest.java
@@ -965,7 +965,7 @@ public class OSMReaderTest {
                 .setProfile("profile")
                 .setPathDetails(Collections.singletonList(Toll.KEY)));
         Throwable ex = response.getErrors().get(0);
-        assertTrue(ex.getMessage(), ex.getMessage().contains("You requested the details [toll]"));
+        assertTrue(ex.getMessage(), ex.getMessage().contains("Missing encoded values for path detail: toll"));
     }
 
     class GraphHopperFacade extends GraphHopperOSM {


### PR DESCRIPTION
* only use `PathDetailsBuilderFactory` within `PathDetailsFromEdges.calcDetails()`
* use a Set for the request path details as duplicate entries make no sense
* create all PathDetailsBuilders within a switch statement for better readability
* provide varargs `GHRequest.setPathDetails()` variant for better readability when using hardcoded list of values(e.g unittests)