### PR TITLE
Location index without pt bloat

### DIFF
--- a/core/src/main/java/com/graphhopper/storage/index/LocationIndexTree.java
+++ b/core/src/main/java/com/graphhopper/storage/index/LocationIndexTree.java
@@ -254,6 +254,10 @@ public class LocationIndexTree implements LocationIndex {
         if (dataAccess.getHeader(0) != MAGIC_INT)
             throw new IllegalStateException("incorrect location index version, expected:" + MAGIC_INT);
 
+        if (dataAccess.getHeader(1 * 4) != calcChecksum())
+            throw new IllegalStateException("location index was opened with incorrect graph: "
+                    + dataAccess.getHeader(1 * 4) + " vs. " + calcChecksum());
+
         setMinResolutionInMeter(dataAccess.getHeader(2 * 4));
         prepareAlgo();
         initialized = true;

--- a/core/src/main/java/com/graphhopper/storage/index/LocationIndexTree.java
+++ b/core/src/main/java/com/graphhopper/storage/index/LocationIndexTree.java
@@ -307,9 +307,12 @@ public class LocationIndexTree implements LocationIndex {
     }
 
     int calcChecksum() {
-        // do not include the edges as we could get problem with CHGraph due to shortcuts
-        // ^ graph.getAllEdges().count();
-        return graph.getNodes();
+        // Just some property of the graph this LocationIndex was created for.
+        // Intention is to more-or-less ensure that we aren't loading a LocationIndex for a totally different
+        // Graph. This is a possibility because the LocationIndex is normally the first thing that's written to disk.
+        // And in that case we want to avoid loading it instead of regenerating it.
+        BBox bounds = graph.getBounds();
+        return Objects.hash(Helper.round6(bounds.minLon), Helper.round6(bounds.maxLon), Helper.round6(bounds.minLat), Helper.round6(bounds.maxLat));
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/storage/index/LocationIndexTree.java
+++ b/core/src/main/java/com/graphhopper/storage/index/LocationIndexTree.java
@@ -254,10 +254,6 @@ public class LocationIndexTree implements LocationIndex {
         if (dataAccess.getHeader(0) != MAGIC_INT)
             throw new IllegalStateException("incorrect location index version, expected:" + MAGIC_INT);
 
-        if (dataAccess.getHeader(1 * 4) != calcChecksum())
-            throw new IllegalStateException("location index was opened with incorrect graph: "
-                    + dataAccess.getHeader(1 * 4) + " vs. " + calcChecksum());
-
         setMinResolutionInMeter(dataAccess.getHeader(2 * 4));
         prepareAlgo();
         initialized = true;

--- a/reader-gtfs/src/main/java/com/graphhopper/gtfs/GraphHopperGtfs.java
+++ b/reader-gtfs/src/main/java/com/graphhopper/gtfs/GraphHopperGtfs.java
@@ -181,18 +181,18 @@ public class GraphHopperGtfs extends GraphHopperOSM {
                                 t.transfer.min_transfer_time = (int) (t.time / 1000L);
                                 gtfsFeed.transfers.put(t.id, t.transfer);
                             });
-                    LOGGER.info("Building transit graph for feed {}", gtfsFeed.feedId);
-                    gtfsReader.buildPtNetwork();
                     readers.put(id, gtfsReader);
                 });
+                //
+                streetNetworkIndex.close();
+                LocationIndexTree locationIndex = new LocationIndexTree(getGraphHopperStorage(), getGraphHopperStorage().getDirectory());
+                locationIndex.prepareIndex();
+                setLocationIndex(locationIndex);
+                readers.forEach((id, gtfsReader) -> gtfsReader.buildPtNetwork());
                 insertTransfersBetweenFeeds(readers);
             } catch (Exception e) {
                 throw new RuntimeException("Error while constructing transit network. Is your GTFS file valid? Please check log for possible causes.", e);
             }
-            streetNetworkIndex.close();
-            LocationIndexTree locationIndex = new LocationIndexTree(getGraphHopperStorage(), getGraphHopperStorage().getDirectory());
-            locationIndex.prepareIndex();
-            setLocationIndex(locationIndex);
         }
     }
 

--- a/reader-gtfs/src/main/java/com/graphhopper/gtfs/GtfsReader.java
+++ b/reader-gtfs/src/main/java/com/graphhopper/gtfs/GtfsReader.java
@@ -138,6 +138,8 @@ class GtfsReader {
     }
 
     void buildPtNetwork() {
+        LOGGER.info("Building transit graph for feed {}", feed.feedId);
+        i = graph.getNodes();
         createTrips();
         wireUpStops();
         insertGtfsTransfers();


### PR DESCRIPTION
For PT, I've been building a LocationIndex that contains the entire Graph, including all the inner nodes and edges of the PT model, even though they are never returned by a location query: Trips can only start and end on the street network, and I always use a Filter to ensure that.

My LocationIndex for Berlin is 100 MB. With only the street network, it is 6 MB. The rest is junk.

I can easily add the PT part of the Graph **after** building the LocationIndex (this PR). The only reason I haven't been doing that until now is because, later, the LocationIndex refuses to load with a Graph that has had stuff added afterwards, because it uses the number of nodes as a checksum.

May I remove this feature (happens in this PR)? I tried hard, but I can't think of any other way to avoid putting 90% junk information into the LocationIndex. Do you have any idea what else we could use as a checksum, that would survive adding additional stuff to the Graph?