### PR TITLE
Remove Activation dependency

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -21,11 +21,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>activation</artifactId>
-            <version>1.1.1</version>
-        </dependency>
-        <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-core</artifactId>
         </dependency>


### PR DESCRIPTION
Related to #1388 

According to https://github.com/dropwizard/dropwizard/issues/2318 the issue was fixed with DW 2.0, so we should not need this dependency anymore?

I couldn't see errors when starting the webserver locally.