### PR TITLE
Force english locale for reader-gtfs tests

### DIFF
--- a/reader-gtfs/pom.xml
+++ b/reader-gtfs/pom.xml
@@ -96,7 +96,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <!-- Currently we need a bit more memory than for other tests -->
                 <configuration>
-                    <argLine>-Xmx1200m -Xms1200m</argLine>
+                    <argLine>-Xmx1200m -Xms1200m -Duser.language=en</argLine>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
We set it explicitly in the parent POM to avoid locale issues when matching message contents in unittests:

https://github.com/graphhopper/graphhopper/blob/f15a52c2b9ccfc3bd7aea39617fe0bec5486e860/pom.xml#L183-L190

As the reader-gtfs POM overrides the argLine, we need to set it here as well.