### PR TITLE
Update Dropwizard to 2.0.15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-dependencies</artifactId>
                 <!-- make sure the dropwizard version is compatible to the below dropwizard-configurable-assets-bundle version -->
-                <version>2.0.8</version>
+                <version>2.0.15</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
This PR updates Dropwizard to the latest version 2.0.15.

I checked the `slf4j-log4j12` version, that is still the version used in Dropwizard. I also checked the `dropwizard-configurable-assets-bundle`, but I couldn't find exact specifications with which version this is compatible, but it's still the latest version.

Tests are still green and a few manual tests did not reveal any issues.