### PR TITLE
removed AbstractFlagEncoder.speedDefault and flagsDefault()

### DIFF
--- a/core/files/changelog.txt
+++ b/core/files/changelog.txt
@@ -1,4 +1,5 @@
 3.0
+	renamed GHUtilities.setProperties to setSpeed
     the name of an encoded value can only contain lower letters, underscore or numbers. It has to start with a lower letter
     default for GraphHopperMatrixWeb (client for Matrix API) is now the sync POST request without the artificial polling delay in most cases
     refactored TransportationMode to better reflect the usage in source data parsing only

--- a/core/src/main/java/com/graphhopper/routing/ev/DecimalEncodedValue.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/DecimalEncodedValue.java
@@ -25,9 +25,4 @@ public interface DecimalEncodedValue extends EncodedValue {
      * The double value this EncodedValue accepts for setDecimal without throwing an exception.
      */
     double getMaxDecimal();
-
-    /**
-     * @return true if this EncodedValue can store a different value for its reverse direction
-     */
-    boolean isStoreTwoDirections();
 }

--- a/core/src/main/java/com/graphhopper/routing/ev/EncodedValue.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/EncodedValue.java
@@ -45,6 +45,11 @@ public interface EncodedValue {
      */
     int getVersion();
 
+    /**
+     * @return true if this EncodedValue can store a different value for its reverse direction
+     */
+    boolean isStoreTwoDirections();
+
     class InitializerConfig {
         int dataIndex = -1;
         int shift = 32;

--- a/core/src/main/java/com/graphhopper/routing/querygraph/QueryGraph.java
+++ b/core/src/main/java/com/graphhopper/routing/querygraph/QueryGraph.java
@@ -277,11 +277,6 @@ public class QueryGraph implements Graph {
     }
 
     @Override
-    public EdgeIteratorState edge(int a, int b, double distance, boolean bothDirections) {
-        throw exc();
-    }
-
-    @Override
     public Graph copyTo(Graph g) {
         throw exc();
     }

--- a/core/src/main/java/com/graphhopper/routing/querygraph/VirtualEdgeIterator.java
+++ b/core/src/main/java/com/graphhopper/routing/querygraph/VirtualEdgeIterator.java
@@ -139,6 +139,12 @@ class VirtualEdgeIterator implements EdgeIterator {
     }
 
     @Override
+    public EdgeIteratorState set(BooleanEncodedValue property, boolean fwd, boolean bwd) {
+        getCurrentEdge().set(property, fwd, bwd);
+        return this;
+    }
+
+    @Override
     public EdgeIteratorState set(IntEncodedValue property, int value) {
         getCurrentEdge().set(property, value);
         return this;
@@ -158,6 +164,12 @@ class VirtualEdgeIterator implements EdgeIterator {
     @Override
     public int getReverse(IntEncodedValue property) {
         return getCurrentEdge().getReverse(property);
+    }
+
+    @Override
+    public EdgeIteratorState set(IntEncodedValue property, int fwd, int bwd) {
+        getCurrentEdge().set(property, fwd, bwd);
+        return this;
     }
 
     @Override
@@ -183,6 +195,12 @@ class VirtualEdgeIterator implements EdgeIterator {
     }
 
     @Override
+    public EdgeIteratorState set(DecimalEncodedValue property, double fwd, double bwd) {
+        getCurrentEdge().set(property, fwd, bwd);
+        return this;
+    }
+
+    @Override
     public <T extends Enum> EdgeIteratorState set(EnumEncodedValue<T> property, T value) {
         getCurrentEdge().set(property, value);
         return this;
@@ -202,6 +220,12 @@ class VirtualEdgeIterator implements EdgeIterator {
     @Override
     public <T extends Enum> T getReverse(EnumEncodedValue<T> property) {
         return getCurrentEdge().getReverse(property);
+    }
+
+    @Override
+    public <T extends Enum> EdgeIteratorState set(EnumEncodedValue<T> property, T fwd, T bwd) {
+        getCurrentEdge().set(property, fwd, bwd);
+        return this;
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/querygraph/VirtualEdgeIteratorState.java
+++ b/core/src/main/java/com/graphhopper/routing/querygraph/VirtualEdgeIteratorState.java
@@ -172,8 +172,10 @@ public class VirtualEdgeIteratorState implements EdgeIteratorState {
 
     @Override
     public EdgeIteratorState set(BooleanEncodedValue property, boolean fwd, boolean bwd) {
+        if (!property.isStoreTwoDirections())
+            throw new IllegalArgumentException("EncodedValue " + property.getName() + " supports only one direction");
         property.setBool(reverse, edgeFlags, fwd);
-        if (property.isStoreTwoDirections()) property.setBool(!reverse, edgeFlags, bwd);
+        property.setBool(!reverse, edgeFlags, bwd);
         return this;
     }
 
@@ -201,8 +203,10 @@ public class VirtualEdgeIteratorState implements EdgeIteratorState {
 
     @Override
     public EdgeIteratorState set(IntEncodedValue property, int fwd, int bwd) {
+        if (!property.isStoreTwoDirections())
+            throw new IllegalArgumentException("EncodedValue " + property.getName() + " supports only one direction");
         property.setInt(reverse, edgeFlags, fwd);
-        if (property.isStoreTwoDirections()) property.setInt(!reverse, edgeFlags, bwd);
+        property.setInt(!reverse, edgeFlags, bwd);
         return this;
     }
 
@@ -230,8 +234,10 @@ public class VirtualEdgeIteratorState implements EdgeIteratorState {
 
     @Override
     public EdgeIteratorState set(DecimalEncodedValue property, double fwd, double bwd) {
+        if (!property.isStoreTwoDirections())
+            throw new IllegalArgumentException("EncodedValue " + property.getName() + " supports only one direction");
         property.setDecimal(reverse, edgeFlags, fwd);
-        if (property.isStoreTwoDirections()) property.setDecimal(!reverse, edgeFlags, bwd);
+        property.setDecimal(!reverse, edgeFlags, bwd);
         return this;
     }
 
@@ -259,8 +265,10 @@ public class VirtualEdgeIteratorState implements EdgeIteratorState {
 
     @Override
     public <T extends Enum> EdgeIteratorState set(EnumEncodedValue<T> property, T fwd, T bwd) {
+        if (!property.isStoreTwoDirections())
+            throw new IllegalArgumentException("EncodedValue " + property.getName() + " supports only one direction");
         property.setEnum(reverse, edgeFlags, fwd);
-        if (property.isStoreTwoDirections()) property.setEnum(!reverse, edgeFlags, bwd);
+        property.setEnum(!reverse, edgeFlags, bwd);
         return this;
     }
 

--- a/core/src/main/java/com/graphhopper/routing/querygraph/VirtualEdgeIteratorState.java
+++ b/core/src/main/java/com/graphhopper/routing/querygraph/VirtualEdgeIteratorState.java
@@ -171,6 +171,13 @@ public class VirtualEdgeIteratorState implements EdgeIteratorState {
     }
 
     @Override
+    public EdgeIteratorState set(BooleanEncodedValue property, boolean fwd, boolean bwd) {
+        property.setBool(reverse, edgeFlags, fwd);
+        if (property.isStoreTwoDirections()) property.setBool(!reverse, edgeFlags, bwd);
+        return this;
+    }
+
+    @Override
     public int get(IntEncodedValue property) {
         return property.getInt(reverse, edgeFlags);
     }
@@ -189,6 +196,13 @@ public class VirtualEdgeIteratorState implements EdgeIteratorState {
     @Override
     public EdgeIteratorState setReverse(IntEncodedValue property, int value) {
         property.setInt(!reverse, edgeFlags, value);
+        return this;
+    }
+
+    @Override
+    public EdgeIteratorState set(IntEncodedValue property, int fwd, int bwd) {
+        property.setInt(reverse, edgeFlags, fwd);
+        if (property.isStoreTwoDirections()) property.setInt(!reverse, edgeFlags, bwd);
         return this;
     }
 
@@ -215,6 +229,13 @@ public class VirtualEdgeIteratorState implements EdgeIteratorState {
     }
 
     @Override
+    public EdgeIteratorState set(DecimalEncodedValue property, double fwd, double bwd) {
+        property.setDecimal(reverse, edgeFlags, fwd);
+        if (property.isStoreTwoDirections()) property.setDecimal(!reverse, edgeFlags, bwd);
+        return this;
+    }
+
+    @Override
     public <T extends Enum> T get(EnumEncodedValue<T> property) {
         return property.getEnum(reverse, edgeFlags);
     }
@@ -233,6 +254,13 @@ public class VirtualEdgeIteratorState implements EdgeIteratorState {
     @Override
     public <T extends Enum> EdgeIteratorState setReverse(EnumEncodedValue<T> property, T value) {
         property.setEnum(!reverse, edgeFlags, value);
+        return this;
+    }
+
+    @Override
+    public <T extends Enum> EdgeIteratorState set(EnumEncodedValue<T> property, T fwd, T bwd) {
+        property.setEnum(reverse, edgeFlags, fwd);
+        if (property.isStoreTwoDirections()) property.setEnum(!reverse, edgeFlags, bwd);
         return this;
     }
 

--- a/core/src/main/java/com/graphhopper/routing/util/AbstractFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/AbstractFlagEncoder.java
@@ -54,7 +54,6 @@ public abstract class AbstractFlagEncoder implements FlagEncoder {
     protected final Set<String> potentialBarriers = new HashSet<>(5);
     protected final int speedBits;
     protected final double speedFactor;
-    protected double speedDefault;
     private final int maxTurnCosts;
     private long encoderBit;
     protected BooleanEncodedValue accessEnc;
@@ -205,18 +204,6 @@ public abstract class AbstractFlagEncoder implements FlagEncoder {
         }
 
         return 0;
-    }
-
-    /**
-     * Sets default flags with specified access.
-     */
-    protected void flagsDefault(IntsRef edgeFlags, boolean forward, boolean backward) {
-        if (forward)
-            avgSpeedEnc.setDecimal(false, edgeFlags, speedDefault);
-        if (backward && avgSpeedEnc.isStoreTwoDirections())
-            avgSpeedEnc.setDecimal(true, edgeFlags, speedDefault);
-        accessEnc.setBool(false, edgeFlags, forward);
-        accessEnc.setBool(true, edgeFlags, backward);
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
@@ -177,7 +177,6 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
         routeMap.put(REGIONAL, VERY_NICE.getValue());
         routeMap.put(LOCAL, PREFER.getValue());
 
-        speedDefault = highwaySpeeds.get("cycleway");
         setAvoidSpeedLimit(71);
     }
 

--- a/core/src/main/java/com/graphhopper/routing/util/CarFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/CarFlagEncoder.java
@@ -139,7 +139,6 @@ public class CarFlagEncoder extends AbstractFlagEncoder {
         // limit speed on bad surfaces to 30 km/h
         badSurfaceSpeed = 30;
         maxPossibleSpeed = 140;
-        speedDefault = defaultSpeedMap.get("secondary");
     }
 
     public CarFlagEncoder setSpeedTwoDirections(boolean value) {

--- a/core/src/main/java/com/graphhopper/routing/util/EncodingManager.java
+++ b/core/src/main/java/com/graphhopper/routing/util/EncodingManager.java
@@ -673,14 +673,6 @@ public class EncodingManager implements EncodedValueLookup {
         return new IntsRef(2);
     }
 
-    public IntsRef flagsDefault(boolean forward, boolean backward) {
-        IntsRef intsRef = createEdgeFlags();
-        for (AbstractFlagEncoder encoder : edgeEncoders) {
-            encoder.flagsDefault(intsRef, forward, backward);
-        }
-        return intsRef;
-    }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/core/src/main/java/com/graphhopper/routing/util/FootFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/FootFlagEncoder.java
@@ -135,7 +135,6 @@ public class FootFlagEncoder extends AbstractFlagEncoder {
         allowedSacScale.add("demanding_mountain_hiking");
 
         maxPossibleSpeed = FERRY_SPEED;
-        speedDefault = MEAN_SPEED;
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/util/WheelchairFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/WheelchairFlagEncoder.java
@@ -102,7 +102,6 @@ public class WheelchairFlagEncoder extends FootFlagEncoder {
         allowedHighwayTags.add("road");
 
         maxPossibleSpeed = FERRY_SPEED;
-        speedDefault = MEAN_SPEED;
         speedTwoDirections = true;
     }
 

--- a/core/src/main/java/com/graphhopper/storage/BaseGraph.java
+++ b/core/src/main/java/com/graphhopper/storage/BaseGraph.java
@@ -1131,6 +1131,15 @@ class BaseGraph implements Graph {
         }
 
         @Override
+        public EdgeIteratorState set(BooleanEncodedValue property, boolean fwd, boolean bwd) {
+            property.setBool(reverse, getFlags(), fwd);
+            if (property.isStoreTwoDirections())
+                property.setBool(!reverse, getFlags(), bwd);
+            baseGraph.writeFlags(edgePointer, getFlags());
+            return this;
+        }
+
+        @Override
         public int get(IntEncodedValue property) {
             return property.getInt(reverse, getFlags());
         }
@@ -1150,6 +1159,15 @@ class BaseGraph implements Graph {
         @Override
         public EdgeIteratorState setReverse(IntEncodedValue property, int value) {
             property.setInt(!reverse, getFlags(), value);
+            baseGraph.writeFlags(edgePointer, getFlags());
+            return this;
+        }
+
+        @Override
+        public EdgeIteratorState set(IntEncodedValue property, int fwd, int bwd) {
+            property.setInt(reverse, getFlags(), fwd);
+            if (property.isStoreTwoDirections())
+                property.setInt(!reverse, getFlags(), bwd);
             baseGraph.writeFlags(edgePointer, getFlags());
             return this;
         }
@@ -1179,6 +1197,15 @@ class BaseGraph implements Graph {
         }
 
         @Override
+        public EdgeIteratorState set(DecimalEncodedValue property, double fwd, double bwd) {
+            property.setDecimal(reverse, getFlags(), fwd);
+            if (property.isStoreTwoDirections())
+                property.setDecimal(!reverse, getFlags(), bwd);
+            baseGraph.writeFlags(edgePointer, getFlags());
+            return this;
+        }
+
+        @Override
         public <T extends Enum> T get(EnumEncodedValue<T> property) {
             return property.getEnum(reverse, getFlags());
         }
@@ -1198,6 +1225,15 @@ class BaseGraph implements Graph {
         @Override
         public <T extends Enum> EdgeIteratorState setReverse(EnumEncodedValue<T> property, T value) {
             property.setEnum(!reverse, getFlags(), value);
+            baseGraph.writeFlags(edgePointer, getFlags());
+            return this;
+        }
+
+        @Override
+        public <T extends Enum> EdgeIteratorState set(EnumEncodedValue<T> property, T fwd, T bwd) {
+            property.setEnum(reverse, getFlags(), fwd);
+            if (property.isStoreTwoDirections())
+                property.setEnum(!reverse, getFlags(), bwd);
             baseGraph.writeFlags(edgePointer, getFlags());
             return this;
         }

--- a/core/src/main/java/com/graphhopper/storage/BaseGraph.java
+++ b/core/src/main/java/com/graphhopper/storage/BaseGraph.java
@@ -1132,9 +1132,10 @@ class BaseGraph implements Graph {
 
         @Override
         public EdgeIteratorState set(BooleanEncodedValue property, boolean fwd, boolean bwd) {
+            if (!property.isStoreTwoDirections())
+                throw new IllegalArgumentException("EncodedValue " + property.getName() + " supports only one direction");
             property.setBool(reverse, getFlags(), fwd);
-            if (property.isStoreTwoDirections())
-                property.setBool(!reverse, getFlags(), bwd);
+            property.setBool(!reverse, getFlags(), bwd);
             baseGraph.writeFlags(edgePointer, getFlags());
             return this;
         }
@@ -1165,9 +1166,10 @@ class BaseGraph implements Graph {
 
         @Override
         public EdgeIteratorState set(IntEncodedValue property, int fwd, int bwd) {
+            if (!property.isStoreTwoDirections())
+                throw new IllegalArgumentException("EncodedValue " + property.getName() + " supports only one direction");
             property.setInt(reverse, getFlags(), fwd);
-            if (property.isStoreTwoDirections())
-                property.setInt(!reverse, getFlags(), bwd);
+            property.setInt(!reverse, getFlags(), bwd);
             baseGraph.writeFlags(edgePointer, getFlags());
             return this;
         }
@@ -1198,9 +1200,10 @@ class BaseGraph implements Graph {
 
         @Override
         public EdgeIteratorState set(DecimalEncodedValue property, double fwd, double bwd) {
+            if (!property.isStoreTwoDirections())
+                throw new IllegalArgumentException("EncodedValue " + property.getName() + " supports only one direction");
             property.setDecimal(reverse, getFlags(), fwd);
-            if (property.isStoreTwoDirections())
-                property.setDecimal(!reverse, getFlags(), bwd);
+            property.setDecimal(!reverse, getFlags(), bwd);
             baseGraph.writeFlags(edgePointer, getFlags());
             return this;
         }
@@ -1231,9 +1234,10 @@ class BaseGraph implements Graph {
 
         @Override
         public <T extends Enum> EdgeIteratorState set(EnumEncodedValue<T> property, T fwd, T bwd) {
+            if (!property.isStoreTwoDirections())
+                throw new IllegalArgumentException("EncodedValue " + property.getName() + " supports only one direction");
             property.setEnum(reverse, getFlags(), fwd);
-            if (property.isStoreTwoDirections())
-                property.setEnum(!reverse, getFlags(), bwd);
+            property.setEnum(!reverse, getFlags(), bwd);
             baseGraph.writeFlags(edgePointer, getFlags());
             return this;
         }

--- a/core/src/main/java/com/graphhopper/storage/BaseGraph.java
+++ b/core/src/main/java/com/graphhopper/storage/BaseGraph.java
@@ -245,7 +245,7 @@ class BaseGraph implements Graph {
         E_NODEB = nextEdgeEntryIndex(4);
         E_LINKA = nextEdgeEntryIndex(4);
         E_LINKB = nextEdgeEntryIndex(4);
-        E_FLAGS = nextEdgeEntryIndex(encodingManager.getIntsForFlags() * 4);
+        E_FLAGS = nextEdgeEntryIndex(intsForFlags * 4);
 
         E_DIST = nextEdgeEntryIndex(4);
         E_GEO = nextEdgeEntryIndex(4);
@@ -341,11 +341,6 @@ class BaseGraph implements Graph {
     @Override
     public BBox getBounds() {
         return bounds;
-    }
-
-    @Override
-    public EdgeIteratorState edge(int a, int b, double distance, boolean bothDirection) {
-        return edge(a, b).setDistance(distance).setFlags(encodingManager.flagsDefault(true, bothDirection));
     }
 
     private void setSegmentSize(int bytes) {

--- a/core/src/main/java/com/graphhopper/storage/CHGraphImpl.java
+++ b/core/src/main/java/com/graphhopper/storage/CHGraphImpl.java
@@ -841,6 +841,12 @@ public class CHGraphImpl implements CHGraph, Storable<CHGraph> {
         }
 
         @Override
+        public EdgeIteratorState set(BooleanEncodedValue property, boolean fwd, boolean bwd) {
+            checkShortcut(false, "set(BooleanEncodedValue, boolean, boolean)");
+            return edgeIterable.set(property, fwd, bwd);
+        }
+
+        @Override
         public int get(IntEncodedValue property) {
             checkShortcut(false, "get(IntEncodedValue)");
             return edgeIterable.get(property);
@@ -862,6 +868,12 @@ public class CHGraphImpl implements CHGraph, Storable<CHGraph> {
         public EdgeIteratorState setReverse(IntEncodedValue property, int value) {
             checkShortcut(false, "setReverse(IntEncodedValue, int)");
             return edgeIterable.setReverse(property, value);
+        }
+
+        @Override
+        public EdgeIteratorState set(IntEncodedValue property, int fwd, int bwd) {
+            checkShortcut(false, "set(IntEncodedValue, int, int)");
+            return edgeIterable.set(property, fwd, bwd);
         }
 
         @Override
@@ -889,6 +901,12 @@ public class CHGraphImpl implements CHGraph, Storable<CHGraph> {
         }
 
         @Override
+        public EdgeIteratorState set(DecimalEncodedValue property, double fwd, double bwd) {
+            checkShortcut(false, "set(DecimalEncodedValue, double, double)");
+            return edgeIterable.set(property, fwd, bwd);
+        }
+
+        @Override
         public <T extends Enum> T get(EnumEncodedValue<T> property) {
             checkShortcut(false, "get(EnumEncodedValue<T>)");
             return edgeIterable.get(property);
@@ -910,6 +928,12 @@ public class CHGraphImpl implements CHGraph, Storable<CHGraph> {
         public <T extends Enum> EdgeIteratorState setReverse(EnumEncodedValue<T> property, T value) {
             checkShortcut(false, "setReverse(EnumEncodedValue<T>, T)");
             return edgeIterable.setReverse(property, value);
+        }
+
+        @Override
+        public <T extends Enum> EdgeIteratorState set(EnumEncodedValue<T> property, T fwd, T bwd) {
+            checkShortcut(false, "set(EnumEncodedValue<T>, T, T)");
+            return edgeIterable.set(property, fwd, bwd);
         }
 
         @Override

--- a/core/src/main/java/com/graphhopper/storage/Graph.java
+++ b/core/src/main/java/com/graphhopper/storage/Graph.java
@@ -68,11 +68,6 @@ public interface Graph {
     EdgeIteratorState edge(int a, int b);
 
     /**
-     * Use edge(a,b).setDistance().setFlags instead
-     */
-    EdgeIteratorState edge(int a, int b, double distance, boolean bothDirections);
-
-    /**
      * Returns a wrapper over the specified edgeId.
      *
      * @param adjNode is the node that will be returned via getAdjNode(). If adjNode is

--- a/core/src/main/java/com/graphhopper/storage/GraphHopperStorage.java
+++ b/core/src/main/java/com/graphhopper/storage/GraphHopperStorage.java
@@ -386,11 +386,6 @@ public final class GraphHopperStorage implements GraphStorage, Graph {
     }
 
     @Override
-    public EdgeIteratorState edge(int a, int b, double distance, boolean bothDirections) {
-        return baseGraph.edge(a, b, distance, bothDirections);
-    }
-
-    @Override
     public EdgeIteratorState getEdgeIteratorState(int edgeId, int adjNode) {
         return baseGraph.getEdgeIteratorState(edgeId, adjNode);
     }

--- a/core/src/main/java/com/graphhopper/util/EdgeIteratorState.java
+++ b/core/src/main/java/com/graphhopper/util/EdgeIteratorState.java
@@ -66,6 +66,11 @@ public interface EdgeIteratorState {
         public void setBool(boolean reverse, IntsRef ref, boolean value) {
             throw new IllegalStateException("reverse state cannot be modified");
         }
+
+        @Override
+        public boolean isStoreTwoDirections() {
+            return false;
+        }
     };
 
     /**
@@ -155,6 +160,8 @@ public interface EdgeIteratorState {
 
     EdgeIteratorState setReverse(BooleanEncodedValue property, boolean value);
 
+    EdgeIteratorState set(BooleanEncodedValue property, boolean fwd, boolean bwd);
+
     int get(IntEncodedValue property);
 
     EdgeIteratorState set(IntEncodedValue property, int value);
@@ -162,6 +169,8 @@ public interface EdgeIteratorState {
     int getReverse(IntEncodedValue property);
 
     EdgeIteratorState setReverse(IntEncodedValue property, int value);
+
+    EdgeIteratorState set(IntEncodedValue property, int fwd, int bwd);
 
     double get(DecimalEncodedValue property);
 
@@ -171,6 +180,8 @@ public interface EdgeIteratorState {
 
     EdgeIteratorState setReverse(DecimalEncodedValue property, double value);
 
+    EdgeIteratorState set(DecimalEncodedValue property, double fwd, double bwd);
+
     <T extends Enum> T get(EnumEncodedValue<T> property);
 
     <T extends Enum> EdgeIteratorState set(EnumEncodedValue<T> property, T value);
@@ -178,6 +189,8 @@ public interface EdgeIteratorState {
     <T extends Enum> T getReverse(EnumEncodedValue<T> property);
 
     <T extends Enum> EdgeIteratorState setReverse(EnumEncodedValue<T> property, T value);
+
+    <T extends Enum> EdgeIteratorState set(EnumEncodedValue<T> property, T fwd, T bwd);
 
     String getName();
 

--- a/core/src/main/java/com/graphhopper/util/GHUtility.java
+++ b/core/src/main/java/com/graphhopper/util/GHUtility.java
@@ -819,6 +819,11 @@ public class GHUtility {
         }
 
         @Override
+        public EdgeIteratorState set(BooleanEncodedValue property, boolean fwd, boolean bwd) {
+            throw new UnsupportedOperationException("Not supported. Edge is empty.");
+        }
+
+        @Override
         public int get(IntEncodedValue property) {
             throw new UnsupportedOperationException("Not supported. Edge is empty.");
         }
@@ -835,6 +840,11 @@ public class GHUtility {
 
         @Override
         public EdgeIteratorState setReverse(IntEncodedValue property, int value) {
+            throw new UnsupportedOperationException("Not supported. Edge is empty.");
+        }
+
+        @Override
+        public EdgeIteratorState set(IntEncodedValue property, int fwd, int bwd) {
             throw new UnsupportedOperationException("Not supported. Edge is empty.");
         }
 
@@ -859,6 +869,11 @@ public class GHUtility {
         }
 
         @Override
+        public EdgeIteratorState set(DecimalEncodedValue property, double fwd, double bwd) {
+            throw new UnsupportedOperationException("Not supported. Edge is empty.");
+        }
+
+        @Override
         public <T extends Enum> T get(EnumEncodedValue<T> property) {
             throw new UnsupportedOperationException("Not supported. Edge is empty.");
         }
@@ -875,6 +890,11 @@ public class GHUtility {
 
         @Override
         public <T extends Enum> EdgeIteratorState setReverse(EnumEncodedValue<T> property, T value) {
+            throw new UnsupportedOperationException("Not supported. Edge is empty.");
+        }
+
+        @Override
+        public <T extends Enum> EdgeIteratorState set(EnumEncodedValue<T> property, T fwd, T bwd) {
             throw new UnsupportedOperationException("Not supported. Edge is empty.");
         }
 

--- a/core/src/main/java/com/graphhopper/util/GHUtility.java
+++ b/core/src/main/java/com/graphhopper/util/GHUtility.java
@@ -634,8 +634,12 @@ public class GHUtility {
         if (fwdSpeed > 0)
             accessEnc.setBool(false, edgeFlags, true);
 
-        if (avgSpeedEnc.isStoreTwoDirections())
+        if (bwdSpeed > 0 && (fwdSpeed != bwdSpeed || avgSpeedEnc.isStoreTwoDirections())) {
+            if (!avgSpeedEnc.isStoreTwoDirections())
+                throw new IllegalArgumentException("EncodedValue " + avgSpeedEnc.getName() + " supports only one direction " +
+                        "but two different speeds were specified " + fwdSpeed + " " + bwdSpeed);
             avgSpeedEnc.setDecimal(true, edgeFlags, bwdSpeed);
+        }
         if (bwdSpeed > 0)
             accessEnc.setBool(true, edgeFlags, true);
         return edgeFlags;
@@ -655,8 +659,12 @@ public class GHUtility {
             if (fwdSpeed > 0)
                 edge.set(accessEnc, true);
 
-            if (avgSpeedEnc.isStoreTwoDirections())
+            if (bwdSpeed > 0 && (fwdSpeed != bwdSpeed || avgSpeedEnc.isStoreTwoDirections())) {
+                if (!avgSpeedEnc.isStoreTwoDirections())
+                    throw new IllegalArgumentException("EncodedValue " + avgSpeedEnc.getName() + " supports only one direction " +
+                            "but two different speeds were specified " + fwdSpeed + " " + bwdSpeed);
                 edge.setReverse(avgSpeedEnc, bwdSpeed);
+            }
             if (bwdSpeed > 0)
                 edge.setReverse(accessEnc, true);
         }

--- a/core/src/test/java/com/graphhopper/GraphHopperAPITest.java
+++ b/core/src/test/java/com/graphhopper/GraphHopperAPITest.java
@@ -44,8 +44,8 @@ public class GraphHopperAPITest {
         na.setNode(2, 42.1, 10.2);
         na.setNode(3, 42, 10.4);
 
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(10), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(10), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(10));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 3).setDistance(10));
     }
 
     @Test
@@ -61,9 +61,9 @@ public class GraphHopperAPITest {
         NodeAccess na = graph.getNodeAccess();
         na.setNode(4, 41.9, 10.2);
 
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(10), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(0, 4).setDistance(40), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(4, 3).setDistance(40), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 2).setDistance(10));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 4).setDistance(40));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 3).setDistance(40));
 
         GraphHopper instance = createGraphHopper(vehicle).
                 setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting)).
@@ -125,8 +125,8 @@ public class GraphHopperAPITest {
         na.setNode(2, 42.1, 10.2, 1);
         na.setNode(3, 42, 10.4, 1);
 
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(10), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(10), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(10));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 3).setDistance(10));
 
         final AtomicInteger counter = new AtomicInteger(0);
         GraphHopper instance = createGraphHopper(vehicle)

--- a/core/src/test/java/com/graphhopper/GraphHopperAPITest.java
+++ b/core/src/test/java/com/graphhopper/GraphHopperAPITest.java
@@ -19,9 +19,11 @@ package com.graphhopper;
 
 import com.graphhopper.config.Profile;
 import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.storage.GraphBuilder;
 import com.graphhopper.storage.GraphHopperStorage;
 import com.graphhopper.storage.NodeAccess;
+import com.graphhopper.util.GHUtility;
 import com.graphhopper.util.Helper;
 import com.graphhopper.util.PointList;
 import org.junit.Test;
@@ -35,15 +37,15 @@ import static org.junit.Assert.*;
  * @author Peter Karich
  */
 public class GraphHopperAPITest {
-    void initGraph(GraphHopperStorage graph) {
+    void initGraph(GraphHopperStorage graph, FlagEncoder encoder) {
         NodeAccess na = graph.getNodeAccess();
         na.setNode(0, 42, 10);
         na.setNode(1, 42.1, 10.1);
         na.setNode(2, 42.1, 10.2);
         na.setNode(3, 42, 10.4);
 
-        graph.edge(0, 1, 10, true);
-        graph.edge(2, 3, 10, true);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(10), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(10), encoder, 60, true, true);
     }
 
     @Test
@@ -51,15 +53,17 @@ public class GraphHopperAPITest {
         final String profile = "profile";
         final String vehicle = "car";
         final String weighting = "fastest";
-        GraphHopperStorage graph = new GraphBuilder(EncodingManager.create(vehicle)).create();
-        initGraph(graph);
+        EncodingManager em = EncodingManager.create(vehicle);
+        FlagEncoder encoder = em.getEncoder(vehicle);
+        GraphHopperStorage graph = new GraphBuilder(em).create();
+        initGraph(graph, encoder);
         // do further changes:
         NodeAccess na = graph.getNodeAccess();
         na.setNode(4, 41.9, 10.2);
 
-        graph.edge(1, 2, 10, false);
-        graph.edge(0, 4, 40, true);
-        graph.edge(4, 3, 40, true);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(10), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(0, 4).setDistance(40), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(4, 3).setDistance(40), encoder, 60, true, true);
 
         GraphHopper instance = createGraphHopper(vehicle).
                 setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting)).
@@ -85,8 +89,9 @@ public class GraphHopperAPITest {
         final String profile = "profile";
         final String vehicle = "car";
         final String weighting = "fastest";
-        GraphHopperStorage graph = new GraphBuilder(EncodingManager.create(vehicle)).create();
-        initGraph(graph);
+        EncodingManager em = EncodingManager.create(vehicle);
+        GraphHopperStorage graph = new GraphBuilder(em).create();
+        initGraph(graph, em.getEncoder(vehicle));
 
         GraphHopper instance = createGraphHopper(vehicle).
                 setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting)).
@@ -110,6 +115,7 @@ public class GraphHopperAPITest {
         String loc = "./target/issue1645";
         Helper.removeDir(new File(loc));
         EncodingManager encodingManager = EncodingManager.create(vehicle);
+        FlagEncoder encoder = encodingManager.getEncoder(vehicle);
         GraphHopperStorage graph = GraphBuilder.start(encodingManager).setRAM(loc, true).set3D(true).create();
 
         // we need elevation
@@ -119,8 +125,8 @@ public class GraphHopperAPITest {
         na.setNode(2, 42.1, 10.2, 1);
         na.setNode(3, 42, 10.4, 1);
 
-        graph.edge(0, 1, 10, true);
-        graph.edge(2, 3, 10, true);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(10), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(10), encoder, 60, true, true);
 
         final AtomicInteger counter = new AtomicInteger(0);
         GraphHopper instance = createGraphHopper(vehicle)

--- a/core/src/test/java/com/graphhopper/reader/PrincetonReader.java
+++ b/core/src/test/java/com/graphhopper/reader/PrincetonReader.java
@@ -17,7 +17,9 @@
  */
 package com.graphhopper.reader;
 
+import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.storage.Graph;
+import com.graphhopper.util.GHUtility;
 import com.graphhopper.util.Helper;
 
 import java.io.BufferedReader;
@@ -31,10 +33,12 @@ import java.io.InputStreamReader;
  * @author Peter Karich
  */
 public class PrincetonReader {
-    private Graph graph;
+    private final FlagEncoder encoder;
+    private final Graph graph;
     private InputStream is;
 
-    public PrincetonReader(Graph graph) {
+    public PrincetonReader(Graph graph, FlagEncoder encoder) {
+        this.encoder = encoder;
         this.graph = graph;
     }
 
@@ -81,7 +85,7 @@ public class PrincetonReader {
                     throw new RuntimeException("incorrect read!? from:" + from + ", to:" + to + ", dist:" + dist);
                 }
 
-                graph.edge(from, to, dist, false);
+                GHUtility.setProperties(graph.edge(from, to).setDistance(dist), encoder,60, true, false);
             }
         } catch (Exception ex) {
             throw new RuntimeException("Problem in line " + lineNo, ex);

--- a/core/src/test/java/com/graphhopper/reader/PrincetonReader.java
+++ b/core/src/test/java/com/graphhopper/reader/PrincetonReader.java
@@ -85,7 +85,7 @@ public class PrincetonReader {
                     throw new RuntimeException("incorrect read!? from:" + from + ", to:" + to + ", dist:" + dist);
                 }
 
-                GHUtility.setProperties(graph.edge(from, to).setDistance(dist), encoder,60, true, false);
+                GHUtility.setSpeed(60, true, false, encoder, graph.edge(from, to).setDistance(dist));
             }
         } catch (Exception ex) {
             throw new RuntimeException("Problem in line " + lineNo, ex);

--- a/core/src/test/java/com/graphhopper/reader/PrincetonReaderTest.java
+++ b/core/src/test/java/com/graphhopper/reader/PrincetonReaderTest.java
@@ -17,9 +17,7 @@
  */
 package com.graphhopper.reader;
 
-import com.graphhopper.routing.util.DefaultEdgeFilter;
-import com.graphhopper.routing.util.EdgeFilter;
-import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.routing.util.*;
 import com.graphhopper.storage.Graph;
 import com.graphhopper.storage.GraphBuilder;
 import com.graphhopper.util.EdgeExplorer;
@@ -37,13 +35,14 @@ import static org.junit.Assert.assertEquals;
  * @author Peter Karich
  */
 public class PrincetonReaderTest {
-    private EncodingManager encodingManager = EncodingManager.create("car");
-    private EdgeFilter carOutEdges = DefaultEdgeFilter.outEdges(encodingManager.getEncoder("car"));
+    private FlagEncoder encoder = new CarFlagEncoder();
+    private EncodingManager encodingManager = EncodingManager.create(encoder);
+    private EdgeFilter carOutEdges = DefaultEdgeFilter.outEdges(encoder);
 
     @Test
     public void testRead() {
         Graph graph = new GraphBuilder(encodingManager).create();
-        new PrincetonReader(graph).setStream(PrincetonReader.class.getResourceAsStream("tinyEWD.txt")).read();
+        new PrincetonReader(graph, encoder).setStream(PrincetonReader.class.getResourceAsStream("tinyEWD.txt")).read();
         assertEquals(8, graph.getNodes());
         EdgeExplorer explorer = graph.createEdgeExplorer(carOutEdges);
         assertEquals(2, count(explorer.setBaseNode(0)));
@@ -53,7 +52,7 @@ public class PrincetonReaderTest {
     @Test
     public void testMediumRead() throws IOException {
         Graph graph = new GraphBuilder(encodingManager).create();
-        new PrincetonReader(graph).setStream(new GZIPInputStream(PrincetonReader.class.getResourceAsStream("mediumEWD.txt.gz"))).read();
+        new PrincetonReader(graph, encoder).setStream(new GZIPInputStream(PrincetonReader.class.getResourceAsStream("mediumEWD.txt.gz"))).read();
         assertEquals(250, graph.getNodes());
         EdgeExplorer explorer = graph.createEdgeExplorer(carOutEdges);
         assertEquals(13, count(explorer.setBaseNode(244)));

--- a/core/src/test/java/com/graphhopper/reader/dem/BridgeElevationInterpolatorTest.java
+++ b/core/src/test/java/com/graphhopper/reader/dem/BridgeElevationInterpolatorTest.java
@@ -20,12 +20,10 @@ package com.graphhopper.reader.dem;
 import com.graphhopper.coll.GHIntHashSet;
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.RoadEnvironment;
+import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.storage.IntsRef;
 import com.graphhopper.storage.NodeAccess;
-import com.graphhopper.util.EdgeIteratorState;
-import com.graphhopper.util.FetchMode;
-import com.graphhopper.util.Helper;
-import com.graphhopper.util.PointList;
+import com.graphhopper.util.*;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -75,17 +73,19 @@ public class BridgeElevationInterpolatorTest extends EdgeElevationInterpolatorTe
         na.setNode(8, 30, 10, 10);
         na.setNode(9, 40, 10, 0);
 
-        EdgeIteratorState edge01 = graph.edge(0, 1, 10, true);
-        EdgeIteratorState edge12 = graph.edge(1, 2, 10, true);
-        EdgeIteratorState edge23 = graph.edge(2, 3, 10, true);
-        EdgeIteratorState edge34 = graph.edge(3, 4, 10, true);
-        EdgeIteratorState edge56 = graph.edge(5, 6, 10, true);
-        EdgeIteratorState edge67 = graph.edge(6, 7, 10, true);
-        EdgeIteratorState edge78 = graph.edge(7, 8, 10, true);
-        EdgeIteratorState edge89 = graph.edge(8, 9, 10, true);
-        EdgeIteratorState edge17 = graph.edge(1, 7, 10, true);
-        EdgeIteratorState edge27 = graph.edge(2, 7, 10, true);
-        EdgeIteratorState edge37 = graph.edge(3, 7, 10, true);
+        FlagEncoder encoder = encodingManager.getEncoder("car");
+        EdgeIteratorState edge01 = GHUtility.setProperties(graph.edge(0, 1).setDistance(10), encoder, 60, true, true);
+        EdgeIteratorState edge12 = GHUtility.setProperties(graph.edge(1, 2).setDistance(10), encoder, 60, true, true);
+        EdgeIteratorState edge23 = GHUtility.setProperties(graph.edge(2, 3).setDistance(10), encoder, 60, true, true);
+        EdgeIteratorState edge34 = GHUtility.setProperties(graph.edge(3, 4).setDistance(10), encoder, 60, true, true);
+        EdgeIteratorState edge56 = GHUtility.setProperties(graph.edge(5, 6).setDistance(10), encoder, 60, true, true);
+        EdgeIteratorState edge67 = GHUtility.setProperties(graph.edge(6, 7).setDistance(10), encoder, 60, true, true);
+        EdgeIteratorState edge78 = GHUtility.setProperties(graph.edge(7, 8).setDistance(10), encoder, 60, true, true);
+        EdgeIteratorState edge89 = GHUtility.setProperties(graph.edge(8, 9).setDistance(10), encoder, 60, true, true);
+        EdgeIteratorState edge17 = GHUtility.setProperties(graph.edge(1, 7).setDistance(10), encoder, 60, true, true);
+        EdgeIteratorState edge27 = GHUtility.setProperties(graph.edge(2, 7).setDistance(10), encoder, 60, true, true);
+        EdgeIteratorState edge37 = GHUtility.setProperties(graph.edge(3, 7).setDistance(10), encoder, 60, true, true);
+
         edge17.setWayGeometry(Helper.createPointList3D(12, 2, 200, 14, 4, 400, 16, 6, 600, 18, 8, 800));
 
         IntsRef relFlags = encodingManager.createRelationFlags();

--- a/core/src/test/java/com/graphhopper/reader/dem/BridgeElevationInterpolatorTest.java
+++ b/core/src/test/java/com/graphhopper/reader/dem/BridgeElevationInterpolatorTest.java
@@ -74,17 +74,19 @@ public class BridgeElevationInterpolatorTest extends EdgeElevationInterpolatorTe
         na.setNode(9, 40, 10, 0);
 
         FlagEncoder encoder = encodingManager.getEncoder("car");
-        EdgeIteratorState edge01 = GHUtility.setProperties(graph.edge(0, 1).setDistance(10), encoder, 60, true, true);
-        EdgeIteratorState edge12 = GHUtility.setProperties(graph.edge(1, 2).setDistance(10), encoder, 60, true, true);
-        EdgeIteratorState edge23 = GHUtility.setProperties(graph.edge(2, 3).setDistance(10), encoder, 60, true, true);
-        EdgeIteratorState edge34 = GHUtility.setProperties(graph.edge(3, 4).setDistance(10), encoder, 60, true, true);
-        EdgeIteratorState edge56 = GHUtility.setProperties(graph.edge(5, 6).setDistance(10), encoder, 60, true, true);
-        EdgeIteratorState edge67 = GHUtility.setProperties(graph.edge(6, 7).setDistance(10), encoder, 60, true, true);
-        EdgeIteratorState edge78 = GHUtility.setProperties(graph.edge(7, 8).setDistance(10), encoder, 60, true, true);
-        EdgeIteratorState edge89 = GHUtility.setProperties(graph.edge(8, 9).setDistance(10), encoder, 60, true, true);
-        EdgeIteratorState edge17 = GHUtility.setProperties(graph.edge(1, 7).setDistance(10), encoder, 60, true, true);
-        EdgeIteratorState edge27 = GHUtility.setProperties(graph.edge(2, 7).setDistance(10), encoder, 60, true, true);
-        EdgeIteratorState edge37 = GHUtility.setProperties(graph.edge(3, 7).setDistance(10), encoder, 60, true, true);
+        EdgeIteratorState edge01, edge12, edge23, edge34, edge56, edge67, edge78, edge89, edge17, edge27, edge37;
+        GHUtility.setSpeed(60, 60, encoder,
+                edge01 = graph.edge(0, 1).setDistance(10),
+                edge12 = graph.edge(1, 2).setDistance(10),
+                edge23 = graph.edge(2, 3).setDistance(10),
+                edge34 = graph.edge(3, 4).setDistance(10),
+                edge56 = graph.edge(5, 6).setDistance(10),
+                edge67 = graph.edge(6, 7).setDistance(10),
+                edge78 = graph.edge(7, 8).setDistance(10),
+                edge89 = graph.edge(8, 9).setDistance(10),
+                edge17 = graph.edge(1, 7).setDistance(10),
+                edge27 = graph.edge(2, 7).setDistance(10),
+                edge37 = graph.edge(3, 7).setDistance(10));
 
         edge17.setWayGeometry(Helper.createPointList3D(12, 2, 200, 14, 4, 400, 16, 6, 600, 18, 8, 800));
 

--- a/core/src/test/java/com/graphhopper/reader/dem/TunnelElevationInterpolatorTest.java
+++ b/core/src/test/java/com/graphhopper/reader/dem/TunnelElevationInterpolatorTest.java
@@ -64,9 +64,9 @@ public class TunnelElevationInterpolatorTest extends EdgeElevationInterpolatorTe
         na.setNode(4, 40, 0, 0);
 
         FlagEncoder encoder = encodingManager.getEncoder("car");
-        EdgeIteratorState edge01 = GHUtility.setProperties(graph.edge(0, 1).setDistance(10), encoder, 60, true, true);
-        EdgeIteratorState edge12 = GHUtility.setProperties(graph.edge(1, 2).setDistance(10), encoder, 60, true, true);
-        EdgeIteratorState edge34 = GHUtility.setProperties(graph.edge(3, 4).setDistance(10), encoder, 60, true, true);
+        EdgeIteratorState edge01 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(10));
+        EdgeIteratorState edge12 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(10));
+        EdgeIteratorState edge34 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 4).setDistance(10));
 
         edge01.setFlags(encodingManager.handleWayTags(interpolatableWay, ACCEPT_WAY, relFlags));
         edge12.setFlags(encodingManager.handleWayTags(interpolatableWay, ACCEPT_WAY, relFlags));
@@ -104,10 +104,10 @@ public class TunnelElevationInterpolatorTest extends EdgeElevationInterpolatorTe
         na.setNode(4, 40, 0, 00);
 
         FlagEncoder encoder = encodingManager.getEncoder("car");
-        EdgeIteratorState edge01 = GHUtility.setProperties(graph.edge(0, 1).setDistance(10), encoder, 60, true, true);
-        EdgeIteratorState edge12 = GHUtility.setProperties(graph.edge(1, 2).setDistance(10), encoder, 60, true, true);
-        EdgeIteratorState edge23 = GHUtility.setProperties(graph.edge(2, 3).setDistance(10), encoder, 60, true, true);
-        EdgeIteratorState edge34 = GHUtility.setProperties(graph.edge(3, 4).setDistance(10), encoder, 60, true, true);
+        EdgeIteratorState edge01 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(10));
+        EdgeIteratorState edge12 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(10));
+        EdgeIteratorState edge23 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 3).setDistance(10));
+        EdgeIteratorState edge34 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 4).setDistance(10));
 
         edge01.setFlags(encodingManager.handleWayTags(interpolatableWay, ACCEPT_WAY, relFlags));
         edge12.setFlags(encodingManager.handleWayTags(interpolatableWay, ACCEPT_WAY, relFlags));
@@ -146,10 +146,10 @@ public class TunnelElevationInterpolatorTest extends EdgeElevationInterpolatorTe
         na.setNode(4, 40, 0, 40);
 
         FlagEncoder encoder = encodingManager.getEncoder("car");
-        EdgeIteratorState edge01 = GHUtility.setProperties(graph.edge(0, 1).setDistance(10), encoder, 60, true, true);
-        EdgeIteratorState edge12 = GHUtility.setProperties(graph.edge(1, 2).setDistance(10), encoder, 60, true, true);
-        EdgeIteratorState edge23 = GHUtility.setProperties(graph.edge(2, 3).setDistance(10), encoder, 60, true, true);
-        EdgeIteratorState edge34 = GHUtility.setProperties(graph.edge(3, 4).setDistance(10), encoder, 60, true, true);
+        EdgeIteratorState edge01 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(10));
+        EdgeIteratorState edge12 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(10));
+        EdgeIteratorState edge23 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 3).setDistance(10));
+        EdgeIteratorState edge34 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 4).setDistance(10));
 
         edge01.setFlags(encodingManager.handleWayTags(normalWay, ACCEPT_WAY, relFlags));
         edge12.setFlags(encodingManager.handleWayTags(interpolatableWay, ACCEPT_WAY, relFlags));
@@ -197,13 +197,13 @@ public class TunnelElevationInterpolatorTest extends EdgeElevationInterpolatorTe
         na.setNode(7, 40, 10, 40);
 
         FlagEncoder encoder = encodingManager.getEncoder("car");
-        EdgeIteratorState edge01 = GHUtility.setProperties(graph.edge(0, 1).setDistance(10), encoder, 60, true, true);
-        EdgeIteratorState edge12 = GHUtility.setProperties(graph.edge(1, 2).setDistance(10), encoder, 60, true, true);
-        EdgeIteratorState edge23 = GHUtility.setProperties(graph.edge(2, 3).setDistance(10), encoder, 60, true, true);
-        EdgeIteratorState edge34 = GHUtility.setProperties(graph.edge(3, 4).setDistance(10), encoder, 60, true, true);
-        EdgeIteratorState edge25 = GHUtility.setProperties(graph.edge(2, 5).setDistance(10), encoder, 60, true, true);
-        EdgeIteratorState edge56 = GHUtility.setProperties(graph.edge(5, 6).setDistance(10), encoder, 60, true, true);
-        EdgeIteratorState edge67 = GHUtility.setProperties(graph.edge(6, 7).setDistance(10), encoder, 60, true, true);
+        EdgeIteratorState edge01 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(10));
+        EdgeIteratorState edge12 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(10));
+        EdgeIteratorState edge23 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 3).setDistance(10));
+        EdgeIteratorState edge34 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 4).setDistance(10));
+        EdgeIteratorState edge25 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 5).setDistance(10));
+        EdgeIteratorState edge56 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(5, 6).setDistance(10));
+        EdgeIteratorState edge67 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(6, 7).setDistance(10));
 
         edge01.setFlags(encodingManager.handleWayTags(normalWay, ACCEPT_WAY, relFlags));
         edge12.setFlags(encodingManager.handleWayTags(interpolatableWay, ACCEPT_WAY, relFlags));
@@ -259,15 +259,17 @@ public class TunnelElevationInterpolatorTest extends EdgeElevationInterpolatorTe
         na.setNode(9, 40, 10, 0);
 
         FlagEncoder encoder = encodingManager.getEncoder("car");
-        EdgeIteratorState edge01 = GHUtility.setProperties(graph.edge(0, 1).setDistance(10), encoder, 60, true, true);
-        EdgeIteratorState edge12 = GHUtility.setProperties(graph.edge(1, 2).setDistance(10), encoder, 60, true, true);
-        EdgeIteratorState edge23 = GHUtility.setProperties(graph.edge(2, 3).setDistance(10), encoder, 60, true, true);
-        EdgeIteratorState edge34 = GHUtility.setProperties(graph.edge(3, 4).setDistance(10), encoder, 60, true, true);
-        EdgeIteratorState edge56 = GHUtility.setProperties(graph.edge(5, 6).setDistance(10), encoder, 60, true, true);
-        EdgeIteratorState edge67 = GHUtility.setProperties(graph.edge(6, 7).setDistance(10), encoder, 60, true, true);
-        EdgeIteratorState edge78 = GHUtility.setProperties(graph.edge(7, 8).setDistance(10), encoder, 60, true, true);
-        EdgeIteratorState edge89 = GHUtility.setProperties(graph.edge(8, 9).setDistance(10), encoder, 60, true, true);
-        EdgeIteratorState edge27 = GHUtility.setProperties(graph.edge(2, 7).setDistance(10), encoder, 60, true, true);
+        EdgeIteratorState edge01, edge12, edge23, edge34, edge56, edge67, edge78, edge89, edge27;
+        GHUtility.setSpeed(60, 60, encoder,
+                edge01 = graph.edge(0, 1).setDistance(10),
+                edge12 = graph.edge(1, 2).setDistance(10),
+                edge23 = graph.edge(2, 3).setDistance(10),
+                edge34 = graph.edge(3, 4).setDistance(10),
+                edge56 = graph.edge(5, 6).setDistance(10),
+                edge67 = graph.edge(6, 7).setDistance(10),
+                edge78 = graph.edge(7, 8).setDistance(10),
+                edge89 = graph.edge(8, 9).setDistance(10),
+                edge27 = graph.edge(2, 7).setDistance(10));
 
         edge01.setFlags(encodingManager.handleWayTags(normalWay, ACCEPT_WAY, relFlags));
         edge12.setFlags(encodingManager.handleWayTags(interpolatableWay, ACCEPT_WAY, relFlags));

--- a/core/src/test/java/com/graphhopper/reader/dem/TunnelElevationInterpolatorTest.java
+++ b/core/src/test/java/com/graphhopper/reader/dem/TunnelElevationInterpolatorTest.java
@@ -20,8 +20,10 @@ package com.graphhopper.reader.dem;
 import com.graphhopper.coll.GHIntHashSet;
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.RoadEnvironment;
+import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.storage.NodeAccess;
 import com.graphhopper.util.EdgeIteratorState;
+import com.graphhopper.util.GHUtility;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -61,9 +63,10 @@ public class TunnelElevationInterpolatorTest extends EdgeElevationInterpolatorTe
         na.setNode(3, 30, 0, 20);
         na.setNode(4, 40, 0, 0);
 
-        EdgeIteratorState edge01 = graph.edge(0, 1, 10, true);
-        EdgeIteratorState edge12 = graph.edge(1, 2, 10, true);
-        EdgeIteratorState edge34 = graph.edge(3, 4, 10, true);
+        FlagEncoder encoder = encodingManager.getEncoder("car");
+        EdgeIteratorState edge01 = GHUtility.setProperties(graph.edge(0, 1).setDistance(10), encoder, 60, true, true);
+        EdgeIteratorState edge12 = GHUtility.setProperties(graph.edge(1, 2).setDistance(10), encoder, 60, true, true);
+        EdgeIteratorState edge34 = GHUtility.setProperties(graph.edge(3, 4).setDistance(10), encoder, 60, true, true);
 
         edge01.setFlags(encodingManager.handleWayTags(interpolatableWay, ACCEPT_WAY, relFlags));
         edge12.setFlags(encodingManager.handleWayTags(interpolatableWay, ACCEPT_WAY, relFlags));
@@ -100,10 +103,11 @@ public class TunnelElevationInterpolatorTest extends EdgeElevationInterpolatorTe
         na.setNode(3, 30, 0, 20);
         na.setNode(4, 40, 0, 00);
 
-        EdgeIteratorState edge01 = graph.edge(0, 1, 10, true);
-        EdgeIteratorState edge12 = graph.edge(1, 2, 10, true);
-        EdgeIteratorState edge23 = graph.edge(2, 3, 10, true);
-        EdgeIteratorState edge34 = graph.edge(3, 4, 10, true);
+        FlagEncoder encoder = encodingManager.getEncoder("car");
+        EdgeIteratorState edge01 = GHUtility.setProperties(graph.edge(0, 1).setDistance(10), encoder, 60, true, true);
+        EdgeIteratorState edge12 = GHUtility.setProperties(graph.edge(1, 2).setDistance(10), encoder, 60, true, true);
+        EdgeIteratorState edge23 = GHUtility.setProperties(graph.edge(2, 3).setDistance(10), encoder, 60, true, true);
+        EdgeIteratorState edge34 = GHUtility.setProperties(graph.edge(3, 4).setDistance(10), encoder, 60, true, true);
 
         edge01.setFlags(encodingManager.handleWayTags(interpolatableWay, ACCEPT_WAY, relFlags));
         edge12.setFlags(encodingManager.handleWayTags(interpolatableWay, ACCEPT_WAY, relFlags));
@@ -141,10 +145,11 @@ public class TunnelElevationInterpolatorTest extends EdgeElevationInterpolatorTe
         na.setNode(3, 30, 0, 30);
         na.setNode(4, 40, 0, 40);
 
-        EdgeIteratorState edge01 = graph.edge(0, 1, 10, true);
-        EdgeIteratorState edge12 = graph.edge(1, 2, 10, true);
-        EdgeIteratorState edge23 = graph.edge(2, 3, 10, true);
-        EdgeIteratorState edge34 = graph.edge(3, 4, 10, true);
+        FlagEncoder encoder = encodingManager.getEncoder("car");
+        EdgeIteratorState edge01 = GHUtility.setProperties(graph.edge(0, 1).setDistance(10), encoder, 60, true, true);
+        EdgeIteratorState edge12 = GHUtility.setProperties(graph.edge(1, 2).setDistance(10), encoder, 60, true, true);
+        EdgeIteratorState edge23 = GHUtility.setProperties(graph.edge(2, 3).setDistance(10), encoder, 60, true, true);
+        EdgeIteratorState edge34 = GHUtility.setProperties(graph.edge(3, 4).setDistance(10), encoder, 60, true, true);
 
         edge01.setFlags(encodingManager.handleWayTags(normalWay, ACCEPT_WAY, relFlags));
         edge12.setFlags(encodingManager.handleWayTags(interpolatableWay, ACCEPT_WAY, relFlags));
@@ -191,13 +196,14 @@ public class TunnelElevationInterpolatorTest extends EdgeElevationInterpolatorTe
         na.setNode(6, 30, 10, 30);
         na.setNode(7, 40, 10, 40);
 
-        EdgeIteratorState edge01 = graph.edge(0, 1, 10, true);
-        EdgeIteratorState edge12 = graph.edge(1, 2, 10, true);
-        EdgeIteratorState edge23 = graph.edge(2, 3, 10, true);
-        EdgeIteratorState edge34 = graph.edge(3, 4, 10, true);
-        EdgeIteratorState edge25 = graph.edge(2, 5, 10, true);
-        EdgeIteratorState edge56 = graph.edge(5, 6, 10, true);
-        EdgeIteratorState edge67 = graph.edge(6, 7, 10, true);
+        FlagEncoder encoder = encodingManager.getEncoder("car");
+        EdgeIteratorState edge01 = GHUtility.setProperties(graph.edge(0, 1).setDistance(10), encoder, 60, true, true);
+        EdgeIteratorState edge12 = GHUtility.setProperties(graph.edge(1, 2).setDistance(10), encoder, 60, true, true);
+        EdgeIteratorState edge23 = GHUtility.setProperties(graph.edge(2, 3).setDistance(10), encoder, 60, true, true);
+        EdgeIteratorState edge34 = GHUtility.setProperties(graph.edge(3, 4).setDistance(10), encoder, 60, true, true);
+        EdgeIteratorState edge25 = GHUtility.setProperties(graph.edge(2, 5).setDistance(10), encoder, 60, true, true);
+        EdgeIteratorState edge56 = GHUtility.setProperties(graph.edge(5, 6).setDistance(10), encoder, 60, true, true);
+        EdgeIteratorState edge67 = GHUtility.setProperties(graph.edge(6, 7).setDistance(10), encoder, 60, true, true);
 
         edge01.setFlags(encodingManager.handleWayTags(normalWay, ACCEPT_WAY, relFlags));
         edge12.setFlags(encodingManager.handleWayTags(interpolatableWay, ACCEPT_WAY, relFlags));
@@ -252,15 +258,16 @@ public class TunnelElevationInterpolatorTest extends EdgeElevationInterpolatorTe
         na.setNode(8, 30, 10, 10);
         na.setNode(9, 40, 10, 0);
 
-        EdgeIteratorState edge01 = graph.edge(0, 1, 10, true);
-        EdgeIteratorState edge12 = graph.edge(1, 2, 10, true);
-        EdgeIteratorState edge23 = graph.edge(2, 3, 10, true);
-        EdgeIteratorState edge34 = graph.edge(3, 4, 10, true);
-        EdgeIteratorState edge56 = graph.edge(5, 6, 10, true);
-        EdgeIteratorState edge67 = graph.edge(6, 7, 10, true);
-        EdgeIteratorState edge78 = graph.edge(7, 8, 10, true);
-        EdgeIteratorState edge89 = graph.edge(8, 9, 10, true);
-        EdgeIteratorState edge27 = graph.edge(2, 7, 10, true);
+        FlagEncoder encoder = encodingManager.getEncoder("car");
+        EdgeIteratorState edge01 = GHUtility.setProperties(graph.edge(0, 1).setDistance(10), encoder, 60, true, true);
+        EdgeIteratorState edge12 = GHUtility.setProperties(graph.edge(1, 2).setDistance(10), encoder, 60, true, true);
+        EdgeIteratorState edge23 = GHUtility.setProperties(graph.edge(2, 3).setDistance(10), encoder, 60, true, true);
+        EdgeIteratorState edge34 = GHUtility.setProperties(graph.edge(3, 4).setDistance(10), encoder, 60, true, true);
+        EdgeIteratorState edge56 = GHUtility.setProperties(graph.edge(5, 6).setDistance(10), encoder, 60, true, true);
+        EdgeIteratorState edge67 = GHUtility.setProperties(graph.edge(6, 7).setDistance(10), encoder, 60, true, true);
+        EdgeIteratorState edge78 = GHUtility.setProperties(graph.edge(7, 8).setDistance(10), encoder, 60, true, true);
+        EdgeIteratorState edge89 = GHUtility.setProperties(graph.edge(8, 9).setDistance(10), encoder, 60, true, true);
+        EdgeIteratorState edge27 = GHUtility.setProperties(graph.edge(2, 7).setDistance(10), encoder, 60, true, true);
 
         edge01.setFlags(encodingManager.handleWayTags(normalWay, ACCEPT_WAY, relFlags));
         edge12.setFlags(encodingManager.handleWayTags(interpolatableWay, ACCEPT_WAY, relFlags));

--- a/core/src/test/java/com/graphhopper/routing/AlternativeRouteCHTest.java
+++ b/core/src/test/java/com/graphhopper/routing/AlternativeRouteCHTest.java
@@ -26,6 +26,7 @@ import com.graphhopper.routing.weighting.FastestWeighting;
 import com.graphhopper.storage.CHConfig;
 import com.graphhopper.storage.GraphHopperStorage;
 import com.graphhopper.storage.RAMDirectory;
+import com.graphhopper.util.GHUtility;
 import com.graphhopper.util.PMap;
 import org.junit.Test;
 
@@ -57,23 +58,23 @@ public class AlternativeRouteCHTest {
         // has to be locally-shortest to be considered.
         // So we get all three alternatives.
 
-        graph.edge(5, 6, 10000, true);
-        graph.edge(6, 3, 10000, true);
-        graph.edge(3, 4, 10000, true);
-        graph.edge(4, 10, 10000, true);
+        GHUtility.setProperties(graph.edge(5, 6).setDistance(10000), carFE, 60, true, true);
+        GHUtility.setProperties(graph.edge(6, 3).setDistance(10000), carFE, 60, true, true);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(10000), carFE, 60, true, true);
+        GHUtility.setProperties(graph.edge(4, 10).setDistance(10000), carFE, 60, true, true);
 
-        graph.edge(6, 7, 10000, true);
-        graph.edge(7, 8, 10000, true);
-        graph.edge(8, 4, 10000, true);
+        GHUtility.setProperties(graph.edge(6, 7).setDistance(10000), carFE, 60, true, true);
+        GHUtility.setProperties(graph.edge(7, 8).setDistance(10000), carFE, 60, true, true);
+        GHUtility.setProperties(graph.edge(8, 4).setDistance(10000), carFE, 60, true, true);
 
-        graph.edge(5, 1, 10000, true);
-        graph.edge(1, 9, 10000, true);
-        graph.edge(9, 2, 10000, true);
-        graph.edge(2, 3, 10000, true);
+        GHUtility.setProperties(graph.edge(5, 1).setDistance(10000), carFE, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 9).setDistance(10000), carFE, 60, true, true);
+        GHUtility.setProperties(graph.edge(9, 2).setDistance(10000), carFE, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(10000), carFE, 60, true, true);
 
-        graph.edge(4, 11, 9000, true);
-        graph.edge(11, 12, 9000, true);
-        graph.edge(12, 10, 10000, true);
+        GHUtility.setProperties(graph.edge(4, 11).setDistance(9000), carFE, 60, true, true);
+        GHUtility.setProperties(graph.edge(11, 12).setDistance(9000), carFE, 60, true, true);
+        GHUtility.setProperties(graph.edge(12, 10).setDistance(10000), carFE, 60, true, true);
 
         graph.freeze();
 

--- a/core/src/test/java/com/graphhopper/routing/AlternativeRouteCHTest.java
+++ b/core/src/test/java/com/graphhopper/routing/AlternativeRouteCHTest.java
@@ -58,23 +58,21 @@ public class AlternativeRouteCHTest {
         // has to be locally-shortest to be considered.
         // So we get all three alternatives.
 
-        GHUtility.setSpeed(60, true, true, carFE, graph.edge(5, 6).setDistance(10000));
-        GHUtility.setSpeed(60, true, true, carFE, graph.edge(6, 3).setDistance(10000));
-        GHUtility.setSpeed(60, true, true, carFE, graph.edge(3, 4).setDistance(10000));
-        GHUtility.setSpeed(60, true, true, carFE, graph.edge(4, 10).setDistance(10000));
-
-        GHUtility.setSpeed(60, true, true, carFE, graph.edge(6, 7).setDistance(10000));
-        GHUtility.setSpeed(60, true, true, carFE, graph.edge(7, 8).setDistance(10000));
-        GHUtility.setSpeed(60, true, true, carFE, graph.edge(8, 4).setDistance(10000));
-
-        GHUtility.setSpeed(60, true, true, carFE, graph.edge(5, 1).setDistance(10000));
-        GHUtility.setSpeed(60, true, true, carFE, graph.edge(1, 9).setDistance(10000));
-        GHUtility.setSpeed(60, true, true, carFE, graph.edge(9, 2).setDistance(10000));
-        GHUtility.setSpeed(60, true, true, carFE, graph.edge(2, 3).setDistance(10000));
-
-        GHUtility.setSpeed(60, true, true, carFE, graph.edge(4, 11).setDistance(9000));
-        GHUtility.setSpeed(60, true, true, carFE, graph.edge(11, 12).setDistance(9000));
-        GHUtility.setSpeed(60, true, true, carFE, graph.edge(12, 10).setDistance(10000));
+        GHUtility.setSpeed(60, 60, carFE,
+                graph.edge(5, 6).setDistance(10000),
+                graph.edge(6, 3).setDistance(10000),
+                graph.edge(3, 4).setDistance(10000),
+                graph.edge(4, 10).setDistance(10000),
+                graph.edge(6, 7).setDistance(10000),
+                graph.edge(7, 8).setDistance(10000),
+                graph.edge(8, 4).setDistance(10000),
+                graph.edge(5, 1).setDistance(10000),
+                graph.edge(1, 9).setDistance(10000),
+                graph.edge(9, 2).setDistance(10000),
+                graph.edge(2, 3).setDistance(10000),
+                graph.edge(4, 11).setDistance(9000),
+                graph.edge(11, 12).setDistance(9000),
+                graph.edge(12, 10).setDistance(10000));
 
         graph.freeze();
 

--- a/core/src/test/java/com/graphhopper/routing/AlternativeRouteCHTest.java
+++ b/core/src/test/java/com/graphhopper/routing/AlternativeRouteCHTest.java
@@ -58,23 +58,23 @@ public class AlternativeRouteCHTest {
         // has to be locally-shortest to be considered.
         // So we get all three alternatives.
 
-        GHUtility.setProperties(graph.edge(5, 6).setDistance(10000), carFE, 60, true, true);
-        GHUtility.setProperties(graph.edge(6, 3).setDistance(10000), carFE, 60, true, true);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(10000), carFE, 60, true, true);
-        GHUtility.setProperties(graph.edge(4, 10).setDistance(10000), carFE, 60, true, true);
+        GHUtility.setSpeed(60, true, true, carFE, graph.edge(5, 6).setDistance(10000));
+        GHUtility.setSpeed(60, true, true, carFE, graph.edge(6, 3).setDistance(10000));
+        GHUtility.setSpeed(60, true, true, carFE, graph.edge(3, 4).setDistance(10000));
+        GHUtility.setSpeed(60, true, true, carFE, graph.edge(4, 10).setDistance(10000));
 
-        GHUtility.setProperties(graph.edge(6, 7).setDistance(10000), carFE, 60, true, true);
-        GHUtility.setProperties(graph.edge(7, 8).setDistance(10000), carFE, 60, true, true);
-        GHUtility.setProperties(graph.edge(8, 4).setDistance(10000), carFE, 60, true, true);
+        GHUtility.setSpeed(60, true, true, carFE, graph.edge(6, 7).setDistance(10000));
+        GHUtility.setSpeed(60, true, true, carFE, graph.edge(7, 8).setDistance(10000));
+        GHUtility.setSpeed(60, true, true, carFE, graph.edge(8, 4).setDistance(10000));
 
-        GHUtility.setProperties(graph.edge(5, 1).setDistance(10000), carFE, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 9).setDistance(10000), carFE, 60, true, true);
-        GHUtility.setProperties(graph.edge(9, 2).setDistance(10000), carFE, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(10000), carFE, 60, true, true);
+        GHUtility.setSpeed(60, true, true, carFE, graph.edge(5, 1).setDistance(10000));
+        GHUtility.setSpeed(60, true, true, carFE, graph.edge(1, 9).setDistance(10000));
+        GHUtility.setSpeed(60, true, true, carFE, graph.edge(9, 2).setDistance(10000));
+        GHUtility.setSpeed(60, true, true, carFE, graph.edge(2, 3).setDistance(10000));
 
-        GHUtility.setProperties(graph.edge(4, 11).setDistance(9000), carFE, 60, true, true);
-        GHUtility.setProperties(graph.edge(11, 12).setDistance(9000), carFE, 60, true, true);
-        GHUtility.setProperties(graph.edge(12, 10).setDistance(10000), carFE, 60, true, true);
+        GHUtility.setSpeed(60, true, true, carFE, graph.edge(4, 11).setDistance(9000));
+        GHUtility.setSpeed(60, true, true, carFE, graph.edge(11, 12).setDistance(9000));
+        GHUtility.setSpeed(60, true, true, carFE, graph.edge(12, 10).setDistance(10000));
 
         graph.freeze();
 

--- a/core/src/test/java/com/graphhopper/routing/AlternativeRouteEdgeCHTest.java
+++ b/core/src/test/java/com/graphhopper/routing/AlternativeRouteEdgeCHTest.java
@@ -68,23 +68,23 @@ public class AlternativeRouteEdgeCHTest {
         // So we get all three alternatives.
 
         FlagEncoder encoder = carFE;
-        GHUtility.setProperties(graph.edge(5, 6).setDistance(10000), encoder, 60, true, true);
-        EdgeIteratorState e6_3 = GHUtility.setProperties(graph.edge(6, 3).setDistance(10000), encoder, 60, true, true);
-        EdgeIteratorState e3_4 = GHUtility.setProperties(graph.edge(3, 4).setDistance(10000), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(4, 10).setDistance(10000), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(5, 6).setDistance(10000));
+        EdgeIteratorState e6_3 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(6, 3).setDistance(10000));
+        EdgeIteratorState e3_4 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 4).setDistance(10000));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 10).setDistance(10000));
 
-        GHUtility.setProperties(graph.edge(6, 7).setDistance(10000), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(7, 8).setDistance(10000), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(8, 4).setDistance(10000), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(6, 7).setDistance(10000));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(7, 8).setDistance(10000));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(8, 4).setDistance(10000));
 
-        GHUtility.setProperties(graph.edge(5, 1).setDistance(10000), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 9).setDistance(10000), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(9, 2).setDistance(10000), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(10000), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(5, 1).setDistance(10000));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 9).setDistance(10000));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(9, 2).setDistance(10000));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 3).setDistance(10000));
 
-        EdgeIteratorState e4_11 = GHUtility.setProperties(graph.edge(4, 11).setDistance(9000), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(11, 12).setDistance(9000), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(12, 10).setDistance(10000), encoder, 60, true, true);
+        EdgeIteratorState e4_11 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 11).setDistance(9000));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(11, 12).setDistance(9000));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(12, 10).setDistance(10000));
 
         TurnCostStorage turnCostStorage = graph.getTurnCostStorage();
         DecimalEncodedValue carTurnCost = em.getDecimalEncodedValue(TurnCost.key(carFE.toString()));

--- a/core/src/test/java/com/graphhopper/routing/AlternativeRouteEdgeCHTest.java
+++ b/core/src/test/java/com/graphhopper/routing/AlternativeRouteEdgeCHTest.java
@@ -67,23 +67,24 @@ public class AlternativeRouteEdgeCHTest {
         // has to be locally-shortest to be considered.
         // So we get all three alternatives.
 
-        graph.edge(5, 6, 10000, true);
-        EdgeIteratorState e6_3 = graph.edge(6, 3, 10000, true);
-        EdgeIteratorState e3_4 = graph.edge(3, 4, 10000, true);
-        graph.edge(4, 10, 10000, true);
+        FlagEncoder encoder = carFE;
+        GHUtility.setProperties(graph.edge(5, 6).setDistance(10000), encoder, 60, true, true);
+        EdgeIteratorState e6_3 = GHUtility.setProperties(graph.edge(6, 3).setDistance(10000), encoder, 60, true, true);
+        EdgeIteratorState e3_4 = GHUtility.setProperties(graph.edge(3, 4).setDistance(10000), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(4, 10).setDistance(10000), encoder, 60, true, true);
 
-        graph.edge(6, 7, 10000, true);
-        graph.edge(7, 8, 10000, true);
-        graph.edge(8, 4, 10000, true);
+        GHUtility.setProperties(graph.edge(6, 7).setDistance(10000), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(7, 8).setDistance(10000), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(8, 4).setDistance(10000), encoder, 60, true, true);
 
-        graph.edge(5, 1, 10000, true);
-        graph.edge(1, 9, 10000, true);
-        graph.edge(9, 2, 10000, true);
-        graph.edge(2, 3, 10000, true);
+        GHUtility.setProperties(graph.edge(5, 1).setDistance(10000), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 9).setDistance(10000), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(9, 2).setDistance(10000), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(10000), encoder, 60, true, true);
 
-        EdgeIteratorState e4_11 = graph.edge(4, 11, 9000, true);
-        graph.edge(11, 12, 9000, true);
-        graph.edge(12, 10, 10000, true);
+        EdgeIteratorState e4_11 = GHUtility.setProperties(graph.edge(4, 11).setDistance(9000), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(11, 12).setDistance(9000), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(12, 10).setDistance(10000), encoder, 60, true, true);
 
         TurnCostStorage turnCostStorage = graph.getTurnCostStorage();
         DecimalEncodedValue carTurnCost = em.getDecimalEncodedValue(TurnCost.key(carFE.toString()));
@@ -96,7 +97,6 @@ public class AlternativeRouteEdgeCHTest {
         contractionHierarchies.doWork();
         return graph;
     }
-
 
     @Test
     public void testAssumptions() {

--- a/core/src/test/java/com/graphhopper/routing/AlternativeRouteTest.java
+++ b/core/src/test/java/com/graphhopper/routing/AlternativeRouteTest.java
@@ -79,20 +79,18 @@ public class AlternativeRouteTest {
          5--6-7---8
         
          */
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 9).setDistance(1));
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(9, 2).setDistance(1));
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 3).setDistance(1));
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 4).setDistance(1));
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 10).setDistance(1));
-
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(5, 6).setDistance(1));
-
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(6, 7).setDistance(1));
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(7, 8).setDistance(1));
-
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 5).setDistance(2));
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(6, 3).setDistance(1));
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 8).setDistance(1));
+        GHUtility.setSpeed(60, 60, encoder,
+                graph.edge(1, 9).setDistance(1),
+                graph.edge(9, 2).setDistance(1),
+                graph.edge(2, 3).setDistance(1),
+                graph.edge(3, 4).setDistance(1),
+                graph.edge(4, 10).setDistance(1),
+                graph.edge(5, 6).setDistance(1),
+                graph.edge(6, 7).setDistance(1),
+                graph.edge(7, 8).setDistance(1),
+                graph.edge(1, 5).setDistance(2),
+                graph.edge(6, 3).setDistance(1),
+                graph.edge(4, 8).setDistance(1));
 
         updateDistancesFor(graph, 5, 0.00, 0.05);
         updateDistancesFor(graph, 6, 0.00, 0.10);

--- a/core/src/test/java/com/graphhopper/routing/AlternativeRouteTest.java
+++ b/core/src/test/java/com/graphhopper/routing/AlternativeRouteTest.java
@@ -30,6 +30,7 @@ import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.Graph;
 import com.graphhopper.storage.GraphBuilder;
 import com.graphhopper.storage.GraphHopperStorage;
+import com.graphhopper.util.GHUtility;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -46,10 +47,11 @@ public class AlternativeRouteTest {
     private final Weighting weighting;
     private final TraversalMode traversalMode;
     private final GraphHopperStorage graph;
+    private final FlagEncoder carFE;
 
     public AlternativeRouteTest(TraversalMode tMode) {
         this.traversalMode = tMode;
-        FlagEncoder carFE = new CarFlagEncoder();
+        carFE = new CarFlagEncoder();
         EncodingManager em = EncodingManager.create(carFE);
         graph = new GraphBuilder(em).withTurnCosts(true).create();
         TurnCostProvider turnCostProvider = tMode.isEdgeBased()
@@ -69,7 +71,7 @@ public class AlternativeRouteTest {
         });
     }
 
-    public static void initTestGraph(Graph graph) {
+    public static void initTestGraph(Graph graph, FlagEncoder encoder) {
         /* 9
          _/\
          1  2-3-4-10
@@ -77,20 +79,20 @@ public class AlternativeRouteTest {
          5--6-7---8
         
          */
-        graph.edge(1, 9, 1, true);
-        graph.edge(9, 2, 1, true);
-        graph.edge(2, 3, 1, true);
-        graph.edge(3, 4, 1, true);
-        graph.edge(4, 10, 1, true);
+        GHUtility.setProperties(graph.edge(1,9).setDistance(1),encoder,60,true, true);
+        GHUtility.setProperties(graph.edge(9,2).setDistance(1),encoder,60,true, true);
+        GHUtility.setProperties(graph.edge(2,3).setDistance(1),encoder,60,true, true);
+        GHUtility.setProperties(graph.edge(3,4).setDistance(1),encoder,60,true, true);
+        GHUtility.setProperties(graph.edge(4,10).setDistance(1),encoder,60,true, true);
 
-        graph.edge(5, 6, 1, true);
+        GHUtility.setProperties(graph.edge(5,6).setDistance(1),encoder,60,true, true);
 
-        graph.edge(6, 7, 1, true);
-        graph.edge(7, 8, 1, true);
+        GHUtility.setProperties(graph.edge(6,7).setDistance(1),encoder,60,true, true);
+        GHUtility.setProperties(graph.edge(7,8).setDistance(1),encoder,60,true, true);
 
-        graph.edge(1, 5, 2, true);
-        graph.edge(6, 3, 1, true);
-        graph.edge(4, 8, 1, true);
+        GHUtility.setProperties(graph.edge(1,5).setDistance(2),encoder,60,true, true);
+        GHUtility.setProperties(graph.edge(6,3).setDistance(1),encoder,60,true, true);
+        GHUtility.setProperties(graph.edge(4,8).setDistance(1),encoder,60,true, true);
 
         updateDistancesFor(graph, 5, 0.00, 0.05);
         updateDistancesFor(graph, 6, 0.00, 0.10);
@@ -107,7 +109,7 @@ public class AlternativeRouteTest {
 
     @Test
     public void testCalcAlternatives() {
-        initTestGraph(graph);
+        initTestGraph(graph, carFE);
         AlternativeRoute altDijkstra = new AlternativeRoute(graph, weighting, traversalMode);
         altDijkstra.setMaxShareFactor(0.5);
         altDijkstra.setMaxWeightFactor(2);
@@ -135,7 +137,7 @@ public class AlternativeRouteTest {
 
     @Test
     public void testCalcAlternatives2() {
-        initTestGraph(graph);
+        initTestGraph(graph, carFE);
         AlternativeRoute altDijkstra = new AlternativeRoute(graph, weighting, traversalMode);
         altDijkstra.setMaxPaths(3);
         altDijkstra.setMaxShareFactor(0.7);
@@ -171,7 +173,7 @@ public class AlternativeRouteTest {
 
     @Test
     public void testDisconnectedAreas() {
-        initTestGraph(graph);
+        initTestGraph(graph, carFE);
 
         // one single disconnected node
         updateDistancesFor(graph, 20, 0.00, -0.01);

--- a/core/src/test/java/com/graphhopper/routing/AlternativeRouteTest.java
+++ b/core/src/test/java/com/graphhopper/routing/AlternativeRouteTest.java
@@ -79,20 +79,20 @@ public class AlternativeRouteTest {
          5--6-7---8
         
          */
-        GHUtility.setProperties(graph.edge(1,9).setDistance(1),encoder,60,true, true);
-        GHUtility.setProperties(graph.edge(9,2).setDistance(1),encoder,60,true, true);
-        GHUtility.setProperties(graph.edge(2,3).setDistance(1),encoder,60,true, true);
-        GHUtility.setProperties(graph.edge(3,4).setDistance(1),encoder,60,true, true);
-        GHUtility.setProperties(graph.edge(4,10).setDistance(1),encoder,60,true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 9).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(9, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 10).setDistance(1));
 
-        GHUtility.setProperties(graph.edge(5,6).setDistance(1),encoder,60,true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(5, 6).setDistance(1));
 
-        GHUtility.setProperties(graph.edge(6,7).setDistance(1),encoder,60,true, true);
-        GHUtility.setProperties(graph.edge(7,8).setDistance(1),encoder,60,true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(6, 7).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(7, 8).setDistance(1));
 
-        GHUtility.setProperties(graph.edge(1,5).setDistance(2),encoder,60,true, true);
-        GHUtility.setProperties(graph.edge(6,3).setDistance(1),encoder,60,true, true);
-        GHUtility.setProperties(graph.edge(4,8).setDistance(1),encoder,60,true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 5).setDistance(2));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(6, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 8).setDistance(1));
 
         updateDistancesFor(graph, 5, 0.00, 0.05);
         updateDistancesFor(graph, 6, 0.00, 0.10);

--- a/core/src/test/java/com/graphhopper/routing/CHQueryWithTurnCostsTest.java
+++ b/core/src/test/java/com/graphhopper/routing/CHQueryWithTurnCostsTest.java
@@ -73,8 +73,8 @@ public class CHQueryWithTurnCostsTest {
     public void testFindPathWithTurnCosts_bidirected_no_shortcuts_smallGraph() {
         // some special cases where from=to, or start and target edges are the same
         // 1 -- 0 -- 2
-        graph.edge(1, 0, 3, true);
-        graph.edge(0, 2, 5, true);
+        GHUtility.setProperties(graph.edge(1, 0).setDistance(3), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(0, 2).setDistance(5), encoder, 60, true, true);
         setTurnCost(1, 0, 2, 3);
         graph.freeze();
 
@@ -95,12 +95,12 @@ public class CHQueryWithTurnCostsTest {
     @Test
     public void testFindPathWithTurnCosts_bidirected_no_shortcuts() {
         // 0 -- 2 -- 4 -- 6 -- 5 -- 3 -- 1
-        graph.edge(0, 2, 3, true);
-        graph.edge(2, 4, 2, true);
-        graph.edge(4, 6, 7, true);
-        graph.edge(6, 5, 9, true);
-        graph.edge(5, 3, 1, true);
-        graph.edge(3, 1, 4, true);
+        GHUtility.setProperties(graph.edge(0, 2).setDistance(3), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 4).setDistance(2), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(4, 6).setDistance(7), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(6, 5).setDistance(9), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(5, 3).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(3, 1).setDistance(4), encoder, 60, true, true);
         setTurnCost(0, 2, 4, 3);
         setTurnCost(4, 6, 5, 6);
         setTurnCost(5, 6, 4, 2);
@@ -133,15 +133,15 @@ public class CHQueryWithTurnCostsTest {
         //           1   2
         //            \ /
         // 0 - 7 - 8 - 4 - 6 - 5
-        graph.edge(0, 7, 1, false);
-        graph.edge(7, 8, 1, false);
-        graph.edge(8, 4, 1, false);
-        graph.edge(4, 1, 1, false);
-        graph.edge(1, 3, 1, false);
-        graph.edge(3, 2, 1, false);
-        graph.edge(2, 4, 1, false);
-        graph.edge(4, 6, 1, false);
-        graph.edge(6, 5, 1, false);
+        GHUtility.setProperties(graph.edge(0, 7).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(7, 8).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(8, 4).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(4, 1).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 2).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 4).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(4, 6).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(6, 5).setDistance(1), encoder, 60, true, false);
         setRestriction(8, 4, 6);
         setRestriction(8, 4, 2);
         setRestriction(1, 4, 6);
@@ -169,15 +169,15 @@ public class CHQueryWithTurnCostsTest {
         //       1   2
         //        \ /
         // 5 - 6 - 4 - 7 - 8 - 0
-        graph.edge(5, 6, 1, false);
-        graph.edge(6, 4, 1, false);
-        graph.edge(4, 1, 1, false);
-        graph.edge(1, 3, 1, false);
-        graph.edge(3, 2, 1, false);
-        graph.edge(2, 4, 1, false);
-        graph.edge(4, 7, 1, false);
-        graph.edge(7, 8, 1, false);
-        graph.edge(8, 0, 1, false);
+        GHUtility.setProperties(graph.edge(5, 6).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(6, 4).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(4, 1).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 2).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 4).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(4, 7).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(7, 8).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(8, 0).setDistance(1), encoder, 60, true, false);
         setRestriction(6, 4, 7);
         setRestriction(6, 4, 2);
         setRestriction(1, 4, 7);
@@ -202,10 +202,10 @@ public class CHQueryWithTurnCostsTest {
         //   /5\   /1\
         //  /   \2/   \
         // 1     0     4
-        graph.edge(1, 2, 4, false);
-        graph.edge(2, 0, 2, false);
-        graph.edge(0, 3, 3, false);
-        graph.edge(3, 4, 2, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(4), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 0).setDistance(2), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(0, 3).setDistance(3), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(2), encoder, 60, true, false);
         setTurnCost(1, 2, 0, 5);
         setTurnCost(2, 0, 3, 2);
         setTurnCost(0, 3, 4, 1);
@@ -230,10 +230,10 @@ public class CHQueryWithTurnCostsTest {
         //     0
         //    / \
         // 1-2-s-3-4
-        graph.edge(1, 2, 2, false);
-        graph.edge(2, 0, 3, false);
-        graph.edge(0, 3, 1, false);
-        graph.edge(3, 4, 3, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(2), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 0).setDistance(3), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(0, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(3), encoder, 60, true, false);
         graph.freeze();
 
         setTurnCost(1, 2, 0, 2);
@@ -252,10 +252,10 @@ public class CHQueryWithTurnCostsTest {
         //   /5\   /1\
         //  /   \2/   \
         // 2     1     4
-        graph.edge(2, 3, 4, false);
-        graph.edge(3, 1, 2, false);
-        graph.edge(1, 0, 3, false);
-        graph.edge(0, 4, 2, false);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(4), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 1).setDistance(2), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 0).setDistance(3), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(0, 4).setDistance(2), encoder, 60, true, false);
         setTurnCost(2, 3, 1, 5);
         setTurnCost(3, 1, 0, 2);
         setTurnCost(1, 0, 4, 1);
@@ -281,10 +281,10 @@ public class CHQueryWithTurnCostsTest {
         // |         |
         // v         v
         // 2 -> 3 -> 1
-        graph.edge(0, 2, 3, false);
-        graph.edge(2, 3, 2, false);
-        graph.edge(3, 1, 9, false);
-        graph.edge(0, 1, 50, false);
+        GHUtility.setProperties(graph.edge(0, 2).setDistance(3), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(2), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 1).setDistance(9), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(50), encoder, 60, true, false);
         setTurnCost(2, 3, 1, 4);
         graph.freeze();
 
@@ -301,12 +301,12 @@ public class CHQueryWithTurnCostsTest {
         //      |    |
         //      v    v
         //      3 -> 4 -> 2
-        graph.edge(0, 1, 9, false);
-        graph.edge(1, 5, 2, false);
-        graph.edge(1, 3, 2, false);
-        graph.edge(3, 4, 4, false);
-        graph.edge(5, 4, 6, false);
-        graph.edge(4, 2, 3, false);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(9), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 5).setDistance(2), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 3).setDistance(2), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(4), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(5, 4).setDistance(6), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(4, 2).setDistance(3), encoder, 60, true, false);
         setTurnCost(1, 3, 4, 3);
         graph.freeze();
 
@@ -321,10 +321,10 @@ public class CHQueryWithTurnCostsTest {
         //  \   ^
         //   \  |
         //    <-2<-3
-        graph.edge(1, 0, 9, false);
-        graph.edge(2, 0, 14, false);
-        graph.edge(2, 1, 2, false);
-        graph.edge(3, 2, 9, false);
+        GHUtility.setProperties(graph.edge(1, 0).setDistance(9), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 0).setDistance(14), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 1).setDistance(2), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 2).setDistance(9), encoder, 60, true, false);
         graph.freeze();
 
         //no shortcuts
@@ -339,9 +339,9 @@ public class CHQueryWithTurnCostsTest {
         // | __/
         // v/
         // 3 -> 2
-        graph.edge(0, 1, 9, true);
-        graph.edge(0, 3, 14, false);
-        graph.edge(3, 2, 9, false);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(9), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(0, 3).setDistance(14), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 2).setDistance(9), encoder, 60, true, false);
         graph.freeze();
         setLevelEqualToNodeIdForAllNodes();
         addShortcut(1, 3, 0, 1, 0, 1, 23, false);
@@ -353,9 +353,9 @@ public class CHQueryWithTurnCostsTest {
         //       3
         //       |
         // 0 --- 2 --- 1
-        graph.edge(0, 2, 1, false);
-        graph.edge(2, 3, 2, true);
-        graph.edge(2, 1, 3, false);
+        GHUtility.setProperties(graph.edge(0, 2).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(2), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 1).setDistance(3), encoder, 60, true, false);
         setRestriction(0, 2, 1);
         setTurnCost(0, 2, 3, 5);
         setTurnCost(2, 3, 2, 4);
@@ -395,11 +395,11 @@ public class CHQueryWithTurnCostsTest {
             nodeA = nodeB;
             nodeB = tmp;
         }
-        graph.edge(1, nodeA, 4, false);
-        graph.edge(0, 3, 4, false);
-        graph.edge(nodeB, 2, 1, false);
-        final EdgeIteratorState e3toB = graph.edge(3, nodeB, 2, false);
-        final EdgeIteratorState e3toA = graph.edge(3, nodeA, 1, true);
+        GHUtility.setProperties(graph.edge(1, nodeA).setDistance(4), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(0, 3).setDistance(4), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(nodeB, 2).setDistance(1), encoder, 60, true, false);
+        final EdgeIteratorState e3toB = GHUtility.setProperties(graph.edge(3, nodeB).setDistance(2), encoder, 60, true, false);
+        final EdgeIteratorState e3toA = GHUtility.setProperties(graph.edge(3, nodeA).setDistance(1), encoder, 60, true,true);
         graph.freeze();
         setRestriction(0, 3, nodeB);
 
@@ -420,10 +420,10 @@ public class CHQueryWithTurnCostsTest {
         //       3\
         //       |/
         // 0 --- 2 --- 1
-        final EdgeIteratorState edge1 = graph.edge(0, 2, 4, false);
-        final EdgeIteratorState edge2 = graph.edge(2, 3, 1, true);
-        final EdgeIteratorState edge3 = graph.edge(3, 2, 7, false);
-        final EdgeIteratorState edge4 = graph.edge(2, 1, 3, false);
+        final EdgeIteratorState edge1 = GHUtility.setProperties(graph.edge(0, 2).setDistance(4), encoder, 60, true, false);
+        final EdgeIteratorState edge2 = GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, true);
+        final EdgeIteratorState edge3 = GHUtility.setProperties(graph.edge(3, 2).setDistance(7), encoder, 60, true, false);
+        final EdgeIteratorState edge4 = GHUtility.setProperties(graph.edge(2, 1).setDistance(3), encoder, 60, true, false);
         // need to specify edges explicitly because there are two edges between nodes 2 and 3
         setRestriction(edge1, edge4, 2);
         setTurnCost(edge1, edge2, 2, 3);
@@ -446,12 +446,12 @@ public class CHQueryWithTurnCostsTest {
         // 0 --- 3 --- 1
         //  \         /
         //   --- 4 ---
-        graph.edge(0, 2, 1, false);
-        graph.edge(0, 3, 3, false);
-        graph.edge(0, 4, 2, false);
-        graph.edge(2, 1, 1, false);
-        graph.edge(3, 1, 2, false);
-        graph.edge(4, 1, 6, false);
+        GHUtility.setProperties(graph.edge(0, 2).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(0, 3).setDistance(3), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(0, 4).setDistance(2), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 1).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 1).setDistance(2), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(4, 1).setDistance(6), encoder, 60, true, false);
         setTurnCost(0, 2, 1, 9);
         setTurnCost(0, 3, 1, 2);
         setTurnCost(0, 4, 1, 1);
@@ -470,10 +470,10 @@ public class CHQueryWithTurnCostsTest {
         //     ---
         //     \ /
         // 0 -- 3 -- 2 -- 1
-        EdgeIteratorState edge0 = graph.edge(0, 3, 1, true);
-        EdgeIteratorState edge1 = graph.edge(3, 3, 1, false);
-        EdgeIteratorState edge2 = graph.edge(3, 2, 1, true);
-        EdgeIteratorState edge3 = graph.edge(2, 1, 1, false);
+        EdgeIteratorState edge0 = GHUtility.setProperties(graph.edge(0, 3).setDistance(1), encoder, 60, true, true);
+        EdgeIteratorState edge1 = GHUtility.setProperties(graph.edge(3, 3).setDistance(1), encoder, 60, true, false);
+        EdgeIteratorState edge2 = GHUtility.setProperties(graph.edge(3, 2).setDistance(1), encoder, 60, true, true);
+        EdgeIteratorState edge3 = GHUtility.setProperties(graph.edge(2, 1).setDistance(1), encoder, 60, true, false);
         setRestriction(edge0, edge2, 3);
         graph.freeze();
 
@@ -492,11 +492,11 @@ public class CHQueryWithTurnCostsTest {
         //          -0-
         //          \ /
         // 3 -- 4 -- 2 -- 1
-        EdgeIteratorState edge0 = graph.edge(3, 4, 1, true);
-        EdgeIteratorState edge1 = graph.edge(4, 2, 1, true);
-        EdgeIteratorState edge2 = graph.edge(2, 0, 1, false);
-        EdgeIteratorState edge3 = graph.edge(0, 2, 1, false);
-        EdgeIteratorState edge4 = graph.edge(2, 1, 1, false);
+        EdgeIteratorState edge0 = GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, true);
+        EdgeIteratorState edge1 = GHUtility.setProperties(graph.edge(4, 2).setDistance(1), encoder, 60, true, true);
+        EdgeIteratorState edge2 = GHUtility.setProperties(graph.edge(2, 0).setDistance(1), encoder, 60, true, false);
+        EdgeIteratorState edge3 = GHUtility.setProperties(graph.edge(0, 2).setDistance(1), encoder, 60, true, false);
+        EdgeIteratorState edge4 = GHUtility.setProperties(graph.edge(2, 1).setDistance(1), encoder, 60, true, false);
         setRestriction(edge1, edge4, 2);
         graph.freeze();
 
@@ -522,11 +522,11 @@ public class CHQueryWithTurnCostsTest {
         //     |
         //     v  no right turn at 4 when coming from 3!
         //     2
-        graph.edge(3, 4, 2, false);
-        graph.edge(4, 0, 1, true);
-        graph.edge(0, 1, 3, false);
-        graph.edge(4, 1, 5, true);
-        graph.edge(4, 2, 4, false);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(2), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(4, 0).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(3), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(4, 1).setDistance(5), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(4, 2).setDistance(4), encoder, 60, true, false);
         setRestriction(3, 4, 2);
         graph.freeze();
 
@@ -565,14 +565,14 @@ public class CHQueryWithTurnCostsTest {
         //  A-5->2
         //    |
         //    B-7
-        graph.edge(4, nodeA, 1, false);
-        graph.edge(nodeA, 5, 2, false);
-        graph.edge(5, 2, 2, false);
-        graph.edge(2, 3, 1, false);
-        graph.edge(3, 1, 2, false);
-        graph.edge(1, 5, 1, false);
-        graph.edge(5, nodeB, 1, false);
-        graph.edge(nodeB, 7, 2, false);
+        GHUtility.setProperties(graph.edge(4, nodeA).setDistance(1),encoder, 60, true,false);
+        GHUtility.setProperties(graph.edge(nodeA, 5).setDistance(2),encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(5, 2).setDistance(2), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 1).setDistance(2), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 5).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(5, nodeB).setDistance(1),encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(nodeB, 7).setDistance(2),encoder, 60, true, false);
         setRestriction(nodeA, 5, nodeB);
         graph.freeze();
         setLevelEqualToNodeIdForAllNodes();
@@ -595,15 +595,15 @@ public class CHQueryWithTurnCostsTest {
         //     |
         //     |  no right turn at 7 when coming from 4 and no left turn at 7 when coming from 5!
         //     5
-        final EdgeIteratorState e0to1 = graph.edge(0, 1, 2, true);
-        final EdgeIteratorState e1to6 = graph.edge(1, 6, 1, true);
-        final EdgeIteratorState e0to6 = graph.edge(0, 6, 4, true);
-        final EdgeIteratorState e2to6 = graph.edge(2, 6, 5, true);
-        final EdgeIteratorState e2to3 = graph.edge(2, 3, 3, true);
-        final EdgeIteratorState e3to6 = graph.edge(3, 6, 2, true);
-        final EdgeIteratorState e6to7 = graph.edge(7, 6, 1, true);
-        final EdgeIteratorState e4to7 = graph.edge(7, 4, 3, true);
-        final EdgeIteratorState e5to7 = graph.edge(7, 5, 2, true);
+        final EdgeIteratorState e0to1 = GHUtility.setProperties(graph.edge(0, 1).setDistance(2), encoder, 60, true, true);
+        final EdgeIteratorState e1to6 = GHUtility.setProperties(graph.edge(1, 6).setDistance(1), encoder, 60, true, true);
+        final EdgeIteratorState e0to6 = GHUtility.setProperties(graph.edge(0, 6).setDistance(4), encoder, 60, true, true);
+        final EdgeIteratorState e2to6 = GHUtility.setProperties(graph.edge(2, 6).setDistance(5), encoder, 60, true, true);
+        final EdgeIteratorState e2to3 = GHUtility.setProperties(graph.edge(2, 3).setDistance(3), encoder, 60, true, true);
+        final EdgeIteratorState e3to6 = GHUtility.setProperties(graph.edge(3, 6).setDistance(2), encoder, 60, true, true);
+        final EdgeIteratorState e6to7 = GHUtility.setProperties(graph.edge(7, 6).setDistance(1), encoder, 60, true, true);
+        final EdgeIteratorState e4to7 = GHUtility.setProperties(graph.edge(7, 4).setDistance(3), encoder, 60, true, true);
+        final EdgeIteratorState e5to7 = GHUtility.setProperties(graph.edge(7, 5).setDistance(2), encoder, 60, true, true);
 
         setRestriction(e6to7, e1to6, 6);
         setRestriction(e6to7, e2to6, 6);
@@ -645,15 +645,15 @@ public class CHQueryWithTurnCostsTest {
         //     |
         //     v  no right turn at 6 when coming from 3!
         //     2
-        graph.edge(0, 1, 2, false);
-        graph.edge(1, 5, 1, true);
-        graph.edge(5, 0, 1, false);
-        graph.edge(5, 4, 5, false);
-        graph.edge(5, 6, 3, true);
-        graph.edge(6, 4, 4, true);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(2), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 5).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(5, 0).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(5, 4).setDistance(5), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(5, 6).setDistance(3), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(6, 4).setDistance(4), encoder, 60, true, true);
 
-        graph.edge(3, 6, 3, false);
-        graph.edge(6, 2, 4, false);
+        GHUtility.setProperties(graph.edge(3, 6).setDistance(3), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(6, 2).setDistance(4), encoder, 60, true, false);
         setRestriction(3, 6, 2);
         graph.freeze();
 

--- a/core/src/test/java/com/graphhopper/routing/CHQueryWithTurnCostsTest.java
+++ b/core/src/test/java/com/graphhopper/routing/CHQueryWithTurnCostsTest.java
@@ -73,8 +73,8 @@ public class CHQueryWithTurnCostsTest {
     public void testFindPathWithTurnCosts_bidirected_no_shortcuts_smallGraph() {
         // some special cases where from=to, or start and target edges are the same
         // 1 -- 0 -- 2
-        GHUtility.setProperties(graph.edge(1, 0).setDistance(3), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(0, 2).setDistance(5), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 0).setDistance(3));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 2).setDistance(5));
         setTurnCost(1, 0, 2, 3);
         graph.freeze();
 
@@ -95,12 +95,12 @@ public class CHQueryWithTurnCostsTest {
     @Test
     public void testFindPathWithTurnCosts_bidirected_no_shortcuts() {
         // 0 -- 2 -- 4 -- 6 -- 5 -- 3 -- 1
-        GHUtility.setProperties(graph.edge(0, 2).setDistance(3), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 4).setDistance(2), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(4, 6).setDistance(7), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(6, 5).setDistance(9), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(5, 3).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(3, 1).setDistance(4), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 2).setDistance(3));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 4).setDistance(2));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 6).setDistance(7));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(6, 5).setDistance(9));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(5, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 1).setDistance(4));
         setTurnCost(0, 2, 4, 3);
         setTurnCost(4, 6, 5, 6);
         setTurnCost(5, 6, 4, 2);
@@ -133,15 +133,15 @@ public class CHQueryWithTurnCostsTest {
         //           1   2
         //            \ /
         // 0 - 7 - 8 - 4 - 6 - 5
-        GHUtility.setProperties(graph.edge(0, 7).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(7, 8).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(8, 4).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(4, 1).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 3).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 2).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 4).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(4, 6).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(6, 5).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 7).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(7, 8).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(8, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(4, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(4, 6).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(6, 5).setDistance(1));
         setRestriction(8, 4, 6);
         setRestriction(8, 4, 2);
         setRestriction(1, 4, 6);
@@ -169,15 +169,15 @@ public class CHQueryWithTurnCostsTest {
         //       1   2
         //        \ /
         // 5 - 6 - 4 - 7 - 8 - 0
-        GHUtility.setProperties(graph.edge(5, 6).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(6, 4).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(4, 1).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 3).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 2).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 4).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(4, 7).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(7, 8).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(8, 0).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(5, 6).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(6, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(4, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(4, 7).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(7, 8).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(8, 0).setDistance(1));
         setRestriction(6, 4, 7);
         setRestriction(6, 4, 2);
         setRestriction(1, 4, 7);
@@ -202,10 +202,10 @@ public class CHQueryWithTurnCostsTest {
         //   /5\   /1\
         //  /   \2/   \
         // 1     0     4
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(4), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 0).setDistance(2), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(0, 3).setDistance(3), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(2), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 2).setDistance(4));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 0).setDistance(2));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 3).setDistance(3));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 4).setDistance(2));
         setTurnCost(1, 2, 0, 5);
         setTurnCost(2, 0, 3, 2);
         setTurnCost(0, 3, 4, 1);
@@ -230,10 +230,10 @@ public class CHQueryWithTurnCostsTest {
         //     0
         //    / \
         // 1-2-s-3-4
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(2), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 0).setDistance(3), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(0, 3).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(3), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 2).setDistance(2));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 0).setDistance(3));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 4).setDistance(3));
         graph.freeze();
 
         setTurnCost(1, 2, 0, 2);
@@ -252,10 +252,10 @@ public class CHQueryWithTurnCostsTest {
         //   /5\   /1\
         //  /   \2/   \
         // 2     1     4
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(4), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 1).setDistance(2), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 0).setDistance(3), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(0, 4).setDistance(2), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 3).setDistance(4));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 1).setDistance(2));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 0).setDistance(3));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 4).setDistance(2));
         setTurnCost(2, 3, 1, 5);
         setTurnCost(3, 1, 0, 2);
         setTurnCost(1, 0, 4, 1);
@@ -281,10 +281,10 @@ public class CHQueryWithTurnCostsTest {
         // |         |
         // v         v
         // 2 -> 3 -> 1
-        GHUtility.setProperties(graph.edge(0, 2).setDistance(3), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(2), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 1).setDistance(9), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(50), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 2).setDistance(3));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 3).setDistance(2));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 1).setDistance(9));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 1).setDistance(50));
         setTurnCost(2, 3, 1, 4);
         graph.freeze();
 
@@ -301,12 +301,12 @@ public class CHQueryWithTurnCostsTest {
         //      |    |
         //      v    v
         //      3 -> 4 -> 2
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(9), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 5).setDistance(2), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 3).setDistance(2), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(4), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(5, 4).setDistance(6), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(4, 2).setDistance(3), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 1).setDistance(9));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 5).setDistance(2));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 3).setDistance(2));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 4).setDistance(4));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(5, 4).setDistance(6));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(4, 2).setDistance(3));
         setTurnCost(1, 3, 4, 3);
         graph.freeze();
 
@@ -321,10 +321,10 @@ public class CHQueryWithTurnCostsTest {
         //  \   ^
         //   \  |
         //    <-2<-3
-        GHUtility.setProperties(graph.edge(1, 0).setDistance(9), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 0).setDistance(14), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 1).setDistance(2), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 2).setDistance(9), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 0).setDistance(9));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 0).setDistance(14));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 1).setDistance(2));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 2).setDistance(9));
         graph.freeze();
 
         //no shortcuts
@@ -339,9 +339,9 @@ public class CHQueryWithTurnCostsTest {
         // | __/
         // v/
         // 3 -> 2
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(9), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(0, 3).setDistance(14), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 2).setDistance(9), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(9));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 3).setDistance(14));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 2).setDistance(9));
         graph.freeze();
         setLevelEqualToNodeIdForAllNodes();
         addShortcut(1, 3, 0, 1, 0, 1, 23, false);
@@ -353,9 +353,9 @@ public class CHQueryWithTurnCostsTest {
         //       3
         //       |
         // 0 --- 2 --- 1
-        GHUtility.setProperties(graph.edge(0, 2).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(2), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 1).setDistance(3), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 3).setDistance(2));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 1).setDistance(3));
         setRestriction(0, 2, 1);
         setTurnCost(0, 2, 3, 5);
         setTurnCost(2, 3, 2, 4);
@@ -395,11 +395,11 @@ public class CHQueryWithTurnCostsTest {
             nodeA = nodeB;
             nodeB = tmp;
         }
-        GHUtility.setProperties(graph.edge(1, nodeA).setDistance(4), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(0, 3).setDistance(4), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(nodeB, 2).setDistance(1), encoder, 60, true, false);
-        final EdgeIteratorState e3toB = GHUtility.setProperties(graph.edge(3, nodeB).setDistance(2), encoder, 60, true, false);
-        final EdgeIteratorState e3toA = GHUtility.setProperties(graph.edge(3, nodeA).setDistance(1), encoder, 60, true,true);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, nodeA).setDistance(4));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 3).setDistance(4));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(nodeB, 2).setDistance(1));
+        final EdgeIteratorState e3toB = GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, nodeB).setDistance(2));
+        final EdgeIteratorState e3toA = GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, nodeA).setDistance(1));
         graph.freeze();
         setRestriction(0, 3, nodeB);
 
@@ -420,10 +420,10 @@ public class CHQueryWithTurnCostsTest {
         //       3\
         //       |/
         // 0 --- 2 --- 1
-        final EdgeIteratorState edge1 = GHUtility.setProperties(graph.edge(0, 2).setDistance(4), encoder, 60, true, false);
-        final EdgeIteratorState edge2 = GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, true);
-        final EdgeIteratorState edge3 = GHUtility.setProperties(graph.edge(3, 2).setDistance(7), encoder, 60, true, false);
-        final EdgeIteratorState edge4 = GHUtility.setProperties(graph.edge(2, 1).setDistance(3), encoder, 60, true, false);
+        final EdgeIteratorState edge1 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 2).setDistance(4));
+        final EdgeIteratorState edge2 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 3).setDistance(1));
+        final EdgeIteratorState edge3 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 2).setDistance(7));
+        final EdgeIteratorState edge4 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 1).setDistance(3));
         // need to specify edges explicitly because there are two edges between nodes 2 and 3
         setRestriction(edge1, edge4, 2);
         setTurnCost(edge1, edge2, 2, 3);
@@ -446,12 +446,12 @@ public class CHQueryWithTurnCostsTest {
         // 0 --- 3 --- 1
         //  \         /
         //   --- 4 ---
-        GHUtility.setProperties(graph.edge(0, 2).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(0, 3).setDistance(3), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(0, 4).setDistance(2), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 1).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 1).setDistance(2), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(4, 1).setDistance(6), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 3).setDistance(3));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 4).setDistance(2));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 1).setDistance(2));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(4, 1).setDistance(6));
         setTurnCost(0, 2, 1, 9);
         setTurnCost(0, 3, 1, 2);
         setTurnCost(0, 4, 1, 1);
@@ -470,10 +470,10 @@ public class CHQueryWithTurnCostsTest {
         //     ---
         //     \ /
         // 0 -- 3 -- 2 -- 1
-        EdgeIteratorState edge0 = GHUtility.setProperties(graph.edge(0, 3).setDistance(1), encoder, 60, true, true);
-        EdgeIteratorState edge1 = GHUtility.setProperties(graph.edge(3, 3).setDistance(1), encoder, 60, true, false);
-        EdgeIteratorState edge2 = GHUtility.setProperties(graph.edge(3, 2).setDistance(1), encoder, 60, true, true);
-        EdgeIteratorState edge3 = GHUtility.setProperties(graph.edge(2, 1).setDistance(1), encoder, 60, true, false);
+        EdgeIteratorState edge0 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 3).setDistance(1));
+        EdgeIteratorState edge1 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 3).setDistance(1));
+        EdgeIteratorState edge2 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 2).setDistance(1));
+        EdgeIteratorState edge3 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 1).setDistance(1));
         setRestriction(edge0, edge2, 3);
         graph.freeze();
 
@@ -492,11 +492,11 @@ public class CHQueryWithTurnCostsTest {
         //          -0-
         //          \ /
         // 3 -- 4 -- 2 -- 1
-        EdgeIteratorState edge0 = GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, true);
-        EdgeIteratorState edge1 = GHUtility.setProperties(graph.edge(4, 2).setDistance(1), encoder, 60, true, true);
-        EdgeIteratorState edge2 = GHUtility.setProperties(graph.edge(2, 0).setDistance(1), encoder, 60, true, false);
-        EdgeIteratorState edge3 = GHUtility.setProperties(graph.edge(0, 2).setDistance(1), encoder, 60, true, false);
-        EdgeIteratorState edge4 = GHUtility.setProperties(graph.edge(2, 1).setDistance(1), encoder, 60, true, false);
+        EdgeIteratorState edge0 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 4).setDistance(1));
+        EdgeIteratorState edge1 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 2).setDistance(1));
+        EdgeIteratorState edge2 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 0).setDistance(1));
+        EdgeIteratorState edge3 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 2).setDistance(1));
+        EdgeIteratorState edge4 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 1).setDistance(1));
         setRestriction(edge1, edge4, 2);
         graph.freeze();
 
@@ -522,11 +522,11 @@ public class CHQueryWithTurnCostsTest {
         //     |
         //     v  no right turn at 4 when coming from 3!
         //     2
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(2), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(4, 0).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(3), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(4, 1).setDistance(5), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(4, 2).setDistance(4), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 4).setDistance(2));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 0).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 1).setDistance(3));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 1).setDistance(5));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(4, 2).setDistance(4));
         setRestriction(3, 4, 2);
         graph.freeze();
 
@@ -565,14 +565,14 @@ public class CHQueryWithTurnCostsTest {
         //  A-5->2
         //    |
         //    B-7
-        GHUtility.setProperties(graph.edge(4, nodeA).setDistance(1),encoder, 60, true,false);
-        GHUtility.setProperties(graph.edge(nodeA, 5).setDistance(2),encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(5, 2).setDistance(2), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 1).setDistance(2), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 5).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(5, nodeB).setDistance(1),encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(nodeB, 7).setDistance(2),encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(4, nodeA).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(nodeA, 5).setDistance(2));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(5, 2).setDistance(2));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 1).setDistance(2));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 5).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(5, nodeB).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(nodeB, 7).setDistance(2));
         setRestriction(nodeA, 5, nodeB);
         graph.freeze();
         setLevelEqualToNodeIdForAllNodes();
@@ -595,15 +595,15 @@ public class CHQueryWithTurnCostsTest {
         //     |
         //     |  no right turn at 7 when coming from 4 and no left turn at 7 when coming from 5!
         //     5
-        final EdgeIteratorState e0to1 = GHUtility.setProperties(graph.edge(0, 1).setDistance(2), encoder, 60, true, true);
-        final EdgeIteratorState e1to6 = GHUtility.setProperties(graph.edge(1, 6).setDistance(1), encoder, 60, true, true);
-        final EdgeIteratorState e0to6 = GHUtility.setProperties(graph.edge(0, 6).setDistance(4), encoder, 60, true, true);
-        final EdgeIteratorState e2to6 = GHUtility.setProperties(graph.edge(2, 6).setDistance(5), encoder, 60, true, true);
-        final EdgeIteratorState e2to3 = GHUtility.setProperties(graph.edge(2, 3).setDistance(3), encoder, 60, true, true);
-        final EdgeIteratorState e3to6 = GHUtility.setProperties(graph.edge(3, 6).setDistance(2), encoder, 60, true, true);
-        final EdgeIteratorState e6to7 = GHUtility.setProperties(graph.edge(7, 6).setDistance(1), encoder, 60, true, true);
-        final EdgeIteratorState e4to7 = GHUtility.setProperties(graph.edge(7, 4).setDistance(3), encoder, 60, true, true);
-        final EdgeIteratorState e5to7 = GHUtility.setProperties(graph.edge(7, 5).setDistance(2), encoder, 60, true, true);
+        final EdgeIteratorState e0to1 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(2));
+        final EdgeIteratorState e1to6 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 6).setDistance(1));
+        final EdgeIteratorState e0to6 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 6).setDistance(4));
+        final EdgeIteratorState e2to6 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 6).setDistance(5));
+        final EdgeIteratorState e2to3 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 3).setDistance(3));
+        final EdgeIteratorState e3to6 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 6).setDistance(2));
+        final EdgeIteratorState e6to7 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(7, 6).setDistance(1));
+        final EdgeIteratorState e4to7 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(7, 4).setDistance(3));
+        final EdgeIteratorState e5to7 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(7, 5).setDistance(2));
 
         setRestriction(e6to7, e1to6, 6);
         setRestriction(e6to7, e2to6, 6);
@@ -645,15 +645,15 @@ public class CHQueryWithTurnCostsTest {
         //     |
         //     v  no right turn at 6 when coming from 3!
         //     2
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(2), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 5).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(5, 0).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(5, 4).setDistance(5), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(5, 6).setDistance(3), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(6, 4).setDistance(4), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 1).setDistance(2));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 5).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(5, 0).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(5, 4).setDistance(5));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(5, 6).setDistance(3));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(6, 4).setDistance(4));
 
-        GHUtility.setProperties(graph.edge(3, 6).setDistance(3), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(6, 2).setDistance(4), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 6).setDistance(3));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(6, 2).setDistance(4));
         setRestriction(3, 6, 2);
         graph.freeze();
 

--- a/core/src/test/java/com/graphhopper/routing/CHQueryWithTurnCostsTest.java
+++ b/core/src/test/java/com/graphhopper/routing/CHQueryWithTurnCostsTest.java
@@ -169,15 +169,16 @@ public class CHQueryWithTurnCostsTest {
         //       1   2
         //        \ /
         // 5 - 6 - 4 - 7 - 8 - 0
-        GHUtility.setSpeed(60, true, false, encoder, graph.edge(5, 6).setDistance(1));
-        GHUtility.setSpeed(60, true, false, encoder, graph.edge(6, 4).setDistance(1));
-        GHUtility.setSpeed(60, true, false, encoder, graph.edge(4, 1).setDistance(1));
-        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 3).setDistance(1));
-        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 2).setDistance(1));
-        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 4).setDistance(1));
-        GHUtility.setSpeed(60, true, false, encoder, graph.edge(4, 7).setDistance(1));
-        GHUtility.setSpeed(60, true, false, encoder, graph.edge(7, 8).setDistance(1));
-        GHUtility.setSpeed(60, true, false, encoder, graph.edge(8, 0).setDistance(1));
+        GHUtility.setSpeed(60, 0, encoder,
+                graph.edge(5, 6).setDistance(1),
+                graph.edge(6, 4).setDistance(1),
+                graph.edge(4, 1).setDistance(1),
+                graph.edge(1, 3).setDistance(1),
+                graph.edge(3, 2).setDistance(1),
+                graph.edge(2, 4).setDistance(1),
+                graph.edge(4, 7).setDistance(1),
+                graph.edge(7, 8).setDistance(1),
+                graph.edge(8, 0).setDistance(1));
         setRestriction(6, 4, 7);
         setRestriction(6, 4, 2);
         setRestriction(1, 4, 7);
@@ -301,12 +302,13 @@ public class CHQueryWithTurnCostsTest {
         //      |    |
         //      v    v
         //      3 -> 4 -> 2
-        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 1).setDistance(9));
-        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 5).setDistance(2));
-        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 3).setDistance(2));
-        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 4).setDistance(4));
-        GHUtility.setSpeed(60, true, false, encoder, graph.edge(5, 4).setDistance(6));
-        GHUtility.setSpeed(60, true, false, encoder, graph.edge(4, 2).setDistance(3));
+        GHUtility.setSpeed(60, 0, encoder,
+                graph.edge(0, 1).setDistance(9),
+                graph.edge(1, 5).setDistance(2),
+                graph.edge(1, 3).setDistance(2),
+                graph.edge(3, 4).setDistance(4),
+                graph.edge(5, 4).setDistance(6),
+                graph.edge(4, 2).setDistance(3));
         setTurnCost(1, 3, 4, 3);
         graph.freeze();
 
@@ -446,12 +448,13 @@ public class CHQueryWithTurnCostsTest {
         // 0 --- 3 --- 1
         //  \         /
         //   --- 4 ---
-        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 2).setDistance(1));
-        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 3).setDistance(3));
-        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 4).setDistance(2));
-        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 1).setDistance(1));
-        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 1).setDistance(2));
-        GHUtility.setSpeed(60, true, false, encoder, graph.edge(4, 1).setDistance(6));
+        GHUtility.setSpeed(60, 0, encoder,
+                graph.edge(0, 2).setDistance(1),
+                graph.edge(0, 3).setDistance(3),
+                graph.edge(0, 4).setDistance(2),
+                graph.edge(2, 1).setDistance(1),
+                graph.edge(3, 1).setDistance(2),
+                graph.edge(4, 1).setDistance(6));
         setTurnCost(0, 2, 1, 9);
         setTurnCost(0, 3, 1, 2);
         setTurnCost(0, 4, 1, 1);
@@ -565,14 +568,15 @@ public class CHQueryWithTurnCostsTest {
         //  A-5->2
         //    |
         //    B-7
-        GHUtility.setSpeed(60, true, false, encoder, graph.edge(4, nodeA).setDistance(1));
-        GHUtility.setSpeed(60, true, false, encoder, graph.edge(nodeA, 5).setDistance(2));
-        GHUtility.setSpeed(60, true, false, encoder, graph.edge(5, 2).setDistance(2));
-        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 3).setDistance(1));
-        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 1).setDistance(2));
-        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 5).setDistance(1));
-        GHUtility.setSpeed(60, true, false, encoder, graph.edge(5, nodeB).setDistance(1));
-        GHUtility.setSpeed(60, true, false, encoder, graph.edge(nodeB, 7).setDistance(2));
+        GHUtility.setSpeed(60, 0, encoder,
+                graph.edge(4, nodeA).setDistance(1),
+                graph.edge(nodeA, 5).setDistance(2),
+                graph.edge(5, 2).setDistance(2),
+                graph.edge(2, 3).setDistance(1),
+                graph.edge(3, 1).setDistance(2),
+                graph.edge(1, 5).setDistance(1),
+                graph.edge(5, nodeB).setDistance(1),
+                graph.edge(nodeB, 7).setDistance(2));
         setRestriction(nodeA, 5, nodeB);
         graph.freeze();
         setLevelEqualToNodeIdForAllNodes();

--- a/core/src/test/java/com/graphhopper/routing/DefaultBidirPathExtractorTest.java
+++ b/core/src/test/java/com/graphhopper/routing/DefaultBidirPathExtractorTest.java
@@ -49,7 +49,7 @@ public class DefaultBidirPathExtractorTest {
     @Test
     public void testExtract() {
         Graph graph = createGraph();
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(10), carEncoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(1, 2).setDistance(10));
         SPTEntry fwdEntry = new SPTEntry(0, 2, 0);
         fwdEntry.parent = new SPTEntry(EdgeIterator.NO_EDGE, 1, 10);
         SPTEntry bwdEntry = new SPTEntry(EdgeIterator.NO_EDGE, 2, 0);
@@ -62,8 +62,8 @@ public class DefaultBidirPathExtractorTest {
     public void testExtract2() {
         // 1->2->3
         Graph graph = createGraph();
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(10), carEncoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(20), carEncoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(1, 2).setDistance(10));
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(2, 3).setDistance(20));
         // add some turn costs at node 2 where fwd&bwd searches meet. these costs have to be included in the
         // weight and the time of the path
         TurnCostStorage turnCostStorage = graph.getTurnCostStorage();

--- a/core/src/test/java/com/graphhopper/routing/DefaultBidirPathExtractorTest.java
+++ b/core/src/test/java/com/graphhopper/routing/DefaultBidirPathExtractorTest.java
@@ -29,6 +29,7 @@ import com.graphhopper.storage.Graph;
 import com.graphhopper.storage.GraphBuilder;
 import com.graphhopper.storage.TurnCostStorage;
 import com.graphhopper.util.EdgeIterator;
+import com.graphhopper.util.GHUtility;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -47,12 +48,12 @@ public class DefaultBidirPathExtractorTest {
 
     @Test
     public void testExtract() {
-        Graph g = createGraph();
-        g.edge(1, 2, 10, true);
+        Graph graph = createGraph();
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(10), carEncoder, 60, true, true);
         SPTEntry fwdEntry = new SPTEntry(0, 2, 0);
         fwdEntry.parent = new SPTEntry(EdgeIterator.NO_EDGE, 1, 10);
         SPTEntry bwdEntry = new SPTEntry(EdgeIterator.NO_EDGE, 2, 0);
-        Path p = DefaultBidirPathExtractor.extractPath(g, new FastestWeighting(carEncoder), fwdEntry, bwdEntry, 0);
+        Path p = DefaultBidirPathExtractor.extractPath(graph, new FastestWeighting(carEncoder), fwdEntry, bwdEntry, 0);
         assertEquals(IntArrayList.from(1, 2), p.calcNodes());
         assertEquals(10, p.getDistance(), 1e-4);
     }
@@ -60,12 +61,12 @@ public class DefaultBidirPathExtractorTest {
     @Test
     public void testExtract2() {
         // 1->2->3
-        Graph g = createGraph();
-        g.edge(1, 2, 10, false);
-        g.edge(2, 3, 20, false);
+        Graph graph = createGraph();
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(10), carEncoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(20), carEncoder, 60, true, false);
         // add some turn costs at node 2 where fwd&bwd searches meet. these costs have to be included in the
         // weight and the time of the path
-        TurnCostStorage turnCostStorage = g.getTurnCostStorage();
+        TurnCostStorage turnCostStorage = graph.getTurnCostStorage();
         DecimalEncodedValue turnCostEnc = encodingManager.getDecimalEncodedValue(TurnCost.key(carEncoder.toString()));
         turnCostStorage.set(turnCostEnc, 0, 2, 1, 5);
 
@@ -75,7 +76,7 @@ public class DefaultBidirPathExtractorTest {
         SPTEntry bwdEntry = new SPTEntry(1, 2, 1.2);
         bwdEntry.parent = new SPTEntry(EdgeIterator.NO_EDGE, 3, 0);
 
-        Path p = DefaultBidirPathExtractor.extractPath(g, new FastestWeighting(carEncoder, new DefaultTurnCostProvider(carEncoder, turnCostStorage)), fwdEntry, bwdEntry, 0);
+        Path p = DefaultBidirPathExtractor.extractPath(graph, new FastestWeighting(carEncoder, new DefaultTurnCostProvider(carEncoder, turnCostStorage)), fwdEntry, bwdEntry, 0);
         p.setWeight(5 + 1.8);
 
         assertEquals(IntArrayList.from(1, 2, 3), p.calcNodes());

--- a/core/src/test/java/com/graphhopper/routing/DijkstraBidirectionCHTest.java
+++ b/core/src/test/java/com/graphhopper/routing/DijkstraBidirectionCHTest.java
@@ -122,14 +122,15 @@ public class DijkstraBidirectionCHTest {
     public void testStallingNodesReducesNumberOfVisitedNodes() {
         ShortestWeighting weighting = new ShortestWeighting(carEncoder);
         GraphHopperStorage graph = createGHStorage(weighting);
-        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(8, 9).setDistance(100));
-        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(8, 3).setDistance(2));
-        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(8, 5).setDistance(1));
-        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(8, 6).setDistance(1));
-        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(8, 7).setDistance(1));
-        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(1, 2).setDistance(2));
-        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(1, 8).setDistance(1));
-        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(2, 3).setDistance(3));
+        GHUtility.setSpeed(60, 0, carEncoder,
+                graph.edge(8, 9).setDistance(100),
+                graph.edge(8, 3).setDistance(2),
+                graph.edge(8, 5).setDistance(1),
+                graph.edge(8, 6).setDistance(1),
+                graph.edge(8, 7).setDistance(1),
+                graph.edge(1, 2).setDistance(2),
+                graph.edge(1, 8).setDistance(1),
+                graph.edge(2, 3).setDistance(3));
         for (int i = 3; i < 7; ++i) {
             GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(i, i + 1).setDistance(1));
         }

--- a/core/src/test/java/com/graphhopper/routing/DijkstraBidirectionCHTest.java
+++ b/core/src/test/java/com/graphhopper/routing/DijkstraBidirectionCHTest.java
@@ -28,6 +28,7 @@ import com.graphhopper.routing.weighting.ShortestWeighting;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.*;
 import com.graphhopper.util.EdgeIteratorState;
+import com.graphhopper.util.GHUtility;
 import com.graphhopper.util.PMap;
 import org.junit.Test;
 
@@ -40,7 +41,6 @@ import static org.junit.Assert.assertEquals;
  *
  * @author Peter Karich
  * @author easbar
- *
  * @see RoutingAlgorithmTest for test cases covering standard node- and edge-based routing with this algorithm
  */
 public class DijkstraBidirectionCHTest {
@@ -63,7 +63,7 @@ public class DijkstraBidirectionCHTest {
         GraphHopperStorage ghStorage = createGHStorage(weighting);
         RoutingAlgorithmTest.initDirectedAndDiffSpeed(ghStorage, carEncoder);
 
-        // do CH preparation for car        
+        // do CH preparation for car
         prepareCH(ghStorage, CHConfig.nodeBased(weighting.getName(), weighting));
 
         // use base graph for solving normal Dijkstra
@@ -122,19 +122,19 @@ public class DijkstraBidirectionCHTest {
     public void testStallingNodesReducesNumberOfVisitedNodes() {
         ShortestWeighting weighting = new ShortestWeighting(carEncoder);
         GraphHopperStorage graph = createGHStorage(weighting);
-        graph.edge(8, 9, 100, false);
-        graph.edge(8, 3, 2, false);
-        graph.edge(8, 5, 1, false);
-        graph.edge(8, 6, 1, false);
-        graph.edge(8, 7, 1, false);
-        graph.edge(1, 2, 2, false);
-        graph.edge(1, 8, 1, false);
-        graph.edge(2, 3, 3, false);
+        GHUtility.setProperties(graph.edge(8, 9).setDistance(100), carEncoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(8, 3).setDistance(2), carEncoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(8, 5).setDistance(1), carEncoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(8, 6).setDistance(1), carEncoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(8, 7).setDistance(1), carEncoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(2), carEncoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 8).setDistance(1), carEncoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(3), carEncoder, 60, true, false);
         for (int i = 3; i < 7; ++i) {
-            graph.edge(i, i + 1, 1, false);
+            GHUtility.setProperties(graph.edge(i, i + 1).setDistance(1), carEncoder, 60, true, false);
         }
-        graph.edge(9, 0, 1, false);
-        graph.edge(3, 9, 200, false);
+        GHUtility.setProperties(graph.edge(9, 0).setDistance(1), carEncoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 9).setDistance(200), carEncoder, 60, true, false);
         CHGraph chGraph = graph.getCHGraph();
 
         // explicitly set the node levels equal to the node ids
@@ -183,11 +183,11 @@ public class DijkstraBidirectionCHTest {
     private void runTestWithDirectionDependentEdgeSpeed(double speed, double revSpeed, int from, int to, IntArrayList expectedPath, FlagEncoder encoder) {
         FastestWeighting weighting = new FastestWeighting(encoder);
         GraphHopperStorage graph = createGHStorage(weighting);
-        EdgeIteratorState edge = graph.edge(0, 1, 2, true);
+        EdgeIteratorState edge = GHUtility.setProperties(graph.edge(0, 1).setDistance(2), encoder, encoder.getMaxSpeed() / 2, true, true);
         DecimalEncodedValue avSpeedEnc = encodingManager.getDecimalEncodedValue(EncodingManager.getKey(encoder, "average_speed"));
         edge.set(avSpeedEnc, speed).setReverse(avSpeedEnc, revSpeed);
 
-        graph.edge(1, 2, 1, true);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, encoder.getMaxSpeed() / 2, true, true);
 
         CHGraph chGraph = graph.getCHGraph();
         for (int i = 0; i < 3; ++i) {

--- a/core/src/test/java/com/graphhopper/routing/DijkstraBidirectionCHTest.java
+++ b/core/src/test/java/com/graphhopper/routing/DijkstraBidirectionCHTest.java
@@ -122,19 +122,19 @@ public class DijkstraBidirectionCHTest {
     public void testStallingNodesReducesNumberOfVisitedNodes() {
         ShortestWeighting weighting = new ShortestWeighting(carEncoder);
         GraphHopperStorage graph = createGHStorage(weighting);
-        GHUtility.setProperties(graph.edge(8, 9).setDistance(100), carEncoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(8, 3).setDistance(2), carEncoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(8, 5).setDistance(1), carEncoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(8, 6).setDistance(1), carEncoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(8, 7).setDistance(1), carEncoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(2), carEncoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 8).setDistance(1), carEncoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(3), carEncoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(8, 9).setDistance(100));
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(8, 3).setDistance(2));
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(8, 5).setDistance(1));
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(8, 6).setDistance(1));
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(8, 7).setDistance(1));
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(1, 2).setDistance(2));
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(1, 8).setDistance(1));
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(2, 3).setDistance(3));
         for (int i = 3; i < 7; ++i) {
-            GHUtility.setProperties(graph.edge(i, i + 1).setDistance(1), carEncoder, 60, true, false);
+            GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(i, i + 1).setDistance(1));
         }
-        GHUtility.setProperties(graph.edge(9, 0).setDistance(1), carEncoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 9).setDistance(200), carEncoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(9, 0).setDistance(1));
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(3, 9).setDistance(200));
         CHGraph chGraph = graph.getCHGraph();
 
         // explicitly set the node levels equal to the node ids
@@ -183,11 +183,11 @@ public class DijkstraBidirectionCHTest {
     private void runTestWithDirectionDependentEdgeSpeed(double speed, double revSpeed, int from, int to, IntArrayList expectedPath, FlagEncoder encoder) {
         FastestWeighting weighting = new FastestWeighting(encoder);
         GraphHopperStorage graph = createGHStorage(weighting);
-        EdgeIteratorState edge = GHUtility.setProperties(graph.edge(0, 1).setDistance(2), encoder, encoder.getMaxSpeed() / 2, true, true);
+        EdgeIteratorState edge = GHUtility.setSpeed(encoder.getMaxSpeed() / 2, true, true, encoder, graph.edge(0, 1).setDistance(2));
         DecimalEncodedValue avSpeedEnc = encodingManager.getDecimalEncodedValue(EncodingManager.getKey(encoder, "average_speed"));
         edge.set(avSpeedEnc, speed).setReverse(avSpeedEnc, revSpeed);
 
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, encoder.getMaxSpeed() / 2, true, true);
+        GHUtility.setSpeed(encoder.getMaxSpeed() / 2, true, true, encoder, graph.edge(1, 2).setDistance(1));
 
         CHGraph chGraph = graph.getCHGraph();
         for (int i = 0; i < 3; ++i) {

--- a/core/src/test/java/com/graphhopper/routing/DijkstraBidirectionCHTest.java
+++ b/core/src/test/java/com/graphhopper/routing/DijkstraBidirectionCHTest.java
@@ -186,7 +186,7 @@ public class DijkstraBidirectionCHTest {
         GraphHopperStorage graph = createGHStorage(weighting);
         EdgeIteratorState edge = GHUtility.setSpeed(encoder.getMaxSpeed() / 2, true, true, encoder, graph.edge(0, 1).setDistance(2));
         DecimalEncodedValue avSpeedEnc = encodingManager.getDecimalEncodedValue(EncodingManager.getKey(encoder, "average_speed"));
-        edge.set(avSpeedEnc, speed).setReverse(avSpeedEnc, revSpeed);
+        edge.set(avSpeedEnc, speed, revSpeed);
 
         GHUtility.setSpeed(encoder.getMaxSpeed() / 2, true, true, encoder, graph.edge(1, 2).setDistance(1));
 

--- a/core/src/test/java/com/graphhopper/routing/DijkstraOneToManyTest.java
+++ b/core/src/test/java/com/graphhopper/routing/DijkstraOneToManyTest.java
@@ -60,17 +60,17 @@ public class DijkstraOneToManyTest {
         //   |   |   |
         //   4---3---2
 
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(1));
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(1));
-
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 2).setDistance(1));
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 5).setDistance(1));
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(5, 7).setDistance(1));
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 4).setDistance(1));
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 6).setDistance(1));
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(6, 7).setDistance(1));
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(6, 5).setDistance(1));
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 7).setDistance(1));
+        GHUtility.setSpeed(60, 60, encoder,
+                graph.edge(0, 1).setDistance(1),
+                graph.edge(1, 2).setDistance(1),
+                graph.edge(3, 2).setDistance(1),
+                graph.edge(3, 5).setDistance(1),
+                graph.edge(5, 7).setDistance(1),
+                graph.edge(3, 4).setDistance(1),
+                graph.edge(4, 6).setDistance(1),
+                graph.edge(6, 7).setDistance(1),
+                graph.edge(6, 5).setDistance(1),
+                graph.edge(0, 7).setDistance(1));
     }
 
     @Test
@@ -88,13 +88,13 @@ public class DijkstraOneToManyTest {
     @Test
     public void testIssue239_and362() {
         GraphHopperStorage graph = createGHStorage();
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(1));
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(1));
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 0).setDistance(1));
-
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 5).setDistance(1));
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(5, 6).setDistance(1));
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(6, 4).setDistance(1));
+        GHUtility.setSpeed(60, 60, encoder,
+                graph.edge(0, 1).setDistance(1),
+                graph.edge(1, 2).setDistance(1),
+                graph.edge(2, 0).setDistance(1),
+                graph.edge(4, 5).setDistance(1),
+                graph.edge(5, 6).setDistance(1),
+                graph.edge(6, 4).setDistance(1));
 
         DijkstraOneToMany algo = createAlgo(graph);
         assertEquals(-1, algo.findEndNode(0, 4));
@@ -126,15 +126,15 @@ public class DijkstraOneToManyTest {
         // |       /
         // 7-10----
         // \-8
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(1));
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(1));
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 3).setDistance(1));
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 4).setDistance(1));
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 10).setDistance(1));
-
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 7).setDistance(1));
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(7, 8).setDistance(1));
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(7, 10).setDistance(10));
+        GHUtility.setSpeed(60, 60, encoder,
+                graph.edge(0, 1).setDistance(1),
+                graph.edge(1, 2).setDistance(1),
+                graph.edge(2, 3).setDistance(1),
+                graph.edge(3, 4).setDistance(1),
+                graph.edge(4, 10).setDistance(1),
+                graph.edge(0, 7).setDistance(1),
+                graph.edge(7, 8).setDistance(1),
+                graph.edge(7, 10).setDistance(10));
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/routing/DijkstraOneToManyTest.java
+++ b/core/src/test/java/com/graphhopper/routing/DijkstraOneToManyTest.java
@@ -60,17 +60,17 @@ public class DijkstraOneToManyTest {
         //   |   |   |
         //   4---3---2
 
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(1));
 
-        GHUtility.setProperties(graph.edge(3, 2).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(3, 5).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(5, 7).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(4, 6).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(6, 7).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(6, 5).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(0, 7).setDistance(1), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 5).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(5, 7).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 6).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(6, 7).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(6, 5).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 7).setDistance(1));
     }
 
     @Test
@@ -88,13 +88,13 @@ public class DijkstraOneToManyTest {
     @Test
     public void testIssue239_and362() {
         GraphHopperStorage graph = createGHStorage();
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 0).setDistance(1), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 0).setDistance(1));
 
-        GHUtility.setProperties(graph.edge(4, 5).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(5, 6).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(6, 4).setDistance(1), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 5).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(5, 6).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(6, 4).setDistance(1));
 
         DijkstraOneToMany algo = createAlgo(graph);
         assertEquals(-1, algo.findEndNode(0, 4));
@@ -126,15 +126,15 @@ public class DijkstraOneToManyTest {
         // |       /
         // 7-10----
         // \-8
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(4, 10).setDistance(1), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 10).setDistance(1));
 
-        GHUtility.setProperties(graph.edge(0, 7).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(7, 8).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(7, 10).setDistance(10), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 7).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(7, 8).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(7, 10).setDistance(10));
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/routing/DijkstraOneToManyTest.java
+++ b/core/src/test/java/com/graphhopper/routing/DijkstraOneToManyTest.java
@@ -26,6 +26,7 @@ import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.Graph;
 import com.graphhopper.storage.GraphBuilder;
 import com.graphhopper.storage.GraphHopperStorage;
+import com.graphhopper.util.GHUtility;
 import org.junit.Test;
 
 import static com.graphhopper.routing.RoutingAlgorithmTest.initTestStorage;
@@ -41,16 +42,16 @@ import static org.junit.Assert.assertTrue;
 public class DijkstraOneToManyTest {
 
     private final EncodingManager encodingManager;
-    private final FlagEncoder carEncoder;
+    private final FlagEncoder encoder;
     private Weighting defaultWeighting;
 
     public DijkstraOneToManyTest() {
         encodingManager = EncodingManager.create("car");
-        carEncoder = encodingManager.getEncoder("car");
-        defaultWeighting = new ShortestWeighting(carEncoder);
+        encoder = encodingManager.getEncoder("car");
+        defaultWeighting = new ShortestWeighting(encoder);
     }
 
-    private static void initGraphWeightLimit(Graph g) {
+    private static void initGraphWeightLimit(Graph graph, FlagEncoder encoder) {
         //      0----1
         //     /     |
         //    7--    |
@@ -59,17 +60,17 @@ public class DijkstraOneToManyTest {
         //   |   |   |
         //   4---3---2
 
-        g.edge(0, 1, 1, true);
-        g.edge(1, 2, 1, true);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, true);
 
-        g.edge(3, 2, 1, true);
-        g.edge(3, 5, 1, true);
-        g.edge(5, 7, 1, true);
-        g.edge(3, 4, 1, true);
-        g.edge(4, 6, 1, true);
-        g.edge(6, 7, 1, true);
-        g.edge(6, 5, 1, true);
-        g.edge(0, 7, 1, true);
+        GHUtility.setProperties(graph.edge(3, 2).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(3, 5).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(5, 7).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(4, 6).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(6, 7).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(6, 5).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(0, 7).setDistance(1), encoder, 60, true, true);
     }
 
     @Test
@@ -86,16 +87,16 @@ public class DijkstraOneToManyTest {
 
     @Test
     public void testIssue239_and362() {
-        GraphHopperStorage g = createGHStorage();
-        g.edge(0, 1, 1, true);
-        g.edge(1, 2, 1, true);
-        g.edge(2, 0, 1, true);
+        GraphHopperStorage graph = createGHStorage();
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 0).setDistance(1), encoder, 60, true, true);
 
-        g.edge(4, 5, 1, true);
-        g.edge(5, 6, 1, true);
-        g.edge(6, 4, 1, true);
+        GHUtility.setProperties(graph.edge(4, 5).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(5, 6).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(6, 4).setDistance(1), encoder, 60, true, true);
 
-        DijkstraOneToMany algo = createAlgo(g);
+        DijkstraOneToMany algo = createAlgo(graph);
         assertEquals(-1, algo.findEndNode(0, 4));
         assertEquals(-1, algo.findEndNode(0, 4));
 
@@ -106,7 +107,7 @@ public class DijkstraOneToManyTest {
     @Test
     public void testUseCache() {
         GraphHopperStorage graph = createGHStorage();
-        initTestStorage(graph);
+        initTestStorage(graph, encoder);
         RoutingAlgorithm algo = createAlgo(graph);
         Path p = algo.calcPath(0, 4);
         assertEquals(IntArrayList.from(0, 4), p.calcNodes());
@@ -120,26 +121,26 @@ public class DijkstraOneToManyTest {
         assertEquals(IntArrayList.from(0, 1, 2), p.calcNodes());
     }
 
-    private void initGraph(Graph g) {
+    private void initGraph(Graph graph) {
         // 0-1-2-3-4
         // |       /
         // 7-10----
         // \-8
-        g.edge(0, 1, 1, true);
-        g.edge(1, 2, 1, true);
-        g.edge(2, 3, 1, true);
-        g.edge(3, 4, 1, true);
-        g.edge(4, 10, 1, true);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(4, 10).setDistance(1), encoder, 60, true, true);
 
-        g.edge(0, 7, 1, true);
-        g.edge(7, 8, 1, true);
-        g.edge(7, 10, 10, true);
+        GHUtility.setProperties(graph.edge(0, 7).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(7, 8).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(7, 10).setDistance(10), encoder, 60, true, true);
     }
 
     @Test
     public void testWeightLimit_issue380() {
         GraphHopperStorage graph = createGHStorage();
-        initGraphWeightLimit(graph);
+        initGraphWeightLimit(graph, encoder);
 
         DijkstraOneToMany algo = createAlgo(graph);
         algo.setWeightLimit(3);
@@ -156,7 +157,7 @@ public class DijkstraOneToManyTest {
     @Test
     public void testUseCacheZeroPath_issue707() {
         GraphHopperStorage graph = createGHStorage();
-        initTestStorage(graph);
+        initTestStorage(graph, encoder);
         RoutingAlgorithm algo = createAlgo(graph);
 
         Path p = algo.calcPath(0, 0);

--- a/core/src/test/java/com/graphhopper/routing/DirectedBidirectionalDijkstraTest.java
+++ b/core/src/test/java/com/graphhopper/routing/DirectedBidirectionalDijkstraTest.java
@@ -237,18 +237,20 @@ public class DirectedBidirectionalDijkstraTest {
         //   9     2     10
         //   |    / \    |
         //   8 = 7   6 = 5
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(1));
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(1));
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 3).setDistance(1));
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 4).setDistance(3));
-        int rightNorth = GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 10).setDistance(1)).getEdge();
-        int rightSouth = GHUtility.setSpeed(60, true, true, encoder, graph.edge(10, 5).setDistance(1)).getEdge();
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(5, 6).setDistance(2));
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(6, 2).setDistance(1));
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 7).setDistance(1));
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(7, 8).setDistance(9));
-        int leftSouth = GHUtility.setSpeed(60, true, true, encoder, graph.edge(8, 9).setDistance(1)).getEdge();
-        int leftNorth = GHUtility.setSpeed(60, true, true, encoder, graph.edge(9, 0).setDistance(1)).getEdge();
+        EdgeIteratorState rightNorth, rightSouth, leftSouth, leftNorth;
+        GHUtility.setSpeed(60, 60, encoder,
+                graph.edge(0, 1).setDistance(1),
+                graph.edge(1, 2).setDistance(1),
+                graph.edge(2, 3).setDistance(1),
+                graph.edge(3, 4).setDistance(3),
+                rightNorth = graph.edge(4, 10).setDistance(1),
+                rightSouth = graph.edge(10, 5).setDistance(1),
+                graph.edge(5, 6).setDistance(2),
+                graph.edge(6, 2).setDistance(1),
+                graph.edge(2, 7).setDistance(1),
+                graph.edge(7, 8).setDistance(9),
+                leftSouth = graph.edge(8, 9).setDistance(1),
+                leftNorth = graph.edge(9, 0).setDistance(1));
 
         // make paths fully deterministic by applying some turn costs at junction node 2
         setTurnCost(7, 2, 3, 1);
@@ -258,16 +260,16 @@ public class DirectedBidirectionalDijkstraTest {
         setTurnCost(1, 2, 7, 9);
 
         final double unitEdgeWeight = 0.06;
-        assertPath(calcPath(9, 9, leftNorth, leftSouth),
+        assertPath(calcPath(9, 9, leftNorth.getEdge(), leftSouth.getEdge()),
                 23 * unitEdgeWeight + 5, 23, (long) ((23 * unitEdgeWeight + 5) * 1000),
                 nodes(9, 0, 1, 2, 3, 4, 10, 5, 6, 2, 7, 8, 9));
-        assertPath(calcPath(9, 9, leftSouth, leftNorth),
+        assertPath(calcPath(9, 9, leftSouth.getEdge(), leftNorth.getEdge()),
                 14 * unitEdgeWeight, 14, (long) ((14 * unitEdgeWeight) * 1000),
                 nodes(9, 8, 7, 2, 1, 0, 9));
-        assertPath(calcPath(9, 10, leftSouth, rightSouth),
+        assertPath(calcPath(9, 10, leftSouth.getEdge(), rightSouth.getEdge()),
                 15 * unitEdgeWeight + 3, 15, (long) ((15 * unitEdgeWeight + 3) * 1000),
                 nodes(9, 8, 7, 2, 6, 5, 10));
-        assertPath(calcPath(9, 10, leftSouth, rightNorth),
+        assertPath(calcPath(9, 10, leftSouth.getEdge(), rightNorth.getEdge()),
                 16 * unitEdgeWeight + 1, 16, (long) ((16 * unitEdgeWeight + 1) * 1000),
                 nodes(9, 8, 7, 2, 3, 4, 10));
     }

--- a/core/src/test/java/com/graphhopper/routing/DirectedBidirectionalDijkstraTest.java
+++ b/core/src/test/java/com/graphhopper/routing/DirectedBidirectionalDijkstraTest.java
@@ -69,8 +69,8 @@ public class DirectedBidirectionalDijkstraTest {
     public void connectionNotFound() {
         // nodes 0 and 2 are not connected
         // 0 -> 1     2 -> 3
-        graph.edge(0, 1, 1, false);
-        graph.edge(2, 3, 1, false);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
 
         Path path = calcPath(0, 3, 0, 1);
         assertNotFound(path);
@@ -78,7 +78,7 @@ public class DirectedBidirectionalDijkstraTest {
 
     @Test
     public void singleEdge() {
-        graph.edge(0, 1, 1, true);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
 
         // source edge does not exist -> no path
         assertNotFound(calcPath(0, 1, 5, 0));
@@ -97,8 +97,8 @@ public class DirectedBidirectionalDijkstraTest {
     @Test
     public void simpleGraph() {
         // 0 -> 1 -> 2
-        graph.edge(0, 1, 1, true);
-        graph.edge(1, 2, 1, true);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, true);
 
         // source edge does not exist -> no path
         assertNotFound(calcPath(0, 2, 5, 0));
@@ -122,9 +122,9 @@ public class DirectedBidirectionalDijkstraTest {
         // 0 - 1
         //  \  |
         //   - 2
-        graph.edge(0, 1, 1, true);
-        graph.edge(0, 2, 1, true);
-        graph.edge(1, 2, 1, true);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(0, 2).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, true);
         assertPath(calcPath(0, 0, 0, 1), 0.18, 3, 180, nodes(0, 1, 2, 0));
         assertPath(calcPath(0, 0, 1, 0), 0.18, 3, 180, nodes(0, 2, 1, 0));
         // without restrictions the weight should be zero
@@ -140,15 +140,15 @@ public class DirectedBidirectionalDijkstraTest {
         // 0 = 1 - 2 - 3 = 4
         //  \      |      /
         //   - 5 - 6 - 7 -
-        int costlySource = graph.edge(0, 1, 5, true).getEdge();
-        graph.edge(1, 2, 1, true);
-        graph.edge(2, 3, 1, true);
-        int costlyTarget = graph.edge(3, 4, 5, true).getEdge();
-        int cheapSource = graph.edge(0, 5, 1, true).getEdge();
-        graph.edge(5, 6, 1, true);
-        graph.edge(6, 7, 1, true);
-        int cheapTarget = graph.edge(7, 4, 1, true).getEdge();
-        graph.edge(2, 6, 1, true);
+        int costlySource = GHUtility.setProperties(graph.edge(0, 1).setDistance(5), encoder, 60, true, true).getEdge();
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, true);
+        int costlyTarget = GHUtility.setProperties(graph.edge(3, 4).setDistance(5), encoder, 60, true, true).getEdge();
+        int cheapSource = GHUtility.setProperties(graph.edge(0, 5).setDistance(1), encoder, 60, true, true).getEdge();
+        GHUtility.setProperties(graph.edge(5, 6).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(6, 7).setDistance(1), encoder, 60, true, true);
+        int cheapTarget = GHUtility.setProperties(graph.edge(7, 4).setDistance(1), encoder, 60, true, true).getEdge();
+        GHUtility.setProperties(graph.edge(2, 6).setDistance(1), encoder, 60, true, true);
 
         assertPath(calcPath(0, 4, cheapSource, cheapTarget), 0.24, 4, 240, nodes(0, 5, 6, 7, 4));
         assertPath(calcPath(0, 4, cheapSource, costlyTarget), 0.54, 9, 540, nodes(0, 5, 6, 2, 3, 4));
@@ -164,10 +164,10 @@ public class DirectedBidirectionalDijkstraTest {
         //  \     /
         //   - 3 -
         // we cannot go from 0 to 2 if we enforce north-south or south-north
-        int sourceNorth = graph.edge(0, 1, 1, true).getEdge();
-        int sourceSouth = graph.edge(0, 3, 2, true).getEdge();
-        int targetNorth = graph.edge(1, 2, 3, true).getEdge();
-        int targetSouth = graph.edge(3, 2, 4, true).getEdge();
+        int sourceNorth = GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true).getEdge();
+        int sourceSouth = GHUtility.setProperties(graph.edge(0, 3).setDistance(2), encoder, 60, true, true).getEdge();
+        int targetNorth = GHUtility.setProperties(graph.edge(1, 2).setDistance(3), encoder, 60, true, true).getEdge();
+        int targetSouth = GHUtility.setProperties(graph.edge(3, 2).setDistance(4), encoder, 60, true, true).getEdge();
 
         assertPath(calcPath(0, 2, sourceNorth, targetNorth), 0.24, 4, 240, nodes(0, 1, 2));
         assertNotFound(calcPath(0, 2, sourceNorth, targetSouth));
@@ -180,11 +180,11 @@ public class DirectedBidirectionalDijkstraTest {
         // 0 <- 1 <- 2
         //  \   |   /
         //   >--3-->
-        graph.edge(0, 3, 1, false);
-        graph.edge(1, 0, 1, false);
-        graph.edge(3, 2, 1, false);
-        graph.edge(2, 1, 1, false);
-        graph.edge(1, 3, 1, true);
+        GHUtility.setProperties(graph.edge(0, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 0).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 2).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 1).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 3).setDistance(1), encoder, 60, true, true);
 
         assertPath(calcPath(0, 2, 0, 2), 0.12, 2, 120, nodes(0, 3, 2));
         assertNotFound(calcPath(0, 2, 1, 2));
@@ -201,15 +201,15 @@ public class DirectedBidirectionalDijkstraTest {
         // 2 - 3
         // |   |
         // 5 - 4
-        int north = graph.edge(1, 0, 1, true).getEdge();
-        int south = graph.edge(1, 2, 1, true).getEdge();
-        graph.edge(2, 5, 1, false);
-        graph.edge(5, 4, 1, false);
-        graph.edge(4, 3, 1, false);
-        graph.edge(3, 2, 1, false);
-        graph.edge(1, 0, 1, false);
-        graph.edge(0, 6, 1, false);
-        int targetEdge = graph.edge(6, 7, 1, false).getEdge();
+        int north = GHUtility.setProperties(graph.edge(1, 0).setDistance(1), encoder, 60, true, true).getEdge();
+        int south = GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, true).getEdge();
+        GHUtility.setProperties(graph.edge(2, 5).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(5, 4).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(4, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 2).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 0).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(0, 6).setDistance(1), encoder, 60, true, false);
+        int targetEdge = GHUtility.setProperties(graph.edge(6, 7).setDistance(1), encoder, 60, true, false).getEdge();
         assertPath(calcPath(1, 7, north, targetEdge), 0.18, 3, 180, nodes(1, 0, 6, 7));
         assertPath(calcPath(1, 7, south, targetEdge), 0.54, 9, 540, nodes(1, 2, 5, 4, 3, 2, 1, 0, 6, 7));
     }
@@ -219,13 +219,13 @@ public class DirectedBidirectionalDijkstraTest {
         // 0---6--1 -> 2
         // |          /
         // 5 <- 4 <- 3
-        graph.edge(0, 6, 1, true);
-        graph.edge(6, 1, 1, true);
-        graph.edge(1, 2, 1, false);
-        graph.edge(2, 3, 1, false);
-        graph.edge(3, 4, 1, false);
-        graph.edge(4, 5, 1, false);
-        graph.edge(5, 0, 1, false);
+        GHUtility.setProperties(graph.edge(0, 6).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(6, 1).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(4, 5).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(5, 0).setDistance(1), encoder, 60, true, false);
         assertPath(calcPath(6, 0, 1, 6), 0.36, 6, 360, nodes(6, 1, 2, 3, 4, 5, 0));
     }
 
@@ -237,18 +237,18 @@ public class DirectedBidirectionalDijkstraTest {
         //   9     2     10
         //   |    / \    |
         //   8 = 7   6 = 5
-        graph.edge(0, 1, 1, true);
-        graph.edge(1, 2, 1, true);
-        graph.edge(2, 3, 1, true);
-        graph.edge(3, 4, 3, true);
-        int rightNorth = graph.edge(4, 10, 1, true).getEdge();
-        int rightSouth = graph.edge(10, 5, 1, true).getEdge();
-        graph.edge(5, 6, 2, true);
-        graph.edge(6, 2, 1, true);
-        graph.edge(2, 7, 1, true);
-        graph.edge(7, 8, 9, true);
-        int leftSouth = graph.edge(8, 9, 1, true).getEdge();
-        int leftNorth = graph.edge(9, 0, 1, true).getEdge();
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(3), encoder, 60, true, true);
+        int rightNorth = GHUtility.setProperties(graph.edge(4, 10).setDistance(1), encoder, 60, true, true).getEdge();
+        int rightSouth = GHUtility.setProperties(graph.edge(10, 5).setDistance(1), encoder, 60, true, true).getEdge();
+        GHUtility.setProperties(graph.edge(5, 6).setDistance(2), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(6, 2).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 7).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(7, 8).setDistance(9), encoder, 60, true, true);
+        int leftSouth = GHUtility.setProperties(graph.edge(8, 9).setDistance(1), encoder, 60, true, true).getEdge();
+        int leftNorth = GHUtility.setProperties(graph.edge(9, 0).setDistance(1), encoder, 60, true, true).getEdge();
 
         // make paths fully deterministic by applying some turn costs at junction node 2
         setTurnCost(7, 2, 3, 1);
@@ -276,10 +276,10 @@ public class DirectedBidirectionalDijkstraTest {
     public void enforceLoopEdge() {
         //  o       o
         //  0 - 1 - 2
-        graph.edge(0, 0, 1, true);
-        graph.edge(0, 1, 1, true);
-        graph.edge(1, 2, 1, true);
-        graph.edge(2, 2, 1, true);
+        GHUtility.setProperties(graph.edge(0, 0).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 2).setDistance(1), encoder, 60, true, true);
 
         assertPath(calcPath(0, 2, ANY_EDGE, ANY_EDGE), 0.12, 2, 120, nodes(0, 1, 2));
         assertPath(calcPath(0, 2, 1, 2), 0.12, 2, 120, nodes(0, 1, 2));
@@ -292,9 +292,9 @@ public class DirectedBidirectionalDijkstraTest {
     @Test
     public void sourceAndTargetAreNeighbors() {
         // 0-1-2-3
-        graph.edge(0, 1, 100, true);
-        graph.edge(1, 2, 100, true);
-        graph.edge(2, 3, 100, true);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(100), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(100), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(100), encoder, 60, true, true);
         assertPath(calcPath(1, 2, ANY_EDGE, ANY_EDGE), 6, 100, 6000, nodes(1, 2));
         assertPath(calcPath(1, 2, 1, ANY_EDGE), 6, 100, 6000, nodes(1, 2));
         assertPath(calcPath(1, 2, ANY_EDGE, 1), 6, 100, 6000, nodes(1, 2));
@@ -317,13 +317,13 @@ public class DirectedBidirectionalDijkstraTest {
         // 0 - 1 - 2
         // |   |   |
         // 3 - 4 - 5
-        graph.edge(0, 1, 1, true);
-        graph.edge(1, 2, 1, true);
-        graph.edge(1, 4, 1, true);
-        graph.edge(0, 3, 1, true);
-        graph.edge(3, 4, 1, true);
-        graph.edge(4, 5, 1, true);
-        graph.edge(5, 2, 1, true);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 4).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(0, 3).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(4, 5).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(5, 2).setDistance(1), encoder, 60, true, true);
 
         setRestriction(0, 3, 4);
         setTurnCost(4, 5, 2, 6);
@@ -346,17 +346,17 @@ public class DirectedBidirectionalDijkstraTest {
         // 0 -- 1 -- 6
         // |         |
         // 7 -- 8 -- 9
-        int right0 = graph.edge(0, 1, 10, true).getEdge();
-        graph.edge(1, 2, 10, true);
-        graph.edge(2, 3, 10, true);
-        graph.edge(3, 4, 10, true);
-        graph.edge(4, 5, 10, true);
-        graph.edge(5, 2, 1000, true);
-        int left6 = graph.edge(1, 6, 10, true).getEdge();
-        int left0 = graph.edge(0, 7, 10, true).getEdge();
-        graph.edge(7, 8, 10, true);
-        graph.edge(8, 9, 10, true);
-        int right6 = graph.edge(9, 6, 10, true).getEdge();
+        int right0 = GHUtility.setProperties(graph.edge(0, 1).setDistance(10), encoder, 60, true, true).getEdge();
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(10), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(10), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(10), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(4, 5).setDistance(10), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(5, 2).setDistance(1000), encoder, 60, true, true);
+        int left6 = GHUtility.setProperties(graph.edge(1, 6).setDistance(10), encoder, 60, true, true).getEdge();
+        int left0 = GHUtility.setProperties(graph.edge(0, 7).setDistance(10), encoder, 60, true, true).getEdge();
+        GHUtility.setProperties(graph.edge(7, 8).setDistance(10), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(8, 9).setDistance(10), encoder, 60, true, true);
+        int right6 = GHUtility.setProperties(graph.edge(9, 6).setDistance(10), encoder, 60, true, true).getEdge();
 
         // enforce p-turn (using the loop in clockwise direction)
         setRestriction(0, 1, 6);
@@ -394,7 +394,8 @@ public class DirectedBidirectionalDijkstraTest {
 
         Random rnd = new Random(seed);
         int numNodes = 100;
-        GHUtility.buildRandomGraph(graph, rnd, numNodes, 2.2, true, true, encoder.getAverageSpeedEnc(), 0.7, 0.8, 0.8);
+        GHUtility.buildRandomGraph(graph, rnd, numNodes, 2.2, true, true,
+                encoder.getAccessEnc(), encoder.getAverageSpeedEnc(), 60d, 0.7, 0.8, 0.8);
         GHUtility.addRandomTurnCosts(graph, seed, encodingManager, encoder, maxTurnCosts, turnCostStorage);
 
         long numStrictViolations = 0;
@@ -424,13 +425,13 @@ public class DirectedBidirectionalDijkstraTest {
         // 0 - 1 - 2 - 3
         // |           |
         // 4 --- 5 --- 6
-        EdgeIteratorState edge1 = graph.edge(0, 1, 10, true);
-        graph.edge(1, 2, 10, true);
-        EdgeIteratorState edge2 = graph.edge(2, 3, 10, true);
-        graph.edge(0, 4, 100, true);
-        graph.edge(4, 5, 100, true);
-        graph.edge(5, 6, 100, true);
-        graph.edge(6, 3, 100, true);
+        EdgeIteratorState edge1 = GHUtility.setProperties(graph.edge(0, 1).setDistance(10), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(10), encoder, 60, true, true);
+        EdgeIteratorState edge2 = GHUtility.setProperties(graph.edge(2, 3).setDistance(10), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(0, 4).setDistance(100), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(4, 5).setDistance(100), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(5, 6).setDistance(100), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(6, 3).setDistance(100), encoder, 60, true, true);
 
         // usually we would take the direct route
         assertPath(calcPath(0, 3, ANY_EDGE, ANY_EDGE), 1.8, 30, 1800, nodes(0, 1, 2, 3));
@@ -469,12 +470,12 @@ public class DirectedBidirectionalDijkstraTest {
         // 0 -- 1 -> 2
         // |         |
         // 5 <- 4 <- 3
-        graph.edge(0, 1, 1, true);
-        graph.edge(1, 2, 1, false);
-        graph.edge(2, 3, 1, false);
-        graph.edge(3, 4, 1, false);
-        graph.edge(4, 5, 1, false);
-        graph.edge(5, 0, 1, false);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(4, 5).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(5, 0).setDistance(1), encoder, 60, true, false);
         NodeAccess na = graph.getNodeAccess();
         na.setNode(0, 1, 0);
         na.setNode(1, 1, 1);

--- a/core/src/test/java/com/graphhopper/routing/DirectedBidirectionalDijkstraTest.java
+++ b/core/src/test/java/com/graphhopper/routing/DirectedBidirectionalDijkstraTest.java
@@ -69,8 +69,8 @@ public class DirectedBidirectionalDijkstraTest {
     public void connectionNotFound() {
         // nodes 0 and 2 are not connected
         // 0 -> 1     2 -> 3
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 3).setDistance(1));
 
         Path path = calcPath(0, 3, 0, 1);
         assertNotFound(path);
@@ -78,7 +78,7 @@ public class DirectedBidirectionalDijkstraTest {
 
     @Test
     public void singleEdge() {
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(1));
 
         // source edge does not exist -> no path
         assertNotFound(calcPath(0, 1, 5, 0));
@@ -97,8 +97,8 @@ public class DirectedBidirectionalDijkstraTest {
     @Test
     public void simpleGraph() {
         // 0 -> 1 -> 2
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(1));
 
         // source edge does not exist -> no path
         assertNotFound(calcPath(0, 2, 5, 0));
@@ -122,9 +122,9 @@ public class DirectedBidirectionalDijkstraTest {
         // 0 - 1
         //  \  |
         //   - 2
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(0, 2).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(1));
         assertPath(calcPath(0, 0, 0, 1), 0.18, 3, 180, nodes(0, 1, 2, 0));
         assertPath(calcPath(0, 0, 1, 0), 0.18, 3, 180, nodes(0, 2, 1, 0));
         // without restrictions the weight should be zero
@@ -140,15 +140,15 @@ public class DirectedBidirectionalDijkstraTest {
         // 0 = 1 - 2 - 3 = 4
         //  \      |      /
         //   - 5 - 6 - 7 -
-        int costlySource = GHUtility.setProperties(graph.edge(0, 1).setDistance(5), encoder, 60, true, true).getEdge();
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, true);
-        int costlyTarget = GHUtility.setProperties(graph.edge(3, 4).setDistance(5), encoder, 60, true, true).getEdge();
-        int cheapSource = GHUtility.setProperties(graph.edge(0, 5).setDistance(1), encoder, 60, true, true).getEdge();
-        GHUtility.setProperties(graph.edge(5, 6).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(6, 7).setDistance(1), encoder, 60, true, true);
-        int cheapTarget = GHUtility.setProperties(graph.edge(7, 4).setDistance(1), encoder, 60, true, true).getEdge();
-        GHUtility.setProperties(graph.edge(2, 6).setDistance(1), encoder, 60, true, true);
+        int costlySource = GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(5)).getEdge();
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 3).setDistance(1));
+        int costlyTarget = GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 4).setDistance(5)).getEdge();
+        int cheapSource = GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 5).setDistance(1)).getEdge();
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(5, 6).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(6, 7).setDistance(1));
+        int cheapTarget = GHUtility.setSpeed(60, true, true, encoder, graph.edge(7, 4).setDistance(1)).getEdge();
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 6).setDistance(1));
 
         assertPath(calcPath(0, 4, cheapSource, cheapTarget), 0.24, 4, 240, nodes(0, 5, 6, 7, 4));
         assertPath(calcPath(0, 4, cheapSource, costlyTarget), 0.54, 9, 540, nodes(0, 5, 6, 2, 3, 4));
@@ -164,10 +164,10 @@ public class DirectedBidirectionalDijkstraTest {
         //  \     /
         //   - 3 -
         // we cannot go from 0 to 2 if we enforce north-south or south-north
-        int sourceNorth = GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true).getEdge();
-        int sourceSouth = GHUtility.setProperties(graph.edge(0, 3).setDistance(2), encoder, 60, true, true).getEdge();
-        int targetNorth = GHUtility.setProperties(graph.edge(1, 2).setDistance(3), encoder, 60, true, true).getEdge();
-        int targetSouth = GHUtility.setProperties(graph.edge(3, 2).setDistance(4), encoder, 60, true, true).getEdge();
+        int sourceNorth = GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(1)).getEdge();
+        int sourceSouth = GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 3).setDistance(2)).getEdge();
+        int targetNorth = GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(3)).getEdge();
+        int targetSouth = GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 2).setDistance(4)).getEdge();
 
         assertPath(calcPath(0, 2, sourceNorth, targetNorth), 0.24, 4, 240, nodes(0, 1, 2));
         assertNotFound(calcPath(0, 2, sourceNorth, targetSouth));
@@ -180,11 +180,11 @@ public class DirectedBidirectionalDijkstraTest {
         // 0 <- 1 <- 2
         //  \   |   /
         //   >--3-->
-        GHUtility.setProperties(graph.edge(0, 3).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 0).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 2).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 1).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 3).setDistance(1), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 0).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 3).setDistance(1));
 
         assertPath(calcPath(0, 2, 0, 2), 0.12, 2, 120, nodes(0, 3, 2));
         assertNotFound(calcPath(0, 2, 1, 2));
@@ -201,15 +201,15 @@ public class DirectedBidirectionalDijkstraTest {
         // 2 - 3
         // |   |
         // 5 - 4
-        int north = GHUtility.setProperties(graph.edge(1, 0).setDistance(1), encoder, 60, true, true).getEdge();
-        int south = GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, true).getEdge();
-        GHUtility.setProperties(graph.edge(2, 5).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(5, 4).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(4, 3).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 2).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 0).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(0, 6).setDistance(1), encoder, 60, true, false);
-        int targetEdge = GHUtility.setProperties(graph.edge(6, 7).setDistance(1), encoder, 60, true, false).getEdge();
+        int north = GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 0).setDistance(1)).getEdge();
+        int south = GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(1)).getEdge();
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 5).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(5, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(4, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 0).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 6).setDistance(1));
+        int targetEdge = GHUtility.setSpeed(60, true, false, encoder, graph.edge(6, 7).setDistance(1)).getEdge();
         assertPath(calcPath(1, 7, north, targetEdge), 0.18, 3, 180, nodes(1, 0, 6, 7));
         assertPath(calcPath(1, 7, south, targetEdge), 0.54, 9, 540, nodes(1, 2, 5, 4, 3, 2, 1, 0, 6, 7));
     }
@@ -219,13 +219,13 @@ public class DirectedBidirectionalDijkstraTest {
         // 0---6--1 -> 2
         // |          /
         // 5 <- 4 <- 3
-        GHUtility.setProperties(graph.edge(0, 6).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(6, 1).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(4, 5).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(5, 0).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 6).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(6, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(4, 5).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(5, 0).setDistance(1));
         assertPath(calcPath(6, 0, 1, 6), 0.36, 6, 360, nodes(6, 1, 2, 3, 4, 5, 0));
     }
 
@@ -237,18 +237,18 @@ public class DirectedBidirectionalDijkstraTest {
         //   9     2     10
         //   |    / \    |
         //   8 = 7   6 = 5
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(3), encoder, 60, true, true);
-        int rightNorth = GHUtility.setProperties(graph.edge(4, 10).setDistance(1), encoder, 60, true, true).getEdge();
-        int rightSouth = GHUtility.setProperties(graph.edge(10, 5).setDistance(1), encoder, 60, true, true).getEdge();
-        GHUtility.setProperties(graph.edge(5, 6).setDistance(2), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(6, 2).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 7).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(7, 8).setDistance(9), encoder, 60, true, true);
-        int leftSouth = GHUtility.setProperties(graph.edge(8, 9).setDistance(1), encoder, 60, true, true).getEdge();
-        int leftNorth = GHUtility.setProperties(graph.edge(9, 0).setDistance(1), encoder, 60, true, true).getEdge();
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 4).setDistance(3));
+        int rightNorth = GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 10).setDistance(1)).getEdge();
+        int rightSouth = GHUtility.setSpeed(60, true, true, encoder, graph.edge(10, 5).setDistance(1)).getEdge();
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(5, 6).setDistance(2));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(6, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 7).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(7, 8).setDistance(9));
+        int leftSouth = GHUtility.setSpeed(60, true, true, encoder, graph.edge(8, 9).setDistance(1)).getEdge();
+        int leftNorth = GHUtility.setSpeed(60, true, true, encoder, graph.edge(9, 0).setDistance(1)).getEdge();
 
         // make paths fully deterministic by applying some turn costs at junction node 2
         setTurnCost(7, 2, 3, 1);
@@ -276,10 +276,10 @@ public class DirectedBidirectionalDijkstraTest {
     public void enforceLoopEdge() {
         //  o       o
         //  0 - 1 - 2
-        GHUtility.setProperties(graph.edge(0, 0).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 2).setDistance(1), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 0).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 2).setDistance(1));
 
         assertPath(calcPath(0, 2, ANY_EDGE, ANY_EDGE), 0.12, 2, 120, nodes(0, 1, 2));
         assertPath(calcPath(0, 2, 1, 2), 0.12, 2, 120, nodes(0, 1, 2));
@@ -292,9 +292,9 @@ public class DirectedBidirectionalDijkstraTest {
     @Test
     public void sourceAndTargetAreNeighbors() {
         // 0-1-2-3
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(100), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(100), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(100), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(100));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(100));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 3).setDistance(100));
         assertPath(calcPath(1, 2, ANY_EDGE, ANY_EDGE), 6, 100, 6000, nodes(1, 2));
         assertPath(calcPath(1, 2, 1, ANY_EDGE), 6, 100, 6000, nodes(1, 2));
         assertPath(calcPath(1, 2, ANY_EDGE, 1), 6, 100, 6000, nodes(1, 2));
@@ -317,13 +317,13 @@ public class DirectedBidirectionalDijkstraTest {
         // 0 - 1 - 2
         // |   |   |
         // 3 - 4 - 5
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 4).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(0, 3).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(4, 5).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(5, 2).setDistance(1), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 5).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(5, 2).setDistance(1));
 
         setRestriction(0, 3, 4);
         setTurnCost(4, 5, 2, 6);
@@ -346,17 +346,17 @@ public class DirectedBidirectionalDijkstraTest {
         // 0 -- 1 -- 6
         // |         |
         // 7 -- 8 -- 9
-        int right0 = GHUtility.setProperties(graph.edge(0, 1).setDistance(10), encoder, 60, true, true).getEdge();
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(10), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(10), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(10), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(4, 5).setDistance(10), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(5, 2).setDistance(1000), encoder, 60, true, true);
-        int left6 = GHUtility.setProperties(graph.edge(1, 6).setDistance(10), encoder, 60, true, true).getEdge();
-        int left0 = GHUtility.setProperties(graph.edge(0, 7).setDistance(10), encoder, 60, true, true).getEdge();
-        GHUtility.setProperties(graph.edge(7, 8).setDistance(10), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(8, 9).setDistance(10), encoder, 60, true, true);
-        int right6 = GHUtility.setProperties(graph.edge(9, 6).setDistance(10), encoder, 60, true, true).getEdge();
+        int right0 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(10)).getEdge();
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(10));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 3).setDistance(10));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 4).setDistance(10));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 5).setDistance(10));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(5, 2).setDistance(1000));
+        int left6 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 6).setDistance(10)).getEdge();
+        int left0 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 7).setDistance(10)).getEdge();
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(7, 8).setDistance(10));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(8, 9).setDistance(10));
+        int right6 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(9, 6).setDistance(10)).getEdge();
 
         // enforce p-turn (using the loop in clockwise direction)
         setRestriction(0, 1, 6);
@@ -425,13 +425,13 @@ public class DirectedBidirectionalDijkstraTest {
         // 0 - 1 - 2 - 3
         // |           |
         // 4 --- 5 --- 6
-        EdgeIteratorState edge1 = GHUtility.setProperties(graph.edge(0, 1).setDistance(10), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(10), encoder, 60, true, true);
-        EdgeIteratorState edge2 = GHUtility.setProperties(graph.edge(2, 3).setDistance(10), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(0, 4).setDistance(100), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(4, 5).setDistance(100), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(5, 6).setDistance(100), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(6, 3).setDistance(100), encoder, 60, true, true);
+        EdgeIteratorState edge1 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(10));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(10));
+        EdgeIteratorState edge2 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 3).setDistance(10));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 4).setDistance(100));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 5).setDistance(100));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(5, 6).setDistance(100));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(6, 3).setDistance(100));
 
         // usually we would take the direct route
         assertPath(calcPath(0, 3, ANY_EDGE, ANY_EDGE), 1.8, 30, 1800, nodes(0, 1, 2, 3));
@@ -470,12 +470,12 @@ public class DirectedBidirectionalDijkstraTest {
         // 0 -- 1 -> 2
         // |         |
         // 5 <- 4 <- 3
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(4, 5).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(5, 0).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(4, 5).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(5, 0).setDistance(1));
         NodeAccess na = graph.getNodeAccess();
         na.setNode(0, 1, 0);
         na.setNode(1, 1, 1);

--- a/core/src/test/java/com/graphhopper/routing/DirectedRoutingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/DirectedRoutingTest.java
@@ -180,7 +180,8 @@ public class DirectedRoutingTest {
         final long seed = System.nanoTime();
         final int numQueries = 50;
         Random rnd = new Random(seed);
-        GHUtility.buildRandomGraph(graph, rnd, 100, 2.2, true, true, encoder.getAverageSpeedEnc(), 0.7, 0.8, 0.8);
+        GHUtility.buildRandomGraph(graph, rnd, 100, 2.2, true, true,
+                encoder.getAccessEnc(), encoder.getAverageSpeedEnc(), 60d, 0.7, 0.8, 0.8);
         GHUtility.addRandomTurnCosts(graph, seed, encodingManager, encoder, maxTurnCosts, turnCostStorage);
 //        GHUtility.printGraphForUnitTest(graph, encoder);
         preProcessGraph();
@@ -221,7 +222,8 @@ public class DirectedRoutingTest {
         // the same as taking the direct edge!
         double pOffset = 0;
         Random rnd = new Random(seed);
-        GHUtility.buildRandomGraph(graph, rnd, 50, 2.2, true, true, encoder.getAverageSpeedEnc(), 0.7, 0.8, pOffset);
+        GHUtility.buildRandomGraph(graph, rnd, 50, 2.2, true, true,
+                encoder.getAccessEnc(), encoder.getAverageSpeedEnc(), 60d, 0.7, 0.8, pOffset);
         GHUtility.addRandomTurnCosts(graph, seed, encodingManager, encoder, maxTurnCosts, turnCostStorage);
         // GHUtility.printGraphForUnitTest(graph, encoder);
         preProcessGraph();

--- a/core/src/test/java/com/graphhopper/routing/DirectionResolverOnQueryGraphTest.java
+++ b/core/src/test/java/com/graphhopper/routing/DirectionResolverOnQueryGraphTest.java
@@ -261,7 +261,7 @@ public class DirectionResolverOnQueryGraphTest {
     }
 
     private EdgeIteratorState addEdge(int from, int to, boolean bothDirections) {
-        return GHUtility.setProperties(graph.edge(from, to).setDistance(1), encoder, 60, true, bothDirections);
+        return GHUtility.setSpeed(60, true, bothDirections, encoder, graph.edge(from, to).setDistance(1));
     }
 
     private void init() {

--- a/core/src/test/java/com/graphhopper/routing/DirectionResolverOnQueryGraphTest.java
+++ b/core/src/test/java/com/graphhopper/routing/DirectionResolverOnQueryGraphTest.java
@@ -30,6 +30,7 @@ import com.graphhopper.storage.index.Snap;
 import com.graphhopper.util.EdgeExplorer;
 import com.graphhopper.util.EdgeIterator;
 import com.graphhopper.util.EdgeIteratorState;
+import com.graphhopper.util.GHUtility;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -52,14 +53,14 @@ public class DirectionResolverOnQueryGraphTest {
     private QueryGraph queryGraph;
     private NodeAccess na;
     private FlagEncoder encoder;
-    private Graph g;
+    private Graph graph;
     private LocationIndex locationIndex;
 
     @Before
     public void setup() {
         encoder = new CarFlagEncoder();
-        g = new GraphBuilder(EncodingManager.create(encoder)).create();
-        na = g.getNodeAccess();
+        graph = new GraphBuilder(EncodingManager.create(encoder)).create();
+        na = graph.getNodeAccess();
     }
 
     @Test
@@ -260,11 +261,11 @@ public class DirectionResolverOnQueryGraphTest {
     }
 
     private EdgeIteratorState addEdge(int from, int to, boolean bothDirections) {
-        return g.edge(from, to, 1, bothDirections);
+        return GHUtility.setProperties(graph.edge(from, to).setDistance(1), encoder, 60, true, bothDirections);
     }
 
     private void init() {
-        locationIndex = new LocationIndexTree(g, new RAMDirectory());
+        locationIndex = new LocationIndexTree(graph, new RAMDirectory());
         locationIndex.prepareIndex();
     }
 
@@ -277,7 +278,7 @@ public class DirectionResolverOnQueryGraphTest {
         for (ExpectedResult r : expectedResults) {
             snaps.add(snapCoordinate(r.lat, r.lon));
         }
-        queryGraph = QueryGraph.create(g, snaps);
+        queryGraph = QueryGraph.create(graph, snaps);
         DirectionResolver resolver = new DirectionResolver(queryGraph, encoder.getAccessEnc());
         for (int i = 0; i < expectedResults.length; i++) {
             assertEquals("unexpected resolved direction",
@@ -300,7 +301,7 @@ public class DirectionResolverOnQueryGraphTest {
 
     private void assertUnrestricted(double lat, double lon) {
         Snap snap = snapCoordinate(lat, lon);
-        queryGraph = QueryGraph.create(g, snap);
+        queryGraph = QueryGraph.create(graph, snap);
         DirectionResolver resolver = new DirectionResolver(queryGraph, encoder.getAccessEnc());
         assertEquals(unrestricted(), resolver.resolveDirections(snap.getClosestNode(), snap.getQueryPoint()));
     }

--- a/core/src/test/java/com/graphhopper/routing/DirectionResolverTest.java
+++ b/core/src/test/java/com/graphhopper/routing/DirectionResolverTest.java
@@ -70,9 +70,7 @@ public class DirectionResolverTest {
         addNode(0, 0, 0);
         addNode(1, 0.1, 0.1);
         // with edges without access flags (blocked edges)
-        graph.edge(0, 1)
-                .set(encoder.getAccessEnc(), false)
-                .setReverse(encoder.getAccessEnc(), false);
+        graph.edge(0, 1).set(encoder.getAccessEnc(), false, false);
 
         checkResult(0, impossible());
         checkResult(1, impossible());

--- a/core/src/test/java/com/graphhopper/routing/DirectionResolverTest.java
+++ b/core/src/test/java/com/graphhopper/routing/DirectionResolverTest.java
@@ -384,7 +384,7 @@ public class DirectionResolverTest {
     }
 
     private EdgeIteratorState addEdge(int from, int to, boolean bothDirections) {
-        return GHUtility.setProperties(graph.edge(from, to).setDistance(1), encoder, 60, true, bothDirections);
+        return GHUtility.setSpeed(60, true, bothDirections, encoder, graph.edge(from, to).setDistance(1));
     }
 
     private void checkResult(int node, DirectionResolverResult expectedResult) {

--- a/core/src/test/java/com/graphhopper/routing/DirectionResolverTest.java
+++ b/core/src/test/java/com/graphhopper/routing/DirectionResolverTest.java
@@ -28,6 +28,7 @@ import com.graphhopper.storage.NodeAccess;
 import com.graphhopper.util.EdgeExplorer;
 import com.graphhopper.util.EdgeIterator;
 import com.graphhopper.util.EdgeIteratorState;
+import com.graphhopper.util.GHUtility;
 import com.graphhopper.util.shapes.GHPoint;
 import org.junit.Before;
 import org.junit.Test;
@@ -43,14 +44,14 @@ import static org.junit.Assert.assertEquals;
  */
 public class DirectionResolverTest {
     private FlagEncoder encoder;
-    private GraphHopperStorage g;
+    private GraphHopperStorage graph;
     private NodeAccess na;
 
     @Before
     public void setup() {
         encoder = new CarFlagEncoder();
-        g = new GraphBuilder(EncodingManager.create(encoder)).create();
-        na = g.getNodeAccess();
+        graph = new GraphBuilder(EncodingManager.create(encoder)).create();
+        na = graph.getNodeAccess();
     }
 
     @Test
@@ -69,7 +70,7 @@ public class DirectionResolverTest {
         addNode(0, 0, 0);
         addNode(1, 0.1, 0.1);
         // with edges without access flags (blocked edges)
-        g.edge(0, 1)
+        graph.edge(0, 1)
                 .set(encoder.getAccessEnc(), false)
                 .setReverse(encoder.getAccessEnc(), false);
 
@@ -383,20 +384,20 @@ public class DirectionResolverTest {
     }
 
     private EdgeIteratorState addEdge(int from, int to, boolean bothDirections) {
-        return g.edge(from, to, 1, bothDirections);
+        return GHUtility.setProperties(graph.edge(from, to).setDistance(1), encoder, 60, true, bothDirections);
     }
 
     private void checkResult(int node, DirectionResolverResult expectedResult) {
-        checkResult(node, g.getNodeAccess().getLat(node), g.getNodeAccess().getLon(node), expectedResult);
+        checkResult(node, graph.getNodeAccess().getLat(node), graph.getNodeAccess().getLon(node), expectedResult);
     }
 
     private void checkResult(int node, double lat, double lon, DirectionResolverResult expectedResult) {
-        DirectionResolver resolver = new DirectionResolver(g, encoder.getAccessEnc());
+        DirectionResolver resolver = new DirectionResolver(graph, encoder.getAccessEnc());
         assertEquals(expectedResult, resolver.resolveDirections(node, new GHPoint(lat, lon)));
     }
 
     private int edge(int from, int to) {
-        EdgeExplorer explorer = g.createEdgeExplorer(DefaultEdgeFilter.outEdges(encoder.getAccessEnc()));
+        EdgeExplorer explorer = graph.createEdgeExplorer(DefaultEdgeFilter.outEdges(encoder.getAccessEnc()));
         EdgeIterator iter = explorer.setBaseNode(from);
         while (iter.next()) {
             if (iter.getAdjNode() == to) {

--- a/core/src/test/java/com/graphhopper/routing/EdgeBasedRoutingAlgorithmTest.java
+++ b/core/src/test/java/com/graphhopper/routing/EdgeBasedRoutingAlgorithmTest.java
@@ -77,17 +77,17 @@ public class EdgeBasedRoutingAlgorithmTest {
     // 2--3--4
     // |  |  |
     // 5--6--7
-    public static void initGraph(Graph g) {
-        g.edge(0, 1, 3, true);
-        g.edge(0, 2, 1, true);
-        g.edge(1, 3, 1, true);
-        g.edge(2, 3, 1, true);
-        g.edge(3, 4, 1, true);
-        g.edge(2, 5, .5, true);
-        g.edge(3, 6, 1, true);
-        g.edge(4, 7, 1, true);
-        g.edge(5, 6, 1, true);
-        g.edge(6, 7, 1, true);
+    public static void initGraph(Graph graph, FlagEncoder encoder) {
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(3), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(0, 2).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 3).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 5).setDistance(0.5), encoder,  60, true, true);
+        GHUtility.setProperties(graph.edge(3, 6).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(4, 7).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(5, 6).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(6, 7).setDistance(1), encoder, 60, true, true);
     }
 
     private EncodingManager createEncodingManager(boolean restrictedOnly) {
@@ -154,7 +154,8 @@ public class EdgeBasedRoutingAlgorithmTest {
         Random rnd = new Random(seed);
         EncodingManager em = createEncodingManager(false);
         GraphHopperStorage g = createStorage(em);
-        GHUtility.buildRandomGraph(g, rnd, 50, 2.2, true, true, carEncoder.getAverageSpeedEnc(), 0.8, 0.8, 0.8);
+        GHUtility.buildRandomGraph(g, rnd, 50, 2.2, true, true,
+                carEncoder.getAccessEnc(), carEncoder.getAverageSpeedEnc(), 60d, 0.8, 0.8, 0.8);
         GHUtility.addRandomTurnCosts(g, seed, em, carEncoder, 3, tcs);
         g.freeze();
         int numPathsNotFound = 0;
@@ -202,7 +203,7 @@ public class EdgeBasedRoutingAlgorithmTest {
     @Test
     public void testBasicTurnRestriction() {
         GraphHopperStorage g = createStorage(createEncodingManager(true));
-        initGraph(g);
+        initGraph(g, carEncoder);
         initTurnRestrictions(g);
         Path p = calcPath(g, 5, 1);
         assertEquals(IntArrayList.from(5, 2, 3, 4, 7, 6, 3, 1), p.calcNodes());
@@ -217,21 +218,21 @@ public class EdgeBasedRoutingAlgorithmTest {
 
     @Test
     public void testLoop_issue1592() {
-        GraphHopperStorage g = createStorage(createEncodingManager(true));
+        GraphHopperStorage graph = createStorage(createEncodingManager(true));
         // 0-6
         //  \ \
         //   4-3
         //   |
         //   1o
-        g.edge(0, 6, 10, true);
-        g.edge(6, 3, 10, true);
-        g.edge(0, 4, 1, true);
-        g.edge(4, 1, 1, true);
-        g.edge(4, 3, 1, true);
-        g.edge(1, 1, 10, true);
-        setTurnRestriction(g, 0, 4, 3);
+        GHUtility.setProperties(graph.edge(0, 6).setDistance(10), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(6, 3).setDistance(10), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(0, 4).setDistance(1), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(4, 1).setDistance(1), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(4, 3).setDistance(1), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 1).setDistance(10), carEncoder, 60, true, true);
+        setTurnRestriction(graph, 0, 4, 3);
 
-        Path p = calcPath(g, 0, 3);
+        Path p = calcPath(graph, 0, 3);
         assertEquals(14, p.getDistance(), 1.e-3);
         assertEquals(IntArrayList.from(0, 4, 1, 1, 4, 3), p.calcNodes());
     }
@@ -239,18 +240,18 @@ public class EdgeBasedRoutingAlgorithmTest {
     @Test
     public void testTurnCosts_timeCalculation() {
         // 0 - 1 - 2 - 3 - 4
-        GraphHopperStorage g = createStorage(createEncodingManager(false));
+        GraphHopperStorage graph = createStorage(createEncodingManager(false));
         final int distance = 100;
         final int turnCosts = 2;
-        g.edge(0, 1, distance, true);
-        g.edge(1, 2, distance, true);
-        g.edge(2, 3, distance, true);
-        g.edge(3, 4, distance, true);
-        setTurnCost(g, turnCosts, 1, 2, 3);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(distance), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(distance), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(distance), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(distance), carEncoder, 60, true, true);
+        setTurnCost(graph, turnCosts, 1, 2, 3);
 
         {
             // simple case where turn cost is encountered during forward search
-            Path p14 = calcPath(g, 1, 4);
+            Path p14 = calcPath(graph, 1, 4);
             assertDistTimeWeight(p14, 3, distance, 6, turnCosts);
             assertEquals(20, p14.getWeight(), 1.e-6);
             assertEquals(20000, p14.getTime());
@@ -259,7 +260,7 @@ public class EdgeBasedRoutingAlgorithmTest {
         {
             // this test is more involved for bidir algos: the turn costs have to be taken into account also at the
             // node where fwd and bwd searches meet
-            Path p04 = calcPath(g, 0, 4);
+            Path p04 = calcPath(graph, 0, 4);
             assertDistTimeWeight(p04, 4, distance, 6, turnCosts);
             assertEquals(26, p04.getWeight(), 1.e-6);
             assertEquals(26000, p04.getTime());
@@ -288,7 +289,7 @@ public class EdgeBasedRoutingAlgorithmTest {
     @Test
     public void testBlockANode() {
         GraphHopperStorage g = createStorage(createEncodingManager(true));
-        initGraph(g);
+        initGraph(g, carEncoder);
         blockNode3(g);
         for (int i = 0; i <= 7; i++) {
             if (i == 3) continue;
@@ -306,7 +307,7 @@ public class EdgeBasedRoutingAlgorithmTest {
     @Test
     public void testUTurns() {
         GraphHopperStorage g = createStorage(createEncodingManager(true));
-        initGraph(g);
+        initGraph(g, carEncoder);
 
         // force u-turn at node 3 by using finite u-turn costs
         getEdge(g, 3, 6).setDistance(0.1);
@@ -343,11 +344,11 @@ public class EdgeBasedRoutingAlgorithmTest {
         //           |
         // 0 -> 1 -> 2 -> 4 -> 5
         GraphHopperStorage g = createStorage(createEncodingManager(false));
-        g.edge(0, 1, 10, false);
-        g.edge(1, 2, 10, false);
-        g.edge(2, 3, 10, true);
-        g.edge(2, 4, 10, false);
-        g.edge(4, 5, 10, false);
+        GHUtility.setProperties(g.edge(0, 1).setDistance(10), carEncoder, 60, true, false);
+        GHUtility.setProperties(g.edge(1, 2).setDistance(10), carEncoder, 60, true, false);
+        GHUtility.setProperties(g.edge(2, 3).setDistance(10), carEncoder, 60, true, true);
+        GHUtility.setProperties(g.edge(2, 4).setDistance(10), carEncoder, 60, true, false);
+        GHUtility.setProperties(g.edge(4, 5).setDistance(10), carEncoder, 60, true, false);
 
         // cannot go straight at node 2
         setTurnRestriction(g, 1, 2, 4);
@@ -371,7 +372,7 @@ public class EdgeBasedRoutingAlgorithmTest {
     @Test
     public void testBasicTurnCosts() {
         GraphHopperStorage g = createStorage(createEncodingManager(false));
-        initGraph(g);
+        initGraph(g, carEncoder);
         Path p = calcPath(g, 5, 1);
 
         // no restriction and costs
@@ -388,7 +389,7 @@ public class EdgeBasedRoutingAlgorithmTest {
     @Test
     public void testTurnCostsBug_991() {
         final GraphHopperStorage g = createStorage(createEncodingManager(false));
-        initGraph(g);
+        initGraph(g, carEncoder);
 
         setTurnCost(g, 2, 5, 2, 3);
         setTurnCost(g, 2, 2, 0, 1);
@@ -417,16 +418,16 @@ public class EdgeBasedRoutingAlgorithmTest {
         // 3-2-4
         //  \|
         //   0
-        final GraphHopperStorage g = createStorage(createEncodingManager(false));
-        g.edge(3, 2, 188, false);
-        g.edge(3, 0, 182, true);
-        g.edge(4, 2, 690, true);
-        g.edge(2, 2, 121, false);
-        g.edge(2, 0, 132, true);
-        setTurnRestriction(g, 2, 2, 0);
-        setTurnRestriction(g, 3, 2, 4);
+        final GraphHopperStorage graph = createStorage(createEncodingManager(false));
+        GHUtility.setProperties(graph.edge(3, 2).setDistance(188), carEncoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 0).setDistance(182), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(4, 2).setDistance(690), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 2).setDistance(121), carEncoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 0).setDistance(132), carEncoder, 60, true, true);
+        setTurnRestriction(graph, 2, 2, 0);
+        setTurnRestriction(graph, 3, 2, 4);
 
-        Path p = calcPath(g, 3, 4);
+        Path p = calcPath(graph, 3, 4);
         assertEquals(IntArrayList.from(3, 2, 2, 4), p.calcNodes());
         assertEquals(999, p.getDistance(), 1.e-3);
     }
@@ -439,16 +440,16 @@ public class EdgeBasedRoutingAlgorithmTest {
         // o3-4o
         //    |
         //    5
-        final GraphHopperStorage g = createStorage(createEncodingManager(false));
-        g.edge(0, 1, 1, true);
-        g.edge(3, 4, 2, true);
-        g.edge(4, 4, 4, true);
-        g.edge(3, 3, 1, true);
-        g.edge(1, 4, 5, true);
-        g.edge(5, 4, 1, true);
-        setTurnRestriction(g, 1, 4, 5);
+        final GraphHopperStorage graph = createStorage(createEncodingManager(false));
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(2), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(4, 4).setDistance(4), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(3, 3).setDistance(1), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 4).setDistance(5), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(5, 4).setDistance(1), carEncoder, 60, true, true);
+        setTurnRestriction(graph, 1, 4, 5);
 
-        Path p = calcPath(g, 0, 5);
+        Path p = calcPath(graph, 0, 5);
         assertEquals(IntArrayList.from(0, 1, 4, 4, 5), p.calcNodes());
         assertEquals(11, p.getDistance(), 1.e-3);
         assertEquals(11 * 0.06, p.getWeight(), 1.e-3);

--- a/core/src/test/java/com/graphhopper/routing/EdgeBasedRoutingAlgorithmTest.java
+++ b/core/src/test/java/com/graphhopper/routing/EdgeBasedRoutingAlgorithmTest.java
@@ -78,16 +78,16 @@ public class EdgeBasedRoutingAlgorithmTest {
     // |  |  |
     // 5--6--7
     public static void initGraph(Graph graph, FlagEncoder encoder) {
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(3), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(0, 2).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 3).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 5).setDistance(0.5), encoder,  60, true, true);
-        GHUtility.setProperties(graph.edge(3, 6).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(4, 7).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(5, 6).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(6, 7).setDistance(1), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(3));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 5).setDistance(0.5));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 6).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 7).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(5, 6).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(6, 7).setDistance(1));
     }
 
     private EncodingManager createEncodingManager(boolean restrictedOnly) {
@@ -224,12 +224,12 @@ public class EdgeBasedRoutingAlgorithmTest {
         //   4-3
         //   |
         //   1o
-        GHUtility.setProperties(graph.edge(0, 6).setDistance(10), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(6, 3).setDistance(10), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(0, 4).setDistance(1), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(4, 1).setDistance(1), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(4, 3).setDistance(1), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 1).setDistance(10), carEncoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(0, 6).setDistance(10));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(6, 3).setDistance(10));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(0, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(4, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(4, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(1, 1).setDistance(10));
         setTurnRestriction(graph, 0, 4, 3);
 
         Path p = calcPath(graph, 0, 3);
@@ -243,10 +243,10 @@ public class EdgeBasedRoutingAlgorithmTest {
         GraphHopperStorage graph = createStorage(createEncodingManager(false));
         final int distance = 100;
         final int turnCosts = 2;
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(distance), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(distance), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(distance), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(distance), carEncoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(0, 1).setDistance(distance));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(1, 2).setDistance(distance));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(2, 3).setDistance(distance));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(3, 4).setDistance(distance));
         setTurnCost(graph, turnCosts, 1, 2, 3);
 
         {
@@ -344,11 +344,11 @@ public class EdgeBasedRoutingAlgorithmTest {
         //           |
         // 0 -> 1 -> 2 -> 4 -> 5
         GraphHopperStorage g = createStorage(createEncodingManager(false));
-        GHUtility.setProperties(g.edge(0, 1).setDistance(10), carEncoder, 60, true, false);
-        GHUtility.setProperties(g.edge(1, 2).setDistance(10), carEncoder, 60, true, false);
-        GHUtility.setProperties(g.edge(2, 3).setDistance(10), carEncoder, 60, true, true);
-        GHUtility.setProperties(g.edge(2, 4).setDistance(10), carEncoder, 60, true, false);
-        GHUtility.setProperties(g.edge(4, 5).setDistance(10), carEncoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, carEncoder, g.edge(0, 1).setDistance(10));
+        GHUtility.setSpeed(60, true, false, carEncoder, g.edge(1, 2).setDistance(10));
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(2, 3).setDistance(10));
+        GHUtility.setSpeed(60, true, false, carEncoder, g.edge(2, 4).setDistance(10));
+        GHUtility.setSpeed(60, true, false, carEncoder, g.edge(4, 5).setDistance(10));
 
         // cannot go straight at node 2
         setTurnRestriction(g, 1, 2, 4);
@@ -419,11 +419,11 @@ public class EdgeBasedRoutingAlgorithmTest {
         //  \|
         //   0
         final GraphHopperStorage graph = createStorage(createEncodingManager(false));
-        GHUtility.setProperties(graph.edge(3, 2).setDistance(188), carEncoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 0).setDistance(182), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(4, 2).setDistance(690), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 2).setDistance(121), carEncoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 0).setDistance(132), carEncoder, 60, true, true);
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(3, 2).setDistance(188));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(3, 0).setDistance(182));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(4, 2).setDistance(690));
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(2, 2).setDistance(121));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(2, 0).setDistance(132));
         setTurnRestriction(graph, 2, 2, 0);
         setTurnRestriction(graph, 3, 2, 4);
 
@@ -441,12 +441,12 @@ public class EdgeBasedRoutingAlgorithmTest {
         //    |
         //    5
         final GraphHopperStorage graph = createStorage(createEncodingManager(false));
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(2), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(4, 4).setDistance(4), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(3, 3).setDistance(1), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 4).setDistance(5), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(5, 4).setDistance(1), carEncoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(3, 4).setDistance(2));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(4, 4).setDistance(4));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(3, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(1, 4).setDistance(5));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(5, 4).setDistance(1));
         setTurnRestriction(graph, 1, 4, 5);
 
         Path p = calcPath(graph, 0, 5);

--- a/core/src/test/java/com/graphhopper/routing/HeadingResolverTest.java
+++ b/core/src/test/java/com/graphhopper/routing/HeadingResolverTest.java
@@ -20,13 +20,16 @@ package com.graphhopper.routing;
 
 import com.carrotsearch.hppc.IntArrayList;
 import com.graphhopper.routing.querygraph.QueryGraph;
+import com.graphhopper.routing.util.CarFlagEncoder;
 import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.storage.GraphBuilder;
 import com.graphhopper.storage.GraphHopperStorage;
 import com.graphhopper.storage.NodeAccess;
 import com.graphhopper.storage.index.Snap;
 import com.graphhopper.util.DistanceCalcEuclidean;
 import com.graphhopper.util.EdgeIteratorState;
+import com.graphhopper.util.GHUtility;
 import com.graphhopper.util.Helper;
 import org.junit.jupiter.api.Test;
 
@@ -41,7 +44,8 @@ class HeadingResolverTest {
         // 7 -- 8 --- 3
         //     /|\
         //    6 5 4
-        EncodingManager em = EncodingManager.create("car");
+        FlagEncoder encoder = new CarFlagEncoder();
+        EncodingManager em = EncodingManager.create(encoder);
         GraphHopperStorage graph = new GraphBuilder(em).create();
         NodeAccess na = graph.getNodeAccess();
         na.setNode(0, 49.5073, 1.5545);
@@ -54,14 +58,14 @@ class HeadingResolverTest {
         na.setNode(7, 48.8611, 1.2194);
         na.setNode(8, 48.8538, 2.3950);
 
-        graph.edge(8, 0, 10, true); // edge 0
-        graph.edge(8, 1, 10, true); // edge 1
-        graph.edge(8, 2, 10, true); // edge 2
-        graph.edge(8, 3, 10, true); // edge 3
-        graph.edge(8, 4, 10, true); // edge 4
-        graph.edge(8, 5, 10, true); // edge 5
-        graph.edge(8, 6, 10, true); // edge 6
-        graph.edge(8, 7, 10, true); // edge 7
+        GHUtility.setProperties(graph.edge(8, 0).setDistance(10), encoder, 60, true, true); // edge 0
+        GHUtility.setProperties(graph.edge(8, 1).setDistance(10), encoder, 60, true, true); // edge 1
+        GHUtility.setProperties(graph.edge(8, 2).setDistance(10), encoder, 60, true, true); // edge 2
+        GHUtility.setProperties(graph.edge(8, 3).setDistance(10), encoder, 60, true, true); // edge 3
+        GHUtility.setProperties(graph.edge(8, 4).setDistance(10), encoder, 60, true, true); // edge 4
+        GHUtility.setProperties(graph.edge(8, 5).setDistance(10), encoder, 60, true, true); // edge 5
+        GHUtility.setProperties(graph.edge(8, 6).setDistance(10), encoder, 60, true, true); // edge 6
+        GHUtility.setProperties(graph.edge(8, 7).setDistance(10), encoder, 60, true, true); // edge 7
 
         HeadingResolver resolver = new HeadingResolver(graph);
         // using default tolerance
@@ -82,14 +86,17 @@ class HeadingResolverTest {
         //    1 -|
         // |- 0 -|
         // |- 2
-        EncodingManager em = EncodingManager.create("car");
+        FlagEncoder encoder = new CarFlagEncoder();
+        EncodingManager em = EncodingManager.create(encoder);
         GraphHopperStorage graph = new GraphBuilder(em).create();
         NodeAccess na = graph.getNodeAccess();
         na.setNode(1, 0.01, 0.00);
         na.setNode(0, 0.00, 0.00);
         na.setNode(2, -0.01, 0.00);
-        graph.edge(0, 1, 10, true).setWayGeometry(Helper.createPointList(0.00, 0.01, 0.01, 0.01));
-        graph.edge(0, 2, 10, true).setWayGeometry(Helper.createPointList(0.00, -0.01, -0.01, -0.01));
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(10), encoder, 60, true, true).
+                setWayGeometry(Helper.createPointList(0.00, 0.01, 0.01, 0.01));
+        GHUtility.setProperties(graph.edge(0, 2).setDistance(10), encoder, 60, true, true).
+                setWayGeometry(Helper.createPointList(0.00, -0.01, -0.01, -0.01));
         HeadingResolver resolver = new HeadingResolver(graph);
         resolver.setTolerance(120);
         // asking for the edges not going east returns 0-2
@@ -102,13 +109,14 @@ class HeadingResolverTest {
     public void withQueryGraph() {
         //    2
         // 0 -x- 1
-        EncodingManager em = EncodingManager.create("car");
+        FlagEncoder encoder = new CarFlagEncoder();
+        EncodingManager em = EncodingManager.create(encoder);
         GraphHopperStorage graph = new GraphBuilder(em).create();
         NodeAccess na = graph.getNodeAccess();
         na.setNode(0, 48.8611, 1.2194);
         na.setNode(1, 48.8538, 2.3950);
 
-        EdgeIteratorState edge = graph.edge(0, 1, 10, true);
+        EdgeIteratorState edge = GHUtility.setProperties(graph.edge(0, 1).setDistance(10), encoder, 60, true, true);
         Snap snap = createSnap(edge, 48.859, 2.00, 0);
         QueryGraph queryGraph = QueryGraph.create(graph, snap);
         HeadingResolver resolver = new HeadingResolver(queryGraph);

--- a/core/src/test/java/com/graphhopper/routing/HeadingResolverTest.java
+++ b/core/src/test/java/com/graphhopper/routing/HeadingResolverTest.java
@@ -58,14 +58,14 @@ class HeadingResolverTest {
         na.setNode(7, 48.8611, 1.2194);
         na.setNode(8, 48.8538, 2.3950);
 
-        GHUtility.setProperties(graph.edge(8, 0).setDistance(10), encoder, 60, true, true); // edge 0
-        GHUtility.setProperties(graph.edge(8, 1).setDistance(10), encoder, 60, true, true); // edge 1
-        GHUtility.setProperties(graph.edge(8, 2).setDistance(10), encoder, 60, true, true); // edge 2
-        GHUtility.setProperties(graph.edge(8, 3).setDistance(10), encoder, 60, true, true); // edge 3
-        GHUtility.setProperties(graph.edge(8, 4).setDistance(10), encoder, 60, true, true); // edge 4
-        GHUtility.setProperties(graph.edge(8, 5).setDistance(10), encoder, 60, true, true); // edge 5
-        GHUtility.setProperties(graph.edge(8, 6).setDistance(10), encoder, 60, true, true); // edge 6
-        GHUtility.setProperties(graph.edge(8, 7).setDistance(10), encoder, 60, true, true); // edge 7
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(8, 0).setDistance(10)); // edge 0
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(8, 1).setDistance(10)); // edge 1
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(8, 2).setDistance(10)); // edge 2
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(8, 3).setDistance(10)); // edge 3
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(8, 4).setDistance(10)); // edge 4
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(8, 5).setDistance(10)); // edge 5
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(8, 6).setDistance(10)); // edge 6
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(8, 7).setDistance(10)); // edge 7
 
         HeadingResolver resolver = new HeadingResolver(graph);
         // using default tolerance
@@ -93,9 +93,9 @@ class HeadingResolverTest {
         na.setNode(1, 0.01, 0.00);
         na.setNode(0, 0.00, 0.00);
         na.setNode(2, -0.01, 0.00);
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(10), encoder, 60, true, true).
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(10)).
                 setWayGeometry(Helper.createPointList(0.00, 0.01, 0.01, 0.01));
-        GHUtility.setProperties(graph.edge(0, 2).setDistance(10), encoder, 60, true, true).
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 2).setDistance(10)).
                 setWayGeometry(Helper.createPointList(0.00, -0.01, -0.01, -0.01));
         HeadingResolver resolver = new HeadingResolver(graph);
         resolver.setTolerance(120);
@@ -116,7 +116,7 @@ class HeadingResolverTest {
         na.setNode(0, 48.8611, 1.2194);
         na.setNode(1, 48.8538, 2.3950);
 
-        EdgeIteratorState edge = GHUtility.setProperties(graph.edge(0, 1).setDistance(10), encoder, 60, true, true);
+        EdgeIteratorState edge = GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(10));
         Snap snap = createSnap(edge, 48.859, 2.00, 0);
         QueryGraph queryGraph = QueryGraph.create(graph, snap);
         HeadingResolver resolver = new HeadingResolver(queryGraph);

--- a/core/src/test/java/com/graphhopper/routing/PathTest.java
+++ b/core/src/test/java/com/graphhopper/routing/PathTest.java
@@ -871,12 +871,14 @@ public class PathTest {
         na.setNode(6, 48.402422, 9.996067);
         na.setNode(7, 48.402604, 9.994962);
 
-        GHUtility.setSpeed(60, true, false, encoder, g.edge(1, 2).setDistance(5)).setName("Olgastraße");
-        GHUtility.setSpeed(60, true, false, encoder, g.edge(2, 3).setDistance(5)).setName("Olgastraße");
-        GHUtility.setSpeed(60, true, false, encoder, g.edge(6, 5).setDistance(5)).setName("Olgastraße");
-        GHUtility.setSpeed(60, true, false, encoder, g.edge(5, 4).setDistance(5)).setName("Olgastraße");
-        GHUtility.setSpeed(60, true, true, encoder, g.edge(2, 5).setDistance(5)).setName("Neithardtstraße");
-        GHUtility.setSpeed(60, true, true, encoder, g.edge(5, 7).setDistance(5)).setName("Neithardtstraße");
+        GHUtility.setSpeed(60, 0, encoder,
+                g.edge(1, 2).setDistance(5).setName("Olgastraße"),
+                g.edge(2, 3).setDistance(5).setName("Olgastraße"),
+                g.edge(6, 5).setDistance(5).setName("Olgastraße"),
+                g.edge(5, 4).setDistance(5).setName("Olgastraße"));
+        GHUtility.setSpeed(60, 60, encoder,
+                g.edge(2, 5).setDistance(5).setName("Neithardtstraße"),
+                g.edge(5, 7).setDistance(5).setName("Neithardtstraße"));
 
         ShortestWeighting weighting = new ShortestWeighting(encoder);
         Path p = new Dijkstra(g, weighting, TraversalMode.NODE_BASED)
@@ -907,12 +909,14 @@ public class PathTest {
         na.setNode(6, -33.885692, 151.181445);
         na.setNode(7, -33.885692, 151.181445);
 
-        GHUtility.setSpeed(60, true, false, encoder, g.edge(1, 2).setDistance(5)).setName("Parramatta Road");
-        GHUtility.setSpeed(60, true, false, encoder, g.edge(2, 3).setDistance(5)).setName("Parramatta Road");
-        GHUtility.setSpeed(60, true, false, encoder, g.edge(4, 5).setDistance(5)).setName("Parramatta Road");
-        GHUtility.setSpeed(60, true, false, encoder, g.edge(5, 6).setDistance(5)).setName("Parramatta Road");
-        GHUtility.setSpeed(60, true, true, encoder, g.edge(2, 5).setDistance(5)).setName("Larkin Street");
-        GHUtility.setSpeed(60, true, true, encoder, g.edge(5, 7).setDistance(5)).setName("Larkin Street");
+        GHUtility.setSpeed(60, 0, encoder,
+                g.edge(1, 2).setDistance(5).setName("Parramatta Road"),
+                g.edge(2, 3).setDistance(5).setName("Parramatta Road"),
+                g.edge(4, 5).setDistance(5).setName("Parramatta Road"),
+                g.edge(5, 6).setDistance(5).setName("Parramatta Road"));
+        GHUtility.setSpeed(60, 60, encoder,
+                g.edge(2, 5).setDistance(5).setName("Larkin Street"),
+                g.edge(5, 7).setDistance(5).setName("Larkin Street"));
 
         ShortestWeighting weighting = new ShortestWeighting(encoder);
         Path p = new Dijkstra(g, weighting, TraversalMode.NODE_BASED)

--- a/core/src/test/java/com/graphhopper/routing/PathTest.java
+++ b/core/src/test/java/com/graphhopper/routing/PathTest.java
@@ -510,40 +510,40 @@ public class PathTest {
         na.setNode(10, 52.5135, 13.348);
         na.setNode(11, 52.514, 13.347);
 
-        GHUtility.setProperties(graph.edge(2, 1).setDistance(5), encoder, 60, true, false).setName("MainStreet 2 1");
-        GHUtility.setProperties(graph.edge(1, 11).setDistance(5), encoder, 60, true, false).setName("MainStreet 1 11");
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 1).setDistance(5)).setName("MainStreet 2 1");
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 11).setDistance(5)).setName("MainStreet 1 11");
 
         // roundabout
         EdgeIteratorState tmpEdge;
-        tmpEdge = GHUtility.setProperties(graph.edge(3, 9).setDistance(2), encoder, 60, true, false).setName("3-9");
+        tmpEdge = GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 9).setDistance(2)).setName("3-9");
         BooleanEncodedValue carManagerRoundabout = carManager.getBooleanEncodedValue(Roundabout.KEY);
         carManagerRoundabout.setBool(false, tmpEdge.getFlags(), true);
         tmpEdge.setFlags(tmpEdge.getFlags());
-        tmpEdge = GHUtility.setProperties(graph.edge(9, 10).setDistance(2), encoder, 60, true, false).setName("9-10");
+        tmpEdge = GHUtility.setSpeed(60, true, false, encoder, graph.edge(9, 10).setDistance(2)).setName("9-10");
         carManagerRoundabout.setBool(false, tmpEdge.getFlags(), true);
         tmpEdge.setFlags(tmpEdge.getFlags());
-        tmpEdge = GHUtility.setProperties(graph.edge(6, 10).setDistance(2), encoder, 60, true, false).setName("6-10");
+        tmpEdge = GHUtility.setSpeed(60, true, false, encoder, graph.edge(6, 10).setDistance(2)).setName("6-10");
         carManagerRoundabout.setBool(false, tmpEdge.getFlags(), true);
         tmpEdge.setFlags(tmpEdge.getFlags());
-        tmpEdge = GHUtility.setProperties(graph.edge(10, 1).setDistance(2), encoder, 60, true, false).setName("10-1");
+        tmpEdge = GHUtility.setSpeed(60, true, false, encoder, graph.edge(10, 1).setDistance(2)).setName("10-1");
         carManagerRoundabout.setBool(false, tmpEdge.getFlags(), true);
         tmpEdge.setFlags(tmpEdge.getFlags());
-        tmpEdge = GHUtility.setProperties(graph.edge(3, 2).setDistance(5), encoder, 60, true, false).setName("2-3");
+        tmpEdge = GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 2).setDistance(5)).setName("2-3");
         carManagerRoundabout.setBool(false, tmpEdge.getFlags(), true);
         tmpEdge.setFlags(tmpEdge.getFlags());
-        tmpEdge = GHUtility.setProperties(graph.edge(4, 3).setDistance(5), encoder, 60, true, false).setName("3-4");
+        tmpEdge = GHUtility.setSpeed(60, true, false, encoder, graph.edge(4, 3).setDistance(5)).setName("3-4");
         carManagerRoundabout.setBool(false, tmpEdge.getFlags(), true);
         tmpEdge.setFlags(tmpEdge.getFlags());
-        tmpEdge = GHUtility.setProperties(graph.edge(5, 4).setDistance(5), encoder, 60, true, false).setName("4-5");
+        tmpEdge = GHUtility.setSpeed(60, true, false, encoder, graph.edge(5, 4).setDistance(5)).setName("4-5");
         carManagerRoundabout.setBool(false, tmpEdge.getFlags(), true);
         tmpEdge.setFlags(tmpEdge.getFlags());
-        tmpEdge = GHUtility.setProperties(graph.edge(2, 5).setDistance(5), encoder, 60, true, false).setName("5-2");
+        tmpEdge = GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 5).setDistance(5)).setName("5-2");
         carManagerRoundabout.setBool(false, tmpEdge.getFlags(), true);
         tmpEdge.setFlags(tmpEdge.getFlags());
 
-        GHUtility.setProperties(graph.edge(4, 7).setDistance(5), encoder, 60, true, true).setName("MainStreet 4 7");
-        GHUtility.setProperties(graph.edge(5, 8).setDistance(5), encoder, 60, true, true).setName("5-8");
-        GHUtility.setProperties(graph.edge(3, 6).setDistance(5), encoder, 60, true, true).setName("3-6");
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 7).setDistance(5)).setName("MainStreet 4 7");
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(5, 8).setDistance(5)).setName("5-8");
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 6).setDistance(5)).setName("3-6");
 
         ShortestWeighting weighting = new ShortestWeighting(encoder);
         Path p = new Dijkstra(graph, weighting, TraversalMode.NODE_BASED)
@@ -619,9 +619,9 @@ public class PathTest {
         na.setNode(3, 48.982611, 13.121012);
         na.setNode(4, 48.982336, 13.121002);
 
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(5), encoder, 60, true, true).setName("Regener Weg");
-        GHUtility.setProperties(graph.edge(2, 4).setDistance(5), encoder, 60, true, true).setName("Regener Weg");
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(5), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(5)).setName("Regener Weg");
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 4).setDistance(5)).setName("Regener Weg");
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 3).setDistance(5));
 
         ShortestWeighting weighting = new ShortestWeighting(encoder);
         Path p = new Dijkstra(graph, weighting, TraversalMode.NODE_BASED)
@@ -652,9 +652,9 @@ public class PathTest {
         EnumEncodedValue<RoadClass> roadClassEnc = carManager.getEnumEncodedValue(RoadClass.KEY, RoadClass.class);
         BooleanEncodedValue roadClassLinkEnc = carManager.getBooleanEncodedValue(RoadClassLink.KEY);
 
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(5), encoder, 60, true, true).setName("A 8").set(roadClassEnc, RoadClass.MOTORWAY).set(roadClassLinkEnc, false);
-        GHUtility.setProperties(graph.edge(2, 4).setDistance(5), encoder, 60, true, true).setName("A 8").set(roadClassEnc, RoadClass.MOTORWAY).set(roadClassLinkEnc, false);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(5), encoder, 60, true, true).set(roadClassEnc, RoadClass.MOTORWAY).set(roadClassLinkEnc, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(5)).setName("A 8").set(roadClassEnc, RoadClass.MOTORWAY).set(roadClassLinkEnc, false);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 4).setDistance(5)).setName("A 8").set(roadClassEnc, RoadClass.MOTORWAY).set(roadClassLinkEnc, false);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 3).setDistance(5)).set(roadClassEnc, RoadClass.MOTORWAY).set(roadClassLinkEnc, true);
 
         ShortestWeighting weighting = new ShortestWeighting(encoder);
         Path p = new Dijkstra(graph, weighting, TraversalMode.NODE_BASED)
@@ -680,9 +680,9 @@ public class PathTest {
         na.setNode(3, 48.630558, 9.459851);
         na.setNode(4, 48.63054, 9.459406);
 
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(5), encoder, 60, true, false).setName("A 8");
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(5), encoder, 60, true, false).setName("A 8");
-        GHUtility.setProperties(graph.edge(4, 2).setDistance(5), encoder, 60, true, false).setName("A 8");
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 2).setDistance(5)).setName("A 8");
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 3).setDistance(5)).setName("A 8");
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(4, 2).setDistance(5)).setName("A 8");
 
         ShortestWeighting weighting = new ShortestWeighting(encoder);
         Path p = new Dijkstra(graph, weighting, TraversalMode.NODE_BASED)
@@ -709,9 +709,9 @@ public class PathTest {
         na.setNode(3, 48.706805, 9.162995);
         na.setNode(4, 48.706705, 9.16329);
 
-        GHUtility.setProperties(g.edge(1, 2).setDistance(5), encoder, 60, true, false).setName("A 8");
-        GHUtility.setProperties(g.edge(2, 3).setDistance(5), encoder, 60, true, false).setName("A 8");
-        GHUtility.setProperties(g.edge(2, 4).setDistance(5), encoder, 60, true, false).setName("A 8");
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(1, 2).setDistance(5)).setName("A 8");
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(2, 3).setDistance(5)).setName("A 8");
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(2, 4).setDistance(5)).setName("A 8");
 
         ShortestWeighting weighting = new ShortestWeighting(encoder);
         Path p = new Dijkstra(g, weighting, TraversalMode.NODE_BASED)
@@ -739,9 +739,9 @@ public class PathTest {
         na.setNode(3, -33.824415, 151.188177);
         na.setNode(4, -33.824437, 151.187925);
 
-        GHUtility.setProperties(g.edge(1, 2).setDistance(5), encoder, 60, true, false).setName("Pacific Highway");
-        GHUtility.setProperties(g.edge(2, 3).setDistance(5), encoder, 60, true, false).setName("Pacific Highway");
-        GHUtility.setProperties(g.edge(4, 2).setDistance(5), encoder, 60, true, true).setName("Greenwich Road");
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(1, 2).setDistance(5)).setName("Pacific Highway");
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(2, 3).setDistance(5)).setName("Pacific Highway");
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(4, 2).setDistance(5)).setName("Greenwich Road");
 
         ShortestWeighting weighting = new ShortestWeighting(encoder);
         Path p = new Dijkstra(g, weighting, TraversalMode.NODE_BASED)
@@ -774,9 +774,9 @@ public class PathTest {
         EnumEncodedValue<RoadClass> roadClassEnc = carManager.getEnumEncodedValue(RoadClass.KEY, RoadClass.class);
         BooleanEncodedValue roadClassLinkEnc = carManager.getBooleanEncodedValue(RoadClassLink.KEY);
 
-        GHUtility.setProperties(g.edge(1, 2).setDistance(5), encoder, 60, true, true).setName("B 156").set(roadClassEnc, RoadClass.PRIMARY).set(roadClassLinkEnc, false);
-        GHUtility.setProperties(g.edge(2, 4).setDistance(5), encoder, 60, true, true).setName("S 108").set(roadClassEnc, RoadClass.SECONDARY).set(roadClassLinkEnc, false);
-        GHUtility.setProperties(g.edge(2, 3).setDistance(5), encoder, 60, true, true).setName("B 156").set(roadClassEnc, RoadClass.PRIMARY).set(roadClassLinkEnc, false);
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(1, 2).setDistance(5)).setName("B 156").set(roadClassEnc, RoadClass.PRIMARY).set(roadClassLinkEnc, false);
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(2, 4).setDistance(5)).setName("S 108").set(roadClassEnc, RoadClass.SECONDARY).set(roadClassLinkEnc, false);
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(2, 3).setDistance(5)).setName("B 156").set(roadClassEnc, RoadClass.PRIMARY).set(roadClassLinkEnc, false);
 
         ShortestWeighting weighting = new ShortestWeighting(encoder);
         Path p = new Dijkstra(g, weighting, TraversalMode.NODE_BASED)
@@ -808,9 +808,9 @@ public class PathTest {
         na.setNode(3, 48.982611, 13.121012);
         na.setNode(4, 48.982565, 13.121002);
 
-        GHUtility.setProperties(g.edge(1, 2).setDistance(5), encoder, 60, true, true).setName("Regener Weg");
-        GHUtility.setProperties(g.edge(2, 4).setDistance(5), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(2, 3).setDistance(5), encoder, 60, true, true).setName("Regener Weg");
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(1, 2).setDistance(5)).setName("Regener Weg");
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(2, 4).setDistance(5));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(2, 3).setDistance(5)).setName("Regener Weg");
 
         ShortestWeighting weighting = new ShortestWeighting(encoder);
         Path p = new Dijkstra(g, weighting, TraversalMode.NODE_BASED)
@@ -838,9 +838,9 @@ public class PathTest {
         na.setNode(3, 48.412034, 15.599411);
         na.setNode(4, 48.411927, 15.599197);
 
-        GHUtility.setProperties(g.edge(1, 2).setDistance(5), encoder, 60, true, true).setName("Stöhrgasse");
-        GHUtility.setProperties(g.edge(2, 3).setDistance(5), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(2, 4).setDistance(5), encoder, 60, true, true).setName("Stöhrgasse");
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(1, 2).setDistance(5)).setName("Stöhrgasse");
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(2, 3).setDistance(5));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(2, 4).setDistance(5)).setName("Stöhrgasse");
 
         ShortestWeighting weighting = new ShortestWeighting(encoder);
         Path p = new Dijkstra(g, weighting, TraversalMode.NODE_BASED)
@@ -871,12 +871,12 @@ public class PathTest {
         na.setNode(6, 48.402422, 9.996067);
         na.setNode(7, 48.402604, 9.994962);
 
-        GHUtility.setProperties(g.edge(1, 2).setDistance(5), encoder, 60, true, false).setName("Olgastraße");
-        GHUtility.setProperties(g.edge(2, 3).setDistance(5), encoder, 60, true, false).setName("Olgastraße");
-        GHUtility.setProperties(g.edge(6, 5).setDistance(5), encoder, 60, true, false).setName("Olgastraße");
-        GHUtility.setProperties(g.edge(5, 4).setDistance(5), encoder, 60, true, false).setName("Olgastraße");
-        GHUtility.setProperties(g.edge(2, 5).setDistance(5), encoder, 60, true, true).setName("Neithardtstraße");
-        GHUtility.setProperties(g.edge(5, 7).setDistance(5), encoder, 60, true, true).setName("Neithardtstraße");
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(1, 2).setDistance(5)).setName("Olgastraße");
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(2, 3).setDistance(5)).setName("Olgastraße");
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(6, 5).setDistance(5)).setName("Olgastraße");
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(5, 4).setDistance(5)).setName("Olgastraße");
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(2, 5).setDistance(5)).setName("Neithardtstraße");
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(5, 7).setDistance(5)).setName("Neithardtstraße");
 
         ShortestWeighting weighting = new ShortestWeighting(encoder);
         Path p = new Dijkstra(g, weighting, TraversalMode.NODE_BASED)
@@ -907,12 +907,12 @@ public class PathTest {
         na.setNode(6, -33.885692, 151.181445);
         na.setNode(7, -33.885692, 151.181445);
 
-        GHUtility.setProperties(g.edge(1, 2).setDistance(5), encoder, 60, true, false).setName("Parramatta Road");
-        GHUtility.setProperties(g.edge(2, 3).setDistance(5), encoder, 60, true, false).setName("Parramatta Road");
-        GHUtility.setProperties(g.edge(4, 5).setDistance(5), encoder, 60, true, false).setName("Parramatta Road");
-        GHUtility.setProperties(g.edge(5, 6).setDistance(5), encoder, 60, true, false).setName("Parramatta Road");
-        GHUtility.setProperties(g.edge(2, 5).setDistance(5), encoder, 60, true, true).setName("Larkin Street");
-        GHUtility.setProperties(g.edge(5, 7).setDistance(5), encoder, 60, true, true).setName("Larkin Street");
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(1, 2).setDistance(5)).setName("Parramatta Road");
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(2, 3).setDistance(5)).setName("Parramatta Road");
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(4, 5).setDistance(5)).setName("Parramatta Road");
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(5, 6).setDistance(5)).setName("Parramatta Road");
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(2, 5).setDistance(5)).setName("Larkin Street");
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(5, 7).setDistance(5)).setName("Larkin Street");
 
         ShortestWeighting weighting = new ShortestWeighting(encoder);
         Path p = new Dijkstra(g, weighting, TraversalMode.NODE_BASED)
@@ -969,9 +969,9 @@ public class PathTest {
         na.setNode(3, 48.764149, 8.678926);
         na.setNode(4, 48.764085, 8.679183);
 
-        GHUtility.setProperties(g.edge(1, 3).setDistance(5), encoder, 60, true, true).setName("Talstraße, K 4313");
-        GHUtility.setProperties(g.edge(2, 3).setDistance(5), encoder, 60, true, true).setName("Calmbacher Straße, K 4312");
-        GHUtility.setProperties(g.edge(3, 4).setDistance(5), encoder, 60, true, true).setName("Calmbacher Straße, K 4312");
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(1, 3).setDistance(5)).setName("Talstraße, K 4313");
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(2, 3).setDistance(5)).setName("Calmbacher Straße, K 4312");
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(3, 4).setDistance(5)).setName("Calmbacher Straße, K 4312");
 
         ShortestWeighting weighting = new ShortestWeighting(encoder);
         Path p = new Dijkstra(g, weighting, TraversalMode.NODE_BASED)
@@ -1020,23 +1020,23 @@ public class PathTest {
         w.setTag("maxspeed", "50");
 
         EdgeIteratorState tmpEdge;
-        tmpEdge = GHUtility.setProperties(graph.edge(1, 2).setDistance(5), encoder, 60, true, true).setName("1-2");
+        tmpEdge = GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(5)).setName("1-2");
         EncodingManager.AcceptWay map = new EncodingManager.AcceptWay();
         assertTrue(carManager.acceptWay(w, map));
         IntsRef relFlags = carManager.createRelationFlags();
         tmpEdge.setFlags(carManager.handleWayTags(w, map, relFlags));
-        tmpEdge = GHUtility.setProperties(graph.edge(4, 5).setDistance(5), encoder, 60, true, true).setName("4-5");
+        tmpEdge = GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 5).setDistance(5)).setName("4-5");
         tmpEdge.setFlags(carManager.handleWayTags(w, map, relFlags));
 
         w.setTag("maxspeed", "100");
-        tmpEdge = GHUtility.setProperties(graph.edge(2, 3).setDistance(5), encoder, 60, true, true).setName("2-3");
+        tmpEdge = GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 3).setDistance(5)).setName("2-3");
         tmpEdge.setFlags(carManager.handleWayTags(w, map, relFlags));
 
         w.setTag("maxspeed", "10");
-        tmpEdge = GHUtility.setProperties(graph.edge(3, 4).setDistance(10), encoder, 60, true, true).setName("3-4");
+        tmpEdge = GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 4).setDistance(10)).setName("3-4");
         tmpEdge.setFlags(carManager.handleWayTags(w, map, relFlags));
 
-        tmpEdge = GHUtility.setProperties(graph.edge(5, 6).setDistance(0.01), encoder, 60, true, true).setName("3-4");
+        tmpEdge = GHUtility.setSpeed(60, true, true, encoder, graph.edge(5, 6).setDistance(0.01)).setName("3-4");
         tmpEdge.setFlags(carManager.handleWayTags(w, map, relFlags));
 
         return graph;
@@ -1112,8 +1112,11 @@ public class PathTest {
             bothDir.add(g.edge(17, 18).setDistance(5));
             bothDir.add(g.edge(17, 19).setDistance(5));
 
-            GHUtility.setProperties(bothDir, em, true, true);
-            GHUtility.setProperties(oneDir, em, true, false);
+            for (FlagEncoder encoder : em.fetchEdgeEncoders()) {
+                double speed = encoder.getMaxSpeed() / 2;
+                GHUtility.setSpeed(speed, speed, encoder, bothDir);
+                GHUtility.setSpeed(speed, 0, encoder, oneDir);
+            }
 
             setRoundabout(clockwise);
             inverse3to9();

--- a/core/src/test/java/com/graphhopper/routing/PathTest.java
+++ b/core/src/test/java/com/graphhopper/routing/PathTest.java
@@ -70,10 +70,10 @@ public class PathTest {
         na.setNode(1, 1.0, 0.1);
         na.setNode(2, 2.0, 0.1);
 
-        EdgeIteratorState edge1 = g.edge(0, 1).setDistance(1000).set(carAccessEnc, true).setReverse(carAccessEnc, true).set(carAvSpeedEnv, 10.0);
+        EdgeIteratorState edge1 = g.edge(0, 1).setDistance(1000).set(carAccessEnc, true, true).set(carAvSpeedEnv, 10.0);
 
         edge1.setWayGeometry(Helper.createPointList(8, 1, 9, 1));
-        EdgeIteratorState edge2 = g.edge(2, 1).setDistance(2000).set(carAccessEnc, true).setReverse(carAccessEnc, true).set(carAvSpeedEnv, 50.0);
+        EdgeIteratorState edge2 = g.edge(2, 1).setDistance(2000).set(carAccessEnc, true, true).set(carAvSpeedEnv, 50.0);
         edge2.setWayGeometry(Helper.createPointList(11, 1, 10, 1));
 
         SPTEntry e1 = new SPTEntry(edge2.getEdge(), 2, 1);
@@ -110,7 +110,7 @@ public class PathTest {
         // force minor change for instructions
         edge2.setName("2");
         na.setNode(3, 1.0, 1.0);
-        g.edge(1, 3).setDistance(1000).set(carAccessEnc, true).setReverse(carAccessEnc, true).set(carAvSpeedEnv, 10.0);
+        g.edge(1, 3).setDistance(1000).set(carAccessEnc, true, true).set(carAvSpeedEnv, 10.0);
 
         e1 = new SPTEntry(edge2.getEdge(), 2, 1);
         e1.parent = new SPTEntry(edge1.getEdge(), 1, 1);
@@ -173,22 +173,22 @@ public class PathTest {
         na.setNode(4, 7.5, 0.25);
         na.setNode(5, 5.0, 1.0);
 
-        EdgeIteratorState edge1 = g.edge(0, 1).setDistance(1000).set(carAccessEnc, true).setReverse(carAccessEnc, true).set(carAvSpeedEnv, 50.0);
+        EdgeIteratorState edge1 = g.edge(0, 1).setDistance(1000).set(carAccessEnc, true, true).set(carAvSpeedEnv, 50.0);
         edge1.setWayGeometry(Helper.createPointList());
         edge1.setName("Street 1");
-        EdgeIteratorState edge2 = g.edge(1, 2).setDistance(1000).set(carAccessEnc, true).setReverse(carAccessEnc, true).set(carAvSpeedEnv, 50.0);
+        EdgeIteratorState edge2 = g.edge(1, 2).setDistance(1000).set(carAccessEnc, true, true).set(carAvSpeedEnv, 50.0);
         edge2.setWayGeometry(Helper.createPointList());
         edge2.setName("Street 2");
-        EdgeIteratorState edge3 = g.edge(2, 3).setDistance(1000).set(carAccessEnc, true).setReverse(carAccessEnc, true).set(carAvSpeedEnv, 50.0);
+        EdgeIteratorState edge3 = g.edge(2, 3).setDistance(1000).set(carAccessEnc, true, true).set(carAvSpeedEnv, 50.0);
         edge3.setWayGeometry(Helper.createPointList());
         edge3.setName("Street 3");
-        EdgeIteratorState edge4 = g.edge(3, 4).setDistance(500).set(carAccessEnc, true).setReverse(carAccessEnc, true).set(carAvSpeedEnv, 50.0);
+        EdgeIteratorState edge4 = g.edge(3, 4).setDistance(500).set(carAccessEnc, true, true).set(carAvSpeedEnv, 50.0);
         edge4.setWayGeometry(Helper.createPointList());
         edge4.setName("Street 4");
 
-        g.edge(1, 5).setDistance(10000).set(carAccessEnc, true).setReverse(carAccessEnc, true).set(carAvSpeedEnv, 50.0);
-        g.edge(2, 5).setDistance(10000).set(carAccessEnc, true).setReverse(carAccessEnc, true).set(carAvSpeedEnv, 50.0);
-        g.edge(3, 5).setDistance(100000).set(carAccessEnc, true).setReverse(carAccessEnc, true).set(carAvSpeedEnv, 50.0);
+        g.edge(1, 5).setDistance(10000).set(carAccessEnc, true, true).set(carAvSpeedEnv, 50.0);
+        g.edge(2, 5).setDistance(10000).set(carAccessEnc, true, true).set(carAvSpeedEnv, 50.0);
+        g.edge(3, 5).setDistance(100000).set(carAccessEnc, true, true).set(carAvSpeedEnv, 50.0);
 
         SPTEntry e1 = new SPTEntry(edge4.getEdge(), 4, 1);
         e1.parent = new SPTEntry(edge3.getEdge(), 3, 1);

--- a/core/src/test/java/com/graphhopper/routing/PathTest.java
+++ b/core/src/test/java/com/graphhopper/routing/PathTest.java
@@ -4,7 +4,7 @@
  *  additional information regarding copyright ownership.
  *
  *  GraphHopper GmbH licenses this file to you under the Apache License,
- *  Version 2.0 (the "License"); you may not use this file except in 
+ *  Version 2.0 (the "License"); you may not use this file except in
  *  compliance with the License. You may obtain a copy of the License at
  *
  *       http://www.apache.org/licenses/LICENSE-2.0
@@ -23,7 +23,10 @@ import com.graphhopper.routing.util.*;
 import com.graphhopper.routing.weighting.FastestWeighting;
 import com.graphhopper.routing.weighting.ShortestWeighting;
 import com.graphhopper.routing.weighting.Weighting;
-import com.graphhopper.storage.*;
+import com.graphhopper.storage.Graph;
+import com.graphhopper.storage.GraphBuilder;
+import com.graphhopper.storage.IntsRef;
+import com.graphhopper.storage.NodeAccess;
 import com.graphhopper.util.*;
 import com.graphhopper.util.details.PathDetail;
 import com.graphhopper.util.details.PathDetailsBuilderFactory;
@@ -47,7 +50,7 @@ public class PathTest {
     private final EncodingManager mixedEncoders = EncodingManager.create(new CarFlagEncoder(), new FootFlagEncoder());
     private final TranslationMap trMap = TranslationMapTest.SINGLETON;
     private final Translation tr = trMap.getWithFallBack(Locale.US);
-    private final RoundaboutGraph roundaboutGraph = new RoundaboutGraph();
+    private final RoundaboutGraph roundaboutGraph = new RoundaboutGraph(mixedEncoders);
     private final Graph pathDetailGraph = generatePathDetailsGraph();
 
     @Test
@@ -481,8 +484,8 @@ public class PathTest {
 
     @Test
     public void testCalcInstructionsRoundaboutIssue353() {
-        final Graph g = new GraphBuilder(carManager).create();
-        final NodeAccess na = g.getNodeAccess();
+        final Graph graph = new GraphBuilder(carManager).create();
+        final NodeAccess na = graph.getNodeAccess();
 
         //
         //          8
@@ -507,43 +510,43 @@ public class PathTest {
         na.setNode(10, 52.5135, 13.348);
         na.setNode(11, 52.514, 13.347);
 
-        g.edge(2, 1, 5, false).setName("MainStreet 2 1");
-        g.edge(1, 11, 5, false).setName("MainStreet 1 11");
+        GHUtility.setProperties(graph.edge(2, 1).setDistance(5), encoder, 60, true, false).setName("MainStreet 2 1");
+        GHUtility.setProperties(graph.edge(1, 11).setDistance(5), encoder, 60, true, false).setName("MainStreet 1 11");
 
         // roundabout
         EdgeIteratorState tmpEdge;
-        tmpEdge = g.edge(3, 9, 2, false).setName("3-9");
+        tmpEdge = GHUtility.setProperties(graph.edge(3, 9).setDistance(2), encoder, 60, true, false).setName("3-9");
         BooleanEncodedValue carManagerRoundabout = carManager.getBooleanEncodedValue(Roundabout.KEY);
         carManagerRoundabout.setBool(false, tmpEdge.getFlags(), true);
         tmpEdge.setFlags(tmpEdge.getFlags());
-        tmpEdge = g.edge(9, 10, 2, false).setName("9-10");
+        tmpEdge = GHUtility.setProperties(graph.edge(9, 10).setDistance(2), encoder, 60, true, false).setName("9-10");
         carManagerRoundabout.setBool(false, tmpEdge.getFlags(), true);
         tmpEdge.setFlags(tmpEdge.getFlags());
-        tmpEdge = g.edge(6, 10, 2, false).setName("6-10");
+        tmpEdge = GHUtility.setProperties(graph.edge(6, 10).setDistance(2), encoder, 60, true, false).setName("6-10");
         carManagerRoundabout.setBool(false, tmpEdge.getFlags(), true);
         tmpEdge.setFlags(tmpEdge.getFlags());
-        tmpEdge = g.edge(10, 1, 2, false).setName("10-1");
+        tmpEdge = GHUtility.setProperties(graph.edge(10, 1).setDistance(2), encoder, 60, true, false).setName("10-1");
         carManagerRoundabout.setBool(false, tmpEdge.getFlags(), true);
         tmpEdge.setFlags(tmpEdge.getFlags());
-        tmpEdge = g.edge(3, 2, 5, false).setName("2-3");
+        tmpEdge = GHUtility.setProperties(graph.edge(3, 2).setDistance(5), encoder, 60, true, false).setName("2-3");
         carManagerRoundabout.setBool(false, tmpEdge.getFlags(), true);
         tmpEdge.setFlags(tmpEdge.getFlags());
-        tmpEdge = g.edge(4, 3, 5, false).setName("3-4");
+        tmpEdge = GHUtility.setProperties(graph.edge(4, 3).setDistance(5), encoder, 60, true, false).setName("3-4");
         carManagerRoundabout.setBool(false, tmpEdge.getFlags(), true);
         tmpEdge.setFlags(tmpEdge.getFlags());
-        tmpEdge = g.edge(5, 4, 5, false).setName("4-5");
+        tmpEdge = GHUtility.setProperties(graph.edge(5, 4).setDistance(5), encoder, 60, true, false).setName("4-5");
         carManagerRoundabout.setBool(false, tmpEdge.getFlags(), true);
         tmpEdge.setFlags(tmpEdge.getFlags());
-        tmpEdge = g.edge(2, 5, 5, false).setName("5-2");
+        tmpEdge = GHUtility.setProperties(graph.edge(2, 5).setDistance(5), encoder, 60, true, false).setName("5-2");
         carManagerRoundabout.setBool(false, tmpEdge.getFlags(), true);
         tmpEdge.setFlags(tmpEdge.getFlags());
 
-        g.edge(4, 7, 5, true).setName("MainStreet 4 7");
-        g.edge(5, 8, 5, true).setName("5-8");
-        g.edge(3, 6, 5, true).setName("3-6");
+        GHUtility.setProperties(graph.edge(4, 7).setDistance(5), encoder, 60, true, true).setName("MainStreet 4 7");
+        GHUtility.setProperties(graph.edge(5, 8).setDistance(5), encoder, 60, true, true).setName("5-8");
+        GHUtility.setProperties(graph.edge(3, 6).setDistance(5), encoder, 60, true, true).setName("3-6");
 
         ShortestWeighting weighting = new ShortestWeighting(encoder);
-        Path p = new Dijkstra(g, weighting, TraversalMode.NODE_BASED)
+        Path p = new Dijkstra(graph, weighting, TraversalMode.NODE_BASED)
                 .calcPath(6, 11);
         assertTrue(p.isFound());
         InstructionList wayList = InstructionsFromEdges.calcInstructions(p, p.graph, weighting, carManager, tr);
@@ -600,8 +603,8 @@ public class PathTest {
 
     @Test
     public void testCalcInstructionForForkWithSameName() {
-        final Graph g = new GraphBuilder(carManager).create();
-        final NodeAccess na = g.getNodeAccess();
+        final Graph graph = new GraphBuilder(carManager).create();
+        final NodeAccess na = graph.getNodeAccess();
 
         // Actual example: point=48.982618%2C13.122021&point=48.982336%2C13.121002
         // 1-2 & 2-4 have the same Street name, but other from that, it would be hard to see the difference
@@ -616,12 +619,12 @@ public class PathTest {
         na.setNode(3, 48.982611, 13.121012);
         na.setNode(4, 48.982336, 13.121002);
 
-        g.edge(1, 2, 5, true).setName("Regener Weg");
-        g.edge(2, 4, 5, true).setName("Regener Weg");
-        g.edge(2, 3, 5, true);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(5), encoder, 60, true, true).setName("Regener Weg");
+        GHUtility.setProperties(graph.edge(2, 4).setDistance(5), encoder, 60, true, true).setName("Regener Weg");
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(5), encoder, 60, true, true);
 
         ShortestWeighting weighting = new ShortestWeighting(encoder);
-        Path p = new Dijkstra(g, weighting, TraversalMode.NODE_BASED)
+        Path p = new Dijkstra(graph, weighting, TraversalMode.NODE_BASED)
                 .calcPath(1, 4);
         assertTrue(p.isFound());
         InstructionList wayList = InstructionsFromEdges.calcInstructions(p, p.graph, weighting, carManager, tr);
@@ -632,8 +635,8 @@ public class PathTest {
 
     @Test
     public void testCalcInstructionForMotorwayFork() {
-        final Graph g = new GraphBuilder(carManager).create();
-        final NodeAccess na = g.getNodeAccess();
+        final Graph graph = new GraphBuilder(carManager).create();
+        final NodeAccess na = graph.getNodeAccess();
 
         // Actual example: point=48.909071%2C8.647136&point=48.908789%2C8.649244
         // 1-2 & 2-4 is a motorway, 2-3 is a motorway_link
@@ -649,12 +652,12 @@ public class PathTest {
         EnumEncodedValue<RoadClass> roadClassEnc = carManager.getEnumEncodedValue(RoadClass.KEY, RoadClass.class);
         BooleanEncodedValue roadClassLinkEnc = carManager.getBooleanEncodedValue(RoadClassLink.KEY);
 
-        g.edge(1, 2, 5, true).setName("A 8").set(roadClassEnc, RoadClass.MOTORWAY).set(roadClassLinkEnc, false);
-        g.edge(2, 4, 5, true).setName("A 8").set(roadClassEnc, RoadClass.MOTORWAY).set(roadClassLinkEnc, false);
-        g.edge(2, 3, 5, true).set(roadClassEnc, RoadClass.MOTORWAY).set(roadClassLinkEnc, true);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(5), encoder, 60, true, true).setName("A 8").set(roadClassEnc, RoadClass.MOTORWAY).set(roadClassLinkEnc, false);
+        GHUtility.setProperties(graph.edge(2, 4).setDistance(5), encoder, 60, true, true).setName("A 8").set(roadClassEnc, RoadClass.MOTORWAY).set(roadClassLinkEnc, false);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(5), encoder, 60, true, true).set(roadClassEnc, RoadClass.MOTORWAY).set(roadClassLinkEnc, true);
 
         ShortestWeighting weighting = new ShortestWeighting(encoder);
-        Path p = new Dijkstra(g, weighting, TraversalMode.NODE_BASED)
+        Path p = new Dijkstra(graph, weighting, TraversalMode.NODE_BASED)
                 .calcPath(1, 4);
         assertTrue(p.isFound());
         InstructionList wayList = InstructionsFromEdges.calcInstructions(p, p.graph, weighting, carManager, tr);
@@ -664,8 +667,8 @@ public class PathTest {
 
     @Test
     public void testCalcInstructionsEnterMotorway() {
-        final Graph g = new GraphBuilder(carManager).create();
-        final NodeAccess na = g.getNodeAccess();
+        final Graph graph = new GraphBuilder(carManager).create();
+        final NodeAccess na = graph.getNodeAccess();
 
         // Actual example: point=48.630533%2C9.459416&point=48.630544%2C9.459829
         // 1 -2 -3 is a motorway and tagged as oneway
@@ -677,12 +680,12 @@ public class PathTest {
         na.setNode(3, 48.630558, 9.459851);
         na.setNode(4, 48.63054, 9.459406);
 
-        g.edge(1, 2, 5, false).setName("A 8");
-        g.edge(2, 3, 5, false).setName("A 8");
-        g.edge(4, 2, 5, false).setName("A 8");
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(5), encoder, 60, true, false).setName("A 8");
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(5), encoder, 60, true, false).setName("A 8");
+        GHUtility.setProperties(graph.edge(4, 2).setDistance(5), encoder, 60, true, false).setName("A 8");
 
         ShortestWeighting weighting = new ShortestWeighting(encoder);
-        Path p = new Dijkstra(g, weighting, TraversalMode.NODE_BASED)
+        Path p = new Dijkstra(graph, weighting, TraversalMode.NODE_BASED)
                 .calcPath(4, 3);
         assertTrue(p.isFound());
         InstructionList wayList = InstructionsFromEdges.calcInstructions(p, p.graph, weighting, carManager, tr);
@@ -706,9 +709,9 @@ public class PathTest {
         na.setNode(3, 48.706805, 9.162995);
         na.setNode(4, 48.706705, 9.16329);
 
-        g.edge(1, 2, 5, false).setName("A 8");
-        g.edge(2, 3, 5, false).setName("A 8");
-        g.edge(2, 4, 5, false).setName("A 8");
+        GHUtility.setProperties(g.edge(1, 2).setDistance(5), encoder, 60, true, false).setName("A 8");
+        GHUtility.setProperties(g.edge(2, 3).setDistance(5), encoder, 60, true, false).setName("A 8");
+        GHUtility.setProperties(g.edge(2, 4).setDistance(5), encoder, 60, true, false).setName("A 8");
 
         ShortestWeighting weighting = new ShortestWeighting(encoder);
         Path p = new Dijkstra(g, weighting, TraversalMode.NODE_BASED)
@@ -736,9 +739,9 @@ public class PathTest {
         na.setNode(3, -33.824415, 151.188177);
         na.setNode(4, -33.824437, 151.187925);
 
-        g.edge(1, 2, 5, false).setName("Pacific Highway");
-        g.edge(2, 3, 5, false).setName("Pacific Highway");
-        g.edge(4, 2, 5, true).setName("Greenwich Road");
+        GHUtility.setProperties(g.edge(1, 2).setDistance(5), encoder, 60, true, false).setName("Pacific Highway");
+        GHUtility.setProperties(g.edge(2, 3).setDistance(5), encoder, 60, true, false).setName("Pacific Highway");
+        GHUtility.setProperties(g.edge(4, 2).setDistance(5), encoder, 60, true, true).setName("Greenwich Road");
 
         ShortestWeighting weighting = new ShortestWeighting(encoder);
         Path p = new Dijkstra(g, weighting, TraversalMode.NODE_BASED)
@@ -771,9 +774,9 @@ public class PathTest {
         EnumEncodedValue<RoadClass> roadClassEnc = carManager.getEnumEncodedValue(RoadClass.KEY, RoadClass.class);
         BooleanEncodedValue roadClassLinkEnc = carManager.getBooleanEncodedValue(RoadClassLink.KEY);
 
-        g.edge(1, 2, 5, true).setName("B 156").set(roadClassEnc, RoadClass.PRIMARY).set(roadClassLinkEnc, false);
-        g.edge(2, 4, 5, true).setName("S 108").set(roadClassEnc, RoadClass.SECONDARY).set(roadClassLinkEnc, false);
-        g.edge(2, 3, 5, true).setName("B 156").set(roadClassEnc, RoadClass.PRIMARY).set(roadClassLinkEnc, false);
+        GHUtility.setProperties(g.edge(1, 2).setDistance(5), encoder, 60, true, true).setName("B 156").set(roadClassEnc, RoadClass.PRIMARY).set(roadClassLinkEnc, false);
+        GHUtility.setProperties(g.edge(2, 4).setDistance(5), encoder, 60, true, true).setName("S 108").set(roadClassEnc, RoadClass.SECONDARY).set(roadClassLinkEnc, false);
+        GHUtility.setProperties(g.edge(2, 3).setDistance(5), encoder, 60, true, true).setName("B 156").set(roadClassEnc, RoadClass.PRIMARY).set(roadClassLinkEnc, false);
 
         ShortestWeighting weighting = new ShortestWeighting(encoder);
         Path p = new Dijkstra(g, weighting, TraversalMode.NODE_BASED)
@@ -805,9 +808,9 @@ public class PathTest {
         na.setNode(3, 48.982611, 13.121012);
         na.setNode(4, 48.982565, 13.121002);
 
-        g.edge(1, 2, 5, true).setName("Regener Weg");
-        g.edge(2, 4, 5, true);
-        g.edge(2, 3, 5, true).setName("Regener Weg");
+        GHUtility.setProperties(g.edge(1, 2).setDistance(5), encoder, 60, true, true).setName("Regener Weg");
+        GHUtility.setProperties(g.edge(2, 4).setDistance(5), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(2, 3).setDistance(5), encoder, 60, true, true).setName("Regener Weg");
 
         ShortestWeighting weighting = new ShortestWeighting(encoder);
         Path p = new Dijkstra(g, weighting, TraversalMode.NODE_BASED)
@@ -835,9 +838,9 @@ public class PathTest {
         na.setNode(3, 48.412034, 15.599411);
         na.setNode(4, 48.411927, 15.599197);
 
-        g.edge(1, 2, 5, true).setName("Stöhrgasse");
-        g.edge(2, 3, 5, true);
-        g.edge(2, 4, 5, true).setName("Stöhrgasse");
+        GHUtility.setProperties(g.edge(1, 2).setDistance(5), encoder, 60, true, true).setName("Stöhrgasse");
+        GHUtility.setProperties(g.edge(2, 3).setDistance(5), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(2, 4).setDistance(5), encoder, 60, true, true).setName("Stöhrgasse");
 
         ShortestWeighting weighting = new ShortestWeighting(encoder);
         Path p = new Dijkstra(g, weighting, TraversalMode.NODE_BASED)
@@ -868,12 +871,12 @@ public class PathTest {
         na.setNode(6, 48.402422, 9.996067);
         na.setNode(7, 48.402604, 9.994962);
 
-        g.edge(1, 2, 5, false).setName("Olgastraße");
-        g.edge(2, 3, 5, false).setName("Olgastraße");
-        g.edge(6, 5, 5, false).setName("Olgastraße");
-        g.edge(5, 4, 5, false).setName("Olgastraße");
-        g.edge(2, 5, 5, true).setName("Neithardtstraße");
-        g.edge(5, 7, 5, true).setName("Neithardtstraße");
+        GHUtility.setProperties(g.edge(1, 2).setDistance(5), encoder, 60, true, false).setName("Olgastraße");
+        GHUtility.setProperties(g.edge(2, 3).setDistance(5), encoder, 60, true, false).setName("Olgastraße");
+        GHUtility.setProperties(g.edge(6, 5).setDistance(5), encoder, 60, true, false).setName("Olgastraße");
+        GHUtility.setProperties(g.edge(5, 4).setDistance(5), encoder, 60, true, false).setName("Olgastraße");
+        GHUtility.setProperties(g.edge(2, 5).setDistance(5), encoder, 60, true, true).setName("Neithardtstraße");
+        GHUtility.setProperties(g.edge(5, 7).setDistance(5), encoder, 60, true, true).setName("Neithardtstraße");
 
         ShortestWeighting weighting = new ShortestWeighting(encoder);
         Path p = new Dijkstra(g, weighting, TraversalMode.NODE_BASED)
@@ -904,12 +907,12 @@ public class PathTest {
         na.setNode(6, -33.885692, 151.181445);
         na.setNode(7, -33.885692, 151.181445);
 
-        g.edge(1, 2, 5, false).setName("Parramatta Road");
-        g.edge(2, 3, 5, false).setName("Parramatta Road");
-        g.edge(4, 5, 5, false).setName("Parramatta Road");
-        g.edge(5, 6, 5, false).setName("Parramatta Road");
-        g.edge(2, 5, 5, true).setName("Larkin Street");
-        g.edge(5, 7, 5, true).setName("Larkin Street");
+        GHUtility.setProperties(g.edge(1, 2).setDistance(5), encoder, 60, true, false).setName("Parramatta Road");
+        GHUtility.setProperties(g.edge(2, 3).setDistance(5), encoder, 60, true, false).setName("Parramatta Road");
+        GHUtility.setProperties(g.edge(4, 5).setDistance(5), encoder, 60, true, false).setName("Parramatta Road");
+        GHUtility.setProperties(g.edge(5, 6).setDistance(5), encoder, 60, true, false).setName("Parramatta Road");
+        GHUtility.setProperties(g.edge(2, 5).setDistance(5), encoder, 60, true, true).setName("Larkin Street");
+        GHUtility.setProperties(g.edge(5, 7).setDistance(5), encoder, 60, true, true).setName("Larkin Street");
 
         ShortestWeighting weighting = new ShortestWeighting(encoder);
         Path p = new Dijkstra(g, weighting, TraversalMode.NODE_BASED)
@@ -966,9 +969,9 @@ public class PathTest {
         na.setNode(3, 48.764149, 8.678926);
         na.setNode(4, 48.764085, 8.679183);
 
-        g.edge(1, 3, 5, true).setName("Talstraße, K 4313");
-        g.edge(2, 3, 5, true).setName("Calmbacher Straße, K 4312");
-        g.edge(3, 4, 5, true).setName("Calmbacher Straße, K 4312");
+        GHUtility.setProperties(g.edge(1, 3).setDistance(5), encoder, 60, true, true).setName("Talstraße, K 4313");
+        GHUtility.setProperties(g.edge(2, 3).setDistance(5), encoder, 60, true, true).setName("Calmbacher Straße, K 4312");
+        GHUtility.setProperties(g.edge(3, 4).setDistance(5), encoder, 60, true, true).setName("Calmbacher Straße, K 4312");
 
         ShortestWeighting weighting = new ShortestWeighting(encoder);
         Path p = new Dijkstra(g, weighting, TraversalMode.NODE_BASED)
@@ -1002,8 +1005,8 @@ public class PathTest {
     }
 
     private Graph generatePathDetailsGraph() {
-        final Graph g = new GraphBuilder(carManager).create();
-        final NodeAccess na = g.getNodeAccess();
+        final Graph graph = new GraphBuilder(carManager).create();
+        final NodeAccess na = graph.getNodeAccess();
 
         na.setNode(1, 52.514, 13.348);
         na.setNode(2, 52.514, 13.349);
@@ -1017,36 +1020,40 @@ public class PathTest {
         w.setTag("maxspeed", "50");
 
         EdgeIteratorState tmpEdge;
-        tmpEdge = g.edge(1, 2, 5, true).setName("1-2");
+        tmpEdge = GHUtility.setProperties(graph.edge(1, 2).setDistance(5), encoder, 60, true, true).setName("1-2");
         EncodingManager.AcceptWay map = new EncodingManager.AcceptWay();
         assertTrue(carManager.acceptWay(w, map));
         IntsRef relFlags = carManager.createRelationFlags();
         tmpEdge.setFlags(carManager.handleWayTags(w, map, relFlags));
-        tmpEdge = g.edge(4, 5, 5, true).setName("4-5");
+        tmpEdge = GHUtility.setProperties(graph.edge(4, 5).setDistance(5), encoder, 60, true, true).setName("4-5");
         tmpEdge.setFlags(carManager.handleWayTags(w, map, relFlags));
 
         w.setTag("maxspeed", "100");
-        tmpEdge = g.edge(2, 3, 5, true).setName("2-3");
+        tmpEdge = GHUtility.setProperties(graph.edge(2, 3).setDistance(5), encoder, 60, true, true).setName("2-3");
         tmpEdge.setFlags(carManager.handleWayTags(w, map, relFlags));
 
         w.setTag("maxspeed", "10");
-        tmpEdge = g.edge(3, 4, 10, true).setName("3-4");
+        tmpEdge = GHUtility.setProperties(graph.edge(3, 4).setDistance(10), encoder, 60, true, true).setName("3-4");
         tmpEdge.setFlags(carManager.handleWayTags(w, map, relFlags));
 
-        tmpEdge = g.edge(5, 6, 0.01, true).setName("3-4");
+        tmpEdge = GHUtility.setProperties(graph.edge(5, 6).setDistance(0.01), encoder, 60, true, true).setName("3-4");
         tmpEdge.setFlags(carManager.handleWayTags(w, map, relFlags));
 
-        return g;
+        return graph;
     }
 
-    private class RoundaboutGraph {
-        final public Graph g = new GraphBuilder(mixedEncoders).create();
-        final public NodeAccess na = g.getNodeAccess();
-        private final EdgeIteratorState edge3to6, edge3to9;
+    private static class RoundaboutGraph {
+        final Graph g;
+        final NodeAccess na;
+        final EdgeIteratorState edge3to6, edge3to9;
+        final EncodingManager em;
         boolean clockwise = false;
         List<EdgeIteratorState> roundaboutEdges = new LinkedList<>();
 
-        private RoundaboutGraph() {
+        private RoundaboutGraph(EncodingManager em) {
+            this.em = em;
+            g = new GraphBuilder(em).create();
+            na = g.getNodeAccess();
             //                                       18
             //      8                 14              |
             //       \                 |      / 16 - 17
@@ -1078,38 +1085,43 @@ public class PathTest {
             na.setNode(18, 52.513, 13.361);
             na.setNode(19, 52.515, 13.368);
 
-            g.edge(1, 2, 5, true).setName("MainStreet 1 2");
-
             // roundabout
-            roundaboutEdges.add(g.edge(3, 2, 5, false).setName("2-3"));
-            roundaboutEdges.add(g.edge(4, 3, 5, false).setName("3-4"));
-            roundaboutEdges.add(g.edge(5, 4, 5, false).setName("4-5"));
-            roundaboutEdges.add(g.edge(2, 5, 5, false).setName("5-2"));
+            roundaboutEdges.add(g.edge(3, 2).setDistance(5).setName("2-3"));
+            roundaboutEdges.add(g.edge(4, 3).setDistance(5).setName("3-4"));
+            roundaboutEdges.add(g.edge(5, 4).setDistance(5).setName("4-5"));
+            roundaboutEdges.add(g.edge(2, 5).setDistance(5).setName("5-2"));
 
-            g.edge(4, 7, 5, true).setName("MainStreet 4 7");
-            g.edge(5, 8, 5, true).setName("5-8");
+            List<EdgeIteratorState> bothDir = new ArrayList<>();
+            List<EdgeIteratorState> oneDir = new ArrayList<>(roundaboutEdges);
 
-            edge3to6 = g.edge(3, 6, 5, true).setName("3-6");
-            edge3to9 = g.edge(3, 9, 5, false).setName("3-9");
+            bothDir.add(g.edge(1, 2).setDistance(5).setName("MainStreet 1 2"));
+            bothDir.add(g.edge(4, 7).setDistance(5).setName("MainStreet 4 7"));
+            bothDir.add(g.edge(5, 8).setDistance(5).setName("5-8"));
 
-            g.edge(7, 10, 5, true);
-            g.edge(10, 11, 5, true);
-            g.edge(11, 12, 5, true);
-            g.edge(12, 13, 5, true);
-            g.edge(12, 14, 5, true);
-            g.edge(13, 15, 5, true);
-            g.edge(13, 16, 5, true);
-            g.edge(16, 17, 5, true);
-            g.edge(17, 18, 5, true);
-            g.edge(17, 19, 5, true);
+            bothDir.add(edge3to6 = g.edge(3, 6).setDistance(5).setName("3-6"));
+            oneDir.add(edge3to9 = g.edge(3, 9).setDistance(5).setName("3-9"));
+
+            bothDir.add(g.edge(7, 10).setDistance(5));
+            bothDir.add(g.edge(10, 11).setDistance(5));
+            bothDir.add(g.edge(11, 12).setDistance(5));
+            bothDir.add(g.edge(12, 13).setDistance(5));
+            bothDir.add(g.edge(12, 14).setDistance(5));
+            bothDir.add(g.edge(13, 15).setDistance(5));
+            bothDir.add(g.edge(13, 16).setDistance(5));
+            bothDir.add(g.edge(16, 17).setDistance(5));
+            bothDir.add(g.edge(17, 18).setDistance(5));
+            bothDir.add(g.edge(17, 19).setDistance(5));
+
+            GHUtility.setProperties(bothDir, em, true, true);
+            GHUtility.setProperties(oneDir, em, true, false);
 
             setRoundabout(clockwise);
             inverse3to9();
         }
 
         public void setRoundabout(boolean clockwise) {
-            BooleanEncodedValue mixedRoundabout = mixedEncoders.getBooleanEncodedValue(Roundabout.KEY);
-            for (FlagEncoder encoder : mixedEncoders.fetchEdgeEncoders()) {
+            BooleanEncodedValue mixedRoundabout = em.getBooleanEncodedValue(Roundabout.KEY);
+            for (FlagEncoder encoder : em.fetchEdgeEncoders()) {
                 BooleanEncodedValue accessEnc = encoder.getAccessEnc();
                 for (EdgeIteratorState edge : roundaboutEdges) {
                     edge.set(accessEnc, clockwise).setReverse(accessEnc, !clockwise);
@@ -1121,14 +1133,14 @@ public class PathTest {
         }
 
         public void inverse3to9() {
-            for (FlagEncoder encoder : mixedEncoders.fetchEdgeEncoders()) {
+            for (FlagEncoder encoder : em.fetchEdgeEncoders()) {
                 BooleanEncodedValue accessEnc = encoder.getAccessEnc();
                 edge3to9.set(accessEnc, !edge3to9.get(accessEnc)).setReverse(accessEnc, false);
             }
         }
 
         public void inverse3to6() {
-            for (FlagEncoder encoder : mixedEncoders.fetchEdgeEncoders()) {
+            for (FlagEncoder encoder : em.fetchEdgeEncoders()) {
                 BooleanEncodedValue accessEnc = encoder.getAccessEnc();
                 edge3to6.set(accessEnc, !edge3to6.get(accessEnc)).setReverse(accessEnc, true);
             }

--- a/core/src/test/java/com/graphhopper/routing/QueryRoutingCHGraphTest.java
+++ b/core/src/test/java/com/graphhopper/routing/QueryRoutingCHGraphTest.java
@@ -66,8 +66,8 @@ class QueryRoutingCHGraphTest {
     @Test
     public void basic() {
         // 0-1-2
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(10), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(10), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(10));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(10));
         graph.freeze();
         assertEquals(2, graph.getEdges());
 
@@ -100,8 +100,8 @@ class QueryRoutingCHGraphTest {
     public void withShortcuts() {
         // 0-1-2
         //  \-/
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(10), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(10), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(10));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(10));
         graph.freeze();
         assertEquals(2, graph.getEdges());
         setIdentityLevels(chGraph);
@@ -250,7 +250,7 @@ class QueryRoutingCHGraphTest {
 
     @Test
     public void getBaseGraph() {
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(10), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(10));
         QueryGraph queryGraph = QueryGraph.create(graph, Collections.<Snap>emptyList());
         assertSame(graph.getBaseGraph(), routingCHGraph.getBaseGraph());
         QueryRoutingCHGraph queryCHGraph = new QueryRoutingCHGraph(routingCHGraph, queryGraph);
@@ -638,7 +638,7 @@ class QueryRoutingCHGraphTest {
     private EdgeIteratorState addEdge(Graph graph, int from, int to) {
         NodeAccess na = graph.getNodeAccess();
         double dist = DistancePlaneProjection.DIST_PLANE.calcDist(na.getLat(from), na.getLon(from), na.getLat(to), na.getLon(to));
-        return GHUtility.setProperties(graph.edge(from, to).setDistance(dist), encoder, 60, true, true);
+        return GHUtility.setSpeed(60, true, true, encoder, graph.edge(from, to).setDistance(dist));
     }
 
 }

--- a/core/src/test/java/com/graphhopper/routing/QueryRoutingCHGraphTest.java
+++ b/core/src/test/java/com/graphhopper/routing/QueryRoutingCHGraphTest.java
@@ -31,6 +31,7 @@ import com.graphhopper.storage.*;
 import com.graphhopper.storage.index.Snap;
 import com.graphhopper.util.DistancePlaneProjection;
 import com.graphhopper.util.EdgeIteratorState;
+import com.graphhopper.util.GHUtility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -65,8 +66,8 @@ class QueryRoutingCHGraphTest {
     @Test
     public void basic() {
         // 0-1-2
-        graph.edge(0, 1, 10, true);
-        graph.edge(1, 2, 10, true);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(10), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(10), encoder, 60, true, true);
         graph.freeze();
         assertEquals(2, graph.getEdges());
 
@@ -99,8 +100,8 @@ class QueryRoutingCHGraphTest {
     public void withShortcuts() {
         // 0-1-2
         //  \-/
-        graph.edge(0, 1, 10, true);
-        graph.edge(1, 2, 10, true);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(10), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(10), encoder, 60, true, true);
         graph.freeze();
         assertEquals(2, graph.getEdges());
         setIdentityLevels(chGraph);
@@ -249,7 +250,7 @@ class QueryRoutingCHGraphTest {
 
     @Test
     public void getBaseGraph() {
-        graph.edge(0, 1, 10, true);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(10), encoder, 60, true, true);
         QueryGraph queryGraph = QueryGraph.create(graph, Collections.<Snap>emptyList());
         assertSame(graph.getBaseGraph(), routingCHGraph.getBaseGraph());
         QueryRoutingCHGraph queryCHGraph = new QueryRoutingCHGraph(routingCHGraph, queryGraph);
@@ -637,7 +638,7 @@ class QueryRoutingCHGraphTest {
     private EdgeIteratorState addEdge(Graph graph, int from, int to) {
         NodeAccess na = graph.getNodeAccess();
         double dist = DistancePlaneProjection.DIST_PLANE.calcDist(na.getLat(from), na.getLon(from), na.getLat(to), na.getLon(to));
-        return graph.edge(from, to, dist, true);
+        return GHUtility.setProperties(graph.edge(from, to).setDistance(dist), encoder, 60, true, true);
     }
 
 }

--- a/core/src/test/java/com/graphhopper/routing/QueryRoutingCHGraphTest.java
+++ b/core/src/test/java/com/graphhopper/routing/QueryRoutingCHGraphTest.java
@@ -330,8 +330,7 @@ class QueryRoutingCHGraphTest {
         na.setNode(2, 50.00, 10.20);
         EdgeIteratorState edge = addEdge(graph, 0, 1)
                 // use different speeds for the two directions
-                .set(encoder.getAverageSpeedEnc(), 90)
-                .setReverse(encoder.getAverageSpeedEnc(), 30);
+                .set(encoder.getAverageSpeedEnc(), 90, 30);
         addEdge(graph, 1, 2);
         graph.freeze();
         setIdentityLevels(chGraph);
@@ -426,10 +425,8 @@ class QueryRoutingCHGraphTest {
         // we set the access flags, but do use direction dependent speeds to make sure we are testing whether or not the
         // access flags are respected and the weight calculation does not simply rely on the speed, see this forum issue
         // https://discuss.graphhopper.com/t/speed-and-access-when-setbothdirections-true-false/5695
-        edge.set(encoder.getAccessEnc(), true);
-        edge.setReverse(encoder.getAccessEnc(), false);
-        edge.set(encoder.getAverageSpeedEnc(), 60);
-        edge.setReverse(encoder.getAverageSpeedEnc(), 60);
+        edge.set(encoder.getAccessEnc(), true, false);
+        edge.set(encoder.getAverageSpeedEnc(), 60, 60);
         graph.freeze();
 
         // without query graph

--- a/core/src/test/java/com/graphhopper/routing/RandomCHRoutingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/RandomCHRoutingTest.java
@@ -85,7 +85,8 @@ public class RandomCHRoutingTest {
         // we may not use an offset when query graph is involved, otherwise traveling via virtual edges will not be
         // the same as taking the direct edge!
         double pOffset = 0;
-        GHUtility.buildRandomGraph(graph, rnd, numNodes, 2.5, true, true, encoder.getAverageSpeedEnc(), 0.7, 0.9, pOffset);
+        GHUtility.buildRandomGraph(graph, rnd, numNodes, 2.5, true, true,
+                encoder.getAccessEnc(), encoder.getAverageSpeedEnc(), 60d, 0.7, 0.9, pOffset);
         if (traversalMode.isEdgeBased()) {
             GHUtility.addRandomTurnCosts(graph, seed, encodingManager, encoder, maxTurnCosts, graph.getTurnCostStorage());
         }
@@ -129,7 +130,8 @@ public class RandomCHRoutingTest {
         Assume.assumeTrue(traversalMode.isEdgeBased());
         long seed = 60643479675316L;
         Random rnd = new Random(seed);
-        GHUtility.buildRandomGraph(graph, rnd, 50, 2.5, true, true, encoder.getAverageSpeedEnc(), 0.7, 0.9, 0.0);
+        GHUtility.buildRandomGraph(graph, rnd, 50, 2.5, true, true,
+                encoder.getAccessEnc(), encoder.getAverageSpeedEnc(), 60d, 0.7, 0.9, 0.0);
         GHUtility.addRandomTurnCosts(graph, seed, encodingManager, encoder, maxTurnCosts, graph.getTurnCostStorage());
         runRandomTest(rnd, 20);
     }
@@ -227,7 +229,7 @@ public class RandomCHRoutingTest {
             maxDist = Math.max(maxDist, distance);
             // using bidirectional edges will increase mean degree of graph above given value
             boolean bothDirections = random.nextDouble() < pBothDir;
-            EdgeIteratorState edge = graph.edge(from, to, distance, bothDirections);
+            EdgeIteratorState edge = GHUtility.setProperties(graph.edge(from, to).setDistance(distance), encoder, 60, true, bothDirections);
             double fwdSpeed = 10 + random.nextDouble() * 120;
             double bwdSpeed = 10 + random.nextDouble() * 120;
             DecimalEncodedValue speedEnc = encoder.getAverageSpeedEnc();

--- a/core/src/test/java/com/graphhopper/routing/RandomCHRoutingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/RandomCHRoutingTest.java
@@ -229,7 +229,7 @@ public class RandomCHRoutingTest {
             maxDist = Math.max(maxDist, distance);
             // using bidirectional edges will increase mean degree of graph above given value
             boolean bothDirections = random.nextDouble() < pBothDir;
-            EdgeIteratorState edge = GHUtility.setProperties(graph.edge(from, to).setDistance(distance), encoder, 60, true, bothDirections);
+            EdgeIteratorState edge = GHUtility.setSpeed(60, true, bothDirections, encoder, graph.edge(from, to).setDistance(distance));
             double fwdSpeed = 10 + random.nextDouble() * 120;
             double bwdSpeed = 10 + random.nextDouble() * 120;
             DecimalEncodedValue speedEnc = encoder.getAverageSpeedEnc();

--- a/core/src/test/java/com/graphhopper/routing/RandomizedRoutingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/RandomizedRoutingTest.java
@@ -196,7 +196,8 @@ public class RandomizedRoutingTest {
         final long seed = System.nanoTime();
         final int numQueries = 50;
         Random rnd = new Random(seed);
-        GHUtility.buildRandomGraph(graph, rnd, 100, 2.2, true, true, encoder.getAverageSpeedEnc(), 0.7, 0.8, 0.8);
+        GHUtility.buildRandomGraph(graph, rnd, 100, 2.2, true, true,
+                encoder.getAccessEnc(), encoder.getAverageSpeedEnc(), 60d, 0.7, 0.8, 0.8);
         GHUtility.addRandomTurnCosts(graph, seed, encodingManager, encoder, maxTurnCosts, turnCostStorage);
 //        GHUtility.printGraphForUnitTest(graph, encoder);
         preProcessGraph();
@@ -232,7 +233,8 @@ public class RandomizedRoutingTest {
         // the same as taking the direct edge!
         double pOffset = 0;
         Random rnd = new Random(seed);
-        GHUtility.buildRandomGraph(graph, rnd, 50, 2.2, true, true, encoder.getAverageSpeedEnc(), 0.7, 0.8, pOffset);
+        GHUtility.buildRandomGraph(graph, rnd, 50, 2.2, true, true,
+                encoder.getAccessEnc(), encoder.getAverageSpeedEnc(), 60d, 0.7, 0.8, pOffset);
         GHUtility.addRandomTurnCosts(graph, seed, encodingManager, encoder, maxTurnCosts, turnCostStorage);
 //        GHUtility.printGraphForUnitTest(graph, encoder);
         preProcessGraph();

--- a/core/src/test/java/com/graphhopper/routing/RoundTripRoutingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/RoundTripRoutingTest.java
@@ -134,7 +134,7 @@ public class RoundTripRoutingTest {
         //    |-1 0 1
         GraphHopperStorage graph = new GraphBuilder(em).create();
         for (int i = 0; i < 8; ++i) {
-            GHUtility.setProperties(graph.edge(i, (i + 1) % 8).setDistance(1), carFE, 60, true, true);
+            GHUtility.setSpeed(60, true, true, carFE, graph.edge(i, (i + 1) % 8).setDistance(1));
         }
         updateDistancesFor(graph, 0, 1, -1);
         updateDistancesFor(graph, 1, 1, 0);

--- a/core/src/test/java/com/graphhopper/routing/RoundTripRoutingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/RoundTripRoutingTest.java
@@ -29,6 +29,7 @@ import com.graphhopper.storage.RAMDirectory;
 import com.graphhopper.storage.index.LocationIndex;
 import com.graphhopper.storage.index.LocationIndexTree;
 import com.graphhopper.storage.index.Snap;
+import com.graphhopper.util.GHUtility;
 import com.graphhopper.util.PMap;
 import com.graphhopper.util.Parameters;
 import com.graphhopper.util.shapes.GHPoint;
@@ -120,7 +121,7 @@ public class RoundTripRoutingTest {
 
     private Graph createTestGraph() {
         Graph graph = new GraphHopperStorage(new RAMDirectory(), em, false, true).create(1000);
-        AlternativeRouteTest.initTestGraph(graph);
+        AlternativeRouteTest.initTestGraph(graph, carFE);
         return graph;
     }
 
@@ -133,7 +134,7 @@ public class RoundTripRoutingTest {
         //    |-1 0 1
         GraphHopperStorage graph = new GraphBuilder(em).create();
         for (int i = 0; i < 8; ++i) {
-            graph.edge(i, (i + 1) % 8, 1, true);
+            GHUtility.setProperties(graph.edge(i, (i + 1) % 8).setDistance(1), carFE, 60, true, true);
         }
         updateDistancesFor(graph, 0, 1, -1);
         updateDistancesFor(graph, 1, 1, 0);

--- a/core/src/test/java/com/graphhopper/routing/RoutingAlgorithmTest.java
+++ b/core/src/test/java/com/graphhopper/routing/RoutingAlgorithmTest.java
@@ -137,8 +137,8 @@ public class RoutingAlgorithmTest {
     public void testCalcShortestPath_sourceEqualsTarget() {
         // 0-1-2
         GraphHopperStorage graph = createGHStorage();
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(2), carEncoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(1, 2).setDistance(2));
 
         Path p = calcPath(graph, 0, 0);
         assertPathFromEqualsTo(p, 0);
@@ -150,11 +150,11 @@ public class RoutingAlgorithmTest {
         //    |  |
         //    3--4
         GraphHopperStorage graph = createGHStorage();
-        GHUtility.setProperties(graph.edge(0, 2).setDistance(9), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 1).setDistance(2), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(11), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(6), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(4, 1).setDistance(9), carEncoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(0, 2).setDistance(9));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(2, 1).setDistance(2));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(2, 3).setDistance(11));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(3, 4).setDistance(6));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(4, 1).setDistance(9));
         Path p = calcPath(graph, 0, 4);
         assertEquals(p.toString(), 20, p.getDistance(), 1e-4);
         assertEquals(nodes(0, 2, 1, 4), p.calcNodes());
@@ -164,10 +164,10 @@ public class RoutingAlgorithmTest {
     public void testBidirectionalLinear() {
         //3--2--1--4--5
         GraphHopperStorage graph = createGHStorage();
-        GHUtility.setProperties(graph.edge(2, 1).setDistance(2), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(11), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(5, 4).setDistance(6), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(4, 1).setDistance(9), carEncoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(2, 1).setDistance(2));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(2, 3).setDistance(11));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(5, 4).setDistance(6));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(4, 1).setDistance(9));
         Path p = calcPath(graph, 3, 5);
         assertEquals(p.toString(), 28, p.getDistance(), 1e-4);
         assertEquals(nodes(3, 2, 1, 4, 5), p.calcNodes());
@@ -197,26 +197,26 @@ public class RoutingAlgorithmTest {
     // |/ \--7
     // 6----/
     static void initDirectedAndDiffSpeed(Graph graph, FlagEncoder enc) {
-        GHUtility.setProperties(graph.edge(0, 1), enc, 10, true, false);
-        GHUtility.setProperties(graph.edge(0, 4), enc, 100, true, false);
+        GHUtility.setSpeed(10, true, false, enc, graph.edge(0, 1));
+        GHUtility.setSpeed(100, true, false, enc, graph.edge(0, 4));
 
-        GHUtility.setProperties(graph.edge(1, 4), enc, 10, true, true);
-        GHUtility.setProperties(graph.edge(1, 5), enc, 10, true, true);
-        EdgeIteratorState edge12 = GHUtility.setProperties(graph.edge(1, 2), enc, 10, true, true);
+        GHUtility.setSpeed(10, true, true, enc, graph.edge(1, 4));
+        GHUtility.setSpeed(10, true, true, enc, graph.edge(1, 5));
+        EdgeIteratorState edge12 = GHUtility.setSpeed(10, true, true, enc, graph.edge(1, 2));
 
-        GHUtility.setProperties(graph.edge(5, 2), enc, 10, true, false);
-        GHUtility.setProperties(graph.edge(2, 3), enc, 10, true, false);
+        GHUtility.setSpeed(10, true, false, enc, graph.edge(5, 2));
+        GHUtility.setSpeed(10, true, false, enc, graph.edge(2, 3));
 
-        EdgeIteratorState edge53 = GHUtility.setProperties(graph.edge(5, 3), enc, 20, true, false);
-        GHUtility.setProperties(graph.edge(3, 7), enc, 10, true, false);
+        EdgeIteratorState edge53 = GHUtility.setSpeed(20, true, false, enc, graph.edge(5, 3));
+        GHUtility.setSpeed(10, true, false, enc, graph.edge(3, 7));
 
-        GHUtility.setProperties(graph.edge(4, 6), enc, 100, true, false);
-        GHUtility.setProperties(graph.edge(5, 4), enc, 10, true, false);
+        GHUtility.setSpeed(100, true, false, enc, graph.edge(4, 6));
+        GHUtility.setSpeed(10, true, false, enc, graph.edge(5, 4));
 
-        GHUtility.setProperties(graph.edge(5, 6), enc, 10, true, false);
-        GHUtility.setProperties(graph.edge(7, 5), enc, 100, true, false);
+        GHUtility.setSpeed(10, true, false, enc, graph.edge(5, 6));
+        GHUtility.setSpeed(100, true, false, enc, graph.edge(7, 5));
 
-        GHUtility.setProperties(graph.edge(6, 7), enc, 100, true, true);
+        GHUtility.setSpeed(100, true, true, enc, graph.edge(6, 7));
 
         updateDistancesFor(graph, 0, 0.002, 0);
         updateDistancesFor(graph, 1, 0.002, 0.001);
@@ -244,63 +244,63 @@ public class RoutingAlgorithmTest {
 
     static void initFootVsCar(FlagEncoder carEncoder, FlagEncoder footEncoder, Graph graph) {
         EdgeIteratorState edge = graph.edge(0, 1).setDistance(7000);
-        GHUtility.setProperties(edge, footEncoder, 5, true, true);
-        GHUtility.setProperties(edge, carEncoder, 10, true, false);
+        GHUtility.setSpeed(5, true, true, footEncoder, edge);
+        GHUtility.setSpeed(10, true, false, carEncoder, edge);
         edge = graph.edge(0, 4).setDistance(5000);
-        GHUtility.setProperties(edge, footEncoder, 5, true, true);
-        GHUtility.setProperties(edge, carEncoder, 20, true, false);
+        GHUtility.setSpeed(5, true, true, footEncoder, edge);
+        GHUtility.setSpeed(20, true, false, carEncoder, edge);
 
-        GHUtility.setProperties(graph.edge(1, 4).setDistance(7000), carEncoder, 10, true, true);
-        GHUtility.setProperties(graph.edge(1, 5).setDistance(7000), carEncoder, 10, true, true);
+        GHUtility.setSpeed(10, true, true, carEncoder, graph.edge(1, 4).setDistance(7000));
+        GHUtility.setSpeed(10, true, true, carEncoder, graph.edge(1, 5).setDistance(7000));
         edge = graph.edge(1, 2).setDistance(20000);
-        GHUtility.setProperties(edge, footEncoder, 5, true, true);
-        GHUtility.setProperties(edge, carEncoder, 10, true, true);
+        GHUtility.setSpeed(5, true, true, footEncoder, edge);
+        GHUtility.setSpeed(10, true, true, carEncoder, edge);
 
-        GHUtility.setProperties(graph.edge(5, 2).setDistance(5000), carEncoder, 10, true, false);
+        GHUtility.setSpeed(10, true, false, carEncoder, graph.edge(5, 2).setDistance(5000));
         edge = graph.edge(2, 3).setDistance(5000);
-        GHUtility.setProperties(edge, footEncoder, 5, true, true);
-        GHUtility.setProperties(edge, carEncoder, 10, true, false);
+        GHUtility.setSpeed(5, true, true, footEncoder, edge);
+        GHUtility.setSpeed(10, true, false, carEncoder, edge);
 
-        GHUtility.setProperties(graph.edge(5, 3).setDistance(11000), carEncoder, 20, true, false);
+        GHUtility.setSpeed(20, true, false, carEncoder, graph.edge(5, 3).setDistance(11000));
         edge = graph.edge(3, 7).setDistance(7000);
-        GHUtility.setProperties(edge, footEncoder, 5, true, true);
-        GHUtility.setProperties(edge, carEncoder, 10, true, false);
+        GHUtility.setSpeed(5, true, true, footEncoder, edge);
+        GHUtility.setSpeed(10, true, false, carEncoder, edge);
 
-        GHUtility.setProperties(graph.edge(4, 6).setDistance(5000), carEncoder, 20, true, false);
+        GHUtility.setSpeed(20, true, false, carEncoder, graph.edge(4, 6).setDistance(5000));
         edge = graph.edge(5, 4).setDistance(7000);
-        GHUtility.setProperties(edge, footEncoder, 5, true, true);
-        GHUtility.setProperties(edge, carEncoder, 10, true, false);
+        GHUtility.setSpeed(5, true, true, footEncoder, edge);
+        GHUtility.setSpeed(10, true, false, carEncoder, edge);
 
-        GHUtility.setProperties(graph.edge(5, 6).setDistance(7000), carEncoder, 10, true, false);
+        GHUtility.setSpeed(10, true, false, carEncoder, graph.edge(5, 6).setDistance(7000));
         edge = graph.edge(7, 5).setDistance(5000);
-        GHUtility.setProperties(edge, footEncoder, 5, true, true);
-        GHUtility.setProperties(edge, carEncoder, 20, true, false);
+        GHUtility.setSpeed(5, true, true, footEncoder, edge);
+        GHUtility.setSpeed(20, true, false, carEncoder, edge);
 
-        GHUtility.setProperties(graph.edge(6, 7).setDistance(5000), carEncoder, 20, true, true);
+        GHUtility.setSpeed(20, true, true, carEncoder, graph.edge(6, 7).setDistance(5000));
     }
 
     // see test-graph.svg !
     static void initTestStorage(Graph graph, FlagEncoder encoder) {
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(7), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(0, 4).setDistance(6), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(7));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 4).setDistance(6));
 
-        GHUtility.setProperties(graph.edge(1, 4).setDistance(2), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 5).setDistance(8), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(2), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 4).setDistance(2));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 5).setDistance(8));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(2));
 
-        GHUtility.setProperties(graph.edge(2, 5).setDistance(5), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(2), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 5).setDistance(5));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 3).setDistance(2));
 
-        GHUtility.setProperties(graph.edge(3, 5).setDistance(2), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(3, 7).setDistance(10), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 5).setDistance(2));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 7).setDistance(10));
 
-        GHUtility.setProperties(graph.edge(4, 6).setDistance(4), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(4, 5).setDistance(7), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 6).setDistance(4));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 5).setDistance(7));
 
-        GHUtility.setProperties(graph.edge(5, 6).setDistance(2), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(5, 7).setDistance(1), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(5, 6).setDistance(2));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(5, 7).setDistance(1));
 
-        EdgeIteratorState edge6_7 = GHUtility.setProperties(graph.edge(6, 7).setDistance(5), encoder, 60, true, true);
+        EdgeIteratorState edge6_7 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(6, 7).setDistance(5));
 
         updateDistancesFor(graph, 0, 0.0010, 0.00001);
         updateDistancesFor(graph, 1, 0.0008, 0.0000);
@@ -329,18 +329,18 @@ public class RoutingAlgorithmTest {
         // 7-5-6
         //  \|
         //   8
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(7), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(5, 6).setDistance(2), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(5, 7).setDistance(1), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(5, 8).setDistance(1), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(7, 8).setDistance(1), carEncoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(0, 1).setDistance(7));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(5, 6).setDistance(2));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(5, 7).setDistance(1));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(5, 8).setDistance(1));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(7, 8).setDistance(1));
         assertFalse(calcPath(graph, 0, 5).isFound());
 
         // disconnected as directed graph
         // 2-0->1
         graph = createGHStorage();
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), carEncoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(0, 2).setDistance(1), carEncoder, 60, true, true);
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(0, 2).setDistance(1));
         assertFalse(calcPath(graph, 1, 2).isFound());
         assertTrue(calcPath(graph, 2, 1).isFound());
     }
@@ -365,15 +365,15 @@ public class RoutingAlgorithmTest {
     // see wikipedia-graph.svg !
     private GraphHopperStorage createWikipediaTestGraph() {
         GraphHopperStorage graph = createGHStorage();
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(7), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(0, 2).setDistance(9), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(0, 5).setDistance(14), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(10), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 3).setDistance(15), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 5).setDistance(2), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(11), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(6), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(4, 5).setDistance(9), carEncoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(0, 1).setDistance(7));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(0, 2).setDistance(9));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(0, 5).setDistance(14));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(1, 2).setDistance(10));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(1, 3).setDistance(15));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(2, 5).setDistance(2));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(2, 3).setDistance(11));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(3, 4).setDistance(6));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(4, 5).setDistance(9));
         return graph;
     }
 
@@ -399,16 +399,16 @@ public class RoutingAlgorithmTest {
     //  7-6----5
     public static void initBiGraph(Graph graph, FlagEncoder encoder) {
         // distance will be overwritten in second step as we need to calculate it from lat,lon
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(4, 5).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(5, 6).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(6, 7).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(7, 0).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(3, 8).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(8, 6).setDistance(1), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 5).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(5, 6).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(6, 7).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(7, 0).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 8).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(8, 6).setDistance(1));
 
         // we need lat,lon for edge precise queries because the distances of snapped point
         // to adjacent nodes is calculated from lat,lon of the necessary points
@@ -433,16 +433,16 @@ public class RoutingAlgorithmTest {
         // \   /   /
         //  7-6-5-/
         GraphHopperStorage graph = createGHStorage();
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(4, 5).setDistance(1), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(5, 6).setDistance(1), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(6, 7).setDistance(1), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(7, 0).setDistance(1), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(3, 8).setDistance(1), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(8, 6).setDistance(1), carEncoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(2, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(3, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(4, 5).setDistance(1));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(5, 6).setDistance(1));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(6, 7).setDistance(1));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(7, 0).setDistance(1));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(3, 8).setDistance(1));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(8, 6).setDistance(1));
 
         // run the same query twice, this can be interesting because in the second call algorithms that pre-process
         // the graph might depend on the state of the graph after the first call 
@@ -480,16 +480,16 @@ public class RoutingAlgorithmTest {
         // |    8  |
         // \   /   /
         //  7-6-5-/
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(100), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(4, 5).setDistance(20), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(5, 6).setDistance(10), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(6, 7).setDistance(5), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(7, 0).setDistance(5), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(3, 8).setDistance(20), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(8, 6).setDistance(20), carEncoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(0, 1).setDistance(100));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(2, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(3, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(4, 5).setDistance(20));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(5, 6).setDistance(10));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(6, 7).setDistance(5));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(7, 0).setDistance(5));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(3, 8).setDistance(20));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(8, 6).setDistance(20));
     }
 
     @Test
@@ -533,7 +533,7 @@ public class RoutingAlgorithmTest {
                     if (print)
                         System.out.print(" " + (int) dist + "\t           ");
 
-                    GHUtility.setProperties(tmpGraph.edge(matrix[w][h], matrix[w][h - 1]).setDistance(dist), encoder, 60, true, true);
+                    GHUtility.setSpeed(60, true, true, encoder, tmpGraph.edge(matrix[w][h], matrix[w][h - 1]).setDistance(dist));
                 }
             }
             if (print) {
@@ -551,7 +551,7 @@ public class RoutingAlgorithmTest {
                     float dist = 5 + Math.abs(rand.nextInt(5));
                     if (print)
                         System.out.print("-- " + (int) dist + "\t-- ");
-                    GHUtility.setProperties(tmpGraph.edge(matrix[w][h], matrix[w - 1][h]).setDistance(dist), encoder, 60, true, true);
+                    GHUtility.setSpeed(60, true, true, encoder, tmpGraph.edge(matrix[w][h], matrix[w - 1][h]).setDistance(dist));
                 }
                 if (print)
                     System.out.print("(" + matrix[w][h] + ")\t");
@@ -578,8 +578,8 @@ public class RoutingAlgorithmTest {
     public void testCannotCalculateSP() {
         // 0->1->2
         GraphHopperStorage graph = createGHStorage();
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), carEncoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), carEncoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(1, 2).setDistance(1));
         Path p = calcPath(graph, 0, 2);
         assertEquals(p.toString(), 3, p.calcNodes().size());
     }
@@ -587,12 +587,12 @@ public class RoutingAlgorithmTest {
     @Test
     public void testDirectedGraphBug1() {
         GraphHopperStorage graph = createGHStorage();
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(3), carEncoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(2.99), carEncoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(0, 1).setDistance(3));
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(1, 2).setDistance(2.99));
 
-        GHUtility.setProperties(graph.edge(0, 3).setDistance(2), carEncoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(3), carEncoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(4, 2).setDistance(1), carEncoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(0, 3).setDistance(2));
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(3, 4).setDistance(3));
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(4, 2).setDistance(1));
 
         Path p = calcPath(graph, 0, 2);
         assertEquals(p.toString(), nodes(0, 1, 2), p.calcNodes());
@@ -605,10 +605,10 @@ public class RoutingAlgorithmTest {
         //    | /
         //    3<
         GraphHopperStorage graph = createGHStorage();
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), carEncoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), carEncoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), carEncoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 1).setDistance(4), carEncoder, 60, true, true);
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(2, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(3, 1).setDistance(4));
 
         Path p = calcPath(graph, 0, 3);
         assertEquals(nodes(0, 1, 2, 3), p.calcNodes());
@@ -622,21 +622,21 @@ public class RoutingAlgorithmTest {
     public void testWithCoordinates() {
         Weighting weighting = new ShortestWeighting(carEncoder);
         GraphHopperStorage graph = createGHStorage(false, weighting);
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(2), carEncoder, 60, true, true).
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(0, 1).setDistance(2)).
                 setWayGeometry(Helper.createPointList(1.5, 1));
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(2), carEncoder, 60, true, true).
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(2, 3).setDistance(2)).
                 setWayGeometry(Helper.createPointList(0, 1.5));
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(2), carEncoder, 60, true, true).
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(3, 4).setDistance(2)).
                 setWayGeometry(Helper.createPointList(0, 2));
 
         // duplicate but the second edge is longer
-        GHUtility.setProperties(graph.edge(0, 2).setDistance(1.2), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(0, 2).setDistance(1.5), carEncoder, 60, true, true).
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(0, 2).setDistance(1.2));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(0, 2).setDistance(1.5)).
                 setWayGeometry(Helper.createPointList(0.5, 0));
 
-        GHUtility.setProperties(graph.edge(1, 3).setDistance(1.3), carEncoder, 60, true, true).
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(1, 3).setDistance(1.3)).
                 setWayGeometry(Helper.createPointList(0.5, 1.5));
-        GHUtility.setProperties(graph.edge(1, 4).setDistance(1), carEncoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(1, 4).setDistance(1));
 
         updateDistancesFor(graph, 0, 1, 0.6);
         updateDistancesFor(graph, 1, 1, 1.5);
@@ -712,11 +712,11 @@ public class RoutingAlgorithmTest {
         // 0->1\
         // |    2
         // 4<-3/
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(7), carEncoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(7), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(7), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(7), carEncoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(4, 0).setDistance(7), carEncoder, 60, true, true);
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(0, 1).setDistance(7));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(1, 2).setDistance(7));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(2, 3).setDistance(7));
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(3, 4).setDistance(7));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(4, 0).setDistance(7));
 
         updateDistancesFor(graph, 4, 0, 0);
         updateDistancesFor(graph, 0, 0.00010, 0);
@@ -779,7 +779,7 @@ public class RoutingAlgorithmTest {
         GraphHopperStorage graph = createGHStorage(true, fastestWeighting);
         initEleGraph(graph, bike2Encoder, 18);
         // force the other path
-        GHUtility.setProperties(GHUtility.getEdge(graph, 0, 3), bike2Encoder, 10, false, true);
+        GHUtility.setSpeed(10, false, true, bike2Encoder, GHUtility.getEdge(graph, 0, 3));
 
         // for two weights per edge it happened that Path (and also the Weighting) read the wrong side
         // of the speed and read 0 => infinity weight => overflow of millis => negative millis!
@@ -945,7 +945,7 @@ public class RoutingAlgorithmTest {
         // refreshed
         ghStorage = createGHStorage(false, footWeighting, carWeighting);
         initFootVsCar(carEncoder, footEncoder, ghStorage);
-        GHUtility.setProperties(GHUtility.getEdge(ghStorage, 4, 6), carEncoder, 20, false, false);
+        GHUtility.setSpeed(20, false, false, carEncoder, GHUtility.getEdge(ghStorage, 4, 6));
 
         // ... car needs to take another way
         Path carPath2 = calcPath(ghStorage, carWeighting, 0, 7);
@@ -965,25 +965,25 @@ public class RoutingAlgorithmTest {
     // | |\|
     // 8-9-10
     private void initEleGraph(Graph graph, FlagEncoder encoder, double s) {
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(10), encoder, s, true, true);
-        GHUtility.setProperties(graph.edge(0, 4).setDistance(12), encoder, s, true, true);
-        GHUtility.setProperties(graph.edge(0, 3).setDistance(5), encoder, s, true, true);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(10), encoder, s, true, true);
-        GHUtility.setProperties(graph.edge(1, 4).setDistance(5), encoder, s, true, true);
-        GHUtility.setProperties(graph.edge(3, 5).setDistance(5), encoder, s, true, false);
-        GHUtility.setProperties(graph.edge(5, 6).setDistance(10), encoder, s, true, true);
-        GHUtility.setProperties(graph.edge(5, 8).setDistance(10), encoder, s, true, true);
-        GHUtility.setProperties(graph.edge(6, 4).setDistance(5), encoder, s, true, true);
-        GHUtility.setProperties(graph.edge(6, 7).setDistance(10), encoder, s, true, true);
-        GHUtility.setProperties(graph.edge(6, 10).setDistance(12), encoder, s, true, true);
-        GHUtility.setProperties(graph.edge(6, 9).setDistance(12), encoder, s, true, true);
-        GHUtility.setProperties(graph.edge(2, 11).setDistance(5), encoder, s, true, false);
-        GHUtility.setProperties(graph.edge(4, 11).setDistance(10), encoder, s, true, true);
-        GHUtility.setProperties(graph.edge(7, 11).setDistance(5), encoder, s, true, true);
-        GHUtility.setProperties(graph.edge(7, 10).setDistance(5), encoder, s, true, true);
-        GHUtility.setProperties(graph.edge(8, 9).setDistance(10), encoder, s, true, false);
-        GHUtility.setProperties(graph.edge(9, 8).setDistance(9), encoder, s, true, false);
-        GHUtility.setProperties(graph.edge(10, 9).setDistance(10), encoder, s, true, false);
+        GHUtility.setSpeed(s, true, true, encoder, graph.edge(0, 1).setDistance(10));
+        GHUtility.setSpeed(s, true, true, encoder, graph.edge(0, 4).setDistance(12));
+        GHUtility.setSpeed(s, true, true, encoder, graph.edge(0, 3).setDistance(5));
+        GHUtility.setSpeed(s, true, true, encoder, graph.edge(1, 2).setDistance(10));
+        GHUtility.setSpeed(s, true, true, encoder, graph.edge(1, 4).setDistance(5));
+        GHUtility.setSpeed(s, true, false, encoder, graph.edge(3, 5).setDistance(5));
+        GHUtility.setSpeed(s, true, true, encoder, graph.edge(5, 6).setDistance(10));
+        GHUtility.setSpeed(s, true, true, encoder, graph.edge(5, 8).setDistance(10));
+        GHUtility.setSpeed(s, true, true, encoder, graph.edge(6, 4).setDistance(5));
+        GHUtility.setSpeed(s, true, true, encoder, graph.edge(6, 7).setDistance(10));
+        GHUtility.setSpeed(s, true, true, encoder, graph.edge(6, 10).setDistance(12));
+        GHUtility.setSpeed(s, true, true, encoder, graph.edge(6, 9).setDistance(12));
+        GHUtility.setSpeed(s, true, false, encoder, graph.edge(2, 11).setDistance(5));
+        GHUtility.setSpeed(s, true, true, encoder, graph.edge(4, 11).setDistance(10));
+        GHUtility.setSpeed(s, true, true, encoder, graph.edge(7, 11).setDistance(5));
+        GHUtility.setSpeed(s, true, true, encoder, graph.edge(7, 10).setDistance(5));
+        GHUtility.setSpeed(s, true, false, encoder, graph.edge(8, 9).setDistance(10));
+        GHUtility.setSpeed(s, true, false, encoder, graph.edge(9, 8).setDistance(9));
+        GHUtility.setSpeed(s, true, false, encoder, graph.edge(10, 9).setDistance(10));
         updateDistancesFor(graph, 0, 3, 0);
         updateDistancesFor(graph, 3, 2.5, 0);
         updateDistancesFor(graph, 5, 1, 0);

--- a/core/src/test/java/com/graphhopper/routing/RoutingAlgorithmTest.java
+++ b/core/src/test/java/com/graphhopper/routing/RoutingAlgorithmTest.java
@@ -127,7 +127,7 @@ public class RoutingAlgorithmTest {
     @Test
     public void testCalcShortestPath() {
         GraphHopperStorage ghStorage = createGHStorage();
-        initTestStorage(ghStorage);
+        initTestStorage(ghStorage, carEncoder);
         Path p = calcPath(ghStorage, 0, 7);
         assertEquals(p.toString(), nodes(0, 4, 5, 7), p.calcNodes());
         assertEquals(p.toString(), 62.1, p.getDistance(), .1);
@@ -137,8 +137,8 @@ public class RoutingAlgorithmTest {
     public void testCalcShortestPath_sourceEqualsTarget() {
         // 0-1-2
         GraphHopperStorage graph = createGHStorage();
-        graph.edge(0, 1, 1, true);
-        graph.edge(1, 2, 2, true);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(2), carEncoder, 60, true, true);
 
         Path p = calcPath(graph, 0, 0);
         assertPathFromEqualsTo(p, 0);
@@ -150,11 +150,11 @@ public class RoutingAlgorithmTest {
         //    |  |
         //    3--4
         GraphHopperStorage graph = createGHStorage();
-        graph.edge(0, 2, 9, true);
-        graph.edge(2, 1, 2, true);
-        graph.edge(2, 3, 11, true);
-        graph.edge(3, 4, 6, true);
-        graph.edge(4, 1, 9, true);
+        GHUtility.setProperties(graph.edge(0, 2).setDistance(9), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 1).setDistance(2), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(11), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(6), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(4, 1).setDistance(9), carEncoder, 60, true, true);
         Path p = calcPath(graph, 0, 4);
         assertEquals(p.toString(), 20, p.getDistance(), 1e-4);
         assertEquals(nodes(0, 2, 1, 4), p.calcNodes());
@@ -164,10 +164,10 @@ public class RoutingAlgorithmTest {
     public void testBidirectionalLinear() {
         //3--2--1--4--5
         GraphHopperStorage graph = createGHStorage();
-        graph.edge(2, 1, 2, true);
-        graph.edge(2, 3, 11, true);
-        graph.edge(5, 4, 6, true);
-        graph.edge(4, 1, 9, true);
+        GHUtility.setProperties(graph.edge(2, 1).setDistance(2), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(11), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(5, 4).setDistance(6), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(4, 1).setDistance(9), carEncoder, 60, true, true);
         Path p = calcPath(graph, 3, 5);
         assertEquals(p.toString(), 28, p.getDistance(), 1e-4);
         assertEquals(nodes(3, 2, 1, 4, 5), p.calcNodes());
@@ -280,27 +280,27 @@ public class RoutingAlgorithmTest {
     }
 
     // see test-graph.svg !
-    static void initTestStorage(Graph graph) {
-        graph.edge(0, 1, 7, true);
-        graph.edge(0, 4, 6, true);
+    static void initTestStorage(Graph graph, FlagEncoder encoder) {
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(7), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(0, 4).setDistance(6), encoder, 60, true, true);
 
-        graph.edge(1, 4, 2, true);
-        graph.edge(1, 5, 8, true);
-        graph.edge(1, 2, 2, true);
+        GHUtility.setProperties(graph.edge(1, 4).setDistance(2), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 5).setDistance(8), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(2), encoder, 60, true, true);
 
-        graph.edge(2, 5, 5, true);
-        graph.edge(2, 3, 2, true);
+        GHUtility.setProperties(graph.edge(2, 5).setDistance(5), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(2), encoder, 60, true, true);
 
-        graph.edge(3, 5, 2, true);
-        graph.edge(3, 7, 10, true);
+        GHUtility.setProperties(graph.edge(3, 5).setDistance(2), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(3, 7).setDistance(10), encoder, 60, true, true);
 
-        graph.edge(4, 6, 4, true);
-        graph.edge(4, 5, 7, true);
+        GHUtility.setProperties(graph.edge(4, 6).setDistance(4), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(4, 5).setDistance(7), encoder, 60, true, true);
 
-        graph.edge(5, 6, 2, true);
-        graph.edge(5, 7, 1, true);
+        GHUtility.setProperties(graph.edge(5, 6).setDistance(2), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(5, 7).setDistance(1), encoder, 60, true, true);
 
-        EdgeIteratorState edge6_7 = graph.edge(6, 7, 5, true);
+        EdgeIteratorState edge6_7 = GHUtility.setProperties(graph.edge(6, 7).setDistance(5), encoder, 60, true, true);
 
         updateDistancesFor(graph, 0, 0.0010, 0.00001);
         updateDistancesFor(graph, 1, 0.0008, 0.0000);
@@ -329,18 +329,18 @@ public class RoutingAlgorithmTest {
         // 7-5-6
         //  \|
         //   8
-        graph.edge(0, 1, 7, true);
-        graph.edge(5, 6, 2, true);
-        graph.edge(5, 7, 1, true);
-        graph.edge(5, 8, 1, true);
-        graph.edge(7, 8, 1, true);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(7), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(5, 6).setDistance(2), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(5, 7).setDistance(1), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(5, 8).setDistance(1), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(7, 8).setDistance(1), carEncoder, 60, true, true);
         assertFalse(calcPath(graph, 0, 5).isFound());
 
         // disconnected as directed graph
         // 2-0->1
         graph = createGHStorage();
-        graph.edge(0, 1, 1, false);
-        graph.edge(0, 2, 1, true);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), carEncoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(0, 2).setDistance(1), carEncoder, 60, true, true);
         assertFalse(calcPath(graph, 1, 2).isFound());
         assertTrue(calcPath(graph, 2, 1).isFound());
     }
@@ -356,7 +356,7 @@ public class RoutingAlgorithmTest {
     @Test
     public void testCalcIf1EdgeAway() {
         GraphHopperStorage graph = createGHStorage();
-        initTestStorage(graph);
+        initTestStorage(graph, carEncoder);
         Path p = calcPath(graph, 1, 2);
         assertEquals(nodes(1, 2), p.calcNodes());
         assertEquals(p.toString(), 35.1, p.getDistance(), .1);
@@ -365,22 +365,22 @@ public class RoutingAlgorithmTest {
     // see wikipedia-graph.svg !
     private GraphHopperStorage createWikipediaTestGraph() {
         GraphHopperStorage graph = createGHStorage();
-        graph.edge(0, 1, 7, true);
-        graph.edge(0, 2, 9, true);
-        graph.edge(0, 5, 14, true);
-        graph.edge(1, 2, 10, true);
-        graph.edge(1, 3, 15, true);
-        graph.edge(2, 5, 2, true);
-        graph.edge(2, 3, 11, true);
-        graph.edge(3, 4, 6, true);
-        graph.edge(4, 5, 9, true);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(7), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(0, 2).setDistance(9), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(0, 5).setDistance(14), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(10), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 3).setDistance(15), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 5).setDistance(2), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(11), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(6), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(4, 5).setDistance(9), carEncoder, 60, true, true);
         return graph;
     }
 
     @Test
     public void testBidirectional() {
         GraphHopperStorage graph = createGHStorage();
-        initBiGraph(graph);
+        initBiGraph(graph, carEncoder);
 
         Path p = calcPath(graph, 0, 4);
         assertEquals(p.toString(), nodes(0, 7, 6, 8, 3, 4), p.calcNodes());
@@ -397,18 +397,18 @@ public class RoutingAlgorithmTest {
     // |    8  |
     // \   /   |
     //  7-6----5
-    public static void initBiGraph(Graph graph) {
+    public static void initBiGraph(Graph graph, FlagEncoder encoder) {
         // distance will be overwritten in second step as we need to calculate it from lat,lon
-        graph.edge(0, 1, 1, true);
-        graph.edge(1, 2, 1, true);
-        graph.edge(2, 3, 1, true);
-        graph.edge(3, 4, 1, true);
-        graph.edge(4, 5, 1, true);
-        graph.edge(5, 6, 1, true);
-        graph.edge(6, 7, 1, true);
-        graph.edge(7, 0, 1, true);
-        graph.edge(3, 8, 1, true);
-        graph.edge(8, 6, 1, true);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(4, 5).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(5, 6).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(6, 7).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(7, 0).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(3, 8).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(8, 6).setDistance(1), encoder, 60, true, true);
 
         // we need lat,lon for edge precise queries because the distances of snapped point
         // to adjacent nodes is calculated from lat,lon of the necessary points
@@ -433,16 +433,16 @@ public class RoutingAlgorithmTest {
         // \   /   /
         //  7-6-5-/
         GraphHopperStorage graph = createGHStorage();
-        graph.edge(0, 1, 1, true);
-        graph.edge(1, 2, 1, true);
-        graph.edge(2, 3, 1, true);
-        graph.edge(3, 4, 1, true);
-        graph.edge(4, 5, 1, true);
-        graph.edge(5, 6, 1, true);
-        graph.edge(6, 7, 1, true);
-        graph.edge(7, 0, 1, true);
-        graph.edge(3, 8, 1, true);
-        graph.edge(8, 6, 1, true);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(4, 5).setDistance(1), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(5, 6).setDistance(1), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(6, 7).setDistance(1), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(7, 0).setDistance(1), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(3, 8).setDistance(1), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(8, 6).setDistance(1), carEncoder, 60, true, true);
 
         // run the same query twice, this can be interesting because in the second call algorithms that pre-process
         // the graph might depend on the state of the graph after the first call 
@@ -455,7 +455,7 @@ public class RoutingAlgorithmTest {
     @Test
     public void testMaxVisitedNodes() {
         GraphHopperStorage graph = createGHStorage();
-        initBiGraph(graph);
+        initBiGraph(graph, carEncoder);
 
         Path p = calcPath(graph, 0, 4);
         assertTrue(p.isFound());
@@ -480,23 +480,23 @@ public class RoutingAlgorithmTest {
         // |    8  |
         // \   /   /
         //  7-6-5-/
-        graph.edge(0, 1, 100, true);
-        graph.edge(1, 2, 1, true);
-        graph.edge(2, 3, 1, true);
-        graph.edge(3, 4, 1, true);
-        graph.edge(4, 5, 20, true);
-        graph.edge(5, 6, 10, true);
-        graph.edge(6, 7, 5, true);
-        graph.edge(7, 0, 5, true);
-        graph.edge(3, 8, 20, true);
-        graph.edge(8, 6, 20, true);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(100), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(4, 5).setDistance(20), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(5, 6).setDistance(10), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(6, 7).setDistance(5), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(7, 0).setDistance(5), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(3, 8).setDistance(20), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(8, 6).setDistance(20), carEncoder, 60, true, true);
     }
 
     @Test
     public void testRekeyBugOfIntBinHeap() {
         // using Dijkstra + IntBinHeap then rekey loops endlessly
         GraphHopperStorage matrixGraph = createGHStorage();
-        initMatrixALikeGraph(matrixGraph);
+        initMatrixALikeGraph(matrixGraph, carEncoder);
         Path p = calcPath(matrixGraph, 36, 91);
         assertEquals(12, p.calcNodes().size());
 
@@ -511,7 +511,7 @@ public class RoutingAlgorithmTest {
         testCorrectWeight(matrixGraph);
     }
 
-    private static void initMatrixALikeGraph(GraphHopperStorage tmpGraph) {
+    private static void initMatrixALikeGraph(GraphHopperStorage tmpGraph, FlagEncoder encoder) {
         int WIDTH = 10;
         int HEIGHT = 15;
         int[][] matrix = new int[WIDTH][HEIGHT];
@@ -533,7 +533,7 @@ public class RoutingAlgorithmTest {
                     if (print)
                         System.out.print(" " + (int) dist + "\t           ");
 
-                    tmpGraph.edge(matrix[w][h], matrix[w][h - 1], dist, true);
+                    GHUtility.setProperties(tmpGraph.edge(matrix[w][h], matrix[w][h - 1]).setDistance(dist), encoder, 60, true, true);
                 }
             }
             if (print) {
@@ -551,7 +551,7 @@ public class RoutingAlgorithmTest {
                     float dist = 5 + Math.abs(rand.nextInt(5));
                     if (print)
                         System.out.print("-- " + (int) dist + "\t-- ");
-                    tmpGraph.edge(matrix[w][h], matrix[w - 1][h], dist, true);
+                    GHUtility.setProperties(tmpGraph.edge(matrix[w][h], matrix[w - 1][h]).setDistance(dist), encoder, 60, true, true);
                 }
                 if (print)
                     System.out.print("(" + matrix[w][h] + ")\t");
@@ -578,8 +578,8 @@ public class RoutingAlgorithmTest {
     public void testCannotCalculateSP() {
         // 0->1->2
         GraphHopperStorage graph = createGHStorage();
-        graph.edge(0, 1, 1, false);
-        graph.edge(1, 2, 1, false);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), carEncoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), carEncoder, 60, true, false);
         Path p = calcPath(graph, 0, 2);
         assertEquals(p.toString(), 3, p.calcNodes().size());
     }
@@ -587,12 +587,12 @@ public class RoutingAlgorithmTest {
     @Test
     public void testDirectedGraphBug1() {
         GraphHopperStorage graph = createGHStorage();
-        graph.edge(0, 1, 3, false);
-        graph.edge(1, 2, 2.99, false);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(3), carEncoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(2.99), carEncoder, 60, true, false);
 
-        graph.edge(0, 3, 2, false);
-        graph.edge(3, 4, 3, false);
-        graph.edge(4, 2, 1, false);
+        GHUtility.setProperties(graph.edge(0, 3).setDistance(2), carEncoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(3), carEncoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(4, 2).setDistance(1), carEncoder, 60, true, false);
 
         Path p = calcPath(graph, 0, 2);
         assertEquals(p.toString(), nodes(0, 1, 2), p.calcNodes());
@@ -605,10 +605,10 @@ public class RoutingAlgorithmTest {
         //    | /
         //    3<
         GraphHopperStorage graph = createGHStorage();
-        graph.edge(0, 1, 1, false);
-        graph.edge(1, 2, 1, false);
-        graph.edge(2, 3, 1, false);
-        graph.edge(3, 1, 4, true);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), carEncoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), carEncoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), carEncoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 1).setDistance(4), carEncoder, 60, true, true);
 
         Path p = calcPath(graph, 0, 3);
         assertEquals(nodes(0, 1, 2, 3), p.calcNodes());
@@ -622,16 +622,21 @@ public class RoutingAlgorithmTest {
     public void testWithCoordinates() {
         Weighting weighting = new ShortestWeighting(carEncoder);
         GraphHopperStorage graph = createGHStorage(false, weighting);
-        graph.edge(0, 1, 2, true).setWayGeometry(Helper.createPointList(1.5, 1));
-        graph.edge(2, 3, 2, true).setWayGeometry(Helper.createPointList(0, 1.5));
-        graph.edge(3, 4, 2, true).setWayGeometry(Helper.createPointList(0, 2));
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(2), carEncoder, 60, true, true).
+                setWayGeometry(Helper.createPointList(1.5, 1));
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(2), carEncoder, 60, true, true).
+                setWayGeometry(Helper.createPointList(0, 1.5));
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(2), carEncoder, 60, true, true).
+                setWayGeometry(Helper.createPointList(0, 2));
 
         // duplicate but the second edge is longer
-        graph.edge(0, 2, 1.2, true);
-        graph.edge(0, 2, 1.5, true).setWayGeometry(Helper.createPointList(0.5, 0));
+        GHUtility.setProperties(graph.edge(0, 2).setDistance(1.2), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(0, 2).setDistance(1.5), carEncoder, 60, true, true).
+                setWayGeometry(Helper.createPointList(0.5, 0));
 
-        graph.edge(1, 3, 1.3, true).setWayGeometry(Helper.createPointList(0.5, 1.5));
-        graph.edge(1, 4, 1, true);
+        GHUtility.setProperties(graph.edge(1, 3).setDistance(1.3), carEncoder, 60, true, true).
+                setWayGeometry(Helper.createPointList(0.5, 1.5));
+        GHUtility.setProperties(graph.edge(1, 4).setDistance(1), carEncoder, 60, true, true);
 
         updateDistancesFor(graph, 0, 1, 0.6);
         updateDistancesFor(graph, 1, 1, 1.5);
@@ -653,7 +658,7 @@ public class RoutingAlgorithmTest {
     @Test
     public void testCalcIfEmptyWay() {
         GraphHopperStorage graph = createGHStorage();
-        initTestStorage(graph);
+        initTestStorage(graph, carEncoder);
         Path p = calcPath(graph, 0, 0);
         assertPathFromEqualsTo(p, 0);
     }
@@ -661,7 +666,7 @@ public class RoutingAlgorithmTest {
     @Test
     public void testViaEdges_FromEqualsTo() {
         GraphHopperStorage ghStorage = createGHStorage();
-        initTestStorage(ghStorage);
+        initTestStorage(ghStorage, carEncoder);
         // identical tower nodes
         Path p = calcPath(ghStorage, new GHPoint(0.001, 0.000), new GHPoint(0.001, 0.000));
         assertPathFromEqualsTo(p, 0);
@@ -679,7 +684,7 @@ public class RoutingAlgorithmTest {
     @Test
     public void testViaEdges_BiGraph() {
         GraphHopperStorage graph = createGHStorage();
-        initBiGraph(graph);
+        initBiGraph(graph, carEncoder);
 
         // 0-7 to 4-3
         Path p = calcPath(graph, new GHPoint(0.0009, 0), new GHPoint(0.001, 0.001105));
@@ -695,7 +700,7 @@ public class RoutingAlgorithmTest {
     @Test
     public void testViaEdges_WithCoordinates() {
         GraphHopperStorage ghStorage = createGHStorage();
-        initTestStorage(ghStorage);
+        initTestStorage(ghStorage, carEncoder);
         Path p = calcPath(ghStorage, defaultWeighting, 0, 1, 2, 3);
         assertEquals(nodes(8, 1, 2, 9), p.calcNodes());
         assertEquals(p.toString(), 56.7, p.getDistance(), .1);
@@ -707,11 +712,11 @@ public class RoutingAlgorithmTest {
         // 0->1\
         // |    2
         // 4<-3/
-        graph.edge(0, 1, 7, false);
-        graph.edge(1, 2, 7, true);
-        graph.edge(2, 3, 7, true);
-        graph.edge(3, 4, 7, false);
-        graph.edge(4, 0, 7, true);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(7), carEncoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(7), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(7), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(7), carEncoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(4, 0).setDistance(7), carEncoder, 60, true, true);
 
         updateDistancesFor(graph, 4, 0, 0);
         updateDistancesFor(graph, 0, 0.00010, 0);
@@ -772,7 +777,7 @@ public class RoutingAlgorithmTest {
     public void testTwoWeightsPerEdge() {
         FastestWeighting fastestWeighting = new FastestWeighting(bike2Encoder);
         GraphHopperStorage graph = createGHStorage(true, fastestWeighting);
-        initEleGraph(graph);
+        initEleGraph(graph, bike2Encoder, 18);
         // force the other path
         GHUtility.setProperties(GHUtility.getEdge(graph, 0, 3), bike2Encoder, 10, false, true);
 
@@ -874,13 +879,12 @@ public class RoutingAlgorithmTest {
         };
 
         GraphHopperStorage graph = createGHStorage(true, defaultWeighting);
-        initEleGraph(graph);
+        initEleGraph(graph, carEncoder, 60);
         Path p = calcPath(graph, 0, 10);
-        // GHUtility.printEdgeInfo(graph, carEncoder);
         assertEquals(nodes(0, 4, 6, 10), p.calcNodes());
 
         graph = createGHStorage(true, fakeWeighting);
-        initEleGraph(graph);
+        initEleGraph(graph, carEncoder, 60);
         p = calcPath(graph, fakeWeighting, 3, 0, 10, 9);
         assertEquals(nodes(12, 0, 1, 2, 11, 7, 10, 13), p.calcNodes());
         assertEquals(37009621, p.getTime());
@@ -891,14 +895,14 @@ public class RoutingAlgorithmTest {
     @Test
     public void testRandomGraph() {
         // todo: use speed both directions
-        DecimalEncodedValue speedEnc = carEncoder.getAverageSpeedEnc();
         FastestWeighting fastestWeighting = new FastestWeighting(carEncoder);
         GraphHopperStorage graph = createGHStorage(false, fastestWeighting);
         final long seed = System.nanoTime();
         LOGGER.info("testRandomGraph - using seed: " + seed);
         Random rnd = new Random(seed);
         // we're not including loops otherwise duplicate nodes in path might fail the test
-        GHUtility.buildRandomGraph(graph, rnd, 10, 2.0, false, true, speedEnc, 0.7, 0.7, 0.7);
+        GHUtility.buildRandomGraph(graph, rnd, 10, 2.0, false, true,
+                carEncoder.getAccessEnc(), carEncoder.getAverageSpeedEnc(), 60d, 0.7, 0.7, 0.7);
         final PathCalculator refCalculator = new DijkstraCalculator();
         int numRuns = 100;
         for (int i = 0; i < numRuns; i++) {
@@ -960,38 +964,38 @@ public class RoutingAlgorithmTest {
     // 5-6-7
     // | |\|
     // 8-9-10
-    private void initEleGraph(Graph g) {
-        g.edge(0, 1, 10, true);
-        g.edge(0, 4, 12, true);
-        g.edge(0, 3, 5, true);
-        g.edge(1, 2, 10, true);
-        g.edge(1, 4, 5, true);
-        g.edge(3, 5, 5, false);
-        g.edge(5, 6, 10, true);
-        g.edge(5, 8, 10, true);
-        g.edge(6, 4, 5, true);
-        g.edge(6, 7, 10, true);
-        g.edge(6, 10, 12, true);
-        g.edge(6, 9, 12, true);
-        g.edge(2, 11, 5, false);
-        g.edge(4, 11, 10, true);
-        g.edge(7, 11, 5, true);
-        g.edge(7, 10, 5, true);
-        g.edge(8, 9, 10, false);
-        g.edge(9, 8, 9, false);
-        g.edge(10, 9, 10, false);
-        updateDistancesFor(g, 0, 3, 0);
-        updateDistancesFor(g, 3, 2.5, 0);
-        updateDistancesFor(g, 5, 1, 0);
-        updateDistancesFor(g, 8, 0, 0);
-        updateDistancesFor(g, 1, 3, 1);
-        updateDistancesFor(g, 4, 2, 1);
-        updateDistancesFor(g, 6, 1, 1);
-        updateDistancesFor(g, 9, 0, 1);
-        updateDistancesFor(g, 2, 3, 2);
-        updateDistancesFor(g, 11, 2, 2);
-        updateDistancesFor(g, 7, 1, 2);
-        updateDistancesFor(g, 10, 0, 2);
+    private void initEleGraph(Graph graph, FlagEncoder encoder, double s) {
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(10), encoder, s, true, true);
+        GHUtility.setProperties(graph.edge(0, 4).setDistance(12), encoder, s, true, true);
+        GHUtility.setProperties(graph.edge(0, 3).setDistance(5), encoder, s, true, true);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(10), encoder, s, true, true);
+        GHUtility.setProperties(graph.edge(1, 4).setDistance(5), encoder, s, true, true);
+        GHUtility.setProperties(graph.edge(3, 5).setDistance(5), encoder, s, true, false);
+        GHUtility.setProperties(graph.edge(5, 6).setDistance(10), encoder, s, true, true);
+        GHUtility.setProperties(graph.edge(5, 8).setDistance(10), encoder, s, true, true);
+        GHUtility.setProperties(graph.edge(6, 4).setDistance(5), encoder, s, true, true);
+        GHUtility.setProperties(graph.edge(6, 7).setDistance(10), encoder, s, true, true);
+        GHUtility.setProperties(graph.edge(6, 10).setDistance(12), encoder, s, true, true);
+        GHUtility.setProperties(graph.edge(6, 9).setDistance(12), encoder, s, true, true);
+        GHUtility.setProperties(graph.edge(2, 11).setDistance(5), encoder, s, true, false);
+        GHUtility.setProperties(graph.edge(4, 11).setDistance(10), encoder, s, true, true);
+        GHUtility.setProperties(graph.edge(7, 11).setDistance(5), encoder, s, true, true);
+        GHUtility.setProperties(graph.edge(7, 10).setDistance(5), encoder, s, true, true);
+        GHUtility.setProperties(graph.edge(8, 9).setDistance(10), encoder, s, true, false);
+        GHUtility.setProperties(graph.edge(9, 8).setDistance(9), encoder, s, true, false);
+        GHUtility.setProperties(graph.edge(10, 9).setDistance(10), encoder, s, true, false);
+        updateDistancesFor(graph, 0, 3, 0);
+        updateDistancesFor(graph, 3, 2.5, 0);
+        updateDistancesFor(graph, 5, 1, 0);
+        updateDistancesFor(graph, 8, 0, 0);
+        updateDistancesFor(graph, 1, 3, 1);
+        updateDistancesFor(graph, 4, 2, 1);
+        updateDistancesFor(graph, 6, 1, 1);
+        updateDistancesFor(graph, 9, 0, 1);
+        updateDistancesFor(graph, 2, 3, 2);
+        updateDistancesFor(graph, 11, 2, 2);
+        updateDistancesFor(graph, 7, 1, 2);
+        updateDistancesFor(graph, 10, 0, 2);
     }
 
     /**

--- a/core/src/test/java/com/graphhopper/routing/RoutingAlgorithmTest.java
+++ b/core/src/test/java/com/graphhopper/routing/RoutingAlgorithmTest.java
@@ -796,10 +796,10 @@ public class RoutingAlgorithmTest {
         EdgeIteratorState edge12 = graph.edge(1, 2).setDistance(10);
         BooleanEncodedValue carAccessEnc = carEncoder.getAccessEnc();
         DecimalEncodedValue carAvSpeedEnc = carEncoder.getAverageSpeedEnc();
-        edge01.set(carAvSpeedEnc, 0.0).set(carAccessEnc, true).setReverse(carAccessEnc, true);
+        edge01.set(carAvSpeedEnc, 0.0).set(carAccessEnc, true, true);
         edge01.setFlags(edge01.getFlags());
 
-        edge12.set(carAvSpeedEnc, 0.0).set(carAccessEnc, true).setReverse(carAccessEnc, true);
+        edge12.set(carAvSpeedEnc, 0.0).set(carAccessEnc, true, true);
         edge12.setFlags(edge12.getFlags());
 
         try {

--- a/core/src/test/java/com/graphhopper/routing/ch/CHTurnCostTest.java
+++ b/core/src/test/java/com/graphhopper/routing/ch/CHTurnCostTest.java
@@ -113,10 +113,10 @@ public class CHTurnCostTest {
     @RepeatedTest(10)
     public void testFindPath_randomContractionOrder_linear() {
         // 2-1-0-3-4
-        GHUtility.setProperties(graph.edge(2, 1).setDistance(2), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 0).setDistance(3), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(0, 3).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(3), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 1).setDistance(2));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 0).setDistance(3));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 4).setDistance(3));
         graph.freeze();
         setTurnCost(2, 1, 0, 2);
         setTurnCost(0, 3, 4, 4);
@@ -128,11 +128,11 @@ public class CHTurnCostTest {
         //  /\    /<-3
         // 0  1--2
         //  \/    \->4
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(5), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(6), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(2), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(3, 2).setDistance(3), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 4).setDistance(3), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(5));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(6));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(2));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 2).setDistance(3));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 4).setDistance(3));
         setRestriction(3, 2, 4);
         graph.freeze();
         compareCHWithDijkstra(10, new int[]{0, 1, 2, 3, 4});
@@ -143,11 +143,11 @@ public class CHTurnCostTest {
         //  /\ /\   
         // 0  1  2--3
         //  \/ \/
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(25.789000), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(26.016000), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(21.902000), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(21.862000), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(52.987000), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(25.789000));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(26.016000));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(21.902000));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(21.862000));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 3).setDistance(52.987000));
         graph.freeze();
         compareCHWithDijkstra(1000, new int[]{0, 1, 2, 3});
     }
@@ -165,17 +165,17 @@ public class CHTurnCostTest {
         // To cover all or at least as many as possible different cases we randomly apply some restrictions and compare
         // the resulting query with a standard Dijkstra search.
         // If this test fails use the logger output to generate code for further debugging.
-        GHUtility.setProperties(graph.edge(0, 5).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 5).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 5).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(5, 3).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(4, 7).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(5, 6).setDistance(3), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(6, 7).setDistance(3), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(7, 8).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(7, 9).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(7, 10).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 5).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 5).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 5).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(5, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(4, 7).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(5, 6).setDistance(3));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(6, 7).setDistance(3));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(7, 8).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(7, 9).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(7, 10).setDistance(1));
 
         long seed = System.nanoTime();
         Random rnd = new Random(seed);
@@ -209,15 +209,15 @@ public class CHTurnCostTest {
         // 1 - 5 - 6 - 7 - 9
         //    /         \
         //   2           10
-        GHUtility.setProperties(graph.edge(1, 5).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 5).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(5, 3).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(4, 7).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(5, 6).setDistance(3), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(6, 7).setDistance(3), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(7, 9).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(7, 10).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 5).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 5).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(5, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(4, 7).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(5, 6).setDistance(3));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(6, 7).setDistance(3));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(7, 9).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(7, 10).setDistance(1));
 
         setTurnCost(2, 5, 6, 4);
         setRestriction(1, 5, 6);
@@ -231,11 +231,11 @@ public class CHTurnCostTest {
     public void testFindPath_duplicateEdge() {
         // 0 -> 1 -> 2 -> 3 -> 4
         //            \->/
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 4).setDistance(1));
         compareCHWithDijkstra(100, new int[]{2, 3, 0, 4, 1});
     }
 
@@ -244,14 +244,14 @@ public class CHTurnCostTest {
         // 0   2   4   6   8
         //  \ / \ / \ / \ /
         //   1   3   5   7
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(4, 5).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(5, 6).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(6, 7).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(7, 8).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(4, 5).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(5, 6).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(6, 7).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(7, 8).setDistance(1));
         graph.freeze();
         setTurnCost(1, 2, 3, 4);
         setTurnCost(3, 4, 5, 2);
@@ -268,12 +268,12 @@ public class CHTurnCostTest {
         //   5 3 2 1 4    turn costs ->
         // 0-1-2-3-4-5-6
         //   0 1 4 2 3    turn costs <-
-        EdgeIteratorState edge0 = GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
-        EdgeIteratorState edge1 = GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, true);
-        EdgeIteratorState edge2 = GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, true);
-        EdgeIteratorState edge3 = GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, true);
-        EdgeIteratorState edge4 = GHUtility.setProperties(graph.edge(4, 5).setDistance(1), encoder, 60, true, true);
-        EdgeIteratorState edge5 = GHUtility.setProperties(graph.edge(5, 6).setDistance(1), encoder, 60, true, true);
+        EdgeIteratorState edge0 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(1));
+        EdgeIteratorState edge1 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(1));
+        EdgeIteratorState edge2 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 3).setDistance(1));
+        EdgeIteratorState edge3 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 4).setDistance(1));
+        EdgeIteratorState edge4 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 5).setDistance(1));
+        EdgeIteratorState edge5 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(5, 6).setDistance(1));
         graph.freeze();
 
         // turn costs ->
@@ -308,11 +308,11 @@ public class CHTurnCostTest {
         //  0-4-3
         //    |
         //    1
-        GHUtility.setProperties(graph.edge(0, 4).setDistance(2), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(4, 3).setDistance(2), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(3, 2).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 4).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(4, 1).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 4).setDistance(2));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 3).setDistance(2));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(4, 1).setDistance(1));
         graph.freeze();
 
         // enforce loop (going counter-clockwise)
@@ -330,14 +330,14 @@ public class CHTurnCostTest {
         //  7-5-0
         //    |
         //    6-4
-        GHUtility.setProperties(graph.edge(3, 7).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(7, 5).setDistance(2), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(5, 0).setDistance(2), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(0, 2).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 1).setDistance(2), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 5).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(5, 6).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(6, 4).setDistance(2), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 7).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(7, 5).setDistance(2));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(5, 0).setDistance(2));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 1).setDistance(2));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 5).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(5, 6).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(6, 4).setDistance(2));
         graph.freeze();
 
         setRestriction(7, 5, 6);
@@ -357,13 +357,13 @@ public class CHTurnCostTest {
         //  1-2-3
         //    |
         //    5-6
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(2), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(2), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(4, 2).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 5).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(5, 6).setDistance(2), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 2).setDistance(2));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 3).setDistance(2));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 5).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(5, 6).setDistance(2));
         graph.freeze();
 
         // enforce loop (going counter-clockwise)
@@ -388,29 +388,29 @@ public class CHTurnCostTest {
         //  }  |  }  }
         // 11~12-13-14
 
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 6).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(6, 7).setDistance(2), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(7, 8).setDistance(2), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(8, 3).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(3, 2).setDistance(2), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 7).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(7, 12).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(12, 13).setDistance(2), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(13, 14).setDistance(2), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 6).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(6, 7).setDistance(2));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(7, 8).setDistance(2));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(8, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 2).setDistance(2));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 7).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(7, 12).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(12, 13).setDistance(2));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(13, 14).setDistance(2));
 
         // some more edges to make it more complicated -> potentially find more bugs
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(8), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(6, 11).setDistance(3), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(11, 12).setDistance(50), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(8, 13).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(0, 15).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(15, 16).setDistance(2), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(16, 17).setDistance(3), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(17, 4).setDistance(2), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(2), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(4, 9).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(9, 14).setDistance(2), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(8));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(6, 11).setDistance(3));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(11, 12).setDistance(50));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(8, 13).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 15).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(15, 16).setDistance(2));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(16, 17).setDistance(3));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(17, 4).setDistance(2));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 4).setDistance(2));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 9).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(9, 14).setDistance(2));
         graph.freeze();
 
         // enforce loop (going counter-clockwise)
@@ -451,49 +451,49 @@ public class CHTurnCostTest {
         // 21-22-23-24 25-26
 
         // first we add all edges that contribute to the shortest path, verticals: cost=1, horizontals: cost=2
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 7).setDistance(3), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(7, 8).setDistance(2), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(8, 3).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(3, 2).setDistance(2), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 7).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(7, 12).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(12, 11).setDistance(2), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(11, 6).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(6, 7).setDistance(2), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(7, 13).setDistance(3), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(13, 14).setDistance(2), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(14, 9).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(9, 4).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(4, 5).setDistance(2), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(5, 10).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(10, 9).setDistance(2), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(14, 19).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(19, 18).setDistance(2), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(18, 17).setDistance(2), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(17, 16).setDistance(2), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(16, 21).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(21, 22).setDistance(2), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(22, 23).setDistance(2), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(23, 24).setDistance(2), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(24, 19).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(19, 20).setDistance(2), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(20, 25).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(25, 26).setDistance(2), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 7).setDistance(3));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(7, 8).setDistance(2));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(8, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 2).setDistance(2));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 7).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(7, 12).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(12, 11).setDistance(2));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(11, 6).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(6, 7).setDistance(2));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(7, 13).setDistance(3));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(13, 14).setDistance(2));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(14, 9).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(9, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 5).setDistance(2));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(5, 10).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(10, 9).setDistance(2));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(14, 19).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(19, 18).setDistance(2));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(18, 17).setDistance(2));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(17, 16).setDistance(2));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(16, 21).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(21, 22).setDistance(2));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(22, 23).setDistance(2));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(23, 24).setDistance(2));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(24, 19).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(19, 20).setDistance(2));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(20, 25).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(25, 26).setDistance(2));
 
         //some more edges to make it more complicated -> potentially find more bugs
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(4, 3).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(8, 9).setDistance(75), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(17, 22).setDistance(9), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(18, 23).setDistance(15), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(12, 17).setDistance(50), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(13, 18).setDistance(80), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(14, 15).setDistance(3), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(15, 27).setDistance(2), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(27, 28).setDistance(100), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(28, 26).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(20, 28).setDistance(1), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(4, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(8, 9).setDistance(75));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(17, 22).setDistance(9));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(18, 23).setDistance(15));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(12, 17).setDistance(50));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(13, 18).setDistance(80));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(14, 15).setDistance(3));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(15, 27).setDistance(2));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(27, 28).setDistance(100));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(28, 26).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(20, 28).setDistance(1));
         graph.freeze();
 
         // enforce figure of eight curve at node 7
@@ -534,13 +534,13 @@ public class CHTurnCostTest {
         //           4- 0
         //           |
         //     5 ->  6 -> 1
-        GHUtility.setProperties(graph.edge(5, 6).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(6, 1).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(6, 4).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(4, 0).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(0, 3).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 2).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 4).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(5, 6).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(6, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(6, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(4, 0).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 4).setDistance(1));
         graph.freeze();
         setRestriction(5, 6, 1);
 
@@ -558,14 +558,14 @@ public class CHTurnCostTest {
         //           1
         //           |
         //     5 ->  6 -> 7
-        GHUtility.setProperties(graph.edge(5, 6).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(6, 7).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(6, 1).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 4).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(4, 0).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(0, 3).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 2).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 4).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(5, 6).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(6, 7).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(6, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(4, 0).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 4).setDistance(1));
         graph.freeze();
         setRestriction(5, 6, 7);
 
@@ -599,7 +599,7 @@ public class CHTurnCostTest {
                 final int from = i * size + j;
                 final int to = from + 1;
                 final double dist = nextDist(maxDist, rnd);
-                GHUtility.setProperties(graph.edge(from, to).setDistance(dist), encoder, 60, true, true);
+                GHUtility.setSpeed(60, true, true, encoder, graph.edge(from, to).setDistance(dist));
                 LOGGER.trace("final EdgeIteratorState edge{} = graph.edge({},{},{},true);", edgeCounter++, from, to, dist);
             }
         }
@@ -609,7 +609,7 @@ public class CHTurnCostTest {
                 final int from = i * size + j;
                 final int to = from + size;
                 double dist = nextDist(maxDist, rnd);
-                GHUtility.setProperties(graph.edge(from, to).setDistance(dist), encoder, 60, true, true);
+                GHUtility.setSpeed(60, true, true, encoder, graph.edge(from, to).setDistance(dist));
                 LOGGER.trace("final EdgeIteratorState edge{} = graph.edge({},{},{},true);", edgeCounter++, from, to, dist);
             }
         }
@@ -620,13 +620,13 @@ public class CHTurnCostTest {
                 if (j < size - 1) {
                     final double dist = nextDist(maxDist, rnd);
                     final int to = from + size + 1;
-                    GHUtility.setProperties(graph.edge(from, to).setDistance(dist), encoder, 60, true, true);
+                    GHUtility.setSpeed(60, true, true, encoder, graph.edge(from, to).setDistance(dist));
                     LOGGER.trace("final EdgeIteratorState edge{} = graph.edge({},{},{},true);", edgeCounter++, from, to, dist);
                 }
                 if (j > 0) {
                     final double dist = nextDist(maxDist, rnd);
                     final int to = from + size - 1;
-                    GHUtility.setProperties(graph.edge(from, to).setDistance(dist), encoder, 60, true, true);
+                    GHUtility.setSpeed(60, true, true, encoder, graph.edge(from, to).setDistance(dist));
                     LOGGER.trace("final EdgeIteratorState edge{} = graph.edge({},{},{},true);", edgeCounter++, from, to, dist);
                 }
             }
@@ -658,11 +658,11 @@ public class CHTurnCostTest {
 
     @Test
     public void testFindPath_bug() {
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(18.364000), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 4).setDistance(29.814000), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(0, 2).setDistance(14.554000), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 4).setDistance(29.819000), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 3).setDistance(29.271000), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 2).setDistance(18.364000));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 4).setDistance(29.814000));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 2).setDistance(14.554000));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 4).setDistance(29.819000));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 3).setDistance(29.271000));
         setRestriction(3, 1, 2);
         graph.freeze();
 
@@ -671,11 +671,11 @@ public class CHTurnCostTest {
 
     @Test
     public void testFindPath_bug2() {
-        GHUtility.setProperties(graph.edge(0, 3).setDistance(24.001000), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(6.087000), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(6.067000), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(46.631000), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 4).setDistance(46.184000), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 3).setDistance(24.001000));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(6.087000));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(6.067000));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 3).setDistance(46.631000));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 4).setDistance(46.184000));
         graph.freeze();
 
         compareCHWithDijkstra(1000, new int[]{1, 0, 3, 2, 4});
@@ -688,15 +688,15 @@ public class CHTurnCostTest {
         //           1   2
         //            \ /
         // 0 - 7 - 8 - 4 - 6 - 5
-        GHUtility.setProperties(graph.edge(0, 7).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(7, 8).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(8, 4).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(4, 1).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 3).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 2).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 4).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(4, 6).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(6, 5).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 7).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(7, 8).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(8, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(4, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(4, 6).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(6, 5).setDistance(1));
         setRestriction(8, 4, 6);
         graph.freeze();
 
@@ -713,11 +713,11 @@ public class CHTurnCostTest {
         // 0-3-4
         //   |/
         //   2
-        GHUtility.setProperties(graph.edge(0, 3).setDistance(100), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(100), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(4, 2).setDistance(500), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(200), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 1).setDistance(100), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 3).setDistance(100));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 4).setDistance(100));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(4, 2).setDistance(500));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 3).setDistance(200));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 1).setDistance(100));
         setRestriction(0, 3, 1);
         graph.freeze();
         chConfig = chConfigs.get(1);
@@ -735,11 +735,11 @@ public class CHTurnCostTest {
         // 2-1--3
         //   |  |
         //   0->4
-        EdgeIteratorState edge0 = GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, true);
-        EdgeIteratorState edge1 = GHUtility.setProperties(graph.edge(0, 4).setDistance(1), encoder, 60, true, false);
-        EdgeIteratorState edge2 = GHUtility.setProperties(graph.edge(4, 3).setDistance(1), encoder, 60, true, true);
-        EdgeIteratorState edge3 = GHUtility.setProperties(graph.edge(1, 3).setDistance(1), encoder, 60, true, true);
-        EdgeIteratorState edge4 = GHUtility.setProperties(graph.edge(1, 0).setDistance(1), encoder, 60, true, true);
+        EdgeIteratorState edge0 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(1));
+        EdgeIteratorState edge1 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 4).setDistance(1));
+        EdgeIteratorState edge2 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 3).setDistance(1));
+        EdgeIteratorState edge3 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 3).setDistance(1));
+        EdgeIteratorState edge4 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 0).setDistance(1));
         setTurnCost(edge0, edge4, 1, 8);
         setRestriction(edge0, edge3, 1);
         graph.freeze();
@@ -751,10 +751,10 @@ public class CHTurnCostTest {
         //     ---
         //     \ /
         // 0 -- 1 -- 2 -- 3
-        EdgeIteratorState edge0 = GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
-        EdgeIteratorState edge1 = GHUtility.setProperties(graph.edge(1, 1).setDistance(1), encoder, 60, true, false);
-        EdgeIteratorState edge2 = GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, true);
-        EdgeIteratorState edge3 = GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
+        EdgeIteratorState edge0 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(1));
+        EdgeIteratorState edge1 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 1).setDistance(1));
+        EdgeIteratorState edge2 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(1));
+        EdgeIteratorState edge3 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 3).setDistance(1));
         setTurnCost(edge0, edge1, 1, 1);
         setRestriction(edge0, edge2, 1);
         graph.freeze();
@@ -764,14 +764,14 @@ public class CHTurnCostTest {
 
     @Test
     public void testFindPath_compareWithDijkstra_zeroWeightLoops_random() {
-        GHUtility.setProperties(graph.edge(5, 3).setDistance(21.329000), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(4, 5).setDistance(29.126000), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 0).setDistance(38.865000), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 4).setDistance(80.005000), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 1).setDistance(91.023000), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(5, 3).setDistance(21.329000));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(4, 5).setDistance(29.126000));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 0).setDistance(38.865000));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 4).setDistance(80.005000));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 1).setDistance(91.023000));
         // add loops with zero weight ...
-        GHUtility.setProperties(graph.edge(1, 1).setDistance(0.000000), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 1).setDistance(0.000000), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 1).setDistance(0.000000));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 1).setDistance(0.000000));
         graph.freeze();
         automaticCompareCHWithDijkstra(100);
     }
@@ -782,12 +782,12 @@ public class CHTurnCostTest {
         // 0 -> 1 -> 2 -> 3 --
         //                | \|
         //                4
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 3).setDistance(0), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 3).setDistance(0), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 3).setDistance(0));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 3).setDistance(0));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 4).setDistance(1));
         graph.freeze();
         IntArrayList expectedPath = IntArrayList.from(0, 1, 2, 3, 4);
         checkPath(expectedPath, 4, 0, 0, 4, new int[]{2, 0, 4, 1, 3});
@@ -799,12 +799,12 @@ public class CHTurnCostTest {
         // 0 -> 1 -> 2 -> 3 --
         //                | \|
         //                4
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
-        EdgeIteratorState edge2 = GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
-        EdgeIteratorState edge3 = GHUtility.setProperties(graph.edge(3, 3).setDistance(0), encoder, 60, true, false);
-        EdgeIteratorState edge4 = GHUtility.setProperties(graph.edge(3, 3).setDistance(0), encoder, 60, true, false);
-        EdgeIteratorState edge5 = GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 2).setDistance(1));
+        EdgeIteratorState edge2 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 3).setDistance(1));
+        EdgeIteratorState edge3 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 3).setDistance(0));
+        EdgeIteratorState edge4 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 3).setDistance(0));
+        EdgeIteratorState edge5 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 4).setDistance(1));
         setTurnCost(edge2, edge3, 3, 5);
         setTurnCost(edge2, edge4, 3, 4);
         setTurnCost(edge3, edge4, 3, 2);
@@ -818,11 +818,11 @@ public class CHTurnCostTest {
     public void testFindPath_oneWayLoop() {
         //     o
         // 0-1-2-3-4
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 2).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 4).setDistance(1));
         setRestriction(1, 2, 3);
         graph.freeze();
         automaticPrepareCH();
@@ -839,11 +839,11 @@ public class CHTurnCostTest {
         // 1-0
         // | |
         // 4-2o
-        GHUtility.setProperties(graph.edge(1, 0).setDistance(802.964000), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 4).setDistance(615.195000), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 2).setDistance(181.788000), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(0, 2).setDistance(191.996000), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 4).setDistance(527.821000), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 0).setDistance(802.964000));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 4).setDistance(615.195000));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 2).setDistance(181.788000));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 2).setDistance(191.996000));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 4).setDistance(527.821000));
         setRestriction(0, 2, 4);
         setTurnCost(0, 2, 2, 3);
         setTurnCost(2, 2, 4, 4);
@@ -867,11 +867,11 @@ public class CHTurnCostTest {
         na.setNode(2, 49.404004, 9.709110);
         na.setNode(3, 49.400160, 9.708787);
         na.setNode(4, 49.400883, 9.706347);
-        EdgeIteratorState edge0 = GHUtility.setProperties(graph.edge(4, 3).setDistance(194.063000), encoder, 60, true, true);
-        EdgeIteratorState edge1 = GHUtility.setProperties(graph.edge(1, 2).setDistance(525.106000), encoder, 60, true, true);
-        EdgeIteratorState edge2 = GHUtility.setProperties(graph.edge(1, 2).setDistance(525.106000), encoder, 60, true, true);
-        EdgeIteratorState edge3 = GHUtility.setProperties(graph.edge(4, 1).setDistance(703.778000), encoder, 60, true, false);
-        EdgeIteratorState edge4 = GHUtility.setProperties(graph.edge(2, 4).setDistance(400.509000), encoder, 60, true, true);
+        EdgeIteratorState edge0 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 3).setDistance(194.063000));
+        EdgeIteratorState edge1 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(525.106000));
+        EdgeIteratorState edge2 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(525.106000));
+        EdgeIteratorState edge3 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(4, 1).setDistance(703.778000));
+        EdgeIteratorState edge4 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 4).setDistance(400.509000));
         // cannot go 4-2-1 and 1-2-4 (at least when using edge1, there is still edge2!)
         setRestriction(edge4, edge1, 2);
         setRestriction(edge1, edge4, 2);
@@ -923,11 +923,11 @@ public class CHTurnCostTest {
         na.setNode(0, 0.1, 0.1);
         na.setNode(5, 0.1, 0.2);
         na.setNode(4, 0.1, 0.3);
-        EdgeIteratorState edge0 = GHUtility.setProperties(graph.edge(3, 1).setDistance(10), encoder, 60, true, true);
-        EdgeIteratorState edge1 = GHUtility.setProperties(graph.edge(2, 3).setDistance(10), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(3, 0).setDistance(10), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(0, 5).setDistance(10), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(5, 4).setDistance(10), encoder, 60, true, true);
+        EdgeIteratorState edge0 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 1).setDistance(10));
+        EdgeIteratorState edge1 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 3).setDistance(10));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 0).setDistance(10));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 5).setDistance(10));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(5, 4).setDistance(10));
         // cannot go, 2-3-1
         setRestriction(edge1, edge0, 3);
         graph.freeze();
@@ -956,8 +956,8 @@ public class CHTurnCostTest {
     public void testRouteViaVirtualNode(String algo) {
         //   3
         // 0-x-1-2
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(0), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(0), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 1).setDistance(0));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 2).setDistance(0));
         updateDistancesFor(graph, 0, 0.00, 0.00);
         updateDistancesFor(graph, 1, 0.02, 0.02);
         updateDistancesFor(graph, 2, 0.03, 0.03);
@@ -983,9 +983,9 @@ public class CHTurnCostTest {
         // 0-x-1
         //  \  |
         //   \-2
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 0).setDistance(1), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 0).setDistance(1));
         updateDistancesFor(graph, 0, 0.01, 0.00);
         updateDistancesFor(graph, 1, 0.01, 0.02);
         updateDistancesFor(graph, 2, 0.00, 0.02);
@@ -1011,12 +1011,12 @@ public class CHTurnCostTest {
         // 4->3->2->1-x-0
         //          |
         //          5->6
-        GHUtility.setProperties(graph.edge(4, 3).setDistance(0), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 2).setDistance(0), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 1).setDistance(0), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 0).setDistance(0), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 5).setDistance(0), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(5, 6).setDistance(0), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(4, 3).setDistance(0));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 2).setDistance(0));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 1).setDistance(0));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 0).setDistance(0));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 5).setDistance(0));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(5, 6).setDistance(0));
         updateDistancesFor(graph, 4, 0.1, 0.0);
         updateDistancesFor(graph, 3, 0.1, 0.1);
         updateDistancesFor(graph, 2, 0.1, 0.2);

--- a/core/src/test/java/com/graphhopper/routing/ch/CHTurnCostTest.java
+++ b/core/src/test/java/com/graphhopper/routing/ch/CHTurnCostTest.java
@@ -113,10 +113,10 @@ public class CHTurnCostTest {
     @RepeatedTest(10)
     public void testFindPath_randomContractionOrder_linear() {
         // 2-1-0-3-4
-        graph.edge(2, 1, 2, true);
-        graph.edge(1, 0, 3, true);
-        graph.edge(0, 3, 1, true);
-        graph.edge(3, 4, 3, true);
+        GHUtility.setProperties(graph.edge(2, 1).setDistance(2), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 0).setDistance(3), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(0, 3).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(3), encoder, 60, true, true);
         graph.freeze();
         setTurnCost(2, 1, 0, 2);
         setTurnCost(0, 3, 4, 4);
@@ -128,11 +128,11 @@ public class CHTurnCostTest {
         //  /\    /<-3
         // 0  1--2
         //  \/    \->4
-        graph.edge(0, 1, 5, true);
-        graph.edge(0, 1, 6, true);
-        graph.edge(1, 2, 2, true);
-        graph.edge(3, 2, 3, false);
-        graph.edge(2, 4, 3, false);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(5), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(6), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(2), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(3, 2).setDistance(3), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 4).setDistance(3), encoder, 60, true, false);
         setRestriction(3, 2, 4);
         graph.freeze();
         compareCHWithDijkstra(10, new int[]{0, 1, 2, 3, 4});
@@ -143,11 +143,11 @@ public class CHTurnCostTest {
         //  /\ /\   
         // 0  1  2--3
         //  \/ \/
-        graph.edge(0, 1, 25.789000, true);
-        graph.edge(0, 1, 26.016000, true);
-        graph.edge(1, 2, 21.902000, true);
-        graph.edge(1, 2, 21.862000, true);
-        graph.edge(2, 3, 52.987000, true);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(25.789000), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(26.016000), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(21.902000), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(21.862000), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(52.987000), encoder, 60, true, true);
         graph.freeze();
         compareCHWithDijkstra(1000, new int[]{0, 1, 2, 3});
     }
@@ -165,17 +165,17 @@ public class CHTurnCostTest {
         // To cover all or at least as many as possible different cases we randomly apply some restrictions and compare
         // the resulting query with a standard Dijkstra search.
         // If this test fails use the logger output to generate code for further debugging.
-        graph.edge(0, 5, 1, false);
-        graph.edge(1, 5, 1, false);
-        graph.edge(2, 5, 1, false);
-        graph.edge(5, 3, 1, false);
-        graph.edge(3, 4, 1, false);
-        graph.edge(4, 7, 1, false);
-        graph.edge(5, 6, 3, false);
-        graph.edge(6, 7, 3, false);
-        graph.edge(7, 8, 1, false);
-        graph.edge(7, 9, 1, false);
-        graph.edge(7, 10, 1, false);
+        GHUtility.setProperties(graph.edge(0, 5).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 5).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 5).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(5, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(4, 7).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(5, 6).setDistance(3), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(6, 7).setDistance(3), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(7, 8).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(7, 9).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(7, 10).setDistance(1), encoder, 60, true, false);
 
         long seed = System.nanoTime();
         Random rnd = new Random(seed);
@@ -209,15 +209,15 @@ public class CHTurnCostTest {
         // 1 - 5 - 6 - 7 - 9
         //    /         \
         //   2           10
-        graph.edge(1, 5, 1, false);
-        graph.edge(2, 5, 1, false);
-        graph.edge(5, 3, 1, false);
-        graph.edge(3, 4, 1, false);
-        graph.edge(4, 7, 1, false);
-        graph.edge(5, 6, 3, false);
-        graph.edge(6, 7, 3, false);
-        graph.edge(7, 9, 1, false);
-        graph.edge(7, 10, 1, false);
+        GHUtility.setProperties(graph.edge(1, 5).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 5).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(5, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(4, 7).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(5, 6).setDistance(3), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(6, 7).setDistance(3), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(7, 9).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(7, 10).setDistance(1), encoder, 60, true, false);
 
         setTurnCost(2, 5, 6, 4);
         setRestriction(1, 5, 6);
@@ -231,11 +231,11 @@ public class CHTurnCostTest {
     public void testFindPath_duplicateEdge() {
         // 0 -> 1 -> 2 -> 3 -> 4
         //            \->/
-        graph.edge(0, 1, 1, false);
-        graph.edge(1, 2, 1, false);
-        graph.edge(2, 3, 1, false);
-        graph.edge(2, 3, 1, false);
-        graph.edge(3, 4, 1, false);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
         compareCHWithDijkstra(100, new int[]{2, 3, 0, 4, 1});
     }
 
@@ -244,14 +244,14 @@ public class CHTurnCostTest {
         // 0   2   4   6   8
         //  \ / \ / \ / \ /
         //   1   3   5   7
-        graph.edge(0, 1, 1, false);
-        graph.edge(1, 2, 1, false);
-        graph.edge(2, 3, 1, false);
-        graph.edge(3, 4, 1, false);
-        graph.edge(4, 5, 1, false);
-        graph.edge(5, 6, 1, false);
-        graph.edge(6, 7, 1, false);
-        graph.edge(7, 8, 1, false);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(4, 5).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(5, 6).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(6, 7).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(7, 8).setDistance(1), encoder, 60, true, false);
         graph.freeze();
         setTurnCost(1, 2, 3, 4);
         setTurnCost(3, 4, 5, 2);
@@ -268,12 +268,12 @@ public class CHTurnCostTest {
         //   5 3 2 1 4    turn costs ->
         // 0-1-2-3-4-5-6
         //   0 1 4 2 3    turn costs <-
-        EdgeIteratorState edge0 = graph.edge(0, 1, 1, true);
-        EdgeIteratorState edge1 = graph.edge(1, 2, 1, true);
-        EdgeIteratorState edge2 = graph.edge(2, 3, 1, true);
-        EdgeIteratorState edge3 = graph.edge(3, 4, 1, true);
-        EdgeIteratorState edge4 = graph.edge(4, 5, 1, true);
-        EdgeIteratorState edge5 = graph.edge(5, 6, 1, true);
+        EdgeIteratorState edge0 = GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
+        EdgeIteratorState edge1 = GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, true);
+        EdgeIteratorState edge2 = GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, true);
+        EdgeIteratorState edge3 = GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, true);
+        EdgeIteratorState edge4 = GHUtility.setProperties(graph.edge(4, 5).setDistance(1), encoder, 60, true, true);
+        EdgeIteratorState edge5 = GHUtility.setProperties(graph.edge(5, 6).setDistance(1), encoder, 60, true, true);
         graph.freeze();
 
         // turn costs ->
@@ -308,11 +308,11 @@ public class CHTurnCostTest {
         //  0-4-3
         //    |
         //    1
-        graph.edge(0, 4, 2, false);
-        graph.edge(4, 3, 2, true);
-        graph.edge(3, 2, 1, true);
-        graph.edge(2, 4, 1, true);
-        graph.edge(4, 1, 1, false);
+        GHUtility.setProperties(graph.edge(0, 4).setDistance(2), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(4, 3).setDistance(2), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(3, 2).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 4).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(4, 1).setDistance(1), encoder, 60, true, false);
         graph.freeze();
 
         // enforce loop (going counter-clockwise)
@@ -330,14 +330,14 @@ public class CHTurnCostTest {
         //  7-5-0
         //    |
         //    6-4
-        graph.edge(3, 7, 1, false);
-        graph.edge(7, 5, 2, false);
-        graph.edge(5, 0, 2, false);
-        graph.edge(0, 2, 1, false);
-        graph.edge(2, 1, 2, false);
-        graph.edge(1, 5, 1, false);
-        graph.edge(5, 6, 1, false);
-        graph.edge(6, 4, 2, false);
+        GHUtility.setProperties(graph.edge(3, 7).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(7, 5).setDistance(2), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(5, 0).setDistance(2), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(0, 2).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 1).setDistance(2), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 5).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(5, 6).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(6, 4).setDistance(2), encoder, 60, true, false);
         graph.freeze();
 
         setRestriction(7, 5, 6);
@@ -357,13 +357,13 @@ public class CHTurnCostTest {
         //  1-2-3
         //    |
         //    5-6
-        graph.edge(0, 1, 1, false);
-        graph.edge(1, 2, 2, false);
-        graph.edge(2, 3, 2, true);
-        graph.edge(3, 4, 1, true);
-        graph.edge(4, 2, 1, true);
-        graph.edge(2, 5, 1, false);
-        graph.edge(5, 6, 2, false);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(2), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(2), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(4, 2).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 5).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(5, 6).setDistance(2), encoder, 60, true, false);
         graph.freeze();
 
         // enforce loop (going counter-clockwise)
@@ -388,29 +388,29 @@ public class CHTurnCostTest {
         //  }  |  }  }
         // 11~12-13-14
 
-        graph.edge(0, 1, 1, true);
-        graph.edge(1, 6, 1, true);
-        graph.edge(6, 7, 2, true);
-        graph.edge(7, 8, 2, true);
-        graph.edge(8, 3, 1, true);
-        graph.edge(3, 2, 2, true);
-        graph.edge(2, 7, 1, true);
-        graph.edge(7, 12, 1, true);
-        graph.edge(12, 13, 2, true);
-        graph.edge(13, 14, 2, true);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 6).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(6, 7).setDistance(2), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(7, 8).setDistance(2), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(8, 3).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(3, 2).setDistance(2), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 7).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(7, 12).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(12, 13).setDistance(2), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(13, 14).setDistance(2), encoder, 60, true, true);
 
         // some more edges to make it more complicated -> potentially find more bugs
-        graph.edge(1, 2, 8, true);
-        graph.edge(6, 11, 3, true);
-        graph.edge(11, 12, 50, true);
-        graph.edge(8, 13, 1, true);
-        graph.edge(0, 15, 1, true);
-        graph.edge(15, 16, 2, true);
-        graph.edge(16, 17, 3, true);
-        graph.edge(17, 4, 2, true);
-        graph.edge(3, 4, 2, true);
-        graph.edge(4, 9, 1, true);
-        graph.edge(9, 14, 2, true);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(8), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(6, 11).setDistance(3), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(11, 12).setDistance(50), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(8, 13).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(0, 15).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(15, 16).setDistance(2), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(16, 17).setDistance(3), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(17, 4).setDistance(2), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(2), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(4, 9).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(9, 14).setDistance(2), encoder, 60, true, true);
         graph.freeze();
 
         // enforce loop (going counter-clockwise)
@@ -451,49 +451,49 @@ public class CHTurnCostTest {
         // 21-22-23-24 25-26
 
         // first we add all edges that contribute to the shortest path, verticals: cost=1, horizontals: cost=2
-        graph.edge(0, 1, 1, true);
-        graph.edge(1, 7, 3, true);
-        graph.edge(7, 8, 2, false);
-        graph.edge(8, 3, 1, true);
-        graph.edge(3, 2, 2, true);
-        graph.edge(2, 7, 1, true);
-        graph.edge(7, 12, 1, true);
-        graph.edge(12, 11, 2, true);
-        graph.edge(11, 6, 1, true);
-        graph.edge(6, 7, 2, false);
-        graph.edge(7, 13, 3, true);
-        graph.edge(13, 14, 2, true);
-        graph.edge(14, 9, 1, true);
-        graph.edge(9, 4, 1, true);
-        graph.edge(4, 5, 2, true);
-        graph.edge(5, 10, 1, true);
-        graph.edge(10, 9, 2, true);
-        graph.edge(14, 19, 1, true);
-        graph.edge(19, 18, 2, true);
-        graph.edge(18, 17, 2, true);
-        graph.edge(17, 16, 2, true);
-        graph.edge(16, 21, 1, true);
-        graph.edge(21, 22, 2, true);
-        graph.edge(22, 23, 2, true);
-        graph.edge(23, 24, 2, true);
-        graph.edge(24, 19, 1, true);
-        graph.edge(19, 20, 2, true);
-        graph.edge(20, 25, 1, true);
-        graph.edge(25, 26, 2, true);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 7).setDistance(3), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(7, 8).setDistance(2), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(8, 3).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(3, 2).setDistance(2), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 7).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(7, 12).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(12, 11).setDistance(2), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(11, 6).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(6, 7).setDistance(2), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(7, 13).setDistance(3), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(13, 14).setDistance(2), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(14, 9).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(9, 4).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(4, 5).setDistance(2), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(5, 10).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(10, 9).setDistance(2), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(14, 19).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(19, 18).setDistance(2), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(18, 17).setDistance(2), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(17, 16).setDistance(2), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(16, 21).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(21, 22).setDistance(2), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(22, 23).setDistance(2), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(23, 24).setDistance(2), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(24, 19).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(19, 20).setDistance(2), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(20, 25).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(25, 26).setDistance(2), encoder, 60, true, true);
 
         //some more edges to make it more complicated -> potentially find more bugs
-        graph.edge(1, 2, 1, true);
-        graph.edge(4, 3, 1, false);
-        graph.edge(8, 9, 75, true);
-        graph.edge(17, 22, 9, true);
-        graph.edge(18, 23, 15, true);
-        graph.edge(12, 17, 50, true);
-        graph.edge(13, 18, 80, true);
-        graph.edge(14, 15, 3, true);
-        graph.edge(15, 27, 2, true);
-        graph.edge(27, 28, 100, true);
-        graph.edge(28, 26, 1, true);
-        graph.edge(20, 28, 1, true);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(4, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(8, 9).setDistance(75), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(17, 22).setDistance(9), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(18, 23).setDistance(15), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(12, 17).setDistance(50), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(13, 18).setDistance(80), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(14, 15).setDistance(3), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(15, 27).setDistance(2), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(27, 28).setDistance(100), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(28, 26).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(20, 28).setDistance(1), encoder, 60, true, true);
         graph.freeze();
 
         // enforce figure of eight curve at node 7
@@ -534,13 +534,13 @@ public class CHTurnCostTest {
         //           4- 0
         //           |
         //     5 ->  6 -> 1
-        graph.edge(5, 6, 1, false);
-        graph.edge(6, 1, 1, false);
-        graph.edge(6, 4, 1, true);
-        graph.edge(4, 0, 1, false);
-        graph.edge(0, 3, 1, false);
-        graph.edge(3, 2, 1, false);
-        graph.edge(2, 4, 1, false);
+        GHUtility.setProperties(graph.edge(5, 6).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(6, 1).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(6, 4).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(4, 0).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(0, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 2).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 4).setDistance(1), encoder, 60, true, false);
         graph.freeze();
         setRestriction(5, 6, 1);
 
@@ -558,14 +558,14 @@ public class CHTurnCostTest {
         //           1
         //           |
         //     5 ->  6 -> 7
-        graph.edge(5, 6, 1, false);
-        graph.edge(6, 7, 1, false);
-        graph.edge(6, 1, 1, true);
-        graph.edge(1, 4, 1, true);
-        graph.edge(4, 0, 1, false);
-        graph.edge(0, 3, 1, false);
-        graph.edge(3, 2, 1, false);
-        graph.edge(2, 4, 1, false);
+        GHUtility.setProperties(graph.edge(5, 6).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(6, 7).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(6, 1).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 4).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(4, 0).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(0, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 2).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 4).setDistance(1), encoder, 60, true, false);
         graph.freeze();
         setRestriction(5, 6, 7);
 
@@ -599,7 +599,7 @@ public class CHTurnCostTest {
                 final int from = i * size + j;
                 final int to = from + 1;
                 final double dist = nextDist(maxDist, rnd);
-                graph.edge(from, to, dist, true);
+                GHUtility.setProperties(graph.edge(from, to).setDistance(dist), encoder, 60, true, true);
                 LOGGER.trace("final EdgeIteratorState edge{} = graph.edge({},{},{},true);", edgeCounter++, from, to, dist);
             }
         }
@@ -609,7 +609,7 @@ public class CHTurnCostTest {
                 final int from = i * size + j;
                 final int to = from + size;
                 double dist = nextDist(maxDist, rnd);
-                graph.edge(from, to, dist, true);
+                GHUtility.setProperties(graph.edge(from, to).setDistance(dist), encoder, 60, true, true);
                 LOGGER.trace("final EdgeIteratorState edge{} = graph.edge({},{},{},true);", edgeCounter++, from, to, dist);
             }
         }
@@ -620,13 +620,13 @@ public class CHTurnCostTest {
                 if (j < size - 1) {
                     final double dist = nextDist(maxDist, rnd);
                     final int to = from + size + 1;
-                    graph.edge(from, to, dist, true);
+                    GHUtility.setProperties(graph.edge(from, to).setDistance(dist), encoder, 60, true, true);
                     LOGGER.trace("final EdgeIteratorState edge{} = graph.edge({},{},{},true);", edgeCounter++, from, to, dist);
                 }
                 if (j > 0) {
                     final double dist = nextDist(maxDist, rnd);
                     final int to = from + size - 1;
-                    graph.edge(from, to, dist, true);
+                    GHUtility.setProperties(graph.edge(from, to).setDistance(dist), encoder, 60, true, true);
                     LOGGER.trace("final EdgeIteratorState edge{} = graph.edge({},{},{},true);", edgeCounter++, from, to, dist);
                 }
             }
@@ -658,11 +658,11 @@ public class CHTurnCostTest {
 
     @Test
     public void testFindPath_bug() {
-        graph.edge(1, 2, 18.364000, false);
-        graph.edge(1, 4, 29.814000, true);
-        graph.edge(0, 2, 14.554000, true);
-        graph.edge(1, 4, 29.819000, true);
-        graph.edge(1, 3, 29.271000, true);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(18.364000), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 4).setDistance(29.814000), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(0, 2).setDistance(14.554000), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 4).setDistance(29.819000), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 3).setDistance(29.271000), encoder, 60, true, true);
         setRestriction(3, 1, 2);
         graph.freeze();
 
@@ -671,11 +671,11 @@ public class CHTurnCostTest {
 
     @Test
     public void testFindPath_bug2() {
-        graph.edge(0, 3, 24.001000, true);
-        graph.edge(0, 1, 6.087000, true);
-        graph.edge(0, 1, 6.067000, true);
-        graph.edge(2, 3, 46.631000, true);
-        graph.edge(2, 4, 46.184000, true);
+        GHUtility.setProperties(graph.edge(0, 3).setDistance(24.001000), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(6.087000), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(6.067000), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(46.631000), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 4).setDistance(46.184000), encoder, 60, true, true);
         graph.freeze();
 
         compareCHWithDijkstra(1000, new int[]{1, 0, 3, 2, 4});
@@ -688,15 +688,15 @@ public class CHTurnCostTest {
         //           1   2
         //            \ /
         // 0 - 7 - 8 - 4 - 6 - 5
-        graph.edge(0, 7, 1, false);
-        graph.edge(7, 8, 1, false);
-        graph.edge(8, 4, 1, false);
-        graph.edge(4, 1, 1, false);
-        graph.edge(1, 3, 1, false);
-        graph.edge(3, 2, 1, false);
-        graph.edge(2, 4, 1, false);
-        graph.edge(4, 6, 1, false);
-        graph.edge(6, 5, 1, false);
+        GHUtility.setProperties(graph.edge(0, 7).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(7, 8).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(8, 4).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(4, 1).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 2).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 4).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(4, 6).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(6, 5).setDistance(1), encoder, 60, true, false);
         setRestriction(8, 4, 6);
         graph.freeze();
 
@@ -713,11 +713,11 @@ public class CHTurnCostTest {
         // 0-3-4
         //   |/
         //   2
-        graph.edge(0, 3, 100, false);
-        graph.edge(3, 4, 100, true);
-        graph.edge(4, 2, 500, false);
-        graph.edge(2, 3, 200, false);
-        graph.edge(3, 1, 100, false);
+        GHUtility.setProperties(graph.edge(0, 3).setDistance(100), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(100), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(4, 2).setDistance(500), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(200), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 1).setDistance(100), encoder, 60, true, false);
         setRestriction(0, 3, 1);
         graph.freeze();
         chConfig = chConfigs.get(1);
@@ -735,11 +735,11 @@ public class CHTurnCostTest {
         // 2-1--3
         //   |  |
         //   0->4
-        EdgeIteratorState edge0 = graph.edge(1, 2, 1, true);
-        EdgeIteratorState edge1 = graph.edge(0, 4, 1, false);
-        EdgeIteratorState edge2 = graph.edge(4, 3, 1, true);
-        EdgeIteratorState edge3 = graph.edge(1, 3, 1, true);
-        EdgeIteratorState edge4 = graph.edge(1, 0, 1, true);
+        EdgeIteratorState edge0 = GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, true);
+        EdgeIteratorState edge1 = GHUtility.setProperties(graph.edge(0, 4).setDistance(1), encoder, 60, true, false);
+        EdgeIteratorState edge2 = GHUtility.setProperties(graph.edge(4, 3).setDistance(1), encoder, 60, true, true);
+        EdgeIteratorState edge3 = GHUtility.setProperties(graph.edge(1, 3).setDistance(1), encoder, 60, true, true);
+        EdgeIteratorState edge4 = GHUtility.setProperties(graph.edge(1, 0).setDistance(1), encoder, 60, true, true);
         setTurnCost(edge0, edge4, 1, 8);
         setRestriction(edge0, edge3, 1);
         graph.freeze();
@@ -751,10 +751,10 @@ public class CHTurnCostTest {
         //     ---
         //     \ /
         // 0 -- 1 -- 2 -- 3
-        EdgeIteratorState edge0 = graph.edge(0, 1, 1, true);
-        EdgeIteratorState edge1 = graph.edge(1, 1, 1, false);
-        EdgeIteratorState edge2 = graph.edge(1, 2, 1, true);
-        EdgeIteratorState edge3 = graph.edge(2, 3, 1, false);
+        EdgeIteratorState edge0 = GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
+        EdgeIteratorState edge1 = GHUtility.setProperties(graph.edge(1, 1).setDistance(1), encoder, 60, true, false);
+        EdgeIteratorState edge2 = GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, true);
+        EdgeIteratorState edge3 = GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
         setTurnCost(edge0, edge1, 1, 1);
         setRestriction(edge0, edge2, 1);
         graph.freeze();
@@ -764,14 +764,14 @@ public class CHTurnCostTest {
 
     @Test
     public void testFindPath_compareWithDijkstra_zeroWeightLoops_random() {
-        graph.edge(5, 3, 21.329000, false);
-        graph.edge(4, 5, 29.126000, false);
-        graph.edge(1, 0, 38.865000, false);
-        graph.edge(1, 4, 80.005000, false);
-        graph.edge(3, 1, 91.023000, false);
+        GHUtility.setProperties(graph.edge(5, 3).setDistance(21.329000), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(4, 5).setDistance(29.126000), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 0).setDistance(38.865000), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 4).setDistance(80.005000), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 1).setDistance(91.023000), encoder, 60, true, false);
         // add loops with zero weight ...
-        graph.edge(1, 1, 0.000000, false);
-        graph.edge(1, 1, 0.000000, false);
+        GHUtility.setProperties(graph.edge(1, 1).setDistance(0.000000), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 1).setDistance(0.000000), encoder, 60, true, false);
         graph.freeze();
         automaticCompareCHWithDijkstra(100);
     }
@@ -782,12 +782,12 @@ public class CHTurnCostTest {
         // 0 -> 1 -> 2 -> 3 --
         //                | \|
         //                4
-        graph.edge(0, 1, 1, false);
-        graph.edge(1, 2, 1, false);
-        graph.edge(2, 3, 1, false);
-        graph.edge(3, 3, 0, false);
-        graph.edge(3, 3, 0, false);
-        graph.edge(3, 4, 1, false);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 3).setDistance(0), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 3).setDistance(0), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
         graph.freeze();
         IntArrayList expectedPath = IntArrayList.from(0, 1, 2, 3, 4);
         checkPath(expectedPath, 4, 0, 0, 4, new int[]{2, 0, 4, 1, 3});
@@ -799,12 +799,12 @@ public class CHTurnCostTest {
         // 0 -> 1 -> 2 -> 3 --
         //                | \|
         //                4
-        graph.edge(0, 1, 1, false);
-        graph.edge(1, 2, 1, false);
-        EdgeIteratorState edge2 = graph.edge(2, 3, 1, false);
-        EdgeIteratorState edge3 = graph.edge(3, 3, 0, false);
-        EdgeIteratorState edge4 = graph.edge(3, 3, 0, false);
-        EdgeIteratorState edge5 = graph.edge(3, 4, 1, false);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
+        EdgeIteratorState edge2 = GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
+        EdgeIteratorState edge3 = GHUtility.setProperties(graph.edge(3, 3).setDistance(0), encoder, 60, true, false);
+        EdgeIteratorState edge4 = GHUtility.setProperties(graph.edge(3, 3).setDistance(0), encoder, 60, true, false);
+        EdgeIteratorState edge5 = GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
         setTurnCost(edge2, edge3, 3, 5);
         setTurnCost(edge2, edge4, 3, 4);
         setTurnCost(edge3, edge4, 3, 2);
@@ -818,11 +818,11 @@ public class CHTurnCostTest {
     public void testFindPath_oneWayLoop() {
         //     o
         // 0-1-2-3-4
-        graph.edge(0, 1, 1, false);
-        graph.edge(1, 2, 1, false);
-        graph.edge(2, 2, 1, false);
-        graph.edge(2, 3, 1, false);
-        graph.edge(3, 4, 1, false);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 2).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
         setRestriction(1, 2, 3);
         graph.freeze();
         automaticPrepareCH();
@@ -839,11 +839,11 @@ public class CHTurnCostTest {
         // 1-0
         // | |
         // 4-2o
-        graph.edge(1, 0, 802.964000, false);
-        graph.edge(1, 4, 615.195000, true);
-        graph.edge(2, 2, 181.788000, true);
-        graph.edge(0, 2, 191.996000, true);
-        graph.edge(2, 4, 527.821000, false);
+        GHUtility.setProperties(graph.edge(1, 0).setDistance(802.964000), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 4).setDistance(615.195000), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 2).setDistance(181.788000), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(0, 2).setDistance(191.996000), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 4).setDistance(527.821000), encoder, 60, true, false);
         setRestriction(0, 2, 4);
         setTurnCost(0, 2, 2, 3);
         setTurnCost(2, 2, 4, 4);
@@ -867,11 +867,11 @@ public class CHTurnCostTest {
         na.setNode(2, 49.404004, 9.709110);
         na.setNode(3, 49.400160, 9.708787);
         na.setNode(4, 49.400883, 9.706347);
-        EdgeIteratorState edge0 = graph.edge(4, 3, 194.063000, true);
-        EdgeIteratorState edge1 = graph.edge(1, 2, 525.106000, true);
-        EdgeIteratorState edge2 = graph.edge(1, 2, 525.106000, true);
-        EdgeIteratorState edge3 = graph.edge(4, 1, 703.778000, false);
-        EdgeIteratorState edge4 = graph.edge(2, 4, 400.509000, true);
+        EdgeIteratorState edge0 = GHUtility.setProperties(graph.edge(4, 3).setDistance(194.063000), encoder, 60, true, true);
+        EdgeIteratorState edge1 = GHUtility.setProperties(graph.edge(1, 2).setDistance(525.106000), encoder, 60, true, true);
+        EdgeIteratorState edge2 = GHUtility.setProperties(graph.edge(1, 2).setDistance(525.106000), encoder, 60, true, true);
+        EdgeIteratorState edge3 = GHUtility.setProperties(graph.edge(4, 1).setDistance(703.778000), encoder, 60, true, false);
+        EdgeIteratorState edge4 = GHUtility.setProperties(graph.edge(2, 4).setDistance(400.509000), encoder, 60, true, true);
         // cannot go 4-2-1 and 1-2-4 (at least when using edge1, there is still edge2!)
         setRestriction(edge4, edge1, 2);
         setRestriction(edge1, edge4, 2);
@@ -923,11 +923,11 @@ public class CHTurnCostTest {
         na.setNode(0, 0.1, 0.1);
         na.setNode(5, 0.1, 0.2);
         na.setNode(4, 0.1, 0.3);
-        EdgeIteratorState edge0 = graph.edge(3, 1, 10, true);
-        EdgeIteratorState edge1 = graph.edge(2, 3, 10, true);
-        graph.edge(3, 0, 10, true);
-        graph.edge(0, 5, 10, true);
-        graph.edge(5, 4, 10, true);
+        EdgeIteratorState edge0 = GHUtility.setProperties(graph.edge(3, 1).setDistance(10), encoder, 60, true, true);
+        EdgeIteratorState edge1 = GHUtility.setProperties(graph.edge(2, 3).setDistance(10), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(3, 0).setDistance(10), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(0, 5).setDistance(10), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(5, 4).setDistance(10), encoder, 60, true, true);
         // cannot go, 2-3-1
         setRestriction(edge1, edge0, 3);
         graph.freeze();
@@ -956,8 +956,8 @@ public class CHTurnCostTest {
     public void testRouteViaVirtualNode(String algo) {
         //   3
         // 0-x-1-2
-        graph.edge(0, 1, 0, false);
-        graph.edge(1, 2, 0, false);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(0), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(0), encoder, 60, true, false);
         updateDistancesFor(graph, 0, 0.00, 0.00);
         updateDistancesFor(graph, 1, 0.02, 0.02);
         updateDistancesFor(graph, 2, 0.03, 0.03);
@@ -983,9 +983,9 @@ public class CHTurnCostTest {
         // 0-x-1
         //  \  |
         //   \-2
-        graph.edge(0, 1, 1, true);
-        graph.edge(1, 2, 1, true);
-        graph.edge(2, 0, 1, true);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 0).setDistance(1), encoder, 60, true, true);
         updateDistancesFor(graph, 0, 0.01, 0.00);
         updateDistancesFor(graph, 1, 0.01, 0.02);
         updateDistancesFor(graph, 2, 0.00, 0.02);
@@ -1011,12 +1011,12 @@ public class CHTurnCostTest {
         // 4->3->2->1-x-0
         //          |
         //          5->6
-        graph.edge(4, 3, 0, false);
-        graph.edge(3, 2, 0, false);
-        graph.edge(2, 1, 0, false);
-        graph.edge(1, 0, 0, true);
-        graph.edge(1, 5, 0, false);
-        graph.edge(5, 6, 0, false);
+        GHUtility.setProperties(graph.edge(4, 3).setDistance(0), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 2).setDistance(0), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 1).setDistance(0), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 0).setDistance(0), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 5).setDistance(0), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(5, 6).setDistance(0), encoder, 60, true, false);
         updateDistancesFor(graph, 4, 0.1, 0.0);
         updateDistancesFor(graph, 3, 0.1, 0.1);
         updateDistancesFor(graph, 2, 0.1, 0.2);
@@ -1076,7 +1076,8 @@ public class CHTurnCostTest {
     private void compareWithDijkstraOnRandomGraph(long seed) {
         final Random rnd = new Random(seed);
         // for larger graphs preparation takes much longer the higher the degree is!
-        GHUtility.buildRandomGraph(graph, rnd, 20, 3.0, true, true, encoder.getAverageSpeedEnc(), 0.7, 0.9, 0.8);
+        GHUtility.buildRandomGraph(graph, rnd, 20, 3.0, true, true,
+                encoder.getAccessEnc(), encoder.getAverageSpeedEnc(), 60d, 0.7, 0.9, 0.8);
         GHUtility.addRandomTurnCosts(graph, seed, encodingManager, encoder, maxCost, turnCostStorage);
         graph.freeze();
         checkStrict = false;
@@ -1103,7 +1104,8 @@ public class CHTurnCostTest {
     }
 
     private void compareWithDijkstraOnRandomGraph_heuristic(long seed) {
-        GHUtility.buildRandomGraph(graph, new Random(seed), 20, 3.0, true, true, encoder.getAverageSpeedEnc(), 0.7, 0.9, 0.8);
+        GHUtility.buildRandomGraph(graph, new Random(seed), 20, 3.0, true, true,
+                encoder.getAccessEnc(), encoder.getAverageSpeedEnc(), 60d, 0.7, 0.9, 0.8);
         GHUtility.addRandomTurnCosts(graph, seed, encodingManager, encoder, maxCost, turnCostStorage);
         graph.freeze();
         checkStrict = false;

--- a/core/src/test/java/com/graphhopper/routing/ch/EdgeBasedNodeContractorTest.java
+++ b/core/src/test/java/com/graphhopper/routing/ch/EdgeBasedNodeContractorTest.java
@@ -84,12 +84,12 @@ public class EdgeBasedNodeContractorTest {
         //  6- 7-8
         //     |
         //     9
-        GHUtility.setProperties(graph.edge(6, 7).setDistance(2), encoder, 60, true, false);
-        final EdgeIteratorState edge7to8 = GHUtility.setProperties(graph.edge(7, 8).setDistance(2), encoder, 60, true, false);
-        final EdgeIteratorState edge8to3 = GHUtility.setProperties(graph.edge(8, 3).setDistance(1), encoder, 60, true, false);
-        final EdgeIteratorState edge3to2 = GHUtility.setProperties(graph.edge(3, 2).setDistance(2), encoder, 60, true, false);
-        final EdgeIteratorState edge2to7 = GHUtility.setProperties(graph.edge(2, 7).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(7, 9).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(6, 7).setDistance(2));
+        final EdgeIteratorState edge7to8 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(7, 8).setDistance(2));
+        final EdgeIteratorState edge8to3 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(8, 3).setDistance(1));
+        final EdgeIteratorState edge3to2 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 2).setDistance(2));
+        final EdgeIteratorState edge2to7 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 7).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(7, 9).setDistance(1));
         graph.freeze();
         setMaxLevelOnAllNodes();
 
@@ -112,13 +112,13 @@ public class EdgeBasedNodeContractorTest {
         // 2 -> 6 -> 3 -> 5 -> 4
         //      |    ^
         //      -> 0-|
-        final EdgeIteratorState e6to0 = GHUtility.setProperties(graph.edge(6, 0).setDistance(4), encoder, 60, true, false);
-        final EdgeIteratorState e0to3 = GHUtility.setProperties(graph.edge(0, 3).setDistance(5), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 6).setDistance(1), encoder, 60, true, false);
-        final EdgeIteratorState e6to3 = GHUtility.setProperties(graph.edge(6, 3).setDistance(1), encoder, 60, true, false);
-        final EdgeIteratorState e3to5 = GHUtility.setProperties(graph.edge(3, 5).setDistance(2), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 6).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(5, 4).setDistance(2), encoder, 60, true, false);
+        final EdgeIteratorState e6to0 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(6, 0).setDistance(4));
+        final EdgeIteratorState e0to3 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 3).setDistance(5));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 6).setDistance(1));
+        final EdgeIteratorState e6to3 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(6, 3).setDistance(1));
+        final EdgeIteratorState e3to5 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 5).setDistance(2));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 6).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(5, 4).setDistance(2));
         graph.freeze();
         setMaxLevelOnAllNodes();
         setRestriction(1, 6, 3);
@@ -139,11 +139,11 @@ public class EdgeBasedNodeContractorTest {
         //    /->0-->
         //   v       \
         //  4 <-----> 2 -> 3 -> 1
-        EdgeIteratorState e0to4 = GHUtility.setProperties(graph.edge(4, 0).setDistance(3), encoder, 60, true, true);
-        EdgeIteratorState e0to2 = GHUtility.setProperties(graph.edge(0, 2).setDistance(5), encoder, 60, true, false);
-        EdgeIteratorState e2to3 = GHUtility.setProperties(graph.edge(2, 3).setDistance(2), encoder, 60, true, false);
-        EdgeIteratorState e1to3 = GHUtility.setProperties(graph.edge(3, 1).setDistance(2), encoder, 60, true, false);
-        EdgeIteratorState e2to4 = GHUtility.setProperties(graph.edge(4, 2).setDistance(2), encoder, 60, true, true);
+        EdgeIteratorState e0to4 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 0).setDistance(3));
+        EdgeIteratorState e0to2 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 2).setDistance(5));
+        EdgeIteratorState e2to3 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 3).setDistance(2));
+        EdgeIteratorState e1to3 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 1).setDistance(2));
+        EdgeIteratorState e2to4 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 2).setDistance(2));
         graph.freeze();
 
         setMaxLevelOnAllNodes();
@@ -166,13 +166,13 @@ public class EdgeBasedNodeContractorTest {
         //  0-4-6
         //    |
         //    5-2
-        GHUtility.setProperties(graph.edge(1, 0).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(0, 4).setDistance(2), encoder, 60, true, false);
-        final EdgeIteratorState e4to6 = GHUtility.setProperties(graph.edge(4, 6).setDistance(2), encoder, 60, true, true);
-        final EdgeIteratorState e3to6 = GHUtility.setProperties(graph.edge(6, 3).setDistance(1), encoder, 60, true, true);
-        final EdgeIteratorState e3to4 = GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, true);
-        final EdgeIteratorState e4to5 = GHUtility.setProperties(graph.edge(4, 5).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(5, 2).setDistance(2), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 0).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 4).setDistance(2));
+        final EdgeIteratorState e4to6 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 6).setDistance(2));
+        final EdgeIteratorState e3to6 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(6, 3).setDistance(1));
+        final EdgeIteratorState e3to4 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 4).setDistance(1));
+        final EdgeIteratorState e4to5 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(4, 5).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(5, 2).setDistance(2));
         graph.freeze();
 
         // enforce loop (going counter-clockwise)
@@ -196,9 +196,9 @@ public class EdgeBasedNodeContractorTest {
     @Test
     public void testContractNode_twoNormalEdges_noSourceEdgeToConnect() {
         // 1 --> 0 --> 2 --> 3
-        GHUtility.setProperties(graph.edge(1, 0).setDistance(3), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(0, 2).setDistance(5), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 0).setDistance(3));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 2).setDistance(5));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 3).setDistance(1));
         graph.freeze();
         setMaxLevelOnAllNodes();
         contractNodes(0, 3, 1, 2);
@@ -211,9 +211,9 @@ public class EdgeBasedNodeContractorTest {
     @Test
     public void testContractNode_twoNormalEdges_noTargetEdgeToConnect() {
         // 3 --> 1 --> 0 --> 2
-        GHUtility.setProperties(graph.edge(3, 1).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 0).setDistance(3), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(0, 2).setDistance(5), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 0).setDistance(3));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 2).setDistance(5));
         graph.freeze();
         setMaxLevelOnAllNodes();
         contractNodes(0, 3, 1, 2);
@@ -226,10 +226,10 @@ public class EdgeBasedNodeContractorTest {
     @Test
     public void testContractNode_twoNormalEdges_noEdgesToConnectBecauseOfTurnRestrictions() {
         // 0 --> 3 --> 2 --> 4 --> 1
-        GHUtility.setProperties(graph.edge(0, 3).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 2).setDistance(3), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 4).setDistance(5), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(4, 1).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 2).setDistance(3));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 4).setDistance(5));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(4, 1).setDistance(1));
         setRestriction(0, 3, 2);
         setRestriction(2, 4, 1);
         graph.freeze();
@@ -242,10 +242,10 @@ public class EdgeBasedNodeContractorTest {
     @Test
     public void testContractNode_twoNormalEdges_noTurncosts() {
         // 0 --> 3 --> 2 --> 4 --> 1
-        GHUtility.setProperties(graph.edge(0, 3).setDistance(1), encoder, 60, true, false);
-        final EdgeIteratorState e3to2 = GHUtility.setProperties(graph.edge(3, 2).setDistance(3), encoder, 60, true, false);
-        final EdgeIteratorState e2to4 = GHUtility.setProperties(graph.edge(2, 4).setDistance(5), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(4, 1).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 3).setDistance(1));
+        final EdgeIteratorState e3to2 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 2).setDistance(3));
+        final EdgeIteratorState e2to4 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 4).setDistance(5));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(4, 1).setDistance(1));
         graph.freeze();
         setMaxLevelOnAllNodes();
         EdgeBasedNodeContractor nodeContractor = createNodeContractor();
@@ -265,10 +265,10 @@ public class EdgeBasedNodeContractorTest {
     @Test
     public void testContractNode_twoNormalEdges_noShortcuts() {
         // 0 --> 1 --> 2 --> 3 --> 4
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(3), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(5), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 2).setDistance(3));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 3).setDistance(5));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 4).setDistance(1));
         graph.freeze();
         setMaxLevelOnAllNodes();
         contractAllNodesInOrder();
@@ -279,10 +279,10 @@ public class EdgeBasedNodeContractorTest {
     @Test
     public void testContractNode_twoNormalEdges_noOutgoingEdges() {
         // 0 --> 1 --> 2 <-- 3 <-- 4
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(3), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 2).setDistance(5), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(4, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 2).setDistance(3));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 2).setDistance(5));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(4, 3).setDistance(1));
         graph.freeze();
         setMaxLevelOnAllNodes();
         contractNodes(2, 0, 4, 1, 3);
@@ -292,10 +292,10 @@ public class EdgeBasedNodeContractorTest {
     @Test
     public void testContractNode_twoNormalEdges_noIncomingEdges() {
         // 0 <-- 1 <-- 2 --> 3 --> 4
-        GHUtility.setProperties(graph.edge(1, 0).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 1).setDistance(3), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(5), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 0).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 1).setDistance(3));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 3).setDistance(5));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 4).setDistance(1));
         graph.freeze();
         setMaxLevelOnAllNodes();
         contractNodes(2, 0, 4, 1, 3);
@@ -309,11 +309,11 @@ public class EdgeBasedNodeContractorTest {
 
         // 0 -> 1 -> 2 -> 3 -> 4
         //            \->/
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(2), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 3).setDistance(2));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 4).setDistance(1));
         graph.freeze();
         setMaxLevelOnAllNodes();
         contractNodes(2, 0, 4, 1, 3);
@@ -327,11 +327,11 @@ public class EdgeBasedNodeContractorTest {
     public void testContractNode_duplicateIncomingEdges_differentWeight() {
         // 0 -> 1 -> 2 -> 3 -> 4
         //       \->/
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(2), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 2).setDistance(2));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 4).setDistance(1));
         graph.freeze();
         setMaxLevelOnAllNodes();
         contractNodes(2, 0, 4, 1, 3);
@@ -349,11 +349,11 @@ public class EdgeBasedNodeContractorTest {
 
         // 0 -> 1 -> 2 -> 3 -> 4
         //            \->/
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 4).setDistance(1));
         graph.freeze();
         setMaxLevelOnAllNodes();
         contractNodes(2, 0, 4, 1, 3);
@@ -364,11 +364,11 @@ public class EdgeBasedNodeContractorTest {
     public void testContractNode_duplicateIncomingEdges_sameWeight() {
         // 0 -> 1 -> 2 -> 3 -> 4
         //       \->/
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 4).setDistance(1));
         graph.freeze();
         setMaxLevelOnAllNodes();
         contractNodes(2, 0, 4, 1, 3);
@@ -378,10 +378,10 @@ public class EdgeBasedNodeContractorTest {
     @Test
     public void testContractNode_twoNormalEdges_withTurnCost() {
         // 0 --> 3 --> 2 --> 4 --> 1
-        GHUtility.setProperties(graph.edge(0, 3).setDistance(1), encoder, 60, true, false);
-        final EdgeIteratorState e3to2 = GHUtility.setProperties(graph.edge(3, 2).setDistance(3), encoder, 60, true, false);
-        final EdgeIteratorState e2to4 = GHUtility.setProperties(graph.edge(2, 4).setDistance(5), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(4, 1).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 3).setDistance(1));
+        final EdgeIteratorState e3to2 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 2).setDistance(3));
+        final EdgeIteratorState e2to4 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 4).setDistance(5));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(4, 1).setDistance(1));
         setTurnCost(3, 2, 4, 4);
         graph.freeze();
         setMaxLevelOnAllNodes();
@@ -392,10 +392,10 @@ public class EdgeBasedNodeContractorTest {
     @Test
     public void testContractNode_twoNormalEdges_withTurnRestriction() {
         // 0 --> 3 --> 2 --> 4 --> 1
-        GHUtility.setProperties(graph.edge(0, 3).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 2).setDistance(3), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 4).setDistance(5), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(4, 1).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 2).setDistance(3));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 4).setDistance(5));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(4, 1).setDistance(1));
         setRestriction(3, 2, 4);
         graph.freeze();
         setMaxLevelOnAllNodes();
@@ -406,10 +406,10 @@ public class EdgeBasedNodeContractorTest {
     @Test
     public void testContractNode_twoNormalEdges_bidirectional() {
         // 0 -- 3 -- 2 -- 4 -- 1
-        GHUtility.setProperties(graph.edge(0, 3).setDistance(1), encoder, 60, true, true);
-        final EdgeIteratorState e3to2 = GHUtility.setProperties(graph.edge(3, 2).setDistance(3), encoder, 60, true, true);
-        final EdgeIteratorState e2to4 = GHUtility.setProperties(graph.edge(2, 4).setDistance(5), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(4, 1).setDistance(1), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 3).setDistance(1));
+        final EdgeIteratorState e3to2 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 2).setDistance(3));
+        final EdgeIteratorState e2to4 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 4).setDistance(5));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 1).setDistance(1));
         setTurnCost(e3to2, e2to4, 2, 4);
         setTurnCost(e2to4, e3to2, 2, 4);
         graph.freeze();
@@ -427,10 +427,10 @@ public class EdgeBasedNodeContractorTest {
     @Test
     public void testContractNode_twoNormalEdges_bidirectional_differentCosts() {
         // 0 -- 3 -- 2 -- 4 -- 1
-        GHUtility.setProperties(graph.edge(0, 3).setDistance(1), encoder, 60, true, true);
-        final EdgeIteratorState e2to3 = GHUtility.setProperties(graph.edge(3, 2).setDistance(3), encoder, 60, true, true);
-        final EdgeIteratorState e2to4 = GHUtility.setProperties(graph.edge(2, 4).setDistance(5), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(4, 1).setDistance(1), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 3).setDistance(1));
+        final EdgeIteratorState e2to3 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 2).setDistance(3));
+        final EdgeIteratorState e2to4 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 4).setDistance(5));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 1).setDistance(1));
         setTurnCost(e2to3, e2to4, 2, 4);
         setTurnCost(e2to4, e2to3, 2, 7);
         graph.freeze();
@@ -445,9 +445,9 @@ public class EdgeBasedNodeContractorTest {
     @Test
     public void testContractNode_multiple_bidirectional_linear() {
         // 3 -- 2 -- 1 -- 4
-        GHUtility.setProperties(graph.edge(3, 2).setDistance(2), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 1).setDistance(3), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 4).setDistance(6), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 2).setDistance(2));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 1).setDistance(3));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 4).setDistance(6));
         graph.freeze();
         setMaxLevelOnAllNodes();
 
@@ -470,11 +470,11 @@ public class EdgeBasedNodeContractorTest {
         //            />\
         //            \ /
         // 0 --> 3 --> 2 --> 4 --> 1
-        GHUtility.setProperties(graph.edge(0, 3).setDistance(1), encoder, 60, true, false);
-        final EdgeIteratorState e3to2 = GHUtility.setProperties(graph.edge(3, 2).setDistance(3), encoder, 60, true, false);
-        final EdgeIteratorState e2to2 = GHUtility.setProperties(graph.edge(2, 2).setDistance(2), encoder, 60, true, false);
-        final EdgeIteratorState e2to4 = GHUtility.setProperties(graph.edge(2, 4).setDistance(5), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(4, 1).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 3).setDistance(1));
+        final EdgeIteratorState e3to2 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 2).setDistance(3));
+        final EdgeIteratorState e2to2 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 2).setDistance(2));
+        final EdgeIteratorState e2to4 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 4).setDistance(5));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(4, 1).setDistance(1));
 
         setTurnCost(e3to2, e2to2, 2, 2);
         setTurnCost(e2to2, e2to4, 2, 1);
@@ -501,12 +501,12 @@ public class EdgeBasedNodeContractorTest {
         // 2 -> 7 -> 3 -> 5 -> 6
         //           |
         //     1 <-> 4
-        final EdgeIteratorState e7to3 = GHUtility.setProperties(graph.edge(7, 3).setDistance(1), encoder, 60, true, false);
-        final EdgeIteratorState e3to5 = GHUtility.setProperties(graph.edge(3, 5).setDistance(1), encoder, 60, true, false);
-        final EdgeIteratorState e3to4 = GHUtility.setProperties(graph.edge(3, 4).setDistance(2), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 7).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(5, 6).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 4).setDistance(1), encoder, 60, true, true);
+        final EdgeIteratorState e7to3 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(7, 3).setDistance(1));
+        final EdgeIteratorState e3to5 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 5).setDistance(1));
+        final EdgeIteratorState e3to4 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 4).setDistance(2));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 7).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(5, 6).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 4).setDistance(1));
         graph.freeze();
         setMaxLevelOnAllNodes();
         setRestriction(7, 3, 5);
@@ -576,19 +576,19 @@ public class EdgeBasedNodeContractorTest {
     // 9--7 5 8--10
     private class GraphWithTwoLoops {
         final int centerNode = 6;
-        final EdgeIteratorState e0to1 = GHUtility.setProperties(graph.edge(0, 1).setDistance(3), encoder, 60, true, false);
-        final EdgeIteratorState e1to6 = GHUtility.setProperties(graph.edge(1, 6).setDistance(2), encoder, 60, true, false);
-        final EdgeIteratorState e6to0 = GHUtility.setProperties(graph.edge(6, 0).setDistance(4), encoder, 60, true, false);
-        final EdgeIteratorState e2to3 = GHUtility.setProperties(graph.edge(2, 3).setDistance(2), encoder, 60, true, false);
-        final EdgeIteratorState e3to6 = GHUtility.setProperties(graph.edge(3, 6).setDistance(7), encoder, 60, true, false);
-        final EdgeIteratorState e6to2 = GHUtility.setProperties(graph.edge(6, 2).setDistance(1), encoder, 60, true, false);
-        final EdgeIteratorState e7to6 = GHUtility.setProperties(graph.edge(7, 6).setDistance(1), encoder, 60, true, false);
-        final EdgeIteratorState e6to8 = GHUtility.setProperties(graph.edge(6, 8).setDistance(6), encoder, 60, true, false);
-        final EdgeIteratorState e9to7 = GHUtility.setProperties(graph.edge(9, 7).setDistance(2), encoder, 60, true, false);
-        final EdgeIteratorState e8to10 = GHUtility.setProperties(graph.edge(8, 10).setDistance(3), encoder, 60, true, false);
+        final EdgeIteratorState e0to1 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 1).setDistance(3));
+        final EdgeIteratorState e1to6 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 6).setDistance(2));
+        final EdgeIteratorState e6to0 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(6, 0).setDistance(4));
+        final EdgeIteratorState e2to3 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 3).setDistance(2));
+        final EdgeIteratorState e3to6 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 6).setDistance(7));
+        final EdgeIteratorState e6to2 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(6, 2).setDistance(1));
+        final EdgeIteratorState e7to6 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(7, 6).setDistance(1));
+        final EdgeIteratorState e6to8 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(6, 8).setDistance(6));
+        final EdgeIteratorState e9to7 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(9, 7).setDistance(2));
+        final EdgeIteratorState e8to10 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(8, 10).setDistance(3));
         // these two edges help to avoid loop avoidance for the left and right loops
-        final EdgeIteratorState e4to6 = GHUtility.setProperties(graph.edge(4, 6).setDistance(1), encoder, 60, true, false);
-        final EdgeIteratorState e5to6 = GHUtility.setProperties(graph.edge(5, 6).setDistance(1), encoder, 60, true, false);
+        final EdgeIteratorState e4to6 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(4, 6).setDistance(1));
+        final EdgeIteratorState e5to6 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(5, 6).setDistance(1));
         final int numEdges = 12;
 
         GraphWithTwoLoops(int turnCost70, int turnCost72, int turnCost12, int turnCost18, int turnCost38, int turnCost78) {
@@ -648,11 +648,11 @@ public class EdgeBasedNodeContractorTest {
     //     / \
     // 4--1---2--3
     private class GraphWithDetour {
-        private final EdgeIteratorState e4to1 = GHUtility.setProperties(graph.edge(4, 1).setDistance(2), encoder, 60, true, false);
-        private final EdgeIteratorState e1to0 = GHUtility.setProperties(graph.edge(1, 0).setDistance(4), encoder, 60, true, false);
-        private final EdgeIteratorState e1to2 = GHUtility.setProperties(graph.edge(1, 2).setDistance(3), encoder, 60, true, false);
-        private final EdgeIteratorState e0to2 = GHUtility.setProperties(graph.edge(0, 2).setDistance(3), encoder, 60, true, false);
-        private final EdgeIteratorState e2to3 = GHUtility.setProperties(graph.edge(2, 3).setDistance(2), encoder, 60, true, false);
+        private final EdgeIteratorState e4to1 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(4, 1).setDistance(2));
+        private final EdgeIteratorState e1to0 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 0).setDistance(4));
+        private final EdgeIteratorState e1to2 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 2).setDistance(3));
+        private final EdgeIteratorState e0to2 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 2).setDistance(3));
+        private final EdgeIteratorState e2to3 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 3).setDistance(2));
 
         GraphWithDetour(int turnCost42, int turnCost13, int turnCost40, int turnCost03) {
             setTurnCost(e4to1, e1to2, 1, turnCost42);
@@ -690,14 +690,14 @@ public class EdgeBasedNodeContractorTest {
     //  \ / \ /
     // 2-1-0-4-6
     private class GraphWithDetourMultipleInOutEdges {
-        final EdgeIteratorState e5to1 = GHUtility.setProperties(graph.edge(5, 1).setDistance(3), encoder, 60, true, false);
-        final EdgeIteratorState e2to1 = GHUtility.setProperties(graph.edge(2, 1).setDistance(2), encoder, 60, true, false);
-        final EdgeIteratorState e1to3 = GHUtility.setProperties(graph.edge(1, 3).setDistance(1), encoder, 60, true, false);
-        final EdgeIteratorState e3to4 = GHUtility.setProperties(graph.edge(3, 4).setDistance(2), encoder, 60, true, false);
-        final EdgeIteratorState e1to0 = GHUtility.setProperties(graph.edge(1, 0).setDistance(5), encoder, 60, true, false);
-        final EdgeIteratorState e0to4 = GHUtility.setProperties(graph.edge(0, 4).setDistance(2), encoder, 60, true, false);
-        final EdgeIteratorState e4to6 = GHUtility.setProperties(graph.edge(4, 6).setDistance(1), encoder, 60, true, false);
-        final EdgeIteratorState e4to7 = GHUtility.setProperties(graph.edge(4, 7).setDistance(3), encoder, 60, true, false);
+        final EdgeIteratorState e5to1 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(5, 1).setDistance(3));
+        final EdgeIteratorState e2to1 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 1).setDistance(2));
+        final EdgeIteratorState e1to3 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 3).setDistance(1));
+        final EdgeIteratorState e3to4 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 4).setDistance(2));
+        final EdgeIteratorState e1to0 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 0).setDistance(5));
+        final EdgeIteratorState e0to4 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 4).setDistance(2));
+        final EdgeIteratorState e4to6 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(4, 6).setDistance(1));
+        final EdgeIteratorState e4to7 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(4, 7).setDistance(3));
 
         GraphWithDetourMultipleInOutEdges(int turnCost20, int turnCost50, int turnCost23, int turnCost53, int turnCost36) {
             setTurnCost(e1to3, e3to4, 3, 2);
@@ -739,12 +739,12 @@ public class EdgeBasedNodeContractorTest {
     //     |
     //     5
     private class GraphWithLoop {
-        final EdgeIteratorState e0to1 = GHUtility.setProperties(graph.edge(0, 1).setDistance(2), encoder, 60, true, false);
-        final EdgeIteratorState e1to2 = GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
-        final EdgeIteratorState e2to0 = GHUtility.setProperties(graph.edge(2, 0).setDistance(1), encoder, 60, true, false);
-        final EdgeIteratorState e3to2 = GHUtility.setProperties(graph.edge(3, 2).setDistance(3), encoder, 60, true, false);
-        final EdgeIteratorState e2to4 = GHUtility.setProperties(graph.edge(2, 4).setDistance(5), encoder, 60, true, false);
-        final EdgeIteratorState e5to2 = GHUtility.setProperties(graph.edge(5, 2).setDistance(2), encoder, 60, true, false);
+        final EdgeIteratorState e0to1 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 1).setDistance(2));
+        final EdgeIteratorState e1to2 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 2).setDistance(1));
+        final EdgeIteratorState e2to0 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 0).setDistance(1));
+        final EdgeIteratorState e3to2 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 2).setDistance(3));
+        final EdgeIteratorState e2to4 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 4).setDistance(5));
+        final EdgeIteratorState e5to2 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(5, 2).setDistance(2));
 
         GraphWithLoop(int turnCost34) {
             setTurnCost(e3to2, e2to4, 2, turnCost34);
@@ -760,16 +760,16 @@ public class EdgeBasedNodeContractorTest {
         // 0 - 1   3 - 4   |
         //     |   |      /     
         //     5 - 9 ---- 
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(5), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 5).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(5, 9).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(9, 3).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 7).setDistance(6), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(9, 7).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(7, 10).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 3).setDistance(5));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 5).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(5, 9).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(9, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 7).setDistance(6));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(9, 7).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(7, 10).setDistance(1));
         graph.freeze();
         setMaxLevelOnAllNodes();
         contractNodes(2, 0, 10, 4, 1, 5, 7, 9, 3);
@@ -783,13 +783,13 @@ public class EdgeBasedNodeContractorTest {
         // 0 -> 1 -> 5 <_
         //      v    v   \
         //      2 -> 3 -> 4
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 5).setDistance(1), encoder, 60, true, false);
-        EdgeIteratorState e2to3 = GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
-        EdgeIteratorState e3to4 = GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(4, 5).setDistance(1), encoder, 60, true, false);
-        EdgeIteratorState e5to3 = GHUtility.setProperties(graph.edge(5, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 5).setDistance(1));
+        EdgeIteratorState e2to3 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 3).setDistance(1));
+        EdgeIteratorState e3to4 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(4, 5).setDistance(1));
+        EdgeIteratorState e5to3 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(5, 3).setDistance(1));
         graph.freeze();
         setMaxLevelOnAllNodes();
         contractNodes(3, 2, 0, 1, 5, 4);
@@ -811,14 +811,14 @@ public class EdgeBasedNodeContractorTest {
         // 0 --> 1 ---> 3 ---> 5 --> 6 
         //        \           /
         //         \--> 4 ---/   
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 3).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 4).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 5).setDistance(1), encoder, 60, true, true); // bidirectional
-        GHUtility.setProperties(graph.edge(3, 5).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(4, 5).setDistance(1), encoder, 60, true, true); // bidirectional
-        GHUtility.setProperties(graph.edge(5, 6).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 5).setDistance(1)); // bidirectional
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 5).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 5).setDistance(1)); // bidirectional
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(5, 6).setDistance(1));
         graph.freeze();
         setMaxLevelOnAllNodes();
         contractNodes(3, 0, 6, 1, 2, 5, 4);
@@ -842,14 +842,14 @@ public class EdgeBasedNodeContractorTest {
         // 0 --> 1 ---> 3 ---> 5 --> 6 
         //        \           /
         //         \--- 4 ->-/   
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, true); // bidirectional
-        GHUtility.setProperties(graph.edge(1, 3).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 4).setDistance(1), encoder, 60, true, true); // bidirectional
-        GHUtility.setProperties(graph.edge(2, 5).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 5).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(4, 5).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(5, 6).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(1)); // bidirectional
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 4).setDistance(1)); // bidirectional
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 5).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 5).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(4, 5).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(5, 6).setDistance(1));
         graph.freeze();
         setMaxLevelOnAllNodes();
         contractNodes(3, 0, 6, 1, 2, 5, 4);
@@ -870,12 +870,12 @@ public class EdgeBasedNodeContractorTest {
         // 0 -> 1 <-> 5
         //      v     v
         //      2 --> 3 -> 4
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, edge1to2bidirectional);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 5).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(5, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, edge1to2bidirectional, encoder, graph.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 5).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(5, 3).setDistance(1));
         graph.freeze();
         setMaxLevelOnAllNodes();
         contractNodes(2, 0, 1, 5, 4, 3);
@@ -889,12 +889,12 @@ public class EdgeBasedNodeContractorTest {
         // 0 -> 1 <-> 5
         //      v     v
         //      2 --> 3 -> 4
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 5).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(5, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 5).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(5, 3).setDistance(1));
         graph.freeze();
         setMaxLevelOnAllNodes();
         contractNodes(5, 0, 4, 1, 2, 3);
@@ -907,18 +907,18 @@ public class EdgeBasedNodeContractorTest {
         // 0 -> 1 -> 2 -> 3 -> 4 -> 5 -> 6 -> 7 -> 8
         //     /      \                 /      \
         //10 ->        ------> 9 ------>        -> 11
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(4, 5).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(5, 6).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(6, 7).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(7, 8).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 9).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(9, 6).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(10, 1).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(7, 11).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(4, 5).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(5, 6).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(6, 7).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(7, 8).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 9).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(9, 6).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(10, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(7, 11).setDistance(1));
         graph.freeze();
         setMaxLevelOnAllNodes();
         contractNodes(2, 6, 3, 5, 4, 0, 8, 10, 11, 1, 7, 9);
@@ -940,12 +940,12 @@ public class EdgeBasedNodeContractorTest {
         // 0 -> 1 -> 2 -> 3 -> 4
         //       \       /         
         //        -- 5 ->   
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 5).setDistance(3), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(5, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 5).setDistance(3));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(5, 3).setDistance(1));
         setTurnCost(2, 3, 4, 5);
         setTurnCost(5, 3, 4, 2);
         graph.freeze();
@@ -964,12 +964,12 @@ public class EdgeBasedNodeContractorTest {
         // 0 -> 1 -> 2 -> 3 -> 4 -> 5
         //       \        |
         //        ------->|
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 3).setDistance(4), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(4, 5).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 3).setDistance(4));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(4, 5).setDistance(1));
 
         graph.freeze();
         setMaxLevelOnAllNodes();
@@ -988,12 +988,12 @@ public class EdgeBasedNodeContractorTest {
         // 0 -> 1 -> 2 -> 3 -> 4 -> 5
         //           |        / 
         //           ------->
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(4, 5).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 4).setDistance(4), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(4, 5).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 4).setDistance(4));
 
         graph.freeze();
         setMaxLevelOnAllNodes();
@@ -1007,9 +1007,9 @@ public class EdgeBasedNodeContractorTest {
     public void testNodeContraction_parallelEdges_onlyOneLoopShortcutNeeded() {
         // 0 -- 1 -- 2
         //  \--/
-        EdgeIteratorState edge0 = GHUtility.setProperties(graph.edge(0, 1).setDistance(2), encoder, 60, true, true);
-        EdgeIteratorState edge1 = GHUtility.setProperties(graph.edge(1, 0).setDistance(4), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(5), encoder, 60, true, true);
+        EdgeIteratorState edge0 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(2));
+        EdgeIteratorState edge1 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 0).setDistance(4));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(5));
         setTurnCost(edge0, edge1, 0, 1);
         setTurnCost(edge1, edge0, 0, 2);
         graph.freeze();
@@ -1027,12 +1027,12 @@ public class EdgeBasedNodeContractorTest {
         // |\   |
         // | \  /        
         // -- 2 
-        GHUtility.setProperties(graph.edge(1, 3).setDistance(47), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 4).setDistance(19), encoder, 60, true, true);
-        EdgeIteratorState e2 = GHUtility.setProperties(graph.edge(2, 5).setDistance(38), encoder, 60, true, true);
-        EdgeIteratorState e3 = GHUtility.setProperties(graph.edge(2, 5).setDistance(57), encoder, 60, true, true); // note there is a duplicate edge here (with different weight)
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(10), encoder, 60, true, true);
-        EdgeIteratorState e5 = GHUtility.setProperties(graph.edge(4, 5).setDistance(56), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 3).setDistance(47));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 4).setDistance(19));
+        EdgeIteratorState e2 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 5).setDistance(38));
+        EdgeIteratorState e3 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 5).setDistance(57)); // note there is a duplicate edge here (with different weight)
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 4).setDistance(10));
+        EdgeIteratorState e5 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 5).setDistance(56));
 
         setTurnCost(e3, e2, 5, 4);
         setTurnCost(e2, e3, 5, 5);
@@ -1064,9 +1064,9 @@ public class EdgeBasedNodeContractorTest {
 
     @Test
     public void testNodeContraction_tripleConnection() {
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1.0), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(2.0), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(3.5), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(1.0));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(2.0));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(3.5));
         graph.freeze();
         setMaxLevelOnAllNodes();
         contractNodes(1, 0);
@@ -1084,10 +1084,10 @@ public class EdgeBasedNodeContractorTest {
         //    v   ^
         //     \ /
         //      2
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 1).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 3).setDistance(1));
         graph.freeze();
         setMaxLevelOnAllNodes();
         contractNodes(2, 0, 1, 3);
@@ -1101,11 +1101,11 @@ public class EdgeBasedNodeContractorTest {
         //  0-4-3
         //    |
         //    1
-        GHUtility.setProperties(graph.edge(0, 4).setDistance(2), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(4, 3).setDistance(2), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(3, 2).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 4).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(4, 1).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 4).setDistance(2));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 3).setDistance(2));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(4, 1).setDistance(1));
         graph.freeze();
         setMaxLevelOnAllNodes();
 
@@ -1131,11 +1131,11 @@ public class EdgeBasedNodeContractorTest {
         // 0-3-4
         //   |/
         //   2
-        GHUtility.setProperties(graph.edge(0, 3).setDistance(100), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(100), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(4, 2).setDistance(500), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(200), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 1).setDistance(100), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 3).setDistance(100));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 4).setDistance(100));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(4, 2).setDistance(500));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 3).setDistance(200));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 1).setDistance(100));
         graph.freeze();
         setMaxLevelOnAllNodes();
         setRestriction(0, 3, 1);
@@ -1151,11 +1151,11 @@ public class EdgeBasedNodeContractorTest {
         //  /\    /<-3
         // 0  1--2
         //  \/    \->4
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(5), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(6), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(2), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(3, 2).setDistance(3), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 4).setDistance(3), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(5));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(6));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(2));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 2).setDistance(3));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 4).setDistance(3));
         setRestriction(3, 2, 4);
         graph.freeze();
         setMaxLevelOnAllNodes();
@@ -1168,11 +1168,11 @@ public class EdgeBasedNodeContractorTest {
         //     ---
         //     \ /
         // 0 -- 1 -- 2 -- 3 -- 4
-        EdgeIteratorState edge0 = GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
-        EdgeIteratorState edge1 = GHUtility.setProperties(graph.edge(1, 1).setDistance(1), encoder, 60, true, false);
-        EdgeIteratorState edge2 = GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, true);
-        EdgeIteratorState edge3 = GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
-        EdgeIteratorState edge4 = GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
+        EdgeIteratorState edge0 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(1));
+        EdgeIteratorState edge1 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 1).setDistance(1));
+        EdgeIteratorState edge2 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(1));
+        EdgeIteratorState edge3 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 3).setDistance(1));
+        EdgeIteratorState edge4 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 4).setDistance(1));
         setRestriction(edge0, edge2, 1);
         graph.freeze();
         setMaxLevelOnAllNodes();
@@ -1188,10 +1188,10 @@ public class EdgeBasedNodeContractorTest {
     @Test
     public void testNodeContraction_minorWeightDeviation() {
         // 0 -> 1 -> 2 -> 3 -> 4
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(51.401), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(70.041), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(75.806), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(05.003), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 1).setDistance(51.401));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 2).setDistance(70.041));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 3).setDistance(75.806));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 4).setDistance(05.003));
         graph.freeze();
         setMaxLevelOnAllNodes();
         contractNodes(2, 0, 1, 3, 4);
@@ -1205,10 +1205,10 @@ public class EdgeBasedNodeContractorTest {
         // zero weight loops are quite a headache..., also see #1355
         //                  /|
         // 0 -> 1 -> 2 -> 3 --
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 3).setDistance(0), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 3).setDistance(0));
         graph.freeze();
         setMaxLevelOnAllNodes();
         contractNodes(2, 0, 1, 3);
@@ -1223,11 +1223,11 @@ public class EdgeBasedNodeContractorTest {
         // 0 -> 1 -> 2 -> 3 --
         //                |
         //                4
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 3).setDistance(0), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 3).setDistance(0));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 4).setDistance(1));
         graph.freeze();
         setMaxLevelOnAllNodes();
         contractNodes(2, 0, 1, 4, 3);
@@ -1241,11 +1241,11 @@ public class EdgeBasedNodeContractorTest {
         //                  /|
         // 0 -> 1 -> 2 -> 3 --
         //                  \|
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 3).setDistance(0), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 3).setDistance(0), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 3).setDistance(0));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 3).setDistance(0));
         graph.freeze();
         setMaxLevelOnAllNodes();
         contractNodes(2, 0, 1, 3);
@@ -1260,12 +1260,12 @@ public class EdgeBasedNodeContractorTest {
         // 0 -> 1 -> 2 -> 3 --
         //                | \|
         //                4
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 3).setDistance(0), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 3).setDistance(0), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 3).setDistance(0));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 3).setDistance(0));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 4).setDistance(1));
         graph.freeze();
         setMaxLevelOnAllNodes();
         contractNodes(2, 0, 1, 4, 3);
@@ -1280,12 +1280,12 @@ public class EdgeBasedNodeContractorTest {
         // 0 -> 1 -> 2 -> 3 --
         //                | \|
         //                4
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 3).setDistance(0), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 3).setDistance(0), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 3).setDistance(0));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 3).setDistance(0));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 4).setDistance(1));
         graph.freeze();
         setMaxLevelOnAllNodes();
         contractNodes(2, 0, 1, 4, 3);
@@ -1300,16 +1300,16 @@ public class EdgeBasedNodeContractorTest {
         // 0 -> 1 -> 2 -> 3 --
         //                | 
         //                4
-        GHUtility.setProperties(graph.edge(3, 3).setDistance(0), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 3).setDistance(0), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 3).setDistance(0), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 3).setDistance(0), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 3).setDistance(0), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 3).setDistance(0), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 3).setDistance(0));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 3).setDistance(0));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 3).setDistance(0));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 3).setDistance(0));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 3).setDistance(0));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 3).setDistance(0));
         graph.freeze();
         setMaxLevelOnAllNodes();
         contractNodes(2, 0, 1, 4, 3);
@@ -1324,14 +1324,14 @@ public class EdgeBasedNodeContractorTest {
         // 0 -> 1 -> 2 -> 3 --
         //                | 
         //                4
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
-        EdgeIteratorState edge2 = GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
-        EdgeIteratorState edge3 = GHUtility.setProperties(graph.edge(3, 3).setDistance(0), encoder, 60, true, false);
-        EdgeIteratorState edge4 = GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 2).setDistance(1));
+        EdgeIteratorState edge2 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 3).setDistance(1));
+        EdgeIteratorState edge3 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 3).setDistance(0));
+        EdgeIteratorState edge4 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 4).setDistance(1));
         // add a few more loops to make this test more difficult to pass
-        GHUtility.setProperties(graph.edge(3, 3).setDistance(0), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 3).setDistance(0), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 3).setDistance(0));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 3).setDistance(0));
         // we have to use the zero weight loop so it may not be excluded
         setTurnCost(edge2, edge3, 3, 5);
         setRestriction(edge2, edge4, 3);
@@ -1343,14 +1343,14 @@ public class EdgeBasedNodeContractorTest {
 
     @Test
     public void testNodeContraction_numPolledEdges() {
-        GHUtility.setProperties(graph.edge(3, 2).setDistance(71.203000), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(0, 3).setDistance(79.003000), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 0).setDistance(21.328000), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 4).setDistance(16.499000), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(4, 2).setDistance(16.487000), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(6, 1).setDistance(55.603000), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 1).setDistance(33.453000), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(4, 5).setDistance(29.665000), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 2).setDistance(71.203000));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 3).setDistance(79.003000));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 0).setDistance(21.328000));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 4).setDistance(16.499000));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(4, 2).setDistance(16.487000));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(6, 1).setDistance(55.603000));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 1).setDistance(33.453000));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(4, 5).setDistance(29.665000));
         graph.freeze();
         setMaxLevelOnAllNodes();
         EdgeBasedNodeContractor nodeContractor = createNodeContractor();

--- a/core/src/test/java/com/graphhopper/routing/ch/EdgeBasedNodeContractorTest.java
+++ b/core/src/test/java/com/graphhopper/routing/ch/EdgeBasedNodeContractorTest.java
@@ -84,12 +84,12 @@ public class EdgeBasedNodeContractorTest {
         //  6- 7-8
         //     |
         //     9
-        graph.edge(6, 7, 2, false);
-        final EdgeIteratorState edge7to8 = graph.edge(7, 8, 2, false);
-        final EdgeIteratorState edge8to3 = graph.edge(8, 3, 1, false);
-        final EdgeIteratorState edge3to2 = graph.edge(3, 2, 2, false);
-        final EdgeIteratorState edge2to7 = graph.edge(2, 7, 1, false);
-        graph.edge(7, 9, 1, false);
+        GHUtility.setProperties(graph.edge(6, 7).setDistance(2), encoder, 60, true, false);
+        final EdgeIteratorState edge7to8 = GHUtility.setProperties(graph.edge(7, 8).setDistance(2), encoder, 60, true, false);
+        final EdgeIteratorState edge8to3 = GHUtility.setProperties(graph.edge(8, 3).setDistance(1), encoder, 60, true, false);
+        final EdgeIteratorState edge3to2 = GHUtility.setProperties(graph.edge(3, 2).setDistance(2), encoder, 60, true, false);
+        final EdgeIteratorState edge2to7 = GHUtility.setProperties(graph.edge(2, 7).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(7, 9).setDistance(1), encoder, 60, true, false);
         graph.freeze();
         setMaxLevelOnAllNodes();
 
@@ -112,13 +112,13 @@ public class EdgeBasedNodeContractorTest {
         // 2 -> 6 -> 3 -> 5 -> 4
         //      |    ^
         //      -> 0-|
-        final EdgeIteratorState e6to0 = graph.edge(6, 0, 4, false);
-        final EdgeIteratorState e0to3 = graph.edge(0, 3, 5, false);
-        graph.edge(1, 6, 1, false);
-        final EdgeIteratorState e6to3 = graph.edge(6, 3, 1, false);
-        final EdgeIteratorState e3to5 = graph.edge(3, 5, 2, false);
-        graph.edge(2, 6, 1, false);
-        graph.edge(5, 4, 2, false);
+        final EdgeIteratorState e6to0 = GHUtility.setProperties(graph.edge(6, 0).setDistance(4), encoder, 60, true, false);
+        final EdgeIteratorState e0to3 = GHUtility.setProperties(graph.edge(0, 3).setDistance(5), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 6).setDistance(1), encoder, 60, true, false);
+        final EdgeIteratorState e6to3 = GHUtility.setProperties(graph.edge(6, 3).setDistance(1), encoder, 60, true, false);
+        final EdgeIteratorState e3to5 = GHUtility.setProperties(graph.edge(3, 5).setDistance(2), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 6).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(5, 4).setDistance(2), encoder, 60, true, false);
         graph.freeze();
         setMaxLevelOnAllNodes();
         setRestriction(1, 6, 3);
@@ -139,11 +139,11 @@ public class EdgeBasedNodeContractorTest {
         //    /->0-->
         //   v       \
         //  4 <-----> 2 -> 3 -> 1
-        EdgeIteratorState e0to4 = graph.edge(4, 0, 3, true);
-        EdgeIteratorState e0to2 = graph.edge(0, 2, 5, false);
-        EdgeIteratorState e2to3 = graph.edge(2, 3, 2, false);
-        EdgeIteratorState e1to3 = graph.edge(3, 1, 2, false);
-        EdgeIteratorState e2to4 = graph.edge(4, 2, 2, true);
+        EdgeIteratorState e0to4 = GHUtility.setProperties(graph.edge(4, 0).setDistance(3), encoder, 60, true, true);
+        EdgeIteratorState e0to2 = GHUtility.setProperties(graph.edge(0, 2).setDistance(5), encoder, 60, true, false);
+        EdgeIteratorState e2to3 = GHUtility.setProperties(graph.edge(2, 3).setDistance(2), encoder, 60, true, false);
+        EdgeIteratorState e1to3 = GHUtility.setProperties(graph.edge(3, 1).setDistance(2), encoder, 60, true, false);
+        EdgeIteratorState e2to4 = GHUtility.setProperties(graph.edge(4, 2).setDistance(2), encoder, 60, true, true);
         graph.freeze();
 
         setMaxLevelOnAllNodes();
@@ -166,13 +166,13 @@ public class EdgeBasedNodeContractorTest {
         //  0-4-6
         //    |
         //    5-2
-        graph.edge(1, 0, 1, false);
-        graph.edge(0, 4, 2, false);
-        final EdgeIteratorState e4to6 = graph.edge(4, 6, 2, true);
-        final EdgeIteratorState e3to6 = graph.edge(6, 3, 1, true);
-        final EdgeIteratorState e3to4 = graph.edge(3, 4, 1, true);
-        final EdgeIteratorState e4to5 = graph.edge(4, 5, 1, false);
-        graph.edge(5, 2, 2, false);
+        GHUtility.setProperties(graph.edge(1, 0).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(0, 4).setDistance(2), encoder, 60, true, false);
+        final EdgeIteratorState e4to6 = GHUtility.setProperties(graph.edge(4, 6).setDistance(2), encoder, 60, true, true);
+        final EdgeIteratorState e3to6 = GHUtility.setProperties(graph.edge(6, 3).setDistance(1), encoder, 60, true, true);
+        final EdgeIteratorState e3to4 = GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, true);
+        final EdgeIteratorState e4to5 = GHUtility.setProperties(graph.edge(4, 5).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(5, 2).setDistance(2), encoder, 60, true, false);
         graph.freeze();
 
         // enforce loop (going counter-clockwise)
@@ -196,9 +196,9 @@ public class EdgeBasedNodeContractorTest {
     @Test
     public void testContractNode_twoNormalEdges_noSourceEdgeToConnect() {
         // 1 --> 0 --> 2 --> 3
-        graph.edge(1, 0, 3, false);
-        graph.edge(0, 2, 5, false);
-        graph.edge(2, 3, 1, false);
+        GHUtility.setProperties(graph.edge(1, 0).setDistance(3), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(0, 2).setDistance(5), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
         graph.freeze();
         setMaxLevelOnAllNodes();
         contractNodes(0, 3, 1, 2);
@@ -211,9 +211,9 @@ public class EdgeBasedNodeContractorTest {
     @Test
     public void testContractNode_twoNormalEdges_noTargetEdgeToConnect() {
         // 3 --> 1 --> 0 --> 2
-        graph.edge(3, 1, 1, false);
-        graph.edge(1, 0, 3, false);
-        graph.edge(0, 2, 5, false);
+        GHUtility.setProperties(graph.edge(3, 1).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 0).setDistance(3), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(0, 2).setDistance(5), encoder, 60, true, false);
         graph.freeze();
         setMaxLevelOnAllNodes();
         contractNodes(0, 3, 1, 2);
@@ -226,10 +226,10 @@ public class EdgeBasedNodeContractorTest {
     @Test
     public void testContractNode_twoNormalEdges_noEdgesToConnectBecauseOfTurnRestrictions() {
         // 0 --> 3 --> 2 --> 4 --> 1
-        graph.edge(0, 3, 1, false);
-        graph.edge(3, 2, 3, false);
-        graph.edge(2, 4, 5, false);
-        graph.edge(4, 1, 1, false);
+        GHUtility.setProperties(graph.edge(0, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 2).setDistance(3), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 4).setDistance(5), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(4, 1).setDistance(1), encoder, 60, true, false);
         setRestriction(0, 3, 2);
         setRestriction(2, 4, 1);
         graph.freeze();
@@ -242,10 +242,10 @@ public class EdgeBasedNodeContractorTest {
     @Test
     public void testContractNode_twoNormalEdges_noTurncosts() {
         // 0 --> 3 --> 2 --> 4 --> 1
-        graph.edge(0, 3, 1, false);
-        final EdgeIteratorState e3to2 = graph.edge(3, 2, 3, false);
-        final EdgeIteratorState e2to4 = graph.edge(2, 4, 5, false);
-        graph.edge(4, 1, 1, false);
+        GHUtility.setProperties(graph.edge(0, 3).setDistance(1), encoder, 60, true, false);
+        final EdgeIteratorState e3to2 = GHUtility.setProperties(graph.edge(3, 2).setDistance(3), encoder, 60, true, false);
+        final EdgeIteratorState e2to4 = GHUtility.setProperties(graph.edge(2, 4).setDistance(5), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(4, 1).setDistance(1), encoder, 60, true, false);
         graph.freeze();
         setMaxLevelOnAllNodes();
         EdgeBasedNodeContractor nodeContractor = createNodeContractor();
@@ -265,10 +265,10 @@ public class EdgeBasedNodeContractorTest {
     @Test
     public void testContractNode_twoNormalEdges_noShortcuts() {
         // 0 --> 1 --> 2 --> 3 --> 4
-        graph.edge(0, 1, 1, false);
-        graph.edge(1, 2, 3, false);
-        graph.edge(2, 3, 5, false);
-        graph.edge(3, 4, 1, false);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(3), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(5), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
         graph.freeze();
         setMaxLevelOnAllNodes();
         contractAllNodesInOrder();
@@ -279,10 +279,10 @@ public class EdgeBasedNodeContractorTest {
     @Test
     public void testContractNode_twoNormalEdges_noOutgoingEdges() {
         // 0 --> 1 --> 2 <-- 3 <-- 4
-        graph.edge(0, 1, 1, false);
-        graph.edge(1, 2, 3, false);
-        graph.edge(3, 2, 5, false);
-        graph.edge(4, 3, 1, false);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(3), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 2).setDistance(5), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(4, 3).setDistance(1), encoder, 60, true, false);
         graph.freeze();
         setMaxLevelOnAllNodes();
         contractNodes(2, 0, 4, 1, 3);
@@ -292,10 +292,10 @@ public class EdgeBasedNodeContractorTest {
     @Test
     public void testContractNode_twoNormalEdges_noIncomingEdges() {
         // 0 <-- 1 <-- 2 --> 3 --> 4
-        graph.edge(1, 0, 1, false);
-        graph.edge(2, 1, 3, false);
-        graph.edge(2, 3, 5, false);
-        graph.edge(3, 4, 1, false);
+        GHUtility.setProperties(graph.edge(1, 0).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 1).setDistance(3), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(5), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
         graph.freeze();
         setMaxLevelOnAllNodes();
         contractNodes(2, 0, 4, 1, 3);
@@ -309,11 +309,11 @@ public class EdgeBasedNodeContractorTest {
 
         // 0 -> 1 -> 2 -> 3 -> 4
         //            \->/
-        graph.edge(0, 1, 1, false);
-        graph.edge(1, 2, 1, false);
-        graph.edge(2, 3, 2, false);
-        graph.edge(2, 3, 1, false);
-        graph.edge(3, 4, 1, false);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(2), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
         graph.freeze();
         setMaxLevelOnAllNodes();
         contractNodes(2, 0, 4, 1, 3);
@@ -327,11 +327,11 @@ public class EdgeBasedNodeContractorTest {
     public void testContractNode_duplicateIncomingEdges_differentWeight() {
         // 0 -> 1 -> 2 -> 3 -> 4
         //       \->/
-        graph.edge(0, 1, 1, false);
-        graph.edge(1, 2, 2, false);
-        graph.edge(1, 2, 1, false);
-        graph.edge(2, 3, 1, false);
-        graph.edge(3, 4, 1, false);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(2), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
         graph.freeze();
         setMaxLevelOnAllNodes();
         contractNodes(2, 0, 4, 1, 3);
@@ -349,11 +349,11 @@ public class EdgeBasedNodeContractorTest {
 
         // 0 -> 1 -> 2 -> 3 -> 4
         //            \->/
-        graph.edge(0, 1, 1, false);
-        graph.edge(1, 2, 1, false);
-        graph.edge(2, 3, 1, false);
-        graph.edge(2, 3, 1, false);
-        graph.edge(3, 4, 1, false);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
         graph.freeze();
         setMaxLevelOnAllNodes();
         contractNodes(2, 0, 4, 1, 3);
@@ -364,11 +364,11 @@ public class EdgeBasedNodeContractorTest {
     public void testContractNode_duplicateIncomingEdges_sameWeight() {
         // 0 -> 1 -> 2 -> 3 -> 4
         //       \->/
-        graph.edge(0, 1, 1, false);
-        graph.edge(1, 2, 1, false);
-        graph.edge(1, 2, 1, false);
-        graph.edge(2, 3, 1, false);
-        graph.edge(3, 4, 1, false);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
         graph.freeze();
         setMaxLevelOnAllNodes();
         contractNodes(2, 0, 4, 1, 3);
@@ -378,10 +378,10 @@ public class EdgeBasedNodeContractorTest {
     @Test
     public void testContractNode_twoNormalEdges_withTurnCost() {
         // 0 --> 3 --> 2 --> 4 --> 1
-        graph.edge(0, 3, 1, false);
-        final EdgeIteratorState e3to2 = graph.edge(3, 2, 3, false);
-        final EdgeIteratorState e2to4 = graph.edge(2, 4, 5, false);
-        graph.edge(4, 1, 1, false);
+        GHUtility.setProperties(graph.edge(0, 3).setDistance(1), encoder, 60, true, false);
+        final EdgeIteratorState e3to2 = GHUtility.setProperties(graph.edge(3, 2).setDistance(3), encoder, 60, true, false);
+        final EdgeIteratorState e2to4 = GHUtility.setProperties(graph.edge(2, 4).setDistance(5), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(4, 1).setDistance(1), encoder, 60, true, false);
         setTurnCost(3, 2, 4, 4);
         graph.freeze();
         setMaxLevelOnAllNodes();
@@ -392,10 +392,10 @@ public class EdgeBasedNodeContractorTest {
     @Test
     public void testContractNode_twoNormalEdges_withTurnRestriction() {
         // 0 --> 3 --> 2 --> 4 --> 1
-        graph.edge(0, 3, 1, false);
-        graph.edge(3, 2, 3, false);
-        graph.edge(2, 4, 5, false);
-        graph.edge(4, 1, 1, false);
+        GHUtility.setProperties(graph.edge(0, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 2).setDistance(3), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 4).setDistance(5), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(4, 1).setDistance(1), encoder, 60, true, false);
         setRestriction(3, 2, 4);
         graph.freeze();
         setMaxLevelOnAllNodes();
@@ -406,10 +406,10 @@ public class EdgeBasedNodeContractorTest {
     @Test
     public void testContractNode_twoNormalEdges_bidirectional() {
         // 0 -- 3 -- 2 -- 4 -- 1
-        graph.edge(0, 3, 1, true);
-        final EdgeIteratorState e3to2 = graph.edge(3, 2, 3, true);
-        final EdgeIteratorState e2to4 = graph.edge(2, 4, 5, true);
-        graph.edge(4, 1, 1, true);
+        GHUtility.setProperties(graph.edge(0, 3).setDistance(1), encoder, 60, true, true);
+        final EdgeIteratorState e3to2 = GHUtility.setProperties(graph.edge(3, 2).setDistance(3), encoder, 60, true, true);
+        final EdgeIteratorState e2to4 = GHUtility.setProperties(graph.edge(2, 4).setDistance(5), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(4, 1).setDistance(1), encoder, 60, true, true);
         setTurnCost(e3to2, e2to4, 2, 4);
         setTurnCost(e2to4, e3to2, 2, 4);
         graph.freeze();
@@ -427,10 +427,10 @@ public class EdgeBasedNodeContractorTest {
     @Test
     public void testContractNode_twoNormalEdges_bidirectional_differentCosts() {
         // 0 -- 3 -- 2 -- 4 -- 1
-        graph.edge(0, 3, 1, true);
-        final EdgeIteratorState e2to3 = graph.edge(3, 2, 3, true);
-        final EdgeIteratorState e2to4 = graph.edge(2, 4, 5, true);
-        graph.edge(4, 1, 1, true);
+        GHUtility.setProperties(graph.edge(0, 3).setDistance(1), encoder, 60, true, true);
+        final EdgeIteratorState e2to3 = GHUtility.setProperties(graph.edge(3, 2).setDistance(3), encoder, 60, true, true);
+        final EdgeIteratorState e2to4 = GHUtility.setProperties(graph.edge(2, 4).setDistance(5), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(4, 1).setDistance(1), encoder, 60, true, true);
         setTurnCost(e2to3, e2to4, 2, 4);
         setTurnCost(e2to4, e2to3, 2, 7);
         graph.freeze();
@@ -445,9 +445,9 @@ public class EdgeBasedNodeContractorTest {
     @Test
     public void testContractNode_multiple_bidirectional_linear() {
         // 3 -- 2 -- 1 -- 4
-        graph.edge(3, 2, 2, true);
-        graph.edge(2, 1, 3, true);
-        graph.edge(1, 4, 6, true);
+        GHUtility.setProperties(graph.edge(3, 2).setDistance(2), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 1).setDistance(3), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 4).setDistance(6), encoder, 60, true, true);
         graph.freeze();
         setMaxLevelOnAllNodes();
 
@@ -470,11 +470,11 @@ public class EdgeBasedNodeContractorTest {
         //            />\
         //            \ /
         // 0 --> 3 --> 2 --> 4 --> 1
-        graph.edge(0, 3, 1, false);
-        final EdgeIteratorState e3to2 = graph.edge(3, 2, 3, false);
-        final EdgeIteratorState e2to2 = graph.edge(2, 2, 2, false);
-        final EdgeIteratorState e2to4 = graph.edge(2, 4, 5, false);
-        graph.edge(4, 1, 1, false);
+        GHUtility.setProperties(graph.edge(0, 3).setDistance(1), encoder, 60, true, false);
+        final EdgeIteratorState e3to2 = GHUtility.setProperties(graph.edge(3, 2).setDistance(3), encoder, 60, true, false);
+        final EdgeIteratorState e2to2 = GHUtility.setProperties(graph.edge(2, 2).setDistance(2), encoder, 60, true, false);
+        final EdgeIteratorState e2to4 = GHUtility.setProperties(graph.edge(2, 4).setDistance(5), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(4, 1).setDistance(1), encoder, 60, true, false);
 
         setTurnCost(e3to2, e2to2, 2, 2);
         setTurnCost(e2to2, e2to4, 2, 1);
@@ -501,12 +501,12 @@ public class EdgeBasedNodeContractorTest {
         // 2 -> 7 -> 3 -> 5 -> 6
         //           |
         //     1 <-> 4
-        final EdgeIteratorState e7to3 = graph.edge(7, 3, 1, false);
-        final EdgeIteratorState e3to5 = graph.edge(3, 5, 1, false);
-        final EdgeIteratorState e3to4 = graph.edge(3, 4, 2, true);
-        graph.edge(2, 7, 1, false);
-        graph.edge(5, 6, 1, false);
-        graph.edge(1, 4, 1, true);
+        final EdgeIteratorState e7to3 = GHUtility.setProperties(graph.edge(7, 3).setDistance(1), encoder, 60, true, false);
+        final EdgeIteratorState e3to5 = GHUtility.setProperties(graph.edge(3, 5).setDistance(1), encoder, 60, true, false);
+        final EdgeIteratorState e3to4 = GHUtility.setProperties(graph.edge(3, 4).setDistance(2), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 7).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(5, 6).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 4).setDistance(1), encoder, 60, true, true);
         graph.freeze();
         setMaxLevelOnAllNodes();
         setRestriction(7, 3, 5);
@@ -576,19 +576,19 @@ public class EdgeBasedNodeContractorTest {
     // 9--7 5 8--10
     private class GraphWithTwoLoops {
         final int centerNode = 6;
-        final EdgeIteratorState e0to1 = graph.edge(0, 1, 3, false);
-        final EdgeIteratorState e1to6 = graph.edge(1, 6, 2, false);
-        final EdgeIteratorState e6to0 = graph.edge(6, 0, 4, false);
-        final EdgeIteratorState e2to3 = graph.edge(2, 3, 2, false);
-        final EdgeIteratorState e3to6 = graph.edge(3, 6, 7, false);
-        final EdgeIteratorState e6to2 = graph.edge(6, 2, 1, false);
-        final EdgeIteratorState e7to6 = graph.edge(7, 6, 1, false);
-        final EdgeIteratorState e6to8 = graph.edge(6, 8, 6, false);
-        final EdgeIteratorState e9to7 = graph.edge(9, 7, 2, false);
-        final EdgeIteratorState e8to10 = graph.edge(8, 10, 3, false);
+        final EdgeIteratorState e0to1 = GHUtility.setProperties(graph.edge(0, 1).setDistance(3), encoder, 60, true, false);
+        final EdgeIteratorState e1to6 = GHUtility.setProperties(graph.edge(1, 6).setDistance(2), encoder, 60, true, false);
+        final EdgeIteratorState e6to0 = GHUtility.setProperties(graph.edge(6, 0).setDistance(4), encoder, 60, true, false);
+        final EdgeIteratorState e2to3 = GHUtility.setProperties(graph.edge(2, 3).setDistance(2), encoder, 60, true, false);
+        final EdgeIteratorState e3to6 = GHUtility.setProperties(graph.edge(3, 6).setDistance(7), encoder, 60, true, false);
+        final EdgeIteratorState e6to2 = GHUtility.setProperties(graph.edge(6, 2).setDistance(1), encoder, 60, true, false);
+        final EdgeIteratorState e7to6 = GHUtility.setProperties(graph.edge(7, 6).setDistance(1), encoder, 60, true, false);
+        final EdgeIteratorState e6to8 = GHUtility.setProperties(graph.edge(6, 8).setDistance(6), encoder, 60, true, false);
+        final EdgeIteratorState e9to7 = GHUtility.setProperties(graph.edge(9, 7).setDistance(2), encoder, 60, true, false);
+        final EdgeIteratorState e8to10 = GHUtility.setProperties(graph.edge(8, 10).setDistance(3), encoder, 60, true, false);
         // these two edges help to avoid loop avoidance for the left and right loops
-        final EdgeIteratorState e4to6 = graph.edge(4, 6, 1, false);
-        final EdgeIteratorState e5to6 = graph.edge(5, 6, 1, false);
+        final EdgeIteratorState e4to6 = GHUtility.setProperties(graph.edge(4, 6).setDistance(1), encoder, 60, true, false);
+        final EdgeIteratorState e5to6 = GHUtility.setProperties(graph.edge(5, 6).setDistance(1), encoder, 60, true, false);
         final int numEdges = 12;
 
         GraphWithTwoLoops(int turnCost70, int turnCost72, int turnCost12, int turnCost18, int turnCost38, int turnCost78) {
@@ -648,11 +648,11 @@ public class EdgeBasedNodeContractorTest {
     //     / \
     // 4--1---2--3
     private class GraphWithDetour {
-        private final EdgeIteratorState e4to1 = graph.edge(4, 1, 2, false);
-        private final EdgeIteratorState e1to0 = graph.edge(1, 0, 4, false);
-        private final EdgeIteratorState e1to2 = graph.edge(1, 2, 3, false);
-        private final EdgeIteratorState e0to2 = graph.edge(0, 2, 3, false);
-        private final EdgeIteratorState e2to3 = graph.edge(2, 3, 2, false);
+        private final EdgeIteratorState e4to1 = GHUtility.setProperties(graph.edge(4, 1).setDistance(2), encoder, 60, true, false);
+        private final EdgeIteratorState e1to0 = GHUtility.setProperties(graph.edge(1, 0).setDistance(4), encoder, 60, true, false);
+        private final EdgeIteratorState e1to2 = GHUtility.setProperties(graph.edge(1, 2).setDistance(3), encoder, 60, true, false);
+        private final EdgeIteratorState e0to2 = GHUtility.setProperties(graph.edge(0, 2).setDistance(3), encoder, 60, true, false);
+        private final EdgeIteratorState e2to3 = GHUtility.setProperties(graph.edge(2, 3).setDistance(2), encoder, 60, true, false);
 
         GraphWithDetour(int turnCost42, int turnCost13, int turnCost40, int turnCost03) {
             setTurnCost(e4to1, e1to2, 1, turnCost42);
@@ -690,14 +690,14 @@ public class EdgeBasedNodeContractorTest {
     //  \ / \ /
     // 2-1-0-4-6
     private class GraphWithDetourMultipleInOutEdges {
-        final EdgeIteratorState e5to1 = graph.edge(5, 1, 3, false);
-        final EdgeIteratorState e2to1 = graph.edge(2, 1, 2, false);
-        final EdgeIteratorState e1to3 = graph.edge(1, 3, 1, false);
-        final EdgeIteratorState e3to4 = graph.edge(3, 4, 2, false);
-        final EdgeIteratorState e1to0 = graph.edge(1, 0, 5, false);
-        final EdgeIteratorState e0to4 = graph.edge(0, 4, 2, false);
-        final EdgeIteratorState e4to6 = graph.edge(4, 6, 1, false);
-        final EdgeIteratorState e4to7 = graph.edge(4, 7, 3, false);
+        final EdgeIteratorState e5to1 = GHUtility.setProperties(graph.edge(5, 1).setDistance(3), encoder, 60, true, false);
+        final EdgeIteratorState e2to1 = GHUtility.setProperties(graph.edge(2, 1).setDistance(2), encoder, 60, true, false);
+        final EdgeIteratorState e1to3 = GHUtility.setProperties(graph.edge(1, 3).setDistance(1), encoder, 60, true, false);
+        final EdgeIteratorState e3to4 = GHUtility.setProperties(graph.edge(3, 4).setDistance(2), encoder, 60, true, false);
+        final EdgeIteratorState e1to0 = GHUtility.setProperties(graph.edge(1, 0).setDistance(5), encoder, 60, true, false);
+        final EdgeIteratorState e0to4 = GHUtility.setProperties(graph.edge(0, 4).setDistance(2), encoder, 60, true, false);
+        final EdgeIteratorState e4to6 = GHUtility.setProperties(graph.edge(4, 6).setDistance(1), encoder, 60, true, false);
+        final EdgeIteratorState e4to7 = GHUtility.setProperties(graph.edge(4, 7).setDistance(3), encoder, 60, true, false);
 
         GraphWithDetourMultipleInOutEdges(int turnCost20, int turnCost50, int turnCost23, int turnCost53, int turnCost36) {
             setTurnCost(e1to3, e3to4, 3, 2);
@@ -739,12 +739,12 @@ public class EdgeBasedNodeContractorTest {
     //     |
     //     5
     private class GraphWithLoop {
-        final EdgeIteratorState e0to1 = graph.edge(0, 1, 2, false);
-        final EdgeIteratorState e1to2 = graph.edge(1, 2, 1, false);
-        final EdgeIteratorState e2to0 = graph.edge(2, 0, 1, false);
-        final EdgeIteratorState e3to2 = graph.edge(3, 2, 3, false);
-        final EdgeIteratorState e2to4 = graph.edge(2, 4, 5, false);
-        final EdgeIteratorState e5to2 = graph.edge(5, 2, 2, false);
+        final EdgeIteratorState e0to1 = GHUtility.setProperties(graph.edge(0, 1).setDistance(2), encoder, 60, true, false);
+        final EdgeIteratorState e1to2 = GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
+        final EdgeIteratorState e2to0 = GHUtility.setProperties(graph.edge(2, 0).setDistance(1), encoder, 60, true, false);
+        final EdgeIteratorState e3to2 = GHUtility.setProperties(graph.edge(3, 2).setDistance(3), encoder, 60, true, false);
+        final EdgeIteratorState e2to4 = GHUtility.setProperties(graph.edge(2, 4).setDistance(5), encoder, 60, true, false);
+        final EdgeIteratorState e5to2 = GHUtility.setProperties(graph.edge(5, 2).setDistance(2), encoder, 60, true, false);
 
         GraphWithLoop(int turnCost34) {
             setTurnCost(e3to2, e2to4, 2, turnCost34);
@@ -760,16 +760,16 @@ public class EdgeBasedNodeContractorTest {
         // 0 - 1   3 - 4   |
         //     |   |      /     
         //     5 - 9 ---- 
-        graph.edge(0, 1, 1, false);
-        graph.edge(1, 2, 1, false);
-        graph.edge(2, 3, 5, false);
-        graph.edge(3, 4, 1, false);
-        graph.edge(1, 5, 1, false);
-        graph.edge(5, 9, 1, false);
-        graph.edge(9, 3, 1, false);
-        graph.edge(2, 7, 6, false);
-        graph.edge(9, 7, 1, false);
-        graph.edge(7, 10, 1, false);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(5), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 5).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(5, 9).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(9, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 7).setDistance(6), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(9, 7).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(7, 10).setDistance(1), encoder, 60, true, false);
         graph.freeze();
         setMaxLevelOnAllNodes();
         contractNodes(2, 0, 10, 4, 1, 5, 7, 9, 3);
@@ -783,13 +783,13 @@ public class EdgeBasedNodeContractorTest {
         // 0 -> 1 -> 5 <_
         //      v    v   \
         //      2 -> 3 -> 4
-        graph.edge(0, 1, 1, false);
-        graph.edge(1, 2, 1, false);
-        graph.edge(1, 5, 1, false);
-        EdgeIteratorState e2to3 = graph.edge(2, 3, 1, false);
-        EdgeIteratorState e3to4 = graph.edge(3, 4, 1, false);
-        graph.edge(4, 5, 1, false);
-        EdgeIteratorState e5to3 = graph.edge(5, 3, 1, false);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 5).setDistance(1), encoder, 60, true, false);
+        EdgeIteratorState e2to3 = GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
+        EdgeIteratorState e3to4 = GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(4, 5).setDistance(1), encoder, 60, true, false);
+        EdgeIteratorState e5to3 = GHUtility.setProperties(graph.edge(5, 3).setDistance(1), encoder, 60, true, false);
         graph.freeze();
         setMaxLevelOnAllNodes();
         contractNodes(3, 2, 0, 1, 5, 4);
@@ -811,14 +811,14 @@ public class EdgeBasedNodeContractorTest {
         // 0 --> 1 ---> 3 ---> 5 --> 6 
         //        \           /
         //         \--> 4 ---/   
-        graph.edge(0, 1, 1, false);
-        graph.edge(1, 2, 1, false);
-        graph.edge(1, 3, 1, false);
-        graph.edge(1, 4, 1, false);
-        graph.edge(2, 5, 1, true); // bidirectional
-        graph.edge(3, 5, 1, false);
-        graph.edge(4, 5, 1, true); // bidirectional
-        graph.edge(5, 6, 1, false);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 4).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 5).setDistance(1), encoder, 60, true, true); // bidirectional
+        GHUtility.setProperties(graph.edge(3, 5).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(4, 5).setDistance(1), encoder, 60, true, true); // bidirectional
+        GHUtility.setProperties(graph.edge(5, 6).setDistance(1), encoder, 60, true, false);
         graph.freeze();
         setMaxLevelOnAllNodes();
         contractNodes(3, 0, 6, 1, 2, 5, 4);
@@ -842,14 +842,14 @@ public class EdgeBasedNodeContractorTest {
         // 0 --> 1 ---> 3 ---> 5 --> 6 
         //        \           /
         //         \--- 4 ->-/   
-        graph.edge(0, 1, 1, false);
-        graph.edge(1, 2, 1, true); // bidirectional
-        graph.edge(1, 3, 1, false);
-        graph.edge(1, 4, 1, true); // bidirectional
-        graph.edge(2, 5, 1, false);
-        graph.edge(3, 5, 1, false);
-        graph.edge(4, 5, 1, false);
-        graph.edge(5, 6, 1, false);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, true); // bidirectional
+        GHUtility.setProperties(graph.edge(1, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 4).setDistance(1), encoder, 60, true, true); // bidirectional
+        GHUtility.setProperties(graph.edge(2, 5).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 5).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(4, 5).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(5, 6).setDistance(1), encoder, 60, true, false);
         graph.freeze();
         setMaxLevelOnAllNodes();
         contractNodes(3, 0, 6, 1, 2, 5, 4);
@@ -870,12 +870,12 @@ public class EdgeBasedNodeContractorTest {
         // 0 -> 1 <-> 5
         //      v     v
         //      2 --> 3 -> 4
-        graph.edge(0, 1, 1, false);
-        graph.edge(1, 2, 1, edge1to2bidirectional);
-        graph.edge(2, 3, 1, false);
-        graph.edge(3, 4, 1, false);
-        graph.edge(1, 5, 1, true);
-        graph.edge(5, 3, 1, false);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, edge1to2bidirectional);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 5).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(5, 3).setDistance(1), encoder, 60, true, false);
         graph.freeze();
         setMaxLevelOnAllNodes();
         contractNodes(2, 0, 1, 5, 4, 3);
@@ -889,12 +889,12 @@ public class EdgeBasedNodeContractorTest {
         // 0 -> 1 <-> 5
         //      v     v
         //      2 --> 3 -> 4
-        graph.edge(0, 1, 1, false);
-        graph.edge(1, 2, 1, false);
-        graph.edge(2, 3, 1, false);
-        graph.edge(3, 4, 1, false);
-        graph.edge(1, 5, 1, true);
-        graph.edge(5, 3, 1, false);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 5).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(5, 3).setDistance(1), encoder, 60, true, false);
         graph.freeze();
         setMaxLevelOnAllNodes();
         contractNodes(5, 0, 4, 1, 2, 3);
@@ -907,18 +907,18 @@ public class EdgeBasedNodeContractorTest {
         // 0 -> 1 -> 2 -> 3 -> 4 -> 5 -> 6 -> 7 -> 8
         //     /      \                 /      \
         //10 ->        ------> 9 ------>        -> 11
-        graph.edge(0, 1, 1, false);
-        graph.edge(1, 2, 1, false);
-        graph.edge(2, 3, 1, false);
-        graph.edge(3, 4, 1, false);
-        graph.edge(4, 5, 1, false);
-        graph.edge(5, 6, 1, false);
-        graph.edge(6, 7, 1, false);
-        graph.edge(7, 8, 1, false);
-        graph.edge(2, 9, 1, false);
-        graph.edge(9, 6, 1, false);
-        graph.edge(10, 1, 1, false);
-        graph.edge(7, 11, 1, false);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(4, 5).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(5, 6).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(6, 7).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(7, 8).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 9).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(9, 6).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(10, 1).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(7, 11).setDistance(1), encoder, 60, true, false);
         graph.freeze();
         setMaxLevelOnAllNodes();
         contractNodes(2, 6, 3, 5, 4, 0, 8, 10, 11, 1, 7, 9);
@@ -940,12 +940,12 @@ public class EdgeBasedNodeContractorTest {
         // 0 -> 1 -> 2 -> 3 -> 4
         //       \       /         
         //        -- 5 ->   
-        graph.edge(0, 1, 1, false);
-        graph.edge(1, 2, 1, false);
-        graph.edge(2, 3, 1, false);
-        graph.edge(3, 4, 1, false);
-        graph.edge(1, 5, 3, false);
-        graph.edge(5, 3, 1, false);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 5).setDistance(3), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(5, 3).setDistance(1), encoder, 60, true, false);
         setTurnCost(2, 3, 4, 5);
         setTurnCost(5, 3, 4, 2);
         graph.freeze();
@@ -964,12 +964,12 @@ public class EdgeBasedNodeContractorTest {
         // 0 -> 1 -> 2 -> 3 -> 4 -> 5
         //       \        |
         //        ------->|
-        graph.edge(0, 1, 1, false);
-        graph.edge(1, 2, 1, false);
-        graph.edge(2, 3, 1, false);
-        graph.edge(3, 4, 1, false);
-        graph.edge(1, 3, 4, false);
-        graph.edge(4, 5, 1, false);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 3).setDistance(4), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(4, 5).setDistance(1), encoder, 60, true, false);
 
         graph.freeze();
         setMaxLevelOnAllNodes();
@@ -988,12 +988,12 @@ public class EdgeBasedNodeContractorTest {
         // 0 -> 1 -> 2 -> 3 -> 4 -> 5
         //           |        / 
         //           ------->
-        graph.edge(0, 1, 1, false);
-        graph.edge(1, 2, 1, false);
-        graph.edge(2, 3, 1, false);
-        graph.edge(3, 4, 1, false);
-        graph.edge(4, 5, 1, false);
-        graph.edge(2, 4, 4, false);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(4, 5).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 4).setDistance(4), encoder, 60, true, false);
 
         graph.freeze();
         setMaxLevelOnAllNodes();
@@ -1007,9 +1007,9 @@ public class EdgeBasedNodeContractorTest {
     public void testNodeContraction_parallelEdges_onlyOneLoopShortcutNeeded() {
         // 0 -- 1 -- 2
         //  \--/
-        EdgeIteratorState edge0 = graph.edge(0, 1, 2, true);
-        EdgeIteratorState edge1 = graph.edge(1, 0, 4, true);
-        graph.edge(1, 2, 5, true);
+        EdgeIteratorState edge0 = GHUtility.setProperties(graph.edge(0, 1).setDistance(2), encoder, 60, true, true);
+        EdgeIteratorState edge1 = GHUtility.setProperties(graph.edge(1, 0).setDistance(4), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(5), encoder, 60, true, true);
         setTurnCost(edge0, edge1, 0, 1);
         setTurnCost(edge1, edge0, 0, 2);
         graph.freeze();
@@ -1027,12 +1027,12 @@ public class EdgeBasedNodeContractorTest {
         // |\   |
         // | \  /        
         // -- 2 
-        graph.edge(1, 3, 47, true);
-        graph.edge(2, 4, 19, true);
-        EdgeIteratorState e2 = graph.edge(2, 5, 38, true);
-        EdgeIteratorState e3 = graph.edge(2, 5, 57, true); // note there is a duplicate edge here (with different weight) 
-        graph.edge(3, 4, 10, true);
-        EdgeIteratorState e5 = graph.edge(4, 5, 56, true);
+        GHUtility.setProperties(graph.edge(1, 3).setDistance(47), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 4).setDistance(19), encoder, 60, true, true);
+        EdgeIteratorState e2 = GHUtility.setProperties(graph.edge(2, 5).setDistance(38), encoder, 60, true, true);
+        EdgeIteratorState e3 = GHUtility.setProperties(graph.edge(2, 5).setDistance(57), encoder, 60, true, true); // note there is a duplicate edge here (with different weight)
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(10), encoder, 60, true, true);
+        EdgeIteratorState e5 = GHUtility.setProperties(graph.edge(4, 5).setDistance(56), encoder, 60, true, true);
 
         setTurnCost(e3, e2, 5, 4);
         setTurnCost(e2, e3, 5, 5);
@@ -1064,9 +1064,9 @@ public class EdgeBasedNodeContractorTest {
 
     @Test
     public void testNodeContraction_tripleConnection() {
-        graph.edge(0, 1, 1.0, true);
-        graph.edge(0, 1, 2.0, true);
-        graph.edge(0, 1, 3.5, true);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1.0), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(2.0), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(3.5), encoder, 60, true, true);
         graph.freeze();
         setMaxLevelOnAllNodes();
         contractNodes(1, 0);
@@ -1084,10 +1084,10 @@ public class EdgeBasedNodeContractorTest {
         //    v   ^
         //     \ /
         //      2
-        graph.edge(0, 1, 1, false);
-        graph.edge(1, 2, 1, false);
-        graph.edge(2, 1, 1, false);
-        graph.edge(1, 3, 1, false);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 1).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 3).setDistance(1), encoder, 60, true, false);
         graph.freeze();
         setMaxLevelOnAllNodes();
         contractNodes(2, 0, 1, 3);
@@ -1101,11 +1101,11 @@ public class EdgeBasedNodeContractorTest {
         //  0-4-3
         //    |
         //    1
-        graph.edge(0, 4, 2, false);
-        graph.edge(4, 3, 2, true);
-        graph.edge(3, 2, 1, true);
-        graph.edge(2, 4, 1, true);
-        graph.edge(4, 1, 1, false);
+        GHUtility.setProperties(graph.edge(0, 4).setDistance(2), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(4, 3).setDistance(2), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(3, 2).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 4).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(4, 1).setDistance(1), encoder, 60, true, false);
         graph.freeze();
         setMaxLevelOnAllNodes();
 
@@ -1131,11 +1131,11 @@ public class EdgeBasedNodeContractorTest {
         // 0-3-4
         //   |/
         //   2
-        graph.edge(0, 3, 100, false);
-        graph.edge(3, 4, 100, true);
-        graph.edge(4, 2, 500, false);
-        graph.edge(2, 3, 200, false);
-        graph.edge(3, 1, 100, false);
+        GHUtility.setProperties(graph.edge(0, 3).setDistance(100), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(100), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(4, 2).setDistance(500), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(200), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 1).setDistance(100), encoder, 60, true, false);
         graph.freeze();
         setMaxLevelOnAllNodes();
         setRestriction(0, 3, 1);
@@ -1151,11 +1151,11 @@ public class EdgeBasedNodeContractorTest {
         //  /\    /<-3
         // 0  1--2
         //  \/    \->4
-        graph.edge(0, 1, 5, true);
-        graph.edge(0, 1, 6, true);
-        graph.edge(1, 2, 2, true);
-        graph.edge(3, 2, 3, false);
-        graph.edge(2, 4, 3, false);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(5), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(6), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(2), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(3, 2).setDistance(3), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 4).setDistance(3), encoder, 60, true, false);
         setRestriction(3, 2, 4);
         graph.freeze();
         setMaxLevelOnAllNodes();
@@ -1168,11 +1168,11 @@ public class EdgeBasedNodeContractorTest {
         //     ---
         //     \ /
         // 0 -- 1 -- 2 -- 3 -- 4
-        EdgeIteratorState edge0 = graph.edge(0, 1, 1, true);
-        EdgeIteratorState edge1 = graph.edge(1, 1, 1, false);
-        EdgeIteratorState edge2 = graph.edge(1, 2, 1, true);
-        EdgeIteratorState edge3 = graph.edge(2, 3, 1, false);
-        EdgeIteratorState edge4 = graph.edge(3, 4, 1, false);
+        EdgeIteratorState edge0 = GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
+        EdgeIteratorState edge1 = GHUtility.setProperties(graph.edge(1, 1).setDistance(1), encoder, 60, true, false);
+        EdgeIteratorState edge2 = GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, true);
+        EdgeIteratorState edge3 = GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
+        EdgeIteratorState edge4 = GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
         setRestriction(edge0, edge2, 1);
         graph.freeze();
         setMaxLevelOnAllNodes();
@@ -1188,10 +1188,10 @@ public class EdgeBasedNodeContractorTest {
     @Test
     public void testNodeContraction_minorWeightDeviation() {
         // 0 -> 1 -> 2 -> 3 -> 4
-        graph.edge(0, 1, 51.401, false);
-        graph.edge(1, 2, 70.041, false);
-        graph.edge(2, 3, 75.806, false);
-        graph.edge(3, 4, 05.003, false);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(51.401), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(70.041), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(75.806), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(05.003), encoder, 60, true, false);
         graph.freeze();
         setMaxLevelOnAllNodes();
         contractNodes(2, 0, 1, 3, 4);
@@ -1205,10 +1205,10 @@ public class EdgeBasedNodeContractorTest {
         // zero weight loops are quite a headache..., also see #1355
         //                  /|
         // 0 -> 1 -> 2 -> 3 --
-        graph.edge(0, 1, 1, false);
-        graph.edge(1, 2, 1, false);
-        graph.edge(2, 3, 1, false);
-        graph.edge(3, 3, 0, false);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 3).setDistance(0), encoder, 60, true, false);
         graph.freeze();
         setMaxLevelOnAllNodes();
         contractNodes(2, 0, 1, 3);
@@ -1223,11 +1223,11 @@ public class EdgeBasedNodeContractorTest {
         // 0 -> 1 -> 2 -> 3 --
         //                |
         //                4
-        graph.edge(0, 1, 1, false);
-        graph.edge(1, 2, 1, false);
-        graph.edge(2, 3, 1, false);
-        graph.edge(3, 3, 0, false);
-        graph.edge(3, 4, 1, false);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 3).setDistance(0), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
         graph.freeze();
         setMaxLevelOnAllNodes();
         contractNodes(2, 0, 1, 4, 3);
@@ -1241,11 +1241,11 @@ public class EdgeBasedNodeContractorTest {
         //                  /|
         // 0 -> 1 -> 2 -> 3 --
         //                  \|
-        graph.edge(0, 1, 1, false);
-        graph.edge(1, 2, 1, false);
-        graph.edge(2, 3, 1, false);
-        graph.edge(3, 3, 0, false);
-        graph.edge(3, 3, 0, false);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 3).setDistance(0), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 3).setDistance(0), encoder, 60, true, false);
         graph.freeze();
         setMaxLevelOnAllNodes();
         contractNodes(2, 0, 1, 3);
@@ -1260,12 +1260,12 @@ public class EdgeBasedNodeContractorTest {
         // 0 -> 1 -> 2 -> 3 --
         //                | \|
         //                4
-        graph.edge(0, 1, 1, false);
-        graph.edge(1, 2, 1, false);
-        graph.edge(2, 3, 1, false);
-        graph.edge(3, 3, 0, false);
-        graph.edge(3, 3, 0, false);
-        graph.edge(3, 4, 1, false);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 3).setDistance(0), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 3).setDistance(0), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
         graph.freeze();
         setMaxLevelOnAllNodes();
         contractNodes(2, 0, 1, 4, 3);
@@ -1280,12 +1280,12 @@ public class EdgeBasedNodeContractorTest {
         // 0 -> 1 -> 2 -> 3 --
         //                | \|
         //                4
-        graph.edge(0, 1, 1, false);
-        graph.edge(1, 2, 1, false);
-        graph.edge(3, 3, 0, false);
-        graph.edge(3, 3, 0, false);
-        graph.edge(2, 3, 1, false);
-        graph.edge(3, 4, 1, false);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 3).setDistance(0), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 3).setDistance(0), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
         graph.freeze();
         setMaxLevelOnAllNodes();
         contractNodes(2, 0, 1, 4, 3);
@@ -1300,16 +1300,16 @@ public class EdgeBasedNodeContractorTest {
         // 0 -> 1 -> 2 -> 3 --
         //                | 
         //                4
-        graph.edge(3, 3, 0, false);
-        graph.edge(0, 1, 1, false);
-        graph.edge(3, 3, 0, false);
-        graph.edge(1, 2, 1, false);
-        graph.edge(3, 3, 0, false);
-        graph.edge(2, 3, 1, false);
-        graph.edge(3, 3, 0, false);
-        graph.edge(3, 3, 0, false);
-        graph.edge(3, 4, 1, false);
-        graph.edge(3, 3, 0, false);
+        GHUtility.setProperties(graph.edge(3, 3).setDistance(0), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 3).setDistance(0), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 3).setDistance(0), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 3).setDistance(0), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 3).setDistance(0), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 3).setDistance(0), encoder, 60, true, false);
         graph.freeze();
         setMaxLevelOnAllNodes();
         contractNodes(2, 0, 1, 4, 3);
@@ -1324,14 +1324,14 @@ public class EdgeBasedNodeContractorTest {
         // 0 -> 1 -> 2 -> 3 --
         //                | 
         //                4
-        graph.edge(0, 1, 1, false);
-        graph.edge(1, 2, 1, false);
-        EdgeIteratorState edge2 = graph.edge(2, 3, 1, false);
-        EdgeIteratorState edge3 = graph.edge(3, 3, 0, false);
-        EdgeIteratorState edge4 = graph.edge(3, 4, 1, false);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
+        EdgeIteratorState edge2 = GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
+        EdgeIteratorState edge3 = GHUtility.setProperties(graph.edge(3, 3).setDistance(0), encoder, 60, true, false);
+        EdgeIteratorState edge4 = GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
         // add a few more loops to make this test more difficult to pass
-        graph.edge(3, 3, 0, false);
-        graph.edge(3, 3, 0, false);
+        GHUtility.setProperties(graph.edge(3, 3).setDistance(0), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 3).setDistance(0), encoder, 60, true, false);
         // we have to use the zero weight loop so it may not be excluded
         setTurnCost(edge2, edge3, 3, 5);
         setRestriction(edge2, edge4, 3);
@@ -1343,14 +1343,14 @@ public class EdgeBasedNodeContractorTest {
 
     @Test
     public void testNodeContraction_numPolledEdges() {
-        graph.edge(3, 2, 71.203000, false);
-        graph.edge(0, 3, 79.003000, false);
-        graph.edge(2, 0, 21.328000, false);
-        graph.edge(2, 4, 16.499000, false);
-        graph.edge(4, 2, 16.487000, false);
-        graph.edge(6, 1, 55.603000, false);
-        graph.edge(2, 1, 33.453000, false);
-        graph.edge(4, 5, 29.665000, false);
+        GHUtility.setProperties(graph.edge(3, 2).setDistance(71.203000), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(0, 3).setDistance(79.003000), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 0).setDistance(21.328000), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 4).setDistance(16.499000), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(4, 2).setDistance(16.487000), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(6, 1).setDistance(55.603000), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 1).setDistance(33.453000), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(4, 5).setDistance(29.665000), encoder, 60, true, false);
         graph.freeze();
         setMaxLevelOnAllNodes();
         EdgeBasedNodeContractor nodeContractor = createNodeContractor();

--- a/core/src/test/java/com/graphhopper/routing/ch/EdgeBasedWitnessPathSearcherTest.java
+++ b/core/src/test/java/com/graphhopper/routing/ch/EdgeBasedWitnessPathSearcherTest.java
@@ -20,11 +20,13 @@ package com.graphhopper.routing.ch;
 
 import com.graphhopper.routing.util.CarFlagEncoder;
 import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.CHGraph;
 import com.graphhopper.storage.GraphBuilder;
 import com.graphhopper.storage.GraphHopperStorage;
 import com.graphhopper.util.EdgeIterator;
+import com.graphhopper.util.GHUtility;
 import com.graphhopper.util.PMap;
 import org.junit.Before;
 import org.junit.Test;
@@ -37,10 +39,11 @@ public class EdgeBasedWitnessPathSearcherTest {
     private GraphHopperStorage graph;
     private CHGraph chGraph;
     private Weighting weighting;
+    private FlagEncoder encoder;
 
     @Before
     public void setup() {
-        CarFlagEncoder encoder = new CarFlagEncoder(5, 5, 10);
+        encoder = new CarFlagEncoder(5, 5, 10);
         EncodingManager encodingManager = EncodingManager.create(encoder);
         graph = new GraphBuilder(encodingManager)
                 .setCHConfigStrings("p|car|shortest|edge")
@@ -52,10 +55,10 @@ public class EdgeBasedWitnessPathSearcherTest {
     @Test
     public void test_shortcut_needed_basic() {
         // 0 -> 1 -> 2 -> 3 -> 4
-        graph.edge(0, 1, 1, false);
-        graph.edge(1, 2, 1, false);
-        graph.edge(2, 3, 1, false);
-        graph.edge(3, 4, 1, false);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
         graph.freeze();
         setMaxLevelOnAllNodes();
         EdgeBasedWitnessPathSearcher finder = createFinder();
@@ -70,10 +73,10 @@ public class EdgeBasedWitnessPathSearcherTest {
     @Test
     public void test_shortcut_needed_bidirectional() {
         // 0 -> 1 -> 2 -> 3 -> 4
-        graph.edge(0, 1, 1, true);
-        graph.edge(1, 2, 1, true);
-        graph.edge(2, 3, 1, true);
-        graph.edge(3, 4, 1, true);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, true);
         graph.freeze();
         setMaxLevelOnAllNodes();
         EdgeBasedWitnessPathSearcher finder = createFinder();
@@ -90,12 +93,12 @@ public class EdgeBasedWitnessPathSearcherTest {
         // 0 -> 1 -> 2 -> 3 -> 4
         //       \       /
         //        \> 5 >/
-        graph.edge(0, 1, 1, false);
-        graph.edge(1, 2, 1, false);
-        graph.edge(2, 3, 2, false);
-        graph.edge(3, 4, 1, false);
-        graph.edge(1, 5, 1, false);
-        graph.edge(5, 3, 1, false);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(2), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 5).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(5, 3).setDistance(1), encoder, 60, true, false);
         graph.freeze();
         setMaxLevelOnAllNodes();
         EdgeBasedWitnessPathSearcher finder = createFinder();
@@ -109,12 +112,12 @@ public class EdgeBasedWitnessPathSearcherTest {
         // 0 -> 1 -> 2 -> 3 -> 4
         //       \       /
         //        \> 5 >/
-        graph.edge(0, 1, 1, true);
-        graph.edge(1, 2, 1, true);
-        graph.edge(2, 3, 2, true);
-        graph.edge(3, 4, 1, true);
-        graph.edge(1, 5, 1, true);
-        graph.edge(5, 3, 1, true);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(2), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 5).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(5, 3).setDistance(1), encoder, 60, true, true);
         graph.freeze();
         setMaxLevelOnAllNodes();
         EdgeBasedWitnessPathSearcher finder = createFinder();

--- a/core/src/test/java/com/graphhopper/routing/ch/EdgeBasedWitnessPathSearcherTest.java
+++ b/core/src/test/java/com/graphhopper/routing/ch/EdgeBasedWitnessPathSearcherTest.java
@@ -55,10 +55,10 @@ public class EdgeBasedWitnessPathSearcherTest {
     @Test
     public void test_shortcut_needed_basic() {
         // 0 -> 1 -> 2 -> 3 -> 4
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 4).setDistance(1));
         graph.freeze();
         setMaxLevelOnAllNodes();
         EdgeBasedWitnessPathSearcher finder = createFinder();
@@ -73,10 +73,10 @@ public class EdgeBasedWitnessPathSearcherTest {
     @Test
     public void test_shortcut_needed_bidirectional() {
         // 0 -> 1 -> 2 -> 3 -> 4
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 4).setDistance(1));
         graph.freeze();
         setMaxLevelOnAllNodes();
         EdgeBasedWitnessPathSearcher finder = createFinder();
@@ -93,12 +93,12 @@ public class EdgeBasedWitnessPathSearcherTest {
         // 0 -> 1 -> 2 -> 3 -> 4
         //       \       /
         //        \> 5 >/
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(2), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 5).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(5, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 3).setDistance(2));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 5).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(5, 3).setDistance(1));
         graph.freeze();
         setMaxLevelOnAllNodes();
         EdgeBasedWitnessPathSearcher finder = createFinder();
@@ -112,12 +112,12 @@ public class EdgeBasedWitnessPathSearcherTest {
         // 0 -> 1 -> 2 -> 3 -> 4
         //       \       /
         //        \> 5 >/
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(2), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 5).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(5, 3).setDistance(1), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 3).setDistance(2));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 5).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(5, 3).setDistance(1));
         graph.freeze();
         setMaxLevelOnAllNodes();
         EdgeBasedWitnessPathSearcher finder = createFinder();

--- a/core/src/test/java/com/graphhopper/routing/ch/NodeBasedNodeContractorTest.java
+++ b/core/src/test/java/com/graphhopper/routing/ch/NodeBasedNodeContractorTest.java
@@ -82,17 +82,17 @@ public class NodeBasedNodeContractorTest {
         //4-3_1<-\ 10
         //     \_|/
         //   0___2_11
-        GHUtility.setProperties(graph.edge(0, 2).setDistance(2), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(10, 2).setDistance(2), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(11, 2).setDistance(2), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 2).setDistance(2));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(10, 2).setDistance(2));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(11, 2).setDistance(2));
         // create a longer one directional edge => no longish one-dir shortcut should be created
-        final EdgeIteratorState edge2to1bidirected = GHUtility.setProperties(graph.edge(2, 1).setDistance(2), encoder, 60, true, true);
-        final EdgeIteratorState edge2to1directed = GHUtility.setProperties(graph.edge(2, 1).setDistance(10), encoder, 60, true, false);
-        final EdgeIteratorState edge1to3 = GHUtility.setProperties(graph.edge(1, 3).setDistance(2), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(2), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(3, 5).setDistance(2), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(3, 6).setDistance(2), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(3, 7).setDistance(2), encoder, 60, true, true);
+        final EdgeIteratorState edge2to1bidirected = GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 1).setDistance(2));
+        final EdgeIteratorState edge2to1directed = GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 1).setDistance(10));
+        final EdgeIteratorState edge1to3 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 3).setDistance(2));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 4).setDistance(2));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 5).setDistance(2));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 6).setDistance(2));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 7).setDistance(2));
         graph.freeze();
 
         setMaxLevelOnAllNodes();
@@ -114,13 +114,13 @@ public class NodeBasedNodeContractorTest {
         // 1 -- 3 -- 4 ---> 5 ---> 6 -- 7
         //            \           /
         //             <--- 8 <--- 
-        final EdgeIteratorState iter1to3 = GHUtility.setProperties(graph.edge(1, 3).setDistance(1), encoder, 60, true, true);
-        final EdgeIteratorState iter3to4 = GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, true);
-        final EdgeIteratorState iter4to5 = GHUtility.setProperties(graph.edge(4, 5).setDistance(1), encoder, 60, true, false);
-        final EdgeIteratorState iter5to6 = GHUtility.setProperties(graph.edge(5, 6).setDistance(1), encoder, 60, true, false);
-        final EdgeIteratorState iter6to8 = GHUtility.setProperties(graph.edge(6, 8).setDistance(2), encoder, 60, true, false);
-        final EdgeIteratorState iter8to4 = GHUtility.setProperties(graph.edge(8, 4).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(6, 7).setDistance(1), encoder, 60, true, true);
+        final EdgeIteratorState iter1to3 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 3).setDistance(1));
+        final EdgeIteratorState iter3to4 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 4).setDistance(1));
+        final EdgeIteratorState iter4to5 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(4, 5).setDistance(1));
+        final EdgeIteratorState iter5to6 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(5, 6).setDistance(1));
+        final EdgeIteratorState iter6to8 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(6, 8).setDistance(2));
+        final EdgeIteratorState iter8to4 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(8, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(6, 7).setDistance(1));
         graph.freeze();
 
         contractInOrder(3, 5, 7, 8, 4, 1, 6);
@@ -151,9 +151,9 @@ public class NodeBasedNodeContractorTest {
         // where there are two roads from 1 to 2 and the directed road has a smaller weight. to get from 2 to 1 we
         // have to use the bidirectional edge despite the higher weight and therefore we need an extra shortcut for
         // this.
-        final EdgeIteratorState edge1to2bidirected = GHUtility.setProperties(graph.edge(1, 2).setDistance(2), encoder, 60, true, true);
-        final EdgeIteratorState edge1to2directed = GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
-        final EdgeIteratorState edge2to3 = GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, true);
+        final EdgeIteratorState edge1to2bidirected = GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(2));
+        final EdgeIteratorState edge1to2directed = GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 2).setDistance(1));
+        final EdgeIteratorState edge2to3 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 3).setDistance(1));
         graph.freeze();
         setMaxLevelOnAllNodes();
         if (reverse) {
@@ -174,8 +174,8 @@ public class NodeBasedNodeContractorTest {
     @Test
     public void testContractNode_directed_shortcutRequired() {
         // 0 --> 1 --> 2
-        final EdgeIteratorState edge1 = GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
-        final EdgeIteratorState edge2 = GHUtility.setProperties(graph.edge(1, 2).setDistance(2), encoder, 60, true, false);
+        final EdgeIteratorState edge1 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 1).setDistance(1));
+        final EdgeIteratorState edge2 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 2).setDistance(2));
         graph.freeze();
         setMaxLevelOnAllNodes();
         contractInOrder(1, 0, 2);
@@ -185,8 +185,8 @@ public class NodeBasedNodeContractorTest {
     @Test
     public void testContractNode_directed_shortcutRequired_reverse() {
         // 0 <-- 1 <-- 2
-        final EdgeIteratorState edge1 = GHUtility.setProperties(graph.edge(2, 1).setDistance(1), encoder, 60, true, false);
-        final EdgeIteratorState edge2 = GHUtility.setProperties(graph.edge(1, 0).setDistance(2), encoder, 60, true, false);
+        final EdgeIteratorState edge1 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 1).setDistance(1));
+        final EdgeIteratorState edge2 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 0).setDistance(2));
         graph.freeze();
         setMaxLevelOnAllNodes();
         contractInOrder(1, 2, 0);
@@ -196,8 +196,8 @@ public class NodeBasedNodeContractorTest {
     @Test
     public void testContractNode_bidirected_shortcutsRequired() {
         // 0 -- 1 -- 2
-        final EdgeIteratorState edge1 = GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
-        final EdgeIteratorState edge2 = GHUtility.setProperties(graph.edge(1, 2).setDistance(2), encoder, 60, true, true);
+        final EdgeIteratorState edge1 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(1));
+        final EdgeIteratorState edge2 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(2));
         graph.freeze();
         contractInOrder(1, 2, 0);
         checkShortcuts(expectedShortcut(2, 0, edge2, edge1, true, true));
@@ -207,9 +207,9 @@ public class NodeBasedNodeContractorTest {
     public void testContractNode_directed_withWitness() {
         // 0 --> 1 --> 2
         //  \_________/
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(2), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(0, 2).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 2).setDistance(2));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 2).setDistance(1));
         graph.freeze();
         setMaxLevelOnAllNodes();
         createNodeContractor().contractNode(1);
@@ -223,11 +223,11 @@ public class NodeBasedNodeContractorTest {
         //  \             /
         //   1 --> 2 --> 3
         double[] distances = {4.019, 1.006, 1.004, 1.006, 1.004};
-        GHUtility.setProperties(graph.edge(0, 4).setDistance(distances[0]), encoder, 60, true, false);
-        EdgeIteratorState edge1 = GHUtility.setProperties(graph.edge(0, 1).setDistance(distances[1]), encoder, 60, true, false);
-        EdgeIteratorState edge2 = GHUtility.setProperties(graph.edge(1, 2).setDistance(distances[2]), encoder, 60, true, false);
-        EdgeIteratorState edge3 = GHUtility.setProperties(graph.edge(2, 3).setDistance(distances[3]), encoder, 60, true, false);
-        EdgeIteratorState edge4 = GHUtility.setProperties(graph.edge(3, 4).setDistance(distances[4]), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 4).setDistance(distances[0]));
+        EdgeIteratorState edge1 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 1).setDistance(distances[1]));
+        EdgeIteratorState edge2 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 2).setDistance(distances[2]));
+        EdgeIteratorState edge3 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 3).setDistance(distances[3]));
+        EdgeIteratorState edge4 = GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 4).setDistance(distances[4]));
         graph.freeze();
         setMaxLevelOnAllNodes();
 
@@ -280,11 +280,11 @@ public class NodeBasedNodeContractorTest {
         //   1 --> 2 --> 3
         double fac = 60 / 3.6;
         double[] distances = {fac * 4.019, fac * 1.006, fac * 1.004, fac * 1.006, fac * 1.004};
-        GHUtility.setProperties(graph.edge(0, 4).setDistance(distances[0]), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(distances[1]), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(distances[2]), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(distances[3]), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(distances[4]), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 4).setDistance(distances[0]));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 1).setDistance(distances[1]));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 2).setDistance(distances[2]));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 3).setDistance(distances[3]));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 4).setDistance(distances[4]));
         graph.freeze();
         setMaxLevelOnAllNodes(lg);
 
@@ -315,11 +315,11 @@ public class NodeBasedNodeContractorTest {
         CHGraph lg = graph.getCHGraph();
         // 0 - 1 - 2 - 3
         // o           o
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(0, 0).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(3, 3).setDistance(1), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 0).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 3).setDistance(1));
 
         graph.freeze();
         setMaxLevelOnAllNodes(lg);

--- a/core/src/test/java/com/graphhopper/routing/ch/NodeBasedNodeContractorTest.java
+++ b/core/src/test/java/com/graphhopper/routing/ch/NodeBasedNodeContractorTest.java
@@ -33,6 +33,7 @@ import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.*;
 import com.graphhopper.util.CHEdgeIteratorState;
 import com.graphhopper.util.EdgeIteratorState;
+import com.graphhopper.util.GHUtility;
 import com.graphhopper.util.PMap;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -81,17 +82,17 @@ public class NodeBasedNodeContractorTest {
         //4-3_1<-\ 10
         //     \_|/
         //   0___2_11
-        graph.edge(0, 2, 2, true);
-        graph.edge(10, 2, 2, true);
-        graph.edge(11, 2, 2, true);
+        GHUtility.setProperties(graph.edge(0, 2).setDistance(2), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(10, 2).setDistance(2), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(11, 2).setDistance(2), encoder, 60, true, true);
         // create a longer one directional edge => no longish one-dir shortcut should be created
-        final EdgeIteratorState edge2to1bidirected = graph.edge(2, 1, 2, true);
-        final EdgeIteratorState edge2to1directed = graph.edge(2, 1, 10, false);
-        final EdgeIteratorState edge1to3 = graph.edge(1, 3, 2, true);
-        graph.edge(3, 4, 2, true);
-        graph.edge(3, 5, 2, true);
-        graph.edge(3, 6, 2, true);
-        graph.edge(3, 7, 2, true);
+        final EdgeIteratorState edge2to1bidirected = GHUtility.setProperties(graph.edge(2, 1).setDistance(2), encoder, 60, true, true);
+        final EdgeIteratorState edge2to1directed = GHUtility.setProperties(graph.edge(2, 1).setDistance(10), encoder, 60, true, false);
+        final EdgeIteratorState edge1to3 = GHUtility.setProperties(graph.edge(1, 3).setDistance(2), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(2), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(3, 5).setDistance(2), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(3, 6).setDistance(2), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(3, 7).setDistance(2), encoder, 60, true, true);
         graph.freeze();
 
         setMaxLevelOnAllNodes();
@@ -113,13 +114,13 @@ public class NodeBasedNodeContractorTest {
         // 1 -- 3 -- 4 ---> 5 ---> 6 -- 7
         //            \           /
         //             <--- 8 <--- 
-        final EdgeIteratorState iter1to3 = graph.edge(1, 3, 1, true);
-        final EdgeIteratorState iter3to4 = graph.edge(3, 4, 1, true);
-        final EdgeIteratorState iter4to5 = graph.edge(4, 5, 1, false);
-        final EdgeIteratorState iter5to6 = graph.edge(5, 6, 1, false);
-        final EdgeIteratorState iter6to8 = graph.edge(6, 8, 2, false);
-        final EdgeIteratorState iter8to4 = graph.edge(8, 4, 1, false);
-        graph.edge(6, 7, 1, true);
+        final EdgeIteratorState iter1to3 = GHUtility.setProperties(graph.edge(1, 3).setDistance(1), encoder, 60, true, true);
+        final EdgeIteratorState iter3to4 = GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, true);
+        final EdgeIteratorState iter4to5 = GHUtility.setProperties(graph.edge(4, 5).setDistance(1), encoder, 60, true, false);
+        final EdgeIteratorState iter5to6 = GHUtility.setProperties(graph.edge(5, 6).setDistance(1), encoder, 60, true, false);
+        final EdgeIteratorState iter6to8 = GHUtility.setProperties(graph.edge(6, 8).setDistance(2), encoder, 60, true, false);
+        final EdgeIteratorState iter8to4 = GHUtility.setProperties(graph.edge(8, 4).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(6, 7).setDistance(1), encoder, 60, true, true);
         graph.freeze();
 
         contractInOrder(3, 5, 7, 8, 4, 1, 6);
@@ -150,9 +151,9 @@ public class NodeBasedNodeContractorTest {
         // where there are two roads from 1 to 2 and the directed road has a smaller weight. to get from 2 to 1 we
         // have to use the bidirectional edge despite the higher weight and therefore we need an extra shortcut for
         // this.
-        final EdgeIteratorState edge1to2bidirected = graph.edge(1, 2, 2, true);
-        final EdgeIteratorState edge1to2directed = graph.edge(1, 2, 1, false);
-        final EdgeIteratorState edge2to3 = graph.edge(2, 3, 1, true);
+        final EdgeIteratorState edge1to2bidirected = GHUtility.setProperties(graph.edge(1, 2).setDistance(2), encoder, 60, true, true);
+        final EdgeIteratorState edge1to2directed = GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
+        final EdgeIteratorState edge2to3 = GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, true);
         graph.freeze();
         setMaxLevelOnAllNodes();
         if (reverse) {
@@ -173,8 +174,8 @@ public class NodeBasedNodeContractorTest {
     @Test
     public void testContractNode_directed_shortcutRequired() {
         // 0 --> 1 --> 2
-        final EdgeIteratorState edge1 = graph.edge(0, 1, 1, false);
-        final EdgeIteratorState edge2 = graph.edge(1, 2, 2, false);
+        final EdgeIteratorState edge1 = GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
+        final EdgeIteratorState edge2 = GHUtility.setProperties(graph.edge(1, 2).setDistance(2), encoder, 60, true, false);
         graph.freeze();
         setMaxLevelOnAllNodes();
         contractInOrder(1, 0, 2);
@@ -184,8 +185,8 @@ public class NodeBasedNodeContractorTest {
     @Test
     public void testContractNode_directed_shortcutRequired_reverse() {
         // 0 <-- 1 <-- 2
-        final EdgeIteratorState edge1 = graph.edge(2, 1, 1, false);
-        final EdgeIteratorState edge2 = graph.edge(1, 0, 2, false);
+        final EdgeIteratorState edge1 = GHUtility.setProperties(graph.edge(2, 1).setDistance(1), encoder, 60, true, false);
+        final EdgeIteratorState edge2 = GHUtility.setProperties(graph.edge(1, 0).setDistance(2), encoder, 60, true, false);
         graph.freeze();
         setMaxLevelOnAllNodes();
         contractInOrder(1, 2, 0);
@@ -195,8 +196,8 @@ public class NodeBasedNodeContractorTest {
     @Test
     public void testContractNode_bidirected_shortcutsRequired() {
         // 0 -- 1 -- 2
-        final EdgeIteratorState edge1 = graph.edge(0, 1, 1, true);
-        final EdgeIteratorState edge2 = graph.edge(1, 2, 2, true);
+        final EdgeIteratorState edge1 = GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
+        final EdgeIteratorState edge2 = GHUtility.setProperties(graph.edge(1, 2).setDistance(2), encoder, 60, true, true);
         graph.freeze();
         contractInOrder(1, 2, 0);
         checkShortcuts(expectedShortcut(2, 0, edge2, edge1, true, true));
@@ -206,9 +207,9 @@ public class NodeBasedNodeContractorTest {
     public void testContractNode_directed_withWitness() {
         // 0 --> 1 --> 2
         //  \_________/
-        graph.edge(0, 1, 1, false);
-        graph.edge(1, 2, 2, false);
-        graph.edge(0, 2, 1, false);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(2), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(0, 2).setDistance(1), encoder, 60, true, false);
         graph.freeze();
         setMaxLevelOnAllNodes();
         createNodeContractor().contractNode(1);
@@ -222,11 +223,11 @@ public class NodeBasedNodeContractorTest {
         //  \             /
         //   1 --> 2 --> 3
         double[] distances = {4.019, 1.006, 1.004, 1.006, 1.004};
-        graph.edge(0, 4, distances[0], false);
-        EdgeIteratorState edge1 = graph.edge(0, 1, distances[1], false);
-        EdgeIteratorState edge2 = graph.edge(1, 2, distances[2], false);
-        EdgeIteratorState edge3 = graph.edge(2, 3, distances[3], false);
-        EdgeIteratorState edge4 = graph.edge(3, 4, distances[4], false);
+        GHUtility.setProperties(graph.edge(0, 4).setDistance(distances[0]), encoder, 60, true, false);
+        EdgeIteratorState edge1 = GHUtility.setProperties(graph.edge(0, 1).setDistance(distances[1]), encoder, 60, true, false);
+        EdgeIteratorState edge2 = GHUtility.setProperties(graph.edge(1, 2).setDistance(distances[2]), encoder, 60, true, false);
+        EdgeIteratorState edge3 = GHUtility.setProperties(graph.edge(2, 3).setDistance(distances[3]), encoder, 60, true, false);
+        EdgeIteratorState edge4 = GHUtility.setProperties(graph.edge(3, 4).setDistance(distances[4]), encoder, 60, true, false);
         graph.freeze();
         setMaxLevelOnAllNodes();
 
@@ -279,11 +280,11 @@ public class NodeBasedNodeContractorTest {
         //   1 --> 2 --> 3
         double fac = 60 / 3.6;
         double[] distances = {fac * 4.019, fac * 1.006, fac * 1.004, fac * 1.006, fac * 1.004};
-        graph.edge(0, 4, distances[0], false);
-        graph.edge(0, 1, distances[1], false);
-        graph.edge(1, 2, distances[2], false);
-        graph.edge(2, 3, distances[3], false);
-        graph.edge(3, 4, distances[4], false);
+        GHUtility.setProperties(graph.edge(0, 4).setDistance(distances[0]), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(distances[1]), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(distances[2]), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(distances[3]), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(distances[4]), encoder, 60, true, false);
         graph.freeze();
         setMaxLevelOnAllNodes(lg);
 
@@ -314,11 +315,11 @@ public class NodeBasedNodeContractorTest {
         CHGraph lg = graph.getCHGraph();
         // 0 - 1 - 2 - 3
         // o           o
-        graph.edge(0, 1, 1, true);
-        graph.edge(1, 2, 1, true);
-        graph.edge(2, 3, 1, true);
-        graph.edge(0, 0, 1, true);
-        graph.edge(3, 3, 1, true);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(0, 0).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(3, 3).setDistance(1), encoder, 60, true, true);
 
         graph.freeze();
         setMaxLevelOnAllNodes(lg);

--- a/core/src/test/java/com/graphhopper/routing/ch/NodeBasedWitnessPathSearcherTest.java
+++ b/core/src/test/java/com/graphhopper/routing/ch/NodeBasedWitnessPathSearcherTest.java
@@ -28,6 +28,7 @@ import com.graphhopper.storage.CHConfig;
 import com.graphhopper.storage.CHGraph;
 import com.graphhopper.storage.GraphBuilder;
 import com.graphhopper.storage.GraphHopperStorage;
+import com.graphhopper.util.GHUtility;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -104,13 +105,13 @@ class NodeBasedWitnessPathSearcherTest {
         //   /    |
         //  4-----3
         //
-        graph.edge(0, 1, 1, true);
-        graph.edge(0, 2, 1, true);
-        graph.edge(0, 4, 3, true);
-        graph.edge(1, 2, 3, true);
-        graph.edge(2, 3, 1, true);
-        graph.edge(4, 3, 2, true);
-        graph.edge(5, 1, 2, true);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(0, 2).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(0, 4).setDistance(3), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(3), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(4, 3).setDistance(2), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(5, 1).setDistance(2), encoder, 60, true, true);
         graph.freeze();
     }
 

--- a/core/src/test/java/com/graphhopper/routing/ch/NodeBasedWitnessPathSearcherTest.java
+++ b/core/src/test/java/com/graphhopper/routing/ch/NodeBasedWitnessPathSearcherTest.java
@@ -105,13 +105,13 @@ class NodeBasedWitnessPathSearcherTest {
         //   /    |
         //  4-----3
         //
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(0, 2).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(0, 4).setDistance(3), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(3), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(4, 3).setDistance(2), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(5, 1).setDistance(2), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 4).setDistance(3));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(3));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 3).setDistance(2));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(5, 1).setDistance(2));
         graph.freeze();
     }
 

--- a/core/src/test/java/com/graphhopper/routing/ch/PrepareContractionHierarchiesTest.java
+++ b/core/src/test/java/com/graphhopper/routing/ch/PrepareContractionHierarchiesTest.java
@@ -54,68 +54,68 @@ public class PrepareContractionHierarchiesTest {
     // |         ^   \
     // |         |    |
     // 17-16-...-11<-/
-    private static void initDirected2(Graph g) {
-        g.edge(0, 1, 1, true);
-        g.edge(1, 2, 1, true);
-        g.edge(2, 3, 1, true);
-        g.edge(3, 4, 1, true);
-        g.edge(4, 5, 1, true);
-        g.edge(5, 6, 1, true);
-        g.edge(6, 7, 1, true);
-        g.edge(7, 8, 1, true);
-        g.edge(8, 9, 1, true);
-        g.edge(9, 10, 1, true);
-        g.edge(10, 11, 1, false);
-        g.edge(11, 12, 1, true);
-        g.edge(11, 9, 3, false);
-        g.edge(12, 13, 1, true);
-        g.edge(13, 14, 1, true);
-        g.edge(14, 15, 1, true);
-        g.edge(15, 16, 1, true);
-        g.edge(16, 17, 1, true);
-        g.edge(17, 0, 1, true);
+    private static void initDirected2(Graph g, FlagEncoder encoder) {
+        GHUtility.setProperties(g.edge(0, 1).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(1, 2).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(2, 3).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(3, 4).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(4, 5).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(5, 6).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(6, 7).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(7, 8).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(8, 9).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(9, 10).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(10, 11).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(g.edge(11, 12).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(11, 9).setDistance(3), encoder, 60, true, false);
+        GHUtility.setProperties(g.edge(12, 13).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(13, 14).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(14, 15).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(15, 16).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(16, 17).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(17, 0).setDistance(1), encoder, 60, true, true);
     }
 
     // prepare-routing.svg
-    private static void initShortcutsGraph(Graph g) {
-        g.edge(0, 1, 1, true);
-        g.edge(0, 2, 1, true);
-        g.edge(1, 2, 1, true);
-        g.edge(2, 3, 1.5, true);
-        g.edge(1, 4, 1, true);
-        g.edge(2, 9, 1, true);
-        g.edge(9, 3, 1, true);
-        g.edge(10, 3, 1, true);
-        g.edge(4, 5, 1, true);
-        g.edge(5, 6, 1, true);
-        g.edge(6, 7, 1, true);
-        g.edge(7, 8, 1, true);
-        g.edge(8, 9, 1, true);
-        g.edge(4, 11, 1, true);
-        g.edge(9, 14, 1, true);
-        g.edge(10, 14, 1, true);
-        g.edge(11, 12, 1, true);
-        g.edge(12, 15, 1, true);
-        g.edge(12, 13, 1, true);
-        g.edge(13, 16, 1, true);
-        g.edge(15, 16, 2, true);
-        g.edge(14, 16, 1, true);
+    private static void initShortcutsGraph(Graph g, FlagEncoder encoder) {
+        GHUtility.setProperties(g.edge(0, 1).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(0, 2).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(1, 2).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(2, 3).setDistance(1.5), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(1, 4).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(2, 9).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(9, 3).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(10, 3).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(4, 5).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(5, 6).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(6, 7).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(7, 8).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(8, 9).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(4, 11).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(9, 14).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(10, 14).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(11, 12).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(12, 15).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(12, 13).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(13, 16).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(15, 16).setDistance(2), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(14, 16).setDistance(1), encoder, 60, true, true);
     }
 
-    private static void initExampleGraph(Graph g) {
+    private static void initExampleGraph(Graph g, FlagEncoder encoder) {
         //5-1-----2
         //   \ __/|
         //    0   |
         //   /    |
         //  4-----3
         //
-        g.edge(0, 1, 1, true);
-        g.edge(0, 2, 1, true);
-        g.edge(0, 4, 3, true);
-        g.edge(1, 2, 3, true);
-        g.edge(2, 3, 1, true);
-        g.edge(4, 3, 2, true);
-        g.edge(5, 1, 2, true);
+        GHUtility.setProperties(g.edge(0, 1).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(0, 2).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(0, 4).setDistance(3), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(1, 2).setDistance(3), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(2, 3).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(4, 3).setDistance(2), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(5, 1).setDistance(2), encoder, 60, true, true);
     }
 
     @Before
@@ -142,7 +142,7 @@ public class PrepareContractionHierarchiesTest {
 
     @Test
     public void testAddShortcuts() {
-        initExampleGraph(g);
+        initExampleGraph(g, carEncoder);
         int old = routingCHGraph.getEdges();
         PrepareContractionHierarchies prepare = createPrepareContractionHierarchies(g);
         useNodeOrdering(prepare, new int[]{5, 3, 4, 0, 1, 2});
@@ -152,7 +152,7 @@ public class PrepareContractionHierarchiesTest {
 
     @Test
     public void testMoreComplexGraph() {
-        initShortcutsGraph(g);
+        initShortcutsGraph(g, carEncoder);
         int oldCount = routingCHGraph.getEdges();
         PrepareContractionHierarchies prepare = createPrepareContractionHierarchies(g);
         useNodeOrdering(prepare, new int[]{0, 5, 6, 7, 8, 10, 11, 13, 15, 1, 3, 9, 14, 16, 12, 4, 2});
@@ -163,12 +163,12 @@ public class PrepareContractionHierarchiesTest {
 
     @Test
     public void testDirectedGraph() {
-        g.edge(5, 4, 3, false);
-        g.edge(4, 5, 10, false);
-        g.edge(2, 4, 1, false);
-        g.edge(5, 2, 1, false);
-        g.edge(3, 5, 1, false);
-        g.edge(4, 3, 1, false);
+        GHUtility.setProperties(g.edge(5, 4).setDistance(3), carEncoder, 60, true, false);
+        GHUtility.setProperties(g.edge(4, 5).setDistance(10), carEncoder, 60, true, false);
+        GHUtility.setProperties(g.edge(2, 4).setDistance(1), carEncoder, 60, true, false);
+        GHUtility.setProperties(g.edge(5, 2).setDistance(1), carEncoder, 60, true, false);
+        GHUtility.setProperties(g.edge(3, 5).setDistance(1), carEncoder, 60, true, false);
+        GHUtility.setProperties(g.edge(4, 3).setDistance(1), carEncoder, 60, true, false);
         g.freeze();
         int oldCount = routingCHGraph.getEdges();
         assertEquals(6, oldCount);
@@ -185,7 +185,7 @@ public class PrepareContractionHierarchiesTest {
 
     @Test
     public void testDirectedGraph2() {
-        initDirected2(g);
+        initDirected2(g, carEncoder);
         int oldCount = g.getEdges();
         assertEquals(19, oldCount);
         PrepareContractionHierarchies prepare = createPrepareContractionHierarchies(g);
@@ -205,7 +205,7 @@ public class PrepareContractionHierarchiesTest {
         assertEquals(IntArrayList.from(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10), p.calcNodes());
     }
 
-    private void initRoundaboutGraph(Graph g) {
+    private static void initRoundaboutGraph(Graph g, FlagEncoder encoder) {
         //              roundabout:
         //16-0-9-10--11   12<-13
         //    \       \  /      \
@@ -214,51 +214,51 @@ public class PrepareContractionHierarchiesTest {
         //     /         \-5->6/     /
         //  -14            \________/
 
-        g.edge(16, 0, 1, true);
-        g.edge(0, 9, 1, true);
-        g.edge(0, 17, 1, true);
-        g.edge(9, 10, 1, true);
-        g.edge(10, 11, 1, true);
-        g.edge(11, 28, 1, true);
-        g.edge(28, 29, 1, true);
-        g.edge(29, 30, 1, true);
-        g.edge(30, 31, 1, true);
-        g.edge(31, 4, 1, true);
+        GHUtility.setProperties(g.edge(16, 0).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(0, 9).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(0, 17).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(9, 10).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(10, 11).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(11, 28).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(28, 29).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(29, 30).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(30, 31).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(31, 4).setDistance(1), encoder, 60, true, true);
 
-        g.edge(17, 1, 1, true);
-        g.edge(15, 1, 1, true);
-        g.edge(14, 1, 1, true);
-        g.edge(14, 18, 1, true);
-        g.edge(18, 19, 1, true);
-        g.edge(19, 20, 1, true);
-        g.edge(20, 15, 1, true);
-        g.edge(19, 21, 1, true);
-        g.edge(21, 16, 1, true);
-        g.edge(1, 2, 1, true);
-        g.edge(2, 3, 1, true);
-        g.edge(3, 4, 1, true);
+        GHUtility.setProperties(g.edge(17, 1).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(15, 1).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(14, 1).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(14, 18).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(18, 19).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(19, 20).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(20, 15).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(19, 21).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(21, 16).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(1, 2).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(2, 3).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(3, 4).setDistance(1), encoder, 60, true, true);
 
-        g.edge(4, 5, 1, false);
-        g.edge(5, 6, 1, false);
-        g.edge(6, 7, 1, false);
-        g.edge(7, 13, 1, false);
-        g.edge(13, 12, 1, false);
-        g.edge(12, 4, 1, false);
+        GHUtility.setProperties(g.edge(4, 5).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(g.edge(5, 6).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(g.edge(6, 7).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(g.edge(7, 13).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(g.edge(13, 12).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(g.edge(12, 4).setDistance(1), encoder, 60, true, false);
 
-        g.edge(7, 8, 1, true);
-        g.edge(8, 22, 1, true);
-        g.edge(22, 23, 1, true);
-        g.edge(23, 24, 1, true);
-        g.edge(24, 25, 1, true);
-        g.edge(25, 27, 1, true);
-        g.edge(27, 5, 1, true);
-        g.edge(25, 26, 1, false);
-        g.edge(26, 25, 1, false);
+        GHUtility.setProperties(g.edge(7, 8).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(8, 22).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(22, 23).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(23, 24).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(24, 25).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(25, 27).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(27, 5).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(25, 26).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(g.edge(26, 25).setDistance(1), encoder, 60, true, false);
     }
 
     @Test
     public void testRoundaboutUnpacking() {
-        initRoundaboutGraph(g);
+        initRoundaboutGraph(g, carEncoder);
         int oldCount = g.getEdges();
         PrepareContractionHierarchies prepare = createPrepareContractionHierarchies(g);
         useNodeOrdering(prepare, new int[]{26, 6, 12, 13, 2, 3, 8, 9, 10, 11, 14, 15, 16, 17, 18, 20, 21, 23, 24, 25, 19, 22, 27, 5, 29, 30, 31, 28, 7, 1, 0, 4});
@@ -282,14 +282,14 @@ public class PrepareContractionHierarchiesTest {
         //            2
         //            v
         //            7
-        g.edge(8, 3, 1, false);
-        g.edge(3, 6, 1, false);
-        g.edge(6, 1, 1, false);
-        g.edge(1, 5, 1, false);
-        g.edge(4, 0, 1, false);
-        g.edge(0, 6, 1, false);
-        g.edge(6, 2, 1, false);
-        g.edge(2, 7, 1, false);
+        GHUtility.setProperties(g.edge(8, 3).setDistance(1), carEncoder, 60, true, false);
+        GHUtility.setProperties(g.edge(3, 6).setDistance(1), carEncoder, 60, true, false);
+        GHUtility.setProperties(g.edge(6, 1).setDistance(1), carEncoder, 60, true, false);
+        GHUtility.setProperties(g.edge(1, 5).setDistance(1), carEncoder, 60, true, false);
+        GHUtility.setProperties(g.edge(4, 0).setDistance(1), carEncoder, 60, true, false);
+        GHUtility.setProperties(g.edge(0, 6).setDistance(1), carEncoder, 60, true, false);
+        GHUtility.setProperties(g.edge(6, 2).setDistance(1), carEncoder, 60, true, false);
+        GHUtility.setProperties(g.edge(2, 7).setDistance(1), carEncoder, 60, true, false);
         g.freeze();
 
         PrepareContractionHierarchies prepare = createPrepareContractionHierarchies(g)
@@ -337,13 +337,13 @@ public class PrepareContractionHierarchiesTest {
         // start 0 - 3 - x - 1 - 2
         //             \         |
         //               sc ---- 4 - 5 - 6 - 7 finish
-        g.edge(0, 3, 1, true);
-        EdgeIteratorState edge31 = g.edge(3, 1, 1, true);
-        g.edge(1, 2, 1, true);
-        EdgeIteratorState edge24 = g.edge(2, 4, 1, true);
-        g.edge(4, 5, 1, true);
-        g.edge(5, 6, 1, true);
-        g.edge(6, 7, 1, true);
+        GHUtility.setProperties(g.edge(0, 3).setDistance(1), carEncoder, 60, true, true);
+        EdgeIteratorState edge31 = GHUtility.setProperties(g.edge(3, 1).setDistance(1), carEncoder, 60, true, true);
+        GHUtility.setProperties(g.edge(1, 2).setDistance(1), carEncoder, 60, true, true);
+        EdgeIteratorState edge24 = GHUtility.setProperties(g.edge(2, 4).setDistance(1), carEncoder, 60, true, true);
+        GHUtility.setProperties(g.edge(4, 5).setDistance(1), carEncoder, 60, true, true);
+        GHUtility.setProperties(g.edge(5, 6).setDistance(1), carEncoder, 60, true, true);
+        GHUtility.setProperties(g.edge(6, 7).setDistance(1), carEncoder, 60, true, true);
         updateDistancesFor(g, 0, 0.001, 0.0000);
         updateDistancesFor(g, 3, 0.001, 0.0001);
         updateDistancesFor(g, 1, 0.001, 0.0002);
@@ -428,10 +428,10 @@ public class PrepareContractionHierarchiesTest {
         //  /--1
         // -0--/
         //  |
-        g.edge(0, 1, 10, true);
-        g.edge(0, 1, 4, true);
-        g.edge(0, 2, 10, true);
-        g.edge(0, 3, 10, true);
+        GHUtility.setProperties(g.edge(0, 1).setDistance(10), carEncoder, 60, true, true);
+        GHUtility.setProperties(g.edge(0, 1).setDistance(4), carEncoder, 60, true, true);
+        GHUtility.setProperties(g.edge(0, 2).setDistance(10), carEncoder, 60, true, true);
+        GHUtility.setProperties(g.edge(0, 3).setDistance(10), carEncoder, 60, true, true);
         PrepareContractionHierarchies prepare = createPrepareContractionHierarchies(g);
         prepare.doWork();
         assertEquals(0, prepare.getShortcuts());
@@ -444,15 +444,15 @@ public class PrepareContractionHierarchiesTest {
         // 0-1->-2--3--4
         //   \-<-/
         //
-        g.edge(1, 2, 1, false);
-        g.edge(2, 1, 1, false);
+        GHUtility.setProperties(g.edge(1, 2).setDistance(1), carEncoder, 60, true, false);
+        GHUtility.setProperties(g.edge(2, 1).setDistance(1), carEncoder, 60, true, false);
 
-        g.edge(5, 0, 1, true);
-        g.edge(5, 6, 1, true);
-        g.edge(0, 1, 1, true);
-        g.edge(2, 3, 1, true);
-        g.edge(3, 4, 1, true);
-        g.edge(6, 3, 1, true);
+        GHUtility.setProperties(g.edge(5, 0).setDistance(1), carEncoder, 60, true, true);
+        GHUtility.setProperties(g.edge(5, 6).setDistance(1), carEncoder, 60, true, true);
+        GHUtility.setProperties(g.edge(0, 1).setDistance(1), carEncoder, 60, true, true);
+        GHUtility.setProperties(g.edge(2, 3).setDistance(1), carEncoder, 60, true, true);
+        GHUtility.setProperties(g.edge(3, 4).setDistance(1), carEncoder, 60, true, true);
+        GHUtility.setProperties(g.edge(6, 3).setDistance(1), carEncoder, 60, true, true);
 
         PrepareContractionHierarchies prepare = createPrepareContractionHierarchies(g);
         useNodeOrdering(prepare, new int[]{4, 1, 2, 0, 5, 6, 3});
@@ -482,8 +482,11 @@ public class PrepareContractionHierarchiesTest {
 
         List<CHConfig> configs = Arrays.asList(carProfile, bikeProfile);
         GraphHopperStorage ghStorage = new GraphBuilder(tmpEncodingManager).setCHConfigs(configs).create();
-        initShortcutsGraph(ghStorage);
-
+        initShortcutsGraph(ghStorage, carEncoder);
+        AllEdgesIterator iter = ghStorage.getAllEdges();
+        while (iter.next()) {
+            GHUtility.setProperties(iter, tmpBikeEncoder, 18, true, true);
+        }
         ghStorage.freeze();
 
         checkPath(ghStorage, carProfile, 7, 5, IntArrayList.from(3, 9, 14, 16, 13, 12), new int[]{0, 5, 6, 7, 8, 10, 11, 13, 15, 1, 3, 9, 14, 16, 12, 4, 2});
@@ -500,7 +503,11 @@ public class PrepareContractionHierarchiesTest {
         CHConfig bikeConfig = CHConfig.nodeBased("c2", new FastestWeighting(tmpBikeEncoder));
 
         GraphHopperStorage ghStorage = new GraphBuilder(tmpEncodingManager).setCHConfigs(carConfig, bikeConfig).create();
-        initShortcutsGraph(ghStorage);
+        initShortcutsGraph(ghStorage, carEncoder);
+        AllEdgesIterator iter = ghStorage.getAllEdges();
+        while (iter.next()) {
+            GHUtility.setProperties(iter, tmpBikeEncoder, 18, true, true);
+        }
         GHUtility.getEdge(ghStorage, 9, 14).
                 set(tmpBikeEncoder.getAccessEnc(), false).
                 setReverse(tmpBikeEncoder.getAccessEnc(), false);
@@ -525,7 +532,8 @@ public class PrepareContractionHierarchiesTest {
         int numQueries = 100;
         long seed = System.nanoTime();
         Random rnd = new Random(seed);
-        GHUtility.buildRandomGraph(ghStorage, rnd, numNodes, 1.3, true, true, carFlagEncoder.getAverageSpeedEnc(), 0.7, 0.9, 0.8);
+        GHUtility.buildRandomGraph(ghStorage, rnd, numNodes, 1.3, true, true,
+                carFlagEncoder.getAccessEnc(), carFlagEncoder.getAverageSpeedEnc(), 60d, 0.7, 0.9, 0.8);
         ghStorage.freeze();
 
         // create CH for cars

--- a/core/src/test/java/com/graphhopper/routing/ch/PrepareContractionHierarchiesTest.java
+++ b/core/src/test/java/com/graphhopper/routing/ch/PrepareContractionHierarchiesTest.java
@@ -358,16 +358,14 @@ public class PrepareContractionHierarchiesTest {
         // at node 2 coming from 3. this happens because due to the virtual node x between 3 and 1, the weight of the
         // spt entry at 2 is different to the sum of the weights of the spt entry at node 3 and the shortcut edge. this
         // is due to different floating point rounding arithmetic of shortcuts and virtual edges on the query graph.
-        edge31.set(carEncoder.getAverageSpeedEnc(), 22);
-        edge31.setReverse(carEncoder.getAverageSpeedEnc(), 22);
+        edge31.set(carEncoder.getAverageSpeedEnc(), 22, 22);
 
         // just stalling node 2 alone would not lead to connection not found, because the shortcut 3-4 still finds node
         // 4. however, we can choose the weight of edge 2-4 such that node 4 also gets stalled via node 2.
         // it is important that node 2 gets stalled before otherwise node 4 would have already be discovered.
         // note that without the virtual node between 3 and 1 node 2 would not even be explored in the forward search,
         // but because of the virtual node the strict upward search is modified and goes like 0-3-x-1-2.
-        edge24.set(carEncoder.getAverageSpeedEnc(), 27.5);
-        edge24.setReverse(carEncoder.getAverageSpeedEnc(), 27.5);
+        edge24.set(carEncoder.getAverageSpeedEnc(), 27.5, 27.5);
 
         // prepare ch, use node ids as levels
         PrepareContractionHierarchies pch = createPrepareContractionHierarchies(g, chConfig);

--- a/core/src/test/java/com/graphhopper/routing/ch/PrepareContractionHierarchiesTest.java
+++ b/core/src/test/java/com/graphhopper/routing/ch/PrepareContractionHierarchiesTest.java
@@ -55,51 +55,51 @@ public class PrepareContractionHierarchiesTest {
     // |         |    |
     // 17-16-...-11<-/
     private static void initDirected2(Graph g, FlagEncoder encoder) {
-        GHUtility.setProperties(g.edge(0, 1).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(1, 2).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(2, 3).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(3, 4).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(4, 5).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(5, 6).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(6, 7).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(7, 8).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(8, 9).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(9, 10).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(10, 11).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(g.edge(11, 12).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(11, 9).setDistance(3), encoder, 60, true, false);
-        GHUtility.setProperties(g.edge(12, 13).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(13, 14).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(14, 15).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(15, 16).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(16, 17).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(17, 0).setDistance(1), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(2, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(3, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(4, 5).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(5, 6).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(6, 7).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(7, 8).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(8, 9).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(9, 10).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(10, 11).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(11, 12).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(11, 9).setDistance(3));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(12, 13).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(13, 14).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(14, 15).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(15, 16).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(16, 17).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(17, 0).setDistance(1));
     }
 
     // prepare-routing.svg
     private static void initShortcutsGraph(Graph g, FlagEncoder encoder) {
-        GHUtility.setProperties(g.edge(0, 1).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(0, 2).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(1, 2).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(2, 3).setDistance(1.5), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(1, 4).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(2, 9).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(9, 3).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(10, 3).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(4, 5).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(5, 6).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(6, 7).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(7, 8).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(8, 9).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(4, 11).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(9, 14).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(10, 14).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(11, 12).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(12, 15).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(12, 13).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(13, 16).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(15, 16).setDistance(2), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(14, 16).setDistance(1), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(0, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(2, 3).setDistance(1.5));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(1, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(2, 9).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(9, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(10, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(4, 5).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(5, 6).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(6, 7).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(7, 8).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(8, 9).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(4, 11).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(9, 14).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(10, 14).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(11, 12).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(12, 15).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(12, 13).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(13, 16).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(15, 16).setDistance(2));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(14, 16).setDistance(1));
     }
 
     private static void initExampleGraph(Graph g, FlagEncoder encoder) {
@@ -109,13 +109,13 @@ public class PrepareContractionHierarchiesTest {
         //   /    |
         //  4-----3
         //
-        GHUtility.setProperties(g.edge(0, 1).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(0, 2).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(0, 4).setDistance(3), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(1, 2).setDistance(3), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(2, 3).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(4, 3).setDistance(2), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(5, 1).setDistance(2), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(0, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(0, 4).setDistance(3));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(1, 2).setDistance(3));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(2, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(4, 3).setDistance(2));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(5, 1).setDistance(2));
     }
 
     @Before
@@ -163,12 +163,12 @@ public class PrepareContractionHierarchiesTest {
 
     @Test
     public void testDirectedGraph() {
-        GHUtility.setProperties(g.edge(5, 4).setDistance(3), carEncoder, 60, true, false);
-        GHUtility.setProperties(g.edge(4, 5).setDistance(10), carEncoder, 60, true, false);
-        GHUtility.setProperties(g.edge(2, 4).setDistance(1), carEncoder, 60, true, false);
-        GHUtility.setProperties(g.edge(5, 2).setDistance(1), carEncoder, 60, true, false);
-        GHUtility.setProperties(g.edge(3, 5).setDistance(1), carEncoder, 60, true, false);
-        GHUtility.setProperties(g.edge(4, 3).setDistance(1), carEncoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, carEncoder, g.edge(5, 4).setDistance(3));
+        GHUtility.setSpeed(60, true, false, carEncoder, g.edge(4, 5).setDistance(10));
+        GHUtility.setSpeed(60, true, false, carEncoder, g.edge(2, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, false, carEncoder, g.edge(5, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, false, carEncoder, g.edge(3, 5).setDistance(1));
+        GHUtility.setSpeed(60, true, false, carEncoder, g.edge(4, 3).setDistance(1));
         g.freeze();
         int oldCount = routingCHGraph.getEdges();
         assertEquals(6, oldCount);
@@ -214,46 +214,46 @@ public class PrepareContractionHierarchiesTest {
         //     /         \-5->6/     /
         //  -14            \________/
 
-        GHUtility.setProperties(g.edge(16, 0).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(0, 9).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(0, 17).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(9, 10).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(10, 11).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(11, 28).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(28, 29).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(29, 30).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(30, 31).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(31, 4).setDistance(1), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(16, 0).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(0, 9).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(0, 17).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(9, 10).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(10, 11).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(11, 28).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(28, 29).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(29, 30).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(30, 31).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(31, 4).setDistance(1));
 
-        GHUtility.setProperties(g.edge(17, 1).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(15, 1).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(14, 1).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(14, 18).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(18, 19).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(19, 20).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(20, 15).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(19, 21).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(21, 16).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(1, 2).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(2, 3).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(3, 4).setDistance(1), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(17, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(15, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(14, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(14, 18).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(18, 19).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(19, 20).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(20, 15).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(19, 21).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(21, 16).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(2, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(3, 4).setDistance(1));
 
-        GHUtility.setProperties(g.edge(4, 5).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(g.edge(5, 6).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(g.edge(6, 7).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(g.edge(7, 13).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(g.edge(13, 12).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(g.edge(12, 4).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(4, 5).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(5, 6).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(6, 7).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(7, 13).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(13, 12).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(12, 4).setDistance(1));
 
-        GHUtility.setProperties(g.edge(7, 8).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(8, 22).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(22, 23).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(23, 24).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(24, 25).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(25, 27).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(27, 5).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(25, 26).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(g.edge(26, 25).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(7, 8).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(8, 22).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(22, 23).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(23, 24).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(24, 25).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(25, 27).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(27, 5).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(25, 26).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(26, 25).setDistance(1));
     }
 
     @Test
@@ -282,14 +282,14 @@ public class PrepareContractionHierarchiesTest {
         //            2
         //            v
         //            7
-        GHUtility.setProperties(g.edge(8, 3).setDistance(1), carEncoder, 60, true, false);
-        GHUtility.setProperties(g.edge(3, 6).setDistance(1), carEncoder, 60, true, false);
-        GHUtility.setProperties(g.edge(6, 1).setDistance(1), carEncoder, 60, true, false);
-        GHUtility.setProperties(g.edge(1, 5).setDistance(1), carEncoder, 60, true, false);
-        GHUtility.setProperties(g.edge(4, 0).setDistance(1), carEncoder, 60, true, false);
-        GHUtility.setProperties(g.edge(0, 6).setDistance(1), carEncoder, 60, true, false);
-        GHUtility.setProperties(g.edge(6, 2).setDistance(1), carEncoder, 60, true, false);
-        GHUtility.setProperties(g.edge(2, 7).setDistance(1), carEncoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, carEncoder, g.edge(8, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, false, carEncoder, g.edge(3, 6).setDistance(1));
+        GHUtility.setSpeed(60, true, false, carEncoder, g.edge(6, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, false, carEncoder, g.edge(1, 5).setDistance(1));
+        GHUtility.setSpeed(60, true, false, carEncoder, g.edge(4, 0).setDistance(1));
+        GHUtility.setSpeed(60, true, false, carEncoder, g.edge(0, 6).setDistance(1));
+        GHUtility.setSpeed(60, true, false, carEncoder, g.edge(6, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, false, carEncoder, g.edge(2, 7).setDistance(1));
         g.freeze();
 
         PrepareContractionHierarchies prepare = createPrepareContractionHierarchies(g)
@@ -337,13 +337,13 @@ public class PrepareContractionHierarchiesTest {
         // start 0 - 3 - x - 1 - 2
         //             \         |
         //               sc ---- 4 - 5 - 6 - 7 finish
-        GHUtility.setProperties(g.edge(0, 3).setDistance(1), carEncoder, 60, true, true);
-        EdgeIteratorState edge31 = GHUtility.setProperties(g.edge(3, 1).setDistance(1), carEncoder, 60, true, true);
-        GHUtility.setProperties(g.edge(1, 2).setDistance(1), carEncoder, 60, true, true);
-        EdgeIteratorState edge24 = GHUtility.setProperties(g.edge(2, 4).setDistance(1), carEncoder, 60, true, true);
-        GHUtility.setProperties(g.edge(4, 5).setDistance(1), carEncoder, 60, true, true);
-        GHUtility.setProperties(g.edge(5, 6).setDistance(1), carEncoder, 60, true, true);
-        GHUtility.setProperties(g.edge(6, 7).setDistance(1), carEncoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(0, 3).setDistance(1));
+        EdgeIteratorState edge31 = GHUtility.setSpeed(60, true, true, carEncoder, g.edge(3, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(1, 2).setDistance(1));
+        EdgeIteratorState edge24 = GHUtility.setSpeed(60, true, true, carEncoder, g.edge(2, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(4, 5).setDistance(1));
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(5, 6).setDistance(1));
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(6, 7).setDistance(1));
         updateDistancesFor(g, 0, 0.001, 0.0000);
         updateDistancesFor(g, 3, 0.001, 0.0001);
         updateDistancesFor(g, 1, 0.001, 0.0002);
@@ -428,10 +428,10 @@ public class PrepareContractionHierarchiesTest {
         //  /--1
         // -0--/
         //  |
-        GHUtility.setProperties(g.edge(0, 1).setDistance(10), carEncoder, 60, true, true);
-        GHUtility.setProperties(g.edge(0, 1).setDistance(4), carEncoder, 60, true, true);
-        GHUtility.setProperties(g.edge(0, 2).setDistance(10), carEncoder, 60, true, true);
-        GHUtility.setProperties(g.edge(0, 3).setDistance(10), carEncoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(0, 1).setDistance(10));
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(0, 1).setDistance(4));
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(0, 2).setDistance(10));
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(0, 3).setDistance(10));
         PrepareContractionHierarchies prepare = createPrepareContractionHierarchies(g);
         prepare.doWork();
         assertEquals(0, prepare.getShortcuts());
@@ -444,15 +444,15 @@ public class PrepareContractionHierarchiesTest {
         // 0-1->-2--3--4
         //   \-<-/
         //
-        GHUtility.setProperties(g.edge(1, 2).setDistance(1), carEncoder, 60, true, false);
-        GHUtility.setProperties(g.edge(2, 1).setDistance(1), carEncoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, carEncoder, g.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, false, carEncoder, g.edge(2, 1).setDistance(1));
 
-        GHUtility.setProperties(g.edge(5, 0).setDistance(1), carEncoder, 60, true, true);
-        GHUtility.setProperties(g.edge(5, 6).setDistance(1), carEncoder, 60, true, true);
-        GHUtility.setProperties(g.edge(0, 1).setDistance(1), carEncoder, 60, true, true);
-        GHUtility.setProperties(g.edge(2, 3).setDistance(1), carEncoder, 60, true, true);
-        GHUtility.setProperties(g.edge(3, 4).setDistance(1), carEncoder, 60, true, true);
-        GHUtility.setProperties(g.edge(6, 3).setDistance(1), carEncoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(5, 0).setDistance(1));
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(5, 6).setDistance(1));
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(2, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(3, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(6, 3).setDistance(1));
 
         PrepareContractionHierarchies prepare = createPrepareContractionHierarchies(g);
         useNodeOrdering(prepare, new int[]{4, 1, 2, 0, 5, 6, 3});
@@ -485,7 +485,7 @@ public class PrepareContractionHierarchiesTest {
         initShortcutsGraph(ghStorage, carEncoder);
         AllEdgesIterator iter = ghStorage.getAllEdges();
         while (iter.next()) {
-            GHUtility.setProperties(iter, tmpBikeEncoder, 18, true, true);
+            GHUtility.setSpeed(18, true, true, tmpBikeEncoder, iter);
         }
         ghStorage.freeze();
 
@@ -506,7 +506,7 @@ public class PrepareContractionHierarchiesTest {
         initShortcutsGraph(ghStorage, carEncoder);
         AllEdgesIterator iter = ghStorage.getAllEdges();
         while (iter.next()) {
-            GHUtility.setProperties(iter, tmpBikeEncoder, 18, true, true);
+            GHUtility.setSpeed(18, true, true, tmpBikeEncoder, iter);
         }
         GHUtility.getEdge(ghStorage, 9, 14).
                 set(tmpBikeEncoder.getAccessEnc(), false).

--- a/core/src/test/java/com/graphhopper/routing/lm/LMApproximatorTest.java
+++ b/core/src/test/java/com/graphhopper/routing/lm/LMApproximatorTest.java
@@ -64,7 +64,8 @@ public class LMApproximatorTest {
         GraphHopperStorage graph = new GraphBuilder(encodingManager).setDir(dir).withTurnCosts(true).create();
 
         Random rnd = new Random(seed);
-        GHUtility.buildRandomGraph(graph, rnd, 100, 2.2, true, true, encoder.getAverageSpeedEnc(), 0.7, 0.8, 0.8);
+        GHUtility.buildRandomGraph(graph, rnd, 100, 2.2, true, true,
+                encoder.getAccessEnc(), encoder.getAverageSpeedEnc(), 60d,0.7, 0.8, 0.8);
 
         Weighting weighting = new FastestWeighting(encoder);
 

--- a/core/src/test/java/com/graphhopper/routing/lm/LMIssueTest.java
+++ b/core/src/test/java/com/graphhopper/routing/lm/LMIssueTest.java
@@ -26,6 +26,7 @@ import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.routing.weighting.FastestWeighting;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.*;
+import com.graphhopper.util.GHUtility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -115,13 +116,13 @@ public class LMIssueTest {
         na.setNode(3, 49.403009, 9.708364);
         na.setNode(4, 49.409021, 9.703622);
         // 30s
-        graph.edge(4, 3, 1000, true).set(speedEnc, 120);
-        graph.edge(0, 2, 1000, false).set(speedEnc, 120);
+        GHUtility.setProperties(graph.edge(4, 3).setDistance(1000), encoder, 60, true, true).set(speedEnc, 120);
+        GHUtility.setProperties(graph.edge(0, 2).setDistance(1000), encoder, 60, true, false).set(speedEnc, 120);
         // 360s
-        graph.edge(1, 3, 1000, true).set(speedEnc, 10);
+        GHUtility.setProperties(graph.edge(1, 3).setDistance(1000), encoder, 60, true, true).set(speedEnc, 10);
         // 80s
-        graph.edge(0, 1, 1000, false).set(speedEnc, 45);
-        graph.edge(1, 4, 1000, true).set(speedEnc, 45);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1000), encoder, 60, true, false).set(speedEnc, 45);
+        GHUtility.setProperties(graph.edge(1, 4).setDistance(1000), encoder, 60, true, true).set(speedEnc, 45);
         preProcessGraph();
 
         int source = 0;
@@ -133,7 +134,6 @@ public class LMIssueTest {
         assertEquals(refPath.getTime(), path.getTime(), 50);
         assertEquals(refPath.calcNodes(), path.calcNodes());
     }
-
 
     @ParameterizedTest
     @EnumSource
@@ -158,13 +158,13 @@ public class LMIssueTest {
         na.setNode(7, 49.406965, 9.702660);
         na.setNode(8, 49.405227, 9.702863);
         na.setNode(9, 49.409411, 9.709085);
-        graph.edge(0, 1, 623.197000, true).set(speedEnc, 112);
-        graph.edge(5, 1, 741.414000, true).set(speedEnc, 13);
-        graph.edge(9, 4, 1140.835000, true).set(speedEnc, 35);
-        graph.edge(5, 6, 670.689000, true).set(speedEnc, 18);
-        graph.edge(5, 9, 80.731000, false).set(speedEnc, 88);
-        graph.edge(0, 9, 273.948000, true).set(speedEnc, 82);
-        graph.edge(4, 0, 956.552000, true).set(speedEnc, 60);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(623.197000), encoder, 112, true, true);
+        GHUtility.setProperties(graph.edge(5, 1).setDistance(741.414000), encoder, 13, true, true);
+        GHUtility.setProperties(graph.edge(9, 4).setDistance(1140.835000), encoder, 35, true, true);
+        GHUtility.setProperties(graph.edge(5, 6).setDistance(670.689000), encoder, 18, true, true);
+        GHUtility.setProperties(graph.edge(5, 9).setDistance(80.731000), encoder, 88, true, false);
+        GHUtility.setProperties(graph.edge(0, 9).setDistance(273.948000), encoder, 82, true, true);
+        GHUtility.setProperties(graph.edge(4, 0).setDistance(956.552000), encoder, 60, true, true);
         preProcessGraph();
 
         int source = 5;

--- a/core/src/test/java/com/graphhopper/routing/lm/LMIssueTest.java
+++ b/core/src/test/java/com/graphhopper/routing/lm/LMIssueTest.java
@@ -116,13 +116,13 @@ public class LMIssueTest {
         na.setNode(3, 49.403009, 9.708364);
         na.setNode(4, 49.409021, 9.703622);
         // 30s
-        GHUtility.setProperties(graph.edge(4, 3).setDistance(1000), encoder, 60, true, true).set(speedEnc, 120);
-        GHUtility.setProperties(graph.edge(0, 2).setDistance(1000), encoder, 60, true, false).set(speedEnc, 120);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 3).setDistance(1000)).set(speedEnc, 120);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 2).setDistance(1000)).set(speedEnc, 120);
         // 360s
-        GHUtility.setProperties(graph.edge(1, 3).setDistance(1000), encoder, 60, true, true).set(speedEnc, 10);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 3).setDistance(1000)).set(speedEnc, 10);
         // 80s
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1000), encoder, 60, true, false).set(speedEnc, 45);
-        GHUtility.setProperties(graph.edge(1, 4).setDistance(1000), encoder, 60, true, true).set(speedEnc, 45);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 1).setDistance(1000)).set(speedEnc, 45);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 4).setDistance(1000)).set(speedEnc, 45);
         preProcessGraph();
 
         int source = 0;
@@ -158,13 +158,13 @@ public class LMIssueTest {
         na.setNode(7, 49.406965, 9.702660);
         na.setNode(8, 49.405227, 9.702863);
         na.setNode(9, 49.409411, 9.709085);
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(623.197000), encoder, 112, true, true);
-        GHUtility.setProperties(graph.edge(5, 1).setDistance(741.414000), encoder, 13, true, true);
-        GHUtility.setProperties(graph.edge(9, 4).setDistance(1140.835000), encoder, 35, true, true);
-        GHUtility.setProperties(graph.edge(5, 6).setDistance(670.689000), encoder, 18, true, true);
-        GHUtility.setProperties(graph.edge(5, 9).setDistance(80.731000), encoder, 88, true, false);
-        GHUtility.setProperties(graph.edge(0, 9).setDistance(273.948000), encoder, 82, true, true);
-        GHUtility.setProperties(graph.edge(4, 0).setDistance(956.552000), encoder, 60, true, true);
+        GHUtility.setSpeed(112, true, true, encoder, graph.edge(0, 1).setDistance(623.197000));
+        GHUtility.setSpeed(13, true, true, encoder, graph.edge(5, 1).setDistance(741.414000));
+        GHUtility.setSpeed(35, true, true, encoder, graph.edge(9, 4).setDistance(1140.835000));
+        GHUtility.setSpeed(18, true, true, encoder, graph.edge(5, 6).setDistance(670.689000));
+        GHUtility.setSpeed(88, true, false, encoder, graph.edge(5, 9).setDistance(80.731000));
+        GHUtility.setSpeed(82, true, true, encoder, graph.edge(0, 9).setDistance(273.948000));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 0).setDistance(956.552000));
         preProcessGraph();
 
         int source = 5;

--- a/core/src/test/java/com/graphhopper/routing/lm/LandmarkStorageTest.java
+++ b/core/src/test/java/com/graphhopper/routing/lm/LandmarkStorageTest.java
@@ -48,7 +48,7 @@ import static org.junit.Assert.*;
  * @author Peter Karich
  */
 public class LandmarkStorageTest {
-    private GraphHopperStorage ghStorage;
+    private GraphHopperStorage graph;
     private FlagEncoder encoder;
     private EncodingManager encodingManager;
 
@@ -56,22 +56,22 @@ public class LandmarkStorageTest {
     public void setUp() {
         encoder = new CarFlagEncoder();
         encodingManager = EncodingManager.create(encoder);
-        ghStorage = new GraphHopperStorage(new RAMDirectory(),
+        graph = new GraphHopperStorage(new RAMDirectory(),
                 encodingManager, false);
-        ghStorage.create(1000);
+        graph.create(1000);
     }
 
     @After
     public void tearDown() {
-        if (ghStorage != null)
-            ghStorage.close();
+        if (graph != null)
+            graph.close();
     }
 
     @Test
     public void testInfiniteWeight() {
         Directory dir = new RAMDirectory();
-        EdgeIteratorState edge = ghStorage.edge(0, 1);
-        int res = new LandmarkStorage(ghStorage, dir, new LMConfig("c1", new FastestWeighting(encoder) {
+        EdgeIteratorState edge = graph.edge(0, 1);
+        int res = new LandmarkStorage(graph, dir, new LMConfig("c1", new FastestWeighting(encoder) {
             @Override
             public double calcEdgeWeight(EdgeIteratorState edgeState, boolean reverse) {
                 return Integer.MAX_VALUE * 2L;
@@ -80,7 +80,7 @@ public class LandmarkStorageTest {
         assertEquals(Integer.MAX_VALUE, res);
 
         dir = new RAMDirectory();
-        res = new LandmarkStorage(ghStorage, dir, new LMConfig("c2", new FastestWeighting(encoder) {
+        res = new LandmarkStorage(graph, dir, new LMConfig("c2", new FastestWeighting(encoder) {
             @Override
             public double calcEdgeWeight(EdgeIteratorState edgeState, boolean reverse) {
                 return Double.POSITIVE_INFINITY;
@@ -91,12 +91,12 @@ public class LandmarkStorageTest {
 
     @Test
     public void testSetGetWeight() {
-        ghStorage.edge(0, 1, 40, true);
+        GHUtility.setProperties(graph.edge(0,1).setDistance(40.1),encoder,60,true, true);
         Directory dir = new RAMDirectory();
         DataAccess da = dir.find("landmarks_c1");
         da.create(2000);
 
-        LandmarkStorage lms = new LandmarkStorage(ghStorage, dir, new LMConfig("c1", new FastestWeighting(encoder)), 4).
+        LandmarkStorage lms = new LandmarkStorage(graph, dir, new LMConfig("c1", new FastestWeighting(encoder)), 4).
                 setMaximumWeight(LandmarkStorage.PRECISION);
         // 2^16=65536, use -1 for infinity and -2 for maximum
         lms.setWeight(0, 65536);
@@ -118,14 +118,14 @@ public class LandmarkStorageTest {
 
     @Test
     public void testWithSubnetworks() {
-        ghStorage.edge(0, 1, 10, true);
-        ghStorage.edge(1, 2, 10, true);
+        GHUtility.setProperties(graph.edge(0,1).setDistance(10.1),encoder,60,true, true);
+        GHUtility.setProperties(graph.edge(1,2).setDistance(10.2),encoder,60,true, true);
 
-        ghStorage.edge(2, 4).set(encoder.getAccessEnc(), false).setReverse(encoder.getAccessEnc(), false);
-        ghStorage.edge(4, 5, 10, true);
-        ghStorage.edge(5, 6, 10, false);
+        graph.edge(2, 4).set(encoder.getAccessEnc(), false).setReverse(encoder.getAccessEnc(), false);
+        GHUtility.setProperties(graph.edge(4,5).setDistance(10.5),encoder,60,true, true);
+        GHUtility.setProperties(graph.edge(5,6).setDistance(10.6),encoder,60,true, false);
 
-        LandmarkStorage storage = new LandmarkStorage(ghStorage, new RAMDirectory(), new LMConfig("c1", new FastestWeighting(encoder)), 2);
+        LandmarkStorage storage = new LandmarkStorage(graph, new RAMDirectory(), new LMConfig("c1", new FastestWeighting(encoder)), 2);
         storage.setMinimumNodes(2);
         storage.createLandmarks();
         assertEquals(3, storage.getSubnetworksWithLandmarks());
@@ -137,13 +137,13 @@ public class LandmarkStorageTest {
     public void testWithSubnetworks2() {
         // should not happen with subnetwork preparation
         // 0 - 1 - 2 = 3 - 4
-        ghStorage.edge(0, 1, 10, true);
-        ghStorage.edge(1, 2, 10, true);
-        ghStorage.edge(2, 3, 10, false);
-        ghStorage.edge(3, 2, 10, false);
-        ghStorage.edge(3, 4, 10, true);
+        GHUtility.setProperties(graph.edge(0,1).setDistance(10.1),encoder,60,true, true);
+        GHUtility.setProperties(graph.edge(1,2).setDistance(10.2),encoder,60,true, true);
+        GHUtility.setProperties(graph.edge(2,3).setDistance(10.3),encoder,60,true, false);
+        GHUtility.setProperties(graph.edge(3,2).setDistance(10.2),encoder,60,true, false);
+        GHUtility.setProperties(graph.edge(3,4).setDistance(10.4),encoder,60,true, true);
 
-        LandmarkStorage storage = new LandmarkStorage(ghStorage, new RAMDirectory(), new LMConfig("c", new FastestWeighting(encoder)), 2);
+        LandmarkStorage storage = new LandmarkStorage(graph, new RAMDirectory(), new LMConfig("c", new FastestWeighting(encoder)), 2);
         storage.setMinimumNodes(3);
         storage.createLandmarks();
         assertEquals(2, storage.getSubnetworksWithLandmarks());
@@ -154,14 +154,14 @@ public class LandmarkStorageTest {
     public void testWithOnewaySubnetworks() {
         // should not happen with subnetwork preparation
         // create an indifferent problem: node 2 and 3 are part of two 'disconnected' subnetworks
-        ghStorage.edge(0, 1, 10, true);
-        ghStorage.edge(1, 2, 10, false);
-        ghStorage.edge(2, 3, 10, false);
+        GHUtility.setProperties(graph.edge(0,1).setDistance(10.1),encoder,60,true, true);
+        GHUtility.setProperties(graph.edge(1,2).setDistance(10.2),encoder,60,true, false);
+        GHUtility.setProperties(graph.edge(2,3).setDistance(10.3),encoder,60,true, false);
 
-        ghStorage.edge(4, 5, 10, true);
-        ghStorage.edge(5, 2, 10, false);
+        GHUtility.setProperties(graph.edge(4,5).setDistance(10.5),encoder,60,true, true);
+        GHUtility.setProperties(graph.edge(5,2).setDistance(10.2),encoder,60,true, false);
 
-        LandmarkStorage storage = new LandmarkStorage(ghStorage, new RAMDirectory(), new LMConfig("c", new FastestWeighting(encoder)), 2);
+        LandmarkStorage storage = new LandmarkStorage(graph, new RAMDirectory(), new LMConfig("c", new FastestWeighting(encoder)), 2);
         storage.setMinimumNodes(2);
         storage.createLandmarks();
 
@@ -172,11 +172,11 @@ public class LandmarkStorageTest {
     @Test
     public void testWeightingConsistence() {
         // create an indifferent problem: shortest weighting can pass the speed==0 edge but fastest cannot (?)
-        ghStorage.edge(0, 1, 10, true);
-        GHUtility.setProperties(ghStorage.edge(1, 2).setDistance(10), encoder, 0.9, true, true);
-        ghStorage.edge(2, 3, 10, true);
+        GHUtility.setProperties(graph.edge(0,1).setDistance(10.1),encoder,60,true, true);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(10), encoder, 0.9, true, true);
+        GHUtility.setProperties(graph.edge(2,3).setDistance(10.3),encoder,60,true, true);
 
-        LandmarkStorage storage = new LandmarkStorage(ghStorage, new RAMDirectory(), new LMConfig("c", new FastestWeighting(encoder)), 2);
+        LandmarkStorage storage = new LandmarkStorage(graph, new RAMDirectory(), new LMConfig("c", new FastestWeighting(encoder)), 2);
         storage.setMinimumNodes(2);
         storage.createLandmarks();
 
@@ -186,9 +186,9 @@ public class LandmarkStorageTest {
 
     @Test
     public void testWithBorderBlocking() {
-        RoutingAlgorithmTest.initBiGraph(ghStorage);
+        RoutingAlgorithmTest.initBiGraph(graph, encoder);
 
-        LandmarkStorage storage = new LandmarkStorage(ghStorage, new RAMDirectory(), new LMConfig("c", new FastestWeighting(encoder)), 2);
+        LandmarkStorage storage = new LandmarkStorage(graph, new RAMDirectory(), new LMConfig("c", new FastestWeighting(encoder)), 2);
         final SpatialRule ruleRight = new AbstractSpatialRule(Collections.<Polygon>emptyList()) {
             @Override
             public String getId() {
@@ -202,7 +202,7 @@ public class LandmarkStorageTest {
             }
         };
         final SpatialRuleLookup lookup = new SpatialRuleLookup() {
-            
+
             private final List<SpatialRule> rules = Arrays.asList(ruleLeft, ruleRight);
 
             @Override
@@ -214,9 +214,9 @@ public class LandmarkStorageTest {
                     rule = ruleLeft;
                 }
 
-                return new SpatialRuleSet(Collections.singletonList(rule), rules.indexOf(rule)+1);
+                return new SpatialRuleSet(Collections.singletonList(rule), rules.indexOf(rule) + 1);
             }
-            
+
             @Override
             public List<SpatialRule> getRules() {
                 return rules;

--- a/core/src/test/java/com/graphhopper/routing/lm/LandmarkStorageTest.java
+++ b/core/src/test/java/com/graphhopper/routing/lm/LandmarkStorageTest.java
@@ -91,7 +91,7 @@ public class LandmarkStorageTest {
 
     @Test
     public void testSetGetWeight() {
-        GHUtility.setProperties(graph.edge(0,1).setDistance(40.1),encoder,60,true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(40.1));
         Directory dir = new RAMDirectory();
         DataAccess da = dir.find("landmarks_c1");
         da.create(2000);
@@ -118,12 +118,12 @@ public class LandmarkStorageTest {
 
     @Test
     public void testWithSubnetworks() {
-        GHUtility.setProperties(graph.edge(0,1).setDistance(10.1),encoder,60,true, true);
-        GHUtility.setProperties(graph.edge(1,2).setDistance(10.2),encoder,60,true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(10.1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(10.2));
 
         graph.edge(2, 4).set(encoder.getAccessEnc(), false).setReverse(encoder.getAccessEnc(), false);
-        GHUtility.setProperties(graph.edge(4,5).setDistance(10.5),encoder,60,true, true);
-        GHUtility.setProperties(graph.edge(5,6).setDistance(10.6),encoder,60,true, false);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 5).setDistance(10.5));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(5, 6).setDistance(10.6));
 
         LandmarkStorage storage = new LandmarkStorage(graph, new RAMDirectory(), new LMConfig("c1", new FastestWeighting(encoder)), 2);
         storage.setMinimumNodes(2);
@@ -137,11 +137,11 @@ public class LandmarkStorageTest {
     public void testWithSubnetworks2() {
         // should not happen with subnetwork preparation
         // 0 - 1 - 2 = 3 - 4
-        GHUtility.setProperties(graph.edge(0,1).setDistance(10.1),encoder,60,true, true);
-        GHUtility.setProperties(graph.edge(1,2).setDistance(10.2),encoder,60,true, true);
-        GHUtility.setProperties(graph.edge(2,3).setDistance(10.3),encoder,60,true, false);
-        GHUtility.setProperties(graph.edge(3,2).setDistance(10.2),encoder,60,true, false);
-        GHUtility.setProperties(graph.edge(3,4).setDistance(10.4),encoder,60,true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(10.1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(10.2));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 3).setDistance(10.3));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 2).setDistance(10.2));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 4).setDistance(10.4));
 
         LandmarkStorage storage = new LandmarkStorage(graph, new RAMDirectory(), new LMConfig("c", new FastestWeighting(encoder)), 2);
         storage.setMinimumNodes(3);
@@ -154,12 +154,12 @@ public class LandmarkStorageTest {
     public void testWithOnewaySubnetworks() {
         // should not happen with subnetwork preparation
         // create an indifferent problem: node 2 and 3 are part of two 'disconnected' subnetworks
-        GHUtility.setProperties(graph.edge(0,1).setDistance(10.1),encoder,60,true, true);
-        GHUtility.setProperties(graph.edge(1,2).setDistance(10.2),encoder,60,true, false);
-        GHUtility.setProperties(graph.edge(2,3).setDistance(10.3),encoder,60,true, false);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(10.1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 2).setDistance(10.2));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 3).setDistance(10.3));
 
-        GHUtility.setProperties(graph.edge(4,5).setDistance(10.5),encoder,60,true, true);
-        GHUtility.setProperties(graph.edge(5,2).setDistance(10.2),encoder,60,true, false);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 5).setDistance(10.5));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(5, 2).setDistance(10.2));
 
         LandmarkStorage storage = new LandmarkStorage(graph, new RAMDirectory(), new LMConfig("c", new FastestWeighting(encoder)), 2);
         storage.setMinimumNodes(2);
@@ -172,9 +172,9 @@ public class LandmarkStorageTest {
     @Test
     public void testWeightingConsistence() {
         // create an indifferent problem: shortest weighting can pass the speed==0 edge but fastest cannot (?)
-        GHUtility.setProperties(graph.edge(0,1).setDistance(10.1),encoder,60,true, true);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(10), encoder, 0.9, true, true);
-        GHUtility.setProperties(graph.edge(2,3).setDistance(10.3),encoder,60,true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(10.1));
+        GHUtility.setSpeed(0.9, true, true, encoder, graph.edge(1, 2).setDistance(10));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 3).setDistance(10.3));
 
         LandmarkStorage storage = new LandmarkStorage(graph, new RAMDirectory(), new LMConfig("c", new FastestWeighting(encoder)), 2);
         storage.setMinimumNodes(2);

--- a/core/src/test/java/com/graphhopper/routing/lm/LandmarkStorageTest.java
+++ b/core/src/test/java/com/graphhopper/routing/lm/LandmarkStorageTest.java
@@ -121,7 +121,7 @@ public class LandmarkStorageTest {
         GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(10.1));
         GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(10.2));
 
-        graph.edge(2, 4).set(encoder.getAccessEnc(), false).setReverse(encoder.getAccessEnc(), false);
+        graph.edge(2, 4).set(encoder.getAccessEnc(), false, false);
         GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 5).setDistance(10.5));
         GHUtility.setSpeed(60, true, false, encoder, graph.edge(5, 6).setDistance(10.6));
 

--- a/core/src/test/java/com/graphhopper/routing/lm/PrepareLandmarksTest.java
+++ b/core/src/test/java/com/graphhopper/routing/lm/PrepareLandmarksTest.java
@@ -89,11 +89,11 @@ public class PrepareLandmarksTest {
                 // do not connect first with last column!
                 double speed = 20 + rand.nextDouble() * 30;
                 if (wIndex + 1 < width)
-                    graph.edge(node, node + 1).set(accessEnc, true).setReverse(accessEnc, true).set(avSpeedEnc, speed);
+                    graph.edge(node, node + 1).set(accessEnc, true, true).set(avSpeedEnc, speed);
 
                 // avoid dead ends
                 if (hIndex + 1 < height)
-                    graph.edge(node, node + width).set(accessEnc, true).setReverse(accessEnc, true).set(avSpeedEnc, speed);
+                    graph.edge(node, node + width).set(accessEnc, true, true).set(avSpeedEnc, speed);
 
                 updateDistancesFor(graph, node, -hIndex / 50.0, wIndex / 50.0);
             }

--- a/core/src/test/java/com/graphhopper/routing/lm/PrepareLandmarksTest.java
+++ b/core/src/test/java/com/graphhopper/routing/lm/PrepareLandmarksTest.java
@@ -186,8 +186,8 @@ public class PrepareLandmarksTest {
 
     @Test
     public void testStoreAndLoad() {
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(80_000), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(80_000), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(80_000));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(80_000));
         String fileStr = "./target/tmp-lm";
         Helper.removeDir(new File(fileStr));
 

--- a/core/src/test/java/com/graphhopper/routing/lm/PrepareLandmarksTest.java
+++ b/core/src/test/java/com/graphhopper/routing/lm/PrepareLandmarksTest.java
@@ -33,6 +33,7 @@ import com.graphhopper.storage.RAMDirectory;
 import com.graphhopper.storage.index.LocationIndex;
 import com.graphhopper.storage.index.LocationIndexTree;
 import com.graphhopper.storage.index.Snap;
+import com.graphhopper.util.GHUtility;
 import com.graphhopper.util.Helper;
 import com.graphhopper.util.PMap;
 import com.graphhopper.util.Parameters;
@@ -185,8 +186,8 @@ public class PrepareLandmarksTest {
 
     @Test
     public void testStoreAndLoad() {
-        graph.edge(0, 1, 80_000, true);
-        graph.edge(1, 2, 80_000, true);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(80_000), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(80_000), encoder, 60, true, true);
         String fileStr = "./target/tmp-lm";
         Helper.removeDir(new File(fileStr));
 

--- a/core/src/test/java/com/graphhopper/routing/querygraph/QueryGraphTest.java
+++ b/core/src/test/java/com/graphhopper/routing/querygraph/QueryGraphTest.java
@@ -77,8 +77,9 @@ public class QueryGraphTest {
         na.setNode(0, 1, 0);
         na.setNode(1, 1, 2.5);
         na.setNode(2, 0, 0);
-        g.edge(0, 2, 10, true);
-        g.edge(0, 1, 10, true).setWayGeometry(Helper.createPointList(1.5, 1, 1.5, 1.5));
+        GHUtility.setProperties(g.edge(0, 2).setDistance(10), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(0, 1).setDistance(10), encoder, 60, true, true).
+                setWayGeometry(Helper.createPointList(1.5, 1, 1.5, 1.5));
     }
 
     @Test
@@ -157,8 +158,8 @@ public class QueryGraphTest {
         na.setNode(1, 1, 2.5);
         na.setNode(2, 0, 0);
         na.setNode(3, 0, 1);
-        g.edge(0, 2, 10, true);
-        g.edge(0, 1, 10, true).setWayGeometry(Helper.createPointList(1.5, 1, 1.5, 1.5));
+        GHUtility.setProperties(g.edge(0, 2).setDistance(10), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(0, 1).setDistance(10), encoder, 60, true, true).setWayGeometry(Helper.createPointList(1.5, 1, 1.5, 1.5));
         g.edge(1, 3);
 
         final int baseNode = 1;
@@ -238,7 +239,7 @@ public class QueryGraphTest {
         NodeAccess na = g.getNodeAccess();
         na.setNode(0, 0, 0);
         na.setNode(1, 0, 1);
-        g.edge(0, 1, 10, false);
+        GHUtility.setProperties(g.edge(0, 1).setDistance(10), encoder, 60, true, false);
 
         EdgeIteratorState edge = GHUtility.getEdge(g, 0, 1);
         Snap res1 = createLocationResult(0.1, 0.1, edge, 0, EDGE);
@@ -301,10 +302,10 @@ public class QueryGraphTest {
         //    |  |
         //    x---
         //
-        g.edge(0, 1, 10, true);
-        g.edge(1, 3, 10, true);
-        g.edge(3, 4, 10, true);
-        EdgeIteratorState edge = g.edge(1, 3, 20, true).setWayGeometry(Helper.createPointList(-0.001, 0.001, -0.001, 0.002));
+        GHUtility.setProperties(g.edge(0, 1).setDistance(10), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(1, 3).setDistance(10), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(3, 4).setDistance(10), encoder, 60, true, true);
+        EdgeIteratorState edge = GHUtility.setProperties(g.edge(1, 3).setDistance(20), encoder, 60, true, true).setWayGeometry(Helper.createPointList(-0.001, 0.001, -0.001, 0.002));
         updateDistancesFor(g, 0, 0, 0);
         updateDistancesFor(g, 1, 0, 0.001);
         updateDistancesFor(g, 3, 0, 0.002);
@@ -333,7 +334,7 @@ public class QueryGraphTest {
         NodeAccess na = g.getNodeAccess();
         na.setNode(0, 0, 0);
         na.setNode(1, 0, -0.001);
-        g.edge(0, 1, 10, true);
+        GHUtility.setProperties(g.edge(0, 1).setDistance(10), encoder, 60, true, true);
         BooleanEncodedValue accessEnc = encoder.getAccessEnc();
         DecimalEncodedValue avSpeedEnc = encoder.getAverageSpeedEnc();
         // in the case of identical nodes the wayGeometry defines the direction!
@@ -451,7 +452,8 @@ public class QueryGraphTest {
          */
         g.getNodeAccess().setNode(nodeA, 1, 0);
         g.getNodeAccess().setNode(nodeB, 1, 10);
-        g.edge(nodeA, nodeB, 10, false).setWayGeometry(Helper.createPointList(1.5, 3, 1.5, 7));
+        GHUtility.setProperties(g.edge(nodeA, nodeB).setDistance(10), encoder, 60, true, false).
+                setWayGeometry(Helper.createPointList(1.5, 3, 1.5, 7));
 
         // assert the behavior for classic edgeIterator        
         assertEdgeIdsStayingEqual(inExplorer, outExplorer, nodeA, nodeB);
@@ -505,8 +507,8 @@ public class QueryGraphTest {
         na.setNode(1, .00, .01);
         na.setNode(2, .01, .01);
 
-        EdgeIteratorState edge0 = graphWithTurnCosts.edge(0, 1, 10, true);
-        EdgeIteratorState edge1 = graphWithTurnCosts.edge(2, 1, 10, true);
+        EdgeIteratorState edge0 = GHUtility.setProperties(graphWithTurnCosts.edge(0, 1).setDistance(10), encoder, 60, true, true);
+        EdgeIteratorState edge1 = GHUtility.setProperties(graphWithTurnCosts.edge(2, 1).setDistance(10), encoder, 60, true, true);
 
         Weighting weighting = new FastestWeighting(encoder, new DefaultTurnCostProvider(encoder, graphWithTurnCosts.getTurnCostStorage()));
 
@@ -552,10 +554,11 @@ public class QueryGraphTest {
         //  x    |
         //  |    |
         //  0    1
-        NodeAccess na = ((Graph) g).getNodeAccess();
+        NodeAccess na = g.getNodeAccess();
         na.setNode(0, 0, 0);
         na.setNode(1, 0, 2);
-        ((Graph) g).edge(0, 1, 10, true).setWayGeometry(Helper.createPointList(2, 0, 2, 2));
+        GHUtility.setProperties(g.edge(0, 1).setDistance(10), encoder, 60, true, true).
+                setWayGeometry(Helper.createPointList(2, 0, 2, 2));
         EdgeIteratorState edge = GHUtility.getEdge(g, 0, 1);
 
         // snap on first vertical part of way (upward, base is in south)
@@ -622,7 +625,7 @@ public class QueryGraphTest {
         //       2
         na.setNode(0, 0, 0);
         na.setNode(1, 0, 2);
-        EdgeIteratorState edge = g.edge(0, 1, 10, true);
+        EdgeIteratorState edge = GHUtility.setProperties(g.edge(0, 1).setDistance(10), encoder, 60, true, true);
 
         Snap snap = fakeEdgeSnap(edge, 0, 1, 0);
         QueryGraph queryGraph = QueryGraph.create(g, snap);
@@ -649,10 +652,11 @@ public class QueryGraphTest {
         //  |    |
         //  |    |
         //  0    1
-        NodeAccess na = ((Graph) g).getNodeAccess();
+        NodeAccess na = g.getNodeAccess();
         na.setNode(0, 0, 0);
         na.setNode(1, 0, 2);
-        ((Graph) g).edge(0, 1, 10, true).setWayGeometry(Helper.createPointList(2, 0, 2, 2));
+        GHUtility.setProperties(g.edge(0, 1).setDistance(10), encoder, 60, true, true).
+                setWayGeometry(Helper.createPointList(2, 0, 2, 2));
         EdgeIteratorState edge = GHUtility.getEdge(g, 0, 1);
 
         // snap on first vertical part of way (upward)
@@ -711,7 +715,8 @@ public class QueryGraphTest {
         NodeAccess na = g.getNodeAccess();
         na.setNode(0, 0, 0);
         na.setNode(1, 0.3, 0.3);
-        g.edge(0, 1, 10, true).setWayGeometry(Helper.createPointList(0.1, 0.1, 0.2, 0.2));
+        GHUtility.setProperties(g.edge(0, 1).setDistance(10), encoder, 60, true, true).
+                setWayGeometry(Helper.createPointList(0.1, 0.1, 0.2, 0.2));
 
         LocationIndex locationIndex = new LocationIndexTree(g, new RAMDirectory());
         locationIndex.prepareIndex();
@@ -752,7 +757,8 @@ public class QueryGraphTest {
         NodeAccess na = g.getNodeAccess();
         na.setNode(0, 0, 0);
         na.setNode(1, 0.5, 0.1);
-        g.edge(0, 1, 10, true).setWayGeometry(Helper.createPointList(0.1, 0.1, 0.2, 0.2));
+        GHUtility.setProperties(g.edge(0, 1).setDistance(10), encoder, 60, true, true).
+                setWayGeometry(Helper.createPointList(0.1, 0.1, 0.2, 0.2));
 
         LocationIndex locationIndex = new LocationIndexTree(g, new RAMDirectory());
         locationIndex.prepareIndex();
@@ -797,7 +803,8 @@ public class QueryGraphTest {
         dist += distCalc.calcDist(0, 0, 1, 0);
         dist += distCalc.calcDist(1, 0, 1, 1);
         dist += distCalc.calcDist(1, 1, 0, 1);
-        g.edge(0, 1, dist, true).setWayGeometry(Helper.createPointList(1, 0, 1, 1));
+        GHUtility.setProperties(g.edge(0, 1).setDistance(dist), encoder, 60, true, true).
+                setWayGeometry(Helper.createPointList(1, 0, 1, 1));
         LocationIndexTree index = new LocationIndexTree(g, new RAMDirectory());
         index.prepareIndex();
         Snap snap = index.findClosest(1.01, 0.7, EdgeFilter.ALL_EDGES);
@@ -827,7 +834,7 @@ public class QueryGraphTest {
         na.setNode(0, 50.00, 10.10);
         na.setNode(1, 50.00, 10.20);
         double dist = DistanceCalcEarth.DIST_EARTH.calcDist(na.getLat(0), na.getLon(0), na.getLat(1), na.getLon(1));
-        EdgeIteratorState edge = g.edge(0, 1, dist, true);
+        EdgeIteratorState edge = GHUtility.setProperties(g.edge(0, 1).setDistance(dist), encoder, 60, true, true);
         edge.set(speedEnc, 50);
         edge.setReverse(speedEnc, 100);
 
@@ -902,7 +909,7 @@ public class QueryGraphTest {
         na.setNode(1, 50.00, 10.20);
         double dist = DistanceCalcEarth.DIST_EARTH.calcDist(na.getLat(0), na.getLon(0), na.getLat(1), na.getLon(1));
         // this time we store the edge the other way
-        EdgeIteratorState edge = g.edge(1, 0, dist, true);
+        EdgeIteratorState edge = GHUtility.setProperties(g.edge(1, 0).setDistance(dist), encoder, 60, true, true);
         edge.set(speedEnc, 100);
         edge.setReverse(speedEnc, 50);
 

--- a/core/src/test/java/com/graphhopper/routing/querygraph/QueryGraphTest.java
+++ b/core/src/test/java/com/graphhopper/routing/querygraph/QueryGraphTest.java
@@ -77,8 +77,8 @@ public class QueryGraphTest {
         na.setNode(0, 1, 0);
         na.setNode(1, 1, 2.5);
         na.setNode(2, 0, 0);
-        GHUtility.setProperties(g.edge(0, 2).setDistance(10), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(0, 1).setDistance(10), encoder, 60, true, true).
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(0, 2).setDistance(10));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(0, 1).setDistance(10)).
                 setWayGeometry(Helper.createPointList(1.5, 1, 1.5, 1.5));
     }
 
@@ -158,8 +158,8 @@ public class QueryGraphTest {
         na.setNode(1, 1, 2.5);
         na.setNode(2, 0, 0);
         na.setNode(3, 0, 1);
-        GHUtility.setProperties(g.edge(0, 2).setDistance(10), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(0, 1).setDistance(10), encoder, 60, true, true).setWayGeometry(Helper.createPointList(1.5, 1, 1.5, 1.5));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(0, 2).setDistance(10));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(0, 1).setDistance(10)).setWayGeometry(Helper.createPointList(1.5, 1, 1.5, 1.5));
         g.edge(1, 3);
 
         final int baseNode = 1;
@@ -239,7 +239,7 @@ public class QueryGraphTest {
         NodeAccess na = g.getNodeAccess();
         na.setNode(0, 0, 0);
         na.setNode(1, 0, 1);
-        GHUtility.setProperties(g.edge(0, 1).setDistance(10), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(0, 1).setDistance(10));
 
         EdgeIteratorState edge = GHUtility.getEdge(g, 0, 1);
         Snap res1 = createLocationResult(0.1, 0.1, edge, 0, EDGE);
@@ -302,10 +302,10 @@ public class QueryGraphTest {
         //    |  |
         //    x---
         //
-        GHUtility.setProperties(g.edge(0, 1).setDistance(10), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(1, 3).setDistance(10), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(3, 4).setDistance(10), encoder, 60, true, true);
-        EdgeIteratorState edge = GHUtility.setProperties(g.edge(1, 3).setDistance(20), encoder, 60, true, true).setWayGeometry(Helper.createPointList(-0.001, 0.001, -0.001, 0.002));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(0, 1).setDistance(10));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(1, 3).setDistance(10));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(3, 4).setDistance(10));
+        EdgeIteratorState edge = GHUtility.setSpeed(60, true, true, encoder, g.edge(1, 3).setDistance(20)).setWayGeometry(Helper.createPointList(-0.001, 0.001, -0.001, 0.002));
         updateDistancesFor(g, 0, 0, 0);
         updateDistancesFor(g, 1, 0, 0.001);
         updateDistancesFor(g, 3, 0, 0.002);
@@ -334,7 +334,7 @@ public class QueryGraphTest {
         NodeAccess na = g.getNodeAccess();
         na.setNode(0, 0, 0);
         na.setNode(1, 0, -0.001);
-        GHUtility.setProperties(g.edge(0, 1).setDistance(10), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(0, 1).setDistance(10));
         BooleanEncodedValue accessEnc = encoder.getAccessEnc();
         DecimalEncodedValue avSpeedEnc = encoder.getAverageSpeedEnc();
         // in the case of identical nodes the wayGeometry defines the direction!
@@ -452,7 +452,7 @@ public class QueryGraphTest {
          */
         g.getNodeAccess().setNode(nodeA, 1, 0);
         g.getNodeAccess().setNode(nodeB, 1, 10);
-        GHUtility.setProperties(g.edge(nodeA, nodeB).setDistance(10), encoder, 60, true, false).
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(nodeA, nodeB).setDistance(10)).
                 setWayGeometry(Helper.createPointList(1.5, 3, 1.5, 7));
 
         // assert the behavior for classic edgeIterator        
@@ -507,8 +507,8 @@ public class QueryGraphTest {
         na.setNode(1, .00, .01);
         na.setNode(2, .01, .01);
 
-        EdgeIteratorState edge0 = GHUtility.setProperties(graphWithTurnCosts.edge(0, 1).setDistance(10), encoder, 60, true, true);
-        EdgeIteratorState edge1 = GHUtility.setProperties(graphWithTurnCosts.edge(2, 1).setDistance(10), encoder, 60, true, true);
+        EdgeIteratorState edge0 = GHUtility.setSpeed(60, true, true, encoder, graphWithTurnCosts.edge(0, 1).setDistance(10));
+        EdgeIteratorState edge1 = GHUtility.setSpeed(60, true, true, encoder, graphWithTurnCosts.edge(2, 1).setDistance(10));
 
         Weighting weighting = new FastestWeighting(encoder, new DefaultTurnCostProvider(encoder, graphWithTurnCosts.getTurnCostStorage()));
 
@@ -557,7 +557,7 @@ public class QueryGraphTest {
         NodeAccess na = g.getNodeAccess();
         na.setNode(0, 0, 0);
         na.setNode(1, 0, 2);
-        GHUtility.setProperties(g.edge(0, 1).setDistance(10), encoder, 60, true, true).
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(0, 1).setDistance(10)).
                 setWayGeometry(Helper.createPointList(2, 0, 2, 2));
         EdgeIteratorState edge = GHUtility.getEdge(g, 0, 1);
 
@@ -625,7 +625,7 @@ public class QueryGraphTest {
         //       2
         na.setNode(0, 0, 0);
         na.setNode(1, 0, 2);
-        EdgeIteratorState edge = GHUtility.setProperties(g.edge(0, 1).setDistance(10), encoder, 60, true, true);
+        EdgeIteratorState edge = GHUtility.setSpeed(60, true, true, encoder, g.edge(0, 1).setDistance(10));
 
         Snap snap = fakeEdgeSnap(edge, 0, 1, 0);
         QueryGraph queryGraph = QueryGraph.create(g, snap);
@@ -655,7 +655,7 @@ public class QueryGraphTest {
         NodeAccess na = g.getNodeAccess();
         na.setNode(0, 0, 0);
         na.setNode(1, 0, 2);
-        GHUtility.setProperties(g.edge(0, 1).setDistance(10), encoder, 60, true, true).
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(0, 1).setDistance(10)).
                 setWayGeometry(Helper.createPointList(2, 0, 2, 2));
         EdgeIteratorState edge = GHUtility.getEdge(g, 0, 1);
 
@@ -715,7 +715,7 @@ public class QueryGraphTest {
         NodeAccess na = g.getNodeAccess();
         na.setNode(0, 0, 0);
         na.setNode(1, 0.3, 0.3);
-        GHUtility.setProperties(g.edge(0, 1).setDistance(10), encoder, 60, true, true).
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(0, 1).setDistance(10)).
                 setWayGeometry(Helper.createPointList(0.1, 0.1, 0.2, 0.2));
 
         LocationIndex locationIndex = new LocationIndexTree(g, new RAMDirectory());
@@ -757,7 +757,7 @@ public class QueryGraphTest {
         NodeAccess na = g.getNodeAccess();
         na.setNode(0, 0, 0);
         na.setNode(1, 0.5, 0.1);
-        GHUtility.setProperties(g.edge(0, 1).setDistance(10), encoder, 60, true, true).
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(0, 1).setDistance(10)).
                 setWayGeometry(Helper.createPointList(0.1, 0.1, 0.2, 0.2));
 
         LocationIndex locationIndex = new LocationIndexTree(g, new RAMDirectory());
@@ -803,7 +803,7 @@ public class QueryGraphTest {
         dist += distCalc.calcDist(0, 0, 1, 0);
         dist += distCalc.calcDist(1, 0, 1, 1);
         dist += distCalc.calcDist(1, 1, 0, 1);
-        GHUtility.setProperties(g.edge(0, 1).setDistance(dist), encoder, 60, true, true).
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(0, 1).setDistance(dist)).
                 setWayGeometry(Helper.createPointList(1, 0, 1, 1));
         LocationIndexTree index = new LocationIndexTree(g, new RAMDirectory());
         index.prepareIndex();
@@ -834,7 +834,7 @@ public class QueryGraphTest {
         na.setNode(0, 50.00, 10.10);
         na.setNode(1, 50.00, 10.20);
         double dist = DistanceCalcEarth.DIST_EARTH.calcDist(na.getLat(0), na.getLon(0), na.getLat(1), na.getLon(1));
-        EdgeIteratorState edge = GHUtility.setProperties(g.edge(0, 1).setDistance(dist), encoder, 60, true, true);
+        EdgeIteratorState edge = GHUtility.setSpeed(60, true, true, encoder, g.edge(0, 1).setDistance(dist));
         edge.set(speedEnc, 50);
         edge.setReverse(speedEnc, 100);
 
@@ -909,7 +909,7 @@ public class QueryGraphTest {
         na.setNode(1, 50.00, 10.20);
         double dist = DistanceCalcEarth.DIST_EARTH.calcDist(na.getLat(0), na.getLon(0), na.getLat(1), na.getLon(1));
         // this time we store the edge the other way
-        EdgeIteratorState edge = GHUtility.setProperties(g.edge(1, 0).setDistance(dist), encoder, 60, true, true);
+        EdgeIteratorState edge = GHUtility.setSpeed(60, true, true, encoder, g.edge(1, 0).setDistance(dist));
         edge.set(speedEnc, 100);
         edge.setReverse(speedEnc, 50);
 

--- a/core/src/test/java/com/graphhopper/routing/querygraph/QueryGraphTest.java
+++ b/core/src/test/java/com/graphhopper/routing/querygraph/QueryGraphTest.java
@@ -340,7 +340,7 @@ public class QueryGraphTest {
         // in the case of identical nodes the wayGeometry defines the direction!
         EdgeIteratorState edge = g.edge(0, 0).
                 setDistance(100).
-                set(accessEnc, true).setReverse(accessEnc, false).set(avSpeedEnc, 20.0).
+                set(accessEnc, true, false).set(avSpeedEnc, 20.0).
                 setWayGeometry(Helper.createPointList(0.001, 0, 0, 0.001));
 
         Snap snap = new Snap(0.0011, 0.0009);
@@ -910,8 +910,7 @@ public class QueryGraphTest {
         double dist = DistanceCalcEarth.DIST_EARTH.calcDist(na.getLat(0), na.getLon(0), na.getLat(1), na.getLon(1));
         // this time we store the edge the other way
         EdgeIteratorState edge = GHUtility.setSpeed(60, true, true, encoder, g.edge(1, 0).setDistance(dist));
-        edge.set(speedEnc, 100);
-        edge.setReverse(speedEnc, 50);
+        edge.set(speedEnc, 100, 50);
 
         // query graph
         Snap snap = createLocationResult(50.00, 10.15, edge, 0, EDGE);

--- a/core/src/test/java/com/graphhopper/routing/subnetwork/EdgeBasedTarjanSCCTest.java
+++ b/core/src/test/java/com/graphhopper/routing/subnetwork/EdgeBasedTarjanSCCTest.java
@@ -42,15 +42,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class EdgeBasedTarjanSCCTest {
-    private final FlagEncoder carFlagEncoder = new CarFlagEncoder(5, 5, 1);
-    private final EncodingManager em = EncodingManager.create(carFlagEncoder);
-    private final BooleanEncodedValue accessEnc = carFlagEncoder.getAccessEnc();
+    private final FlagEncoder encoder = new CarFlagEncoder(5, 5, 1);
+    private final EncodingManager em = EncodingManager.create(encoder);
+    private final BooleanEncodedValue accessEnc = encoder.getAccessEnc();
 
     @Test
     public void linearSingle() {
         GraphHopperStorage g = new GraphBuilder(em).create();
         // 0 - 1
-        g.edge(0, 1, 1, true);
+        GHUtility.setProperties(g.edge(0,1).setDistance(1),encoder,60,true, true);
         EdgeBasedTarjanSCC tarjan = new EdgeBasedTarjanSCC(g, accessEnc, NO_TURN_COST_PROVIDER, false);
         ConnectedComponents result = tarjan.findComponentsRecursive();
         assertEquals(2, result.getEdgeKeys());
@@ -65,8 +65,8 @@ class EdgeBasedTarjanSCCTest {
     public void linearSimple() {
         GraphHopperStorage g = new GraphBuilder(em).create();
         // 0 - 1 - 2
-        g.edge(0, 1, 1, true);
-        g.edge(1, 2, 1, true);
+        GHUtility.setProperties(g.edge(0,1).setDistance(1),encoder,60,true, true);
+        GHUtility.setProperties(g.edge(1,2).setDistance(1),encoder,60,true, true);
         EdgeBasedTarjanSCC tarjan = new EdgeBasedTarjanSCC(g, accessEnc, NO_TURN_COST_PROVIDER, false);
         ConnectedComponents result = tarjan.findComponentsRecursive();
         assertEquals(4, result.getEdgeKeys());
@@ -81,8 +81,8 @@ class EdgeBasedTarjanSCCTest {
     public void linearOneWay() {
         GraphHopperStorage g = new GraphBuilder(em).create();
         // 0 -> 1 -> 2
-        g.edge(0, 1, 1, false);
-        g.edge(1, 2, 1, false);
+        GHUtility.setProperties(g.edge(0,1).setDistance(1),encoder,60,true, false);
+        GHUtility.setProperties(g.edge(1,2).setDistance(1),encoder,60,true, false);
         EdgeBasedTarjanSCC tarjan = new EdgeBasedTarjanSCC(g, accessEnc, NO_TURN_COST_PROVIDER, false);
         ConnectedComponents result = tarjan.findComponentsRecursive();
         assertEquals(4, result.getEdgeKeys());
@@ -98,9 +98,9 @@ class EdgeBasedTarjanSCCTest {
     public void linearBidirectionalEdge() {
         GraphHopperStorage g = new GraphBuilder(em).create();
         // 0 -> 1 - 2 <- 3
-        g.edge(0, 1, 1, false);
-        g.edge(1, 2, 1, true);
-        g.edge(3, 2, 1, false);
+        GHUtility.setProperties(g.edge(0,1).setDistance(1),encoder,60,true, false);
+        GHUtility.setProperties(g.edge(1,2).setDistance(1),encoder,60,true, true);
+        GHUtility.setProperties(g.edge(3,2).setDistance(1),encoder,60,true, false);
         EdgeBasedTarjanSCC tarjan = new EdgeBasedTarjanSCC(g, accessEnc, NO_TURN_COST_PROVIDER, false);
         ConnectedComponents result = tarjan.findComponentsRecursive();
         assertEquals(6, result.getEdgeKeys());
@@ -118,14 +118,14 @@ class EdgeBasedTarjanSCCTest {
         // 0 - 1 - 2 - 4 - 5
         //     |    \- 6 - 7
         //     3        \- 8
-        g.edge(0, 1, 1, true);
-        g.edge(1, 2, 1, true);
-        g.edge(1, 3, 1, true);
-        g.edge(2, 4, 1, true);
-        g.edge(2, 6, 1, true);
-        g.edge(4, 5, 1, true);
-        g.edge(6, 7, 1, true);
-        g.edge(6, 8, 1, true);
+        GHUtility.setProperties(g.edge(0,1).setDistance(1),encoder,60,true, true);
+        GHUtility.setProperties(g.edge(1,2).setDistance(1),encoder,60,true, true);
+        GHUtility.setProperties(g.edge(1,3).setDistance(1),encoder,60,true, true);
+        GHUtility.setProperties(g.edge(2,4).setDistance(1),encoder,60,true, true);
+        GHUtility.setProperties(g.edge(2,6).setDistance(1),encoder,60,true, true);
+        GHUtility.setProperties(g.edge(4,5).setDistance(1),encoder,60,true, true);
+        GHUtility.setProperties(g.edge(6,7).setDistance(1),encoder,60,true, true);
+        GHUtility.setProperties(g.edge(6,8).setDistance(1),encoder,60,true, true);
         EdgeBasedTarjanSCC tarjan = new EdgeBasedTarjanSCC(g, accessEnc, NO_TURN_COST_PROVIDER, false);
         ConnectedComponents result = tarjan.findComponentsRecursive();
         assertEquals(16, result.getEdgeKeys());
@@ -141,11 +141,11 @@ class EdgeBasedTarjanSCCTest {
         GraphHopperStorage g = new GraphBuilder(em).create();
         // 3<-0->2-1o
         //    o
-        g.edge(0, 0, 1, true);// edge-keys 0,1
-        g.edge(0, 2, 1, false); // edge-keys 2,3
-        g.edge(0, 3, 1, false); // edge-keys 4,5
-        g.edge(2, 1, 1, true); // edge-keys 6,7
-        g.edge(1, 1, 1, true); // edge-keys 8,9
+        GHUtility.setProperties(g.edge(0,0).setDistance(1),encoder,60,true, true);// edge-keys 0,1
+        GHUtility.setProperties(g.edge(0,2).setDistance(1),encoder,60,true, false); // edge-keys 2,3
+        GHUtility.setProperties(g.edge(0,3).setDistance(1),encoder,60,true, false); // edge-keys 4,5
+        GHUtility.setProperties(g.edge(2,1).setDistance(1),encoder,60,true, true); // edge-keys 6,7
+        GHUtility.setProperties(g.edge(1,1).setDistance(1),encoder,60,true, true); // edge-keys 8,9
         EdgeBasedTarjanSCC tarjan = new EdgeBasedTarjanSCC(g, accessEnc, NO_TURN_COST_PROVIDER, false);
         ConnectedComponents result = tarjan.findComponentsRecursive();
         assertEquals(10, result.getEdgeKeys());
@@ -169,15 +169,15 @@ class EdgeBasedTarjanSCCTest {
         //     |   |       |
         //     |    \< 6 - 7
         //     3        \- 8
-        g.edge(0, 1, 1, true); // edge-keys 0,1
-        g.edge(2, 1, 1, false); // edge-keys 2,3
-        g.edge(1, 3, 1, true); // edge-keys 4,5
-        g.edge(2, 4, 1, true); // edge-keys 6,7
-        g.edge(6, 2, 1, false); // edge-keys 8,9
-        g.edge(4, 5, 1, false); // edge-keys 10,11
-        g.edge(5, 7, 1, true); // edge-keys 12,13
-        g.edge(6, 7, 1, true); // edge-keys 14,15
-        g.edge(6, 8, 1, true); // edge-keys 16,17
+        GHUtility.setProperties(g.edge(0,1).setDistance(1),encoder,60,true, true); // edge-keys 0,1
+        GHUtility.setProperties(g.edge(2,1).setDistance(1),encoder,60,true, false); // edge-keys 2,3
+        GHUtility.setProperties(g.edge(1,3).setDistance(1),encoder,60,true, true); // edge-keys 4,5
+        GHUtility.setProperties(g.edge(2,4).setDistance(1),encoder,60,true, true); // edge-keys 6,7
+        GHUtility.setProperties(g.edge(6,2).setDistance(1),encoder,60,true, false); // edge-keys 8,9
+        GHUtility.setProperties(g.edge(4,5).setDistance(1),encoder,60,true, false); // edge-keys 10,11
+        GHUtility.setProperties(g.edge(5,7).setDistance(1),encoder,60,true, true); // edge-keys 12,13
+        GHUtility.setProperties(g.edge(6,7).setDistance(1),encoder,60,true, true); // edge-keys 14,15
+        GHUtility.setProperties(g.edge(6,8).setDistance(1),encoder,60,true, true); // edge-keys 16,17
         EdgeBasedTarjanSCC tarjan = new EdgeBasedTarjanSCC(g, accessEnc, NO_TURN_COST_PROVIDER, false);
         ConnectedComponents result = tarjan.findComponentsRecursive();
         assertEquals(18, result.getEdgeKeys());
@@ -200,11 +200,11 @@ class EdgeBasedTarjanSCCTest {
         // 0->1
         // |  |
         // 3<-2->4
-        g.edge(0, 1, 1, false); // edge-keys 0,1
-        g.edge(1, 2, 1, false); // edge-keys 2,3
-        g.edge(2, 3, 1, false); // edge-keys 4,5
-        g.edge(3, 0, 1, false); // edge-keys 6,7
-        g.edge(2, 4, 1, false); // edge-keys 8,9
+        GHUtility.setProperties(g.edge(0,1).setDistance(1),encoder,60,true, false); // edge-keys 0,1
+        GHUtility.setProperties(g.edge(1,2).setDistance(1),encoder,60,true, false); // edge-keys 2,3
+        GHUtility.setProperties(g.edge(2,3).setDistance(1),encoder,60,true, false); // edge-keys 4,5
+        GHUtility.setProperties(g.edge(3,0).setDistance(1),encoder,60,true, false); // edge-keys 6,7
+        GHUtility.setProperties(g.edge(2,4).setDistance(1),encoder,60,true, false); // edge-keys 8,9
 
         // first lets check what happens without turn costs
         EdgeBasedTarjanSCC tarjan = new EdgeBasedTarjanSCC(g, accessEnc, NO_TURN_COST_PROVIDER, false);
@@ -250,7 +250,8 @@ class EdgeBasedTarjanSCCTest {
         GraphHopperStorage g = new GraphBuilder(em).create();
         long seed = System.nanoTime();
         Random rnd = new Random(seed);
-        GHUtility.buildRandomGraph(g, rnd, 500, 2, true, true, null, 0.8, 0.7, 0);
+        GHUtility.buildRandomGraph(g, rnd, 500, 2, true, true,
+                encoder.getAccessEnc(), encoder.getAverageSpeedEnc(), null, 0.8, 0.7, 0);
         ConnectedComponents implicit = new EdgeBasedTarjanSCC(g, accessEnc, NO_TURN_COST_PROVIDER, excludeSingle).findComponentsRecursive();
         ConnectedComponents explicit = new EdgeBasedTarjanSCC(g, accessEnc, NO_TURN_COST_PROVIDER, excludeSingle).findComponents();
 
@@ -264,13 +265,13 @@ class EdgeBasedTarjanSCCTest {
         Set<IntWithArray> componentsExplicit = buildComponentSet(explicit.getComponents());
         if (!componentsExplicit.equals(componentsImplicit)) {
             System.out.println("seed: " + seed);
-            GHUtility.printGraphForUnitTest(g, carFlagEncoder);
+            GHUtility.printGraphForUnitTest(g, encoder);
             assertEquals(componentsExplicit, componentsImplicit, "The components found for this graph are different between the implicit and explicit implementation");
         }
 
         if (!implicit.getSingleEdgeComponents().equals(explicit.getSingleEdgeComponents())) {
             System.out.println("seed: " + seed);
-            GHUtility.printGraphForUnitTest(g, carFlagEncoder);
+            GHUtility.printGraphForUnitTest(g, encoder);
             assertEquals(implicit.getSingleEdgeComponents(), explicit.getSingleEdgeComponents());
         }
 

--- a/core/src/test/java/com/graphhopper/routing/subnetwork/EdgeBasedTarjanSCCTest.java
+++ b/core/src/test/java/com/graphhopper/routing/subnetwork/EdgeBasedTarjanSCCTest.java
@@ -50,7 +50,7 @@ class EdgeBasedTarjanSCCTest {
     public void linearSingle() {
         GraphHopperStorage g = new GraphBuilder(em).create();
         // 0 - 1
-        GHUtility.setProperties(g.edge(0,1).setDistance(1),encoder,60,true, true);
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(0, 1).setDistance(1));
         EdgeBasedTarjanSCC tarjan = new EdgeBasedTarjanSCC(g, accessEnc, NO_TURN_COST_PROVIDER, false);
         ConnectedComponents result = tarjan.findComponentsRecursive();
         assertEquals(2, result.getEdgeKeys());
@@ -65,8 +65,8 @@ class EdgeBasedTarjanSCCTest {
     public void linearSimple() {
         GraphHopperStorage g = new GraphBuilder(em).create();
         // 0 - 1 - 2
-        GHUtility.setProperties(g.edge(0,1).setDistance(1),encoder,60,true, true);
-        GHUtility.setProperties(g.edge(1,2).setDistance(1),encoder,60,true, true);
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(1, 2).setDistance(1));
         EdgeBasedTarjanSCC tarjan = new EdgeBasedTarjanSCC(g, accessEnc, NO_TURN_COST_PROVIDER, false);
         ConnectedComponents result = tarjan.findComponentsRecursive();
         assertEquals(4, result.getEdgeKeys());
@@ -81,8 +81,8 @@ class EdgeBasedTarjanSCCTest {
     public void linearOneWay() {
         GraphHopperStorage g = new GraphBuilder(em).create();
         // 0 -> 1 -> 2
-        GHUtility.setProperties(g.edge(0,1).setDistance(1),encoder,60,true, false);
-        GHUtility.setProperties(g.edge(1,2).setDistance(1),encoder,60,true, false);
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(1, 2).setDistance(1));
         EdgeBasedTarjanSCC tarjan = new EdgeBasedTarjanSCC(g, accessEnc, NO_TURN_COST_PROVIDER, false);
         ConnectedComponents result = tarjan.findComponentsRecursive();
         assertEquals(4, result.getEdgeKeys());
@@ -98,9 +98,9 @@ class EdgeBasedTarjanSCCTest {
     public void linearBidirectionalEdge() {
         GraphHopperStorage g = new GraphBuilder(em).create();
         // 0 -> 1 - 2 <- 3
-        GHUtility.setProperties(g.edge(0,1).setDistance(1),encoder,60,true, false);
-        GHUtility.setProperties(g.edge(1,2).setDistance(1),encoder,60,true, true);
-        GHUtility.setProperties(g.edge(3,2).setDistance(1),encoder,60,true, false);
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(3, 2).setDistance(1));
         EdgeBasedTarjanSCC tarjan = new EdgeBasedTarjanSCC(g, accessEnc, NO_TURN_COST_PROVIDER, false);
         ConnectedComponents result = tarjan.findComponentsRecursive();
         assertEquals(6, result.getEdgeKeys());
@@ -118,14 +118,14 @@ class EdgeBasedTarjanSCCTest {
         // 0 - 1 - 2 - 4 - 5
         //     |    \- 6 - 7
         //     3        \- 8
-        GHUtility.setProperties(g.edge(0,1).setDistance(1),encoder,60,true, true);
-        GHUtility.setProperties(g.edge(1,2).setDistance(1),encoder,60,true, true);
-        GHUtility.setProperties(g.edge(1,3).setDistance(1),encoder,60,true, true);
-        GHUtility.setProperties(g.edge(2,4).setDistance(1),encoder,60,true, true);
-        GHUtility.setProperties(g.edge(2,6).setDistance(1),encoder,60,true, true);
-        GHUtility.setProperties(g.edge(4,5).setDistance(1),encoder,60,true, true);
-        GHUtility.setProperties(g.edge(6,7).setDistance(1),encoder,60,true, true);
-        GHUtility.setProperties(g.edge(6,8).setDistance(1),encoder,60,true, true);
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(1, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(2, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(2, 6).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(4, 5).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(6, 7).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(6, 8).setDistance(1));
         EdgeBasedTarjanSCC tarjan = new EdgeBasedTarjanSCC(g, accessEnc, NO_TURN_COST_PROVIDER, false);
         ConnectedComponents result = tarjan.findComponentsRecursive();
         assertEquals(16, result.getEdgeKeys());
@@ -141,11 +141,11 @@ class EdgeBasedTarjanSCCTest {
         GraphHopperStorage g = new GraphBuilder(em).create();
         // 3<-0->2-1o
         //    o
-        GHUtility.setProperties(g.edge(0,0).setDistance(1),encoder,60,true, true);// edge-keys 0,1
-        GHUtility.setProperties(g.edge(0,2).setDistance(1),encoder,60,true, false); // edge-keys 2,3
-        GHUtility.setProperties(g.edge(0,3).setDistance(1),encoder,60,true, false); // edge-keys 4,5
-        GHUtility.setProperties(g.edge(2,1).setDistance(1),encoder,60,true, true); // edge-keys 6,7
-        GHUtility.setProperties(g.edge(1,1).setDistance(1),encoder,60,true, true); // edge-keys 8,9
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(0, 0).setDistance(1));// edge-keys 0,1
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(0, 2).setDistance(1)); // edge-keys 2,3
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(0, 3).setDistance(1)); // edge-keys 4,5
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(2, 1).setDistance(1)); // edge-keys 6,7
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(1, 1).setDistance(1)); // edge-keys 8,9
         EdgeBasedTarjanSCC tarjan = new EdgeBasedTarjanSCC(g, accessEnc, NO_TURN_COST_PROVIDER, false);
         ConnectedComponents result = tarjan.findComponentsRecursive();
         assertEquals(10, result.getEdgeKeys());
@@ -169,15 +169,15 @@ class EdgeBasedTarjanSCCTest {
         //     |   |       |
         //     |    \< 6 - 7
         //     3        \- 8
-        GHUtility.setProperties(g.edge(0,1).setDistance(1),encoder,60,true, true); // edge-keys 0,1
-        GHUtility.setProperties(g.edge(2,1).setDistance(1),encoder,60,true, false); // edge-keys 2,3
-        GHUtility.setProperties(g.edge(1,3).setDistance(1),encoder,60,true, true); // edge-keys 4,5
-        GHUtility.setProperties(g.edge(2,4).setDistance(1),encoder,60,true, true); // edge-keys 6,7
-        GHUtility.setProperties(g.edge(6,2).setDistance(1),encoder,60,true, false); // edge-keys 8,9
-        GHUtility.setProperties(g.edge(4,5).setDistance(1),encoder,60,true, false); // edge-keys 10,11
-        GHUtility.setProperties(g.edge(5,7).setDistance(1),encoder,60,true, true); // edge-keys 12,13
-        GHUtility.setProperties(g.edge(6,7).setDistance(1),encoder,60,true, true); // edge-keys 14,15
-        GHUtility.setProperties(g.edge(6,8).setDistance(1),encoder,60,true, true); // edge-keys 16,17
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(0, 1).setDistance(1)); // edge-keys 0,1
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(2, 1).setDistance(1)); // edge-keys 2,3
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(1, 3).setDistance(1)); // edge-keys 4,5
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(2, 4).setDistance(1)); // edge-keys 6,7
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(6, 2).setDistance(1)); // edge-keys 8,9
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(4, 5).setDistance(1)); // edge-keys 10,11
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(5, 7).setDistance(1)); // edge-keys 12,13
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(6, 7).setDistance(1)); // edge-keys 14,15
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(6, 8).setDistance(1)); // edge-keys 16,17
         EdgeBasedTarjanSCC tarjan = new EdgeBasedTarjanSCC(g, accessEnc, NO_TURN_COST_PROVIDER, false);
         ConnectedComponents result = tarjan.findComponentsRecursive();
         assertEquals(18, result.getEdgeKeys());
@@ -200,11 +200,11 @@ class EdgeBasedTarjanSCCTest {
         // 0->1
         // |  |
         // 3<-2->4
-        GHUtility.setProperties(g.edge(0,1).setDistance(1),encoder,60,true, false); // edge-keys 0,1
-        GHUtility.setProperties(g.edge(1,2).setDistance(1),encoder,60,true, false); // edge-keys 2,3
-        GHUtility.setProperties(g.edge(2,3).setDistance(1),encoder,60,true, false); // edge-keys 4,5
-        GHUtility.setProperties(g.edge(3,0).setDistance(1),encoder,60,true, false); // edge-keys 6,7
-        GHUtility.setProperties(g.edge(2,4).setDistance(1),encoder,60,true, false); // edge-keys 8,9
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(0, 1).setDistance(1)); // edge-keys 0,1
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(1, 2).setDistance(1)); // edge-keys 2,3
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(2, 3).setDistance(1)); // edge-keys 4,5
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(3, 0).setDistance(1)); // edge-keys 6,7
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(2, 4).setDistance(1)); // edge-keys 8,9
 
         // first lets check what happens without turn costs
         EdgeBasedTarjanSCC tarjan = new EdgeBasedTarjanSCC(g, accessEnc, NO_TURN_COST_PROVIDER, false);

--- a/core/src/test/java/com/graphhopper/routing/subnetwork/PrepareRoutingSubnetworksTest.java
+++ b/core/src/test/java/com/graphhopper/routing/subnetwork/PrepareRoutingSubnetworksTest.java
@@ -52,18 +52,18 @@ public class PrepareRoutingSubnetworksTest {
         // 0 - 1 - 3 - 7 - 8
         // |       |
         // 2 -------
-        GHUtility.setProperties(g.edge(0, 1).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(1, 3).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(0, 2).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(2, 3).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(3, 7).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(7, 8).setDistance(1), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(1, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(0, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(2, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(3, 7).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(7, 8).setDistance(1));
         // connecting both but do no set access yet
         g.edge(3, 4).setDistance(1);
 
-        GHUtility.setProperties(g.edge(4, 5).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(5, 6).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(4, 6).setDistance(1), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(4, 5).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(5, 6).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(4, 6).setDistance(1));
         return g;
     }
 
@@ -154,12 +154,12 @@ public class PrepareRoutingSubnetworksTest {
         GraphHopperStorage g = createSubnetworkTestStorage(em, carEncoder);
         AllEdgesIterator allIter = g.getAllEdges();
         while (allIter.next()) {
-            GHUtility.setProperties(allIter, bikeEncoder, bikeEncoder.getMaxSpeed() / 2, true, true);
+            GHUtility.setSpeed(bikeEncoder.getMaxSpeed() / 2, true, true, bikeEncoder, allIter);
         }
 
         EdgeIteratorState edge = GHUtility.getEdge(g, 3, 4);
-        GHUtility.setProperties(edge, carEncoder, 10, false, false);
-        GHUtility.setProperties(edge, bikeEncoder, 5, true, true);
+        GHUtility.setSpeed(10, false, false, carEncoder, edge);
+        GHUtility.setSpeed(5, true, true, bikeEncoder, edge);
         List<PrepareRoutingSubnetworks.PrepareJob> prepareJobs = Arrays.asList(
                 new PrepareRoutingSubnetworks.PrepareJob(carEncoder.toString(), carEncoder.getAccessEnc(), null),
                 new PrepareRoutingSubnetworks.PrepareJob(bikeEncoder.toString(), bikeEncoder.getAccessEnc(), null)
@@ -175,8 +175,8 @@ public class PrepareRoutingSubnetworksTest {
 
         // now we block the edge for both vehicles, in which case the smaller subnetwork gets removed
         edge = GHUtility.getEdge(g, 3, 4);
-        GHUtility.setProperties(edge, carEncoder, 10, false, false);
-        GHUtility.setProperties(edge, bikeEncoder, 5, false, false);
+        GHUtility.setSpeed(10, false, false, carEncoder, edge);
+        GHUtility.setSpeed(5, false, false, bikeEncoder, edge);
         instance = new PrepareRoutingSubnetworks(g, prepareJobs);
         instance.setMinNetworkSize(5);
         instance.doWork();
@@ -185,17 +185,17 @@ public class PrepareRoutingSubnetworksTest {
     GraphHopperStorage createSubnetworkTestStorageWithOneWays(EncodingManager em) {
         GraphHopperStorage g = new GraphBuilder(em).create();
         // 0 - 1 - 2 - 3 - 4 <- 5 - 6
-        GHUtility.setProperties(g.edge(0, 1).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(1, 2).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(2, 3).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(3, 4).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(5, 4).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(g.edge(5, 6).setDistance(1), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(2, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(3, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(5, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(5, 6).setDistance(1));
 
         // 7 -> 8 - 9 - 10
-        GHUtility.setProperties(g.edge(7, 8).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(g.edge(8, 9).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(9, 10).setDistance(1), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(7, 8).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(8, 9).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(9, 10).setDistance(1));
 
         return g;
     }
@@ -236,11 +236,11 @@ public class PrepareRoutingSubnetworksTest {
     public void testNodeOrderingRegression() {
         // 1 -> 2 -> 0 - 3 - 4 - 5
         GraphHopperStorage g = new GraphBuilder(em).create();
-        GHUtility.setProperties(g.edge(1, 2).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(g.edge(2, 0).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(g.edge(0, 3).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(3, 4).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(4, 5).setDistance(1), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(2, 0).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(0, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(3, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(4, 5).setDistance(1));
 
         PrepareRoutingSubnetworks.PrepareJob job = new PrepareRoutingSubnetworks.PrepareJob("car", accessEnc, null);
         PrepareRoutingSubnetworks instance = new PrepareRoutingSubnetworks(g, Collections.singletonList(job)).

--- a/core/src/test/java/com/graphhopper/routing/subnetwork/PrepareRoutingSubnetworksTest.java
+++ b/core/src/test/java/com/graphhopper/routing/subnetwork/PrepareRoutingSubnetworksTest.java
@@ -137,7 +137,7 @@ public class PrepareRoutingSubnetworksTest {
                 GHUtility.getEdge(g, 4, 6))
         ) {
             for (FlagEncoder encoder : em.fetchEdgeEncoders()) {
-                edge.set(encoder.getAccessEnc(), false).setReverse(encoder.getAccessEnc(), false);
+                edge.set(encoder.getAccessEnc(), false, false);
             }
         }
 

--- a/core/src/test/java/com/graphhopper/routing/subnetwork/PrepareRoutingSubnetworksTest.java
+++ b/core/src/test/java/com/graphhopper/routing/subnetwork/PrepareRoutingSubnetworksTest.java
@@ -39,11 +39,11 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author Peter Karich
  */
 public class PrepareRoutingSubnetworksTest {
-    private final FlagEncoder carFlagEncoder = new CarFlagEncoder();
-    private final EncodingManager em = EncodingManager.create(carFlagEncoder);
-    private final BooleanEncodedValue accessEnc = carFlagEncoder.getAccessEnc();
+    private final FlagEncoder encoder = new CarFlagEncoder();
+    private final EncodingManager em = EncodingManager.create(encoder);
+    private final BooleanEncodedValue accessEnc = encoder.getAccessEnc();
 
-    private GraphHopperStorage createSubnetworkTestStorage(EncodingManager em) {
+    private static GraphHopperStorage createSubnetworkTestStorage(EncodingManager em, FlagEncoder encoder) {
         GraphHopperStorage g = new GraphBuilder(em).create();
         //         5 - 6
         //         | /
@@ -52,25 +52,25 @@ public class PrepareRoutingSubnetworksTest {
         // 0 - 1 - 3 - 7 - 8
         // |       |
         // 2 -------
-        g.edge(0, 1, 1, true);
-        g.edge(1, 3, 1, true);
-        g.edge(0, 2, 1, true);
-        g.edge(2, 3, 1, true);
-        g.edge(3, 7, 1, true);
-        g.edge(7, 8, 1, true);
+        GHUtility.setProperties(g.edge(0, 1).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(1, 3).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(0, 2).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(2, 3).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(3, 7).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(7, 8).setDistance(1), encoder, 60, true, true);
         // connecting both but do no set access yet
         g.edge(3, 4).setDistance(1);
 
-        g.edge(4, 5, 1, true);
-        g.edge(5, 6, 1, true);
-        g.edge(4, 6, 1, true);
+        GHUtility.setProperties(g.edge(4, 5).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(5, 6).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(4, 6).setDistance(1), encoder, 60, true, true);
         return g;
     }
 
     @Test
     public void testRemoveSubnetworkIfOnlyOneVehicle() {
         FlagEncoder encoder = em.fetchEdgeEncoders().iterator().next();
-        GraphHopperStorage g = createSubnetworkTestStorage(em);
+        GraphHopperStorage g = createSubnetworkTestStorage(em, encoder);
         PrepareRoutingSubnetworks instance = new PrepareRoutingSubnetworks(g, Collections.singletonList(
                 new PrepareRoutingSubnetworks.PrepareJob("car", accessEnc, null)));
         // this rules out the upper small network
@@ -81,7 +81,7 @@ public class PrepareRoutingSubnetworksTest {
         assertEquals(GHUtility.asSet(), GHUtility.getNeighbors(explorer.setBaseNode(4)));
 
         // this time we lower the threshold and the small network will remain
-        g = createSubnetworkTestStorage(em);
+        g = createSubnetworkTestStorage(em, encoder);
         instance = new PrepareRoutingSubnetworks(g, Collections.singletonList(
                 new PrepareRoutingSubnetworks.PrepareJob("car", accessEnc, null)));
         instance.setMinNetworkSize(3);
@@ -94,7 +94,7 @@ public class PrepareRoutingSubnetworksTest {
     public void testRemoveSubnetworkIfOnlyOneVehicleEdgeBased() {
         EncodingManager encodingManager = EncodingManager.create("car|turn_costs=true");
         FlagEncoder encoder = encodingManager.fetchEdgeEncoders().iterator().next();
-        GraphHopperStorage g = createSubnetworkTestStorage(encodingManager);
+        GraphHopperStorage g = createSubnetworkTestStorage(encodingManager, encoder);
         PrepareRoutingSubnetworks instance = new PrepareRoutingSubnetworks(g, Collections.singletonList(
                 new PrepareRoutingSubnetworks.PrepareJob(encoder.toString(), encoder.getAccessEnc(), new DefaultTurnCostProvider(encoder, g.getTurnCostStorage(), 0))));
         // this rules out the upper small network
@@ -105,7 +105,7 @@ public class PrepareRoutingSubnetworksTest {
         assertEquals(GHUtility.asSet(), GHUtility.getNeighbors(explorer.setBaseNode(4)));
 
         // this time we lower the threshold and the small network will remain
-        g = createSubnetworkTestStorage(em);
+        g = createSubnetworkTestStorage(em, encoder);
         instance = new PrepareRoutingSubnetworks(g, Collections.singletonList(
                 new PrepareRoutingSubnetworks.PrepareJob("car", accessEnc, null)));
         instance.setMinNetworkSize(3);
@@ -119,7 +119,7 @@ public class PrepareRoutingSubnetworksTest {
         FlagEncoder carEncoder = new CarFlagEncoder();
         BikeFlagEncoder bikeEncoder = new BikeFlagEncoder();
         EncodingManager em = EncodingManager.create(carEncoder, bikeEncoder);
-        GraphHopperStorage g = createSubnetworkTestStorage(em);
+        GraphHopperStorage g = createSubnetworkTestStorage(em, encoder);
         PrepareRoutingSubnetworks instance = new PrepareRoutingSubnetworks(g, Arrays.asList(
                 new PrepareRoutingSubnetworks.PrepareJob(carEncoder.toString(), carEncoder.getAccessEnc(), null),
                 new PrepareRoutingSubnetworks.PrepareJob(bikeEncoder.toString(), bikeEncoder.getAccessEnc(), null)
@@ -151,7 +151,11 @@ public class PrepareRoutingSubnetworksTest {
         FlagEncoder carEncoder = new CarFlagEncoder();
         BikeFlagEncoder bikeEncoder = new BikeFlagEncoder();
         EncodingManager em = EncodingManager.create(carEncoder, bikeEncoder);
-        GraphHopperStorage g = createSubnetworkTestStorage(em);
+        GraphHopperStorage g = createSubnetworkTestStorage(em, carEncoder);
+        AllEdgesIterator allIter = g.getAllEdges();
+        while (allIter.next()) {
+            GHUtility.setProperties(allIter, bikeEncoder, bikeEncoder.getMaxSpeed() / 2, true, true);
+        }
 
         EdgeIteratorState edge = GHUtility.getEdge(g, 3, 4);
         GHUtility.setProperties(edge, carEncoder, 10, false, false);
@@ -181,17 +185,17 @@ public class PrepareRoutingSubnetworksTest {
     GraphHopperStorage createSubnetworkTestStorageWithOneWays(EncodingManager em) {
         GraphHopperStorage g = new GraphBuilder(em).create();
         // 0 - 1 - 2 - 3 - 4 <- 5 - 6
-        g.edge(0, 1, 1, true);
-        g.edge(1, 2, 1, true);
-        g.edge(2, 3, 1, true);
-        g.edge(3, 4, 1, true);
-        g.edge(5, 4, 1, false);
-        g.edge(5, 6, 1, true);
+        GHUtility.setProperties(g.edge(0, 1).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(1, 2).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(2, 3).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(3, 4).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(5, 4).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(g.edge(5, 6).setDistance(1), encoder, 60, true, true);
 
         // 7 -> 8 - 9 - 10
-        g.edge(7, 8, 1, false);
-        g.edge(8, 9, 1, true);
-        g.edge(9, 10, 1, true);
+        GHUtility.setProperties(g.edge(7, 8).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(g.edge(8, 9).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(9, 10).setDistance(1), encoder, 60, true, true);
 
         return g;
     }
@@ -232,11 +236,11 @@ public class PrepareRoutingSubnetworksTest {
     public void testNodeOrderingRegression() {
         // 1 -> 2 -> 0 - 3 - 4 - 5
         GraphHopperStorage g = new GraphBuilder(em).create();
-        g.edge(1, 2, 1, false);
-        g.edge(2, 0, 1, false);
-        g.edge(0, 3, 1, true);
-        g.edge(3, 4, 1, true);
-        g.edge(4, 5, 1, true);
+        GHUtility.setProperties(g.edge(1, 2).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(g.edge(2, 0).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(g.edge(0, 3).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(3, 4).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(4, 5).setDistance(1), encoder, 60, true, true);
 
         PrepareRoutingSubnetworks.PrepareJob job = new PrepareRoutingSubnetworks.PrepareJob("car", accessEnc, null);
         PrepareRoutingSubnetworks instance = new PrepareRoutingSubnetworks(g, Collections.singletonList(job)).

--- a/core/src/test/java/com/graphhopper/routing/subnetwork/TarjanSCCTest.java
+++ b/core/src/test/java/com/graphhopper/routing/subnetwork/TarjanSCCTest.java
@@ -49,15 +49,15 @@ class TarjanSCCTest {
         // 4 < 1 - 2
         // |   |
         // <-- 8 - 11 - 12 < 9 - 15
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 4).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 8).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 4).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(8, 4).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(8, 11).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(12, 11).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(9, 12).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(9, 15).setDistance(1), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 8).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(8, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(8, 11).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(12, 11).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(9, 12).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(9, 15).setDistance(1));
 
         // large network
         // 5 --------
@@ -65,17 +65,17 @@ class TarjanSCCTest {
         // 3 - 0 - 13
         //   \ |
         //     7
-        GHUtility.setProperties(graph.edge(0, 13).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(0, 3).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(0, 7).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(3, 7).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(3, 5).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(13, 5).setDistance(1), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 13).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 7).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 7).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 5).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(13, 5).setDistance(1));
 
         // small network
         // 6 - 14 - 10
-        GHUtility.setProperties(graph.edge(6, 14).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(10, 14).setDistance(1), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(6, 14).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(10, 14).setDistance(1));
 
         TarjanSCC tarjan = new TarjanSCC(graph, accessEnc, false);
         TarjanSCC.ConnectedComponents scc = tarjan.findComponentsRecursive();
@@ -98,17 +98,17 @@ class TarjanSCCTest {
         //  \ |      \<-----/
         //    2
         GraphHopperStorage graph = new GraphBuilder(em).create();
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 0).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 0).setDistance(1));
 
-        GHUtility.setProperties(graph.edge(1, 3).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 4).setDistance(1));
 
-        GHUtility.setProperties(graph.edge(4, 5).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(5, 6).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(6, 7).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(7, 4).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(4, 5).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(5, 6).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(6, 7).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(7, 4).setDistance(1));
 
         TarjanSCC tarjan = new TarjanSCC(graph, accessEnc, false);
         TarjanSCC.ConnectedComponents scc = tarjan.findComponentsRecursive();
@@ -147,30 +147,30 @@ class TarjanSCCTest {
         //        8        15-16
 
         // oneway main road
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(4, 5).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(3, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(4, 5).setDistance(1));
 
         // going south from main road
-        GHUtility.setProperties(graph.edge(3, 6).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(6, 7).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(7, 8).setDistance(1), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 6).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(6, 7).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(7, 8).setDistance(1));
 
         // connects the two nodes 2 and 4
-        GHUtility.setProperties(graph.edge(4, 9).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(9, 10).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(10, 11).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(11, 2).setDistance(1), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 9).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(9, 10).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(10, 11).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(11, 2).setDistance(1));
 
         // eastern part (only connected by a single directed edge to the rest of the graph)
-        GHUtility.setProperties(graph.edge(5, 12).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(12, 13).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(13, 14).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(14, 15).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(15, 13).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(15, 16).setDistance(1), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(5, 12).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(12, 13).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(13, 14).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(14, 15).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(15, 13).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(15, 16).setDistance(1));
 
         FlagEncoder encoder = em.fetchEdgeEncoders().iterator().next();
         TarjanSCC tarjan = new TarjanSCC(graph, encoder.getAccessEnc(), false);

--- a/core/src/test/java/com/graphhopper/routing/subnetwork/TarjanSCCTest.java
+++ b/core/src/test/java/com/graphhopper/routing/subnetwork/TarjanSCCTest.java
@@ -36,28 +36,28 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TarjanSCCTest {
-    private final FlagEncoder carFlagEncoder = new CarFlagEncoder();
-    private final EncodingManager em = EncodingManager.create(carFlagEncoder);
-    private final BooleanEncodedValue accessEnc = carFlagEncoder.getAccessEnc();
+    private final FlagEncoder encoder = new CarFlagEncoder();
+    private final EncodingManager em = EncodingManager.create(encoder);
+    private final BooleanEncodedValue accessEnc = encoder.getAccessEnc();
 
     @Test
     public void testFindComponents() {
-        GraphHopperStorage g = new GraphBuilder(em).create();
+        GraphHopperStorage graph = new GraphBuilder(em).create();
         // big network (has two components actually, because 9->12 is a one-way)
         //    ---
         //  /     \
         // 4 < 1 - 2
         // |   |
         // <-- 8 - 11 - 12 < 9 - 15
-        g.edge(1, 2, 1, true);
-        g.edge(1, 4, 1, false);
-        g.edge(1, 8, 1, true);
-        g.edge(2, 4, 1, true);
-        g.edge(8, 4, 1, false);
-        g.edge(8, 11, 1, true);
-        g.edge(12, 11, 1, true);
-        g.edge(9, 12, 1, false);
-        g.edge(9, 15, 1, true);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 4).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 8).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 4).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(8, 4).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(8, 11).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(12, 11).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(9, 12).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(9, 15).setDistance(1), encoder, 60, true, true);
 
         // large network
         // 5 --------
@@ -65,19 +65,19 @@ class TarjanSCCTest {
         // 3 - 0 - 13
         //   \ |
         //     7
-        g.edge(0, 13, 1, true);
-        g.edge(0, 3, 1, true);
-        g.edge(0, 7, 1, true);
-        g.edge(3, 7, 1, true);
-        g.edge(3, 5, 1, true);
-        g.edge(13, 5, 1, true);
+        GHUtility.setProperties(graph.edge(0, 13).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(0, 3).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(0, 7).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(3, 7).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(3, 5).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(13, 5).setDistance(1), encoder, 60, true, true);
 
         // small network
         // 6 - 14 - 10
-        g.edge(6, 14, 1, true);
-        g.edge(10, 14, 1, true);
+        GHUtility.setProperties(graph.edge(6, 14).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(10, 14).setDistance(1), encoder, 60, true, true);
 
-        TarjanSCC tarjan = new TarjanSCC(g, accessEnc, false);
+        TarjanSCC tarjan = new TarjanSCC(graph, accessEnc, false);
         TarjanSCC.ConnectedComponents scc = tarjan.findComponentsRecursive();
         List<IntArrayList> components = scc.getComponents();
 
@@ -97,20 +97,20 @@ class TarjanSCCTest {
         // 0->1->3->4->5->6->7
         //  \ |      \<-----/
         //    2
-        GraphHopperStorage g = new GraphBuilder(em).create();
-        g.edge(0, 1, 1, false);
-        g.edge(1, 2, 1, false);
-        g.edge(2, 0, 1, false);
+        GraphHopperStorage graph = new GraphBuilder(em).create();
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 0).setDistance(1), encoder, 60, true, false);
 
-        g.edge(1, 3, 1, false);
-        g.edge(3, 4, 1, false);
+        GHUtility.setProperties(graph.edge(1, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
 
-        g.edge(4, 5, 1, false);
-        g.edge(5, 6, 1, false);
-        g.edge(6, 7, 1, false);
-        g.edge(7, 4, 1, false);
+        GHUtility.setProperties(graph.edge(4, 5).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(5, 6).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(6, 7).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(7, 4).setDistance(1), encoder, 60, true, false);
 
-        TarjanSCC tarjan = new TarjanSCC(g, accessEnc, false);
+        TarjanSCC tarjan = new TarjanSCC(graph, accessEnc, false);
         TarjanSCC.ConnectedComponents scc = tarjan.findComponentsRecursive();
         List<IntArrayList> components = scc.getComponents();
 
@@ -126,7 +126,7 @@ class TarjanSCCTest {
         assertEquals(components.get(0), scc.getBiggestComponent());
 
         // exclude single
-        scc = new TarjanSCC(g, accessEnc, true).findComponentsRecursive();
+        scc = new TarjanSCC(graph, accessEnc, true).findComponentsRecursive();
         assertTrue(scc.getSingleNodeComponents().isEmpty());
         assertEquals(3, scc.getTotalComponents());
         assertEquals(2, scc.getComponents().size());
@@ -135,7 +135,7 @@ class TarjanSCCTest {
 
     @Test
     public void testTarjan_issue761() {
-        GraphHopperStorage g = new GraphBuilder(em).create();
+        GraphHopperStorage graph = new GraphBuilder(em).create();
         //     11-10-9
         //     |     |
         // 0-1-2->3->4->5
@@ -147,33 +147,33 @@ class TarjanSCCTest {
         //        8        15-16
 
         // oneway main road
-        g.edge(0, 1, 1, true);
-        g.edge(1, 2, 1, true);
-        g.edge(2, 3, 1, false);
-        g.edge(3, 4, 1, false);
-        g.edge(4, 5, 1, false);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(4, 5).setDistance(1), encoder, 60, true, false);
 
         // going south from main road
-        g.edge(3, 6, 1, true);
-        g.edge(6, 7, 1, true);
-        g.edge(7, 8, 1, true);
+        GHUtility.setProperties(graph.edge(3, 6).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(6, 7).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(7, 8).setDistance(1), encoder, 60, true, true);
 
         // connects the two nodes 2 and 4
-        g.edge(4, 9, 1, true);
-        g.edge(9, 10, 1, true);
-        g.edge(10, 11, 1, true);
-        g.edge(11, 2, 1, true);
+        GHUtility.setProperties(graph.edge(4, 9).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(9, 10).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(10, 11).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(11, 2).setDistance(1), encoder, 60, true, true);
 
         // eastern part (only connected by a single directed edge to the rest of the graph)
-        g.edge(5, 12, 1, true);
-        g.edge(12, 13, 1, true);
-        g.edge(13, 14, 1, true);
-        g.edge(14, 15, 1, true);
-        g.edge(15, 13, 1, true);
-        g.edge(15, 16, 1, true);
+        GHUtility.setProperties(graph.edge(5, 12).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(12, 13).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(13, 14).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(14, 15).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(15, 13).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(15, 16).setDistance(1), encoder, 60, true, true);
 
         FlagEncoder encoder = em.fetchEdgeEncoders().iterator().next();
-        TarjanSCC tarjan = new TarjanSCC(g, encoder.getAccessEnc(), false);
+        TarjanSCC tarjan = new TarjanSCC(graph, encoder.getAccessEnc(), false);
         TarjanSCC.ConnectedComponents scc = tarjan.findComponentsRecursive();
         assertEquals(2, scc.getTotalComponents());
         assertTrue(scc.getSingleNodeComponents().isEmpty());
@@ -195,7 +195,8 @@ class TarjanSCCTest {
         GraphHopperStorage g = new GraphBuilder(em).create();
         long seed = System.nanoTime();
         Random rnd = new Random(seed);
-        GHUtility.buildRandomGraph(g, rnd, 1_000, 2, true, true, null, 0.8, 0.7, 0);
+        GHUtility.buildRandomGraph(g, rnd, 1_000, 2, true, true,
+                encoder.getAccessEnc(), encoder.getAverageSpeedEnc(), null, 0.8, 0.7, 0);
         TarjanSCC.ConnectedComponents implicit = new TarjanSCC(g, accessEnc, excludeSingle).findComponentsRecursive();
         TarjanSCC.ConnectedComponents explicit = new TarjanSCC(g, accessEnc, excludeSingle).findComponents();
 
@@ -209,13 +210,13 @@ class TarjanSCCTest {
         Set<IntWithArray> componentsExplicit = buildComponentSet(explicit.getComponents());
         if (!componentsExplicit.equals(componentsImplicit)) {
             System.out.println("seed: " + seed);
-            GHUtility.printGraphForUnitTest(g, carFlagEncoder);
+            GHUtility.printGraphForUnitTest(g, encoder);
             assertEquals(componentsExplicit, componentsImplicit, "The components found for this graph are different between the implicit and explicit implementation");
         }
 
         if (!implicit.getSingleNodeComponents().equals(explicit.getSingleNodeComponents())) {
             System.out.println("seed: " + seed);
-            GHUtility.printGraphForUnitTest(g, carFlagEncoder);
+            GHUtility.printGraphForUnitTest(g, encoder);
             assertEquals(implicit.getSingleNodeComponents(), explicit.getSingleNodeComponents());
         }
 

--- a/core/src/test/java/com/graphhopper/routing/util/Bike2WeightFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/Bike2WeightFlagEncoderTest.java
@@ -43,8 +43,7 @@ public class Bike2WeightFlagEncoderTest extends BikeFlagEncoderTest {
         na.setNode(1, 51.1, 12.002, 60);
         EdgeIteratorState edge = gs.edge(0, 1).
                 setWayGeometry(Helper.createPointList3D(51.1, 12.0011, 49, 51.1, 12.0015, 55));
-        edge.setDistance(100);
-        GHUtility.setProperties(edge, encoder, 10, 15);
+        GHUtility.setSpeed(10, 15, encoder, edge.setDistance(100));
         return gs;
     }
 
@@ -76,7 +75,7 @@ public class Bike2WeightFlagEncoderTest extends BikeFlagEncoderTest {
 
     @Test
     public void testSetSpeed0_issue367() {
-        IntsRef edgeFlags = GHUtility.setProperties(encodingManager.createEdgeFlags(), encoder, 10, 10);
+        IntsRef edgeFlags = GHUtility.setSpeed(10, 10, encoder, encodingManager.createEdgeFlags());
         assertEquals(10, encoder.getSpeed(false, edgeFlags), .1);
         assertEquals(10, encoder.getSpeed(true, edgeFlags), .1);
 

--- a/core/src/test/java/com/graphhopper/routing/util/CarFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/CarFlagEncoderTest.java
@@ -271,19 +271,6 @@ public class CarFlagEncoderTest {
         assertFalse(accessEnc.getBool(false, edgeFlags));
         assertTrue(accessEnc.getBool(true, edgeFlags));
 
-        encoder.flagsDefault(edgeFlags, true, true);
-        assertTrue(accessEnc.getBool(false, edgeFlags));
-        assertTrue(accessEnc.getBool(true, edgeFlags));
-
-        encoder.flagsDefault(edgeFlags, true, false);
-        assertTrue(accessEnc.getBool(false, edgeFlags));
-        assertFalse(accessEnc.getBool(true, edgeFlags));
-
-        encoder.flagsDefault(edgeFlags, true, true);
-        // disable access
-        accessEnc.setBool(false, edgeFlags, false);
-        accessEnc.setBool(true, edgeFlags, false);
-        assertFalse(accessEnc.getBool(false, edgeFlags));
         accessEnc.setBool(false, edgeFlags, false);
         accessEnc.setBool(true, edgeFlags, false);
         assertFalse(accessEnc.getBool(true, edgeFlags));

--- a/core/src/test/java/com/graphhopper/routing/util/DefaultEdgeFilterTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/DefaultEdgeFilterTest.java
@@ -44,9 +44,9 @@ public class DefaultEdgeFilterTest {
         // 0-1
         //  \|
         //   2
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(2), encoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(2, 0).setDistance(3), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(1, 2).setDistance(2));
+        GHUtility.setSpeed(60, true, false, encoder, graph.edge(2, 0).setDistance(3));
         graph.freeze();
         // add loop shortcut in 'fwd' direction
         addShortcut(chGraph, 0, 0, true, 0, 2);

--- a/core/src/test/java/com/graphhopper/routing/util/DefaultEdgeFilterTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/DefaultEdgeFilterTest.java
@@ -25,6 +25,7 @@ import com.graphhopper.storage.GraphBuilder;
 import com.graphhopper.storage.GraphHopperStorage;
 import com.graphhopper.util.CHEdgeExplorer;
 import com.graphhopper.util.CHEdgeIterator;
+import com.graphhopper.util.GHUtility;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -43,9 +44,9 @@ public class DefaultEdgeFilterTest {
         // 0-1
         //  \|
         //   2
-        graph.edge(0, 1, 1, false);
-        graph.edge(1, 2, 2, false);
-        graph.edge(2, 0, 3, false);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(2), encoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(2, 0).setDistance(3), encoder, 60, true, false);
         graph.freeze();
         // add loop shortcut in 'fwd' direction
         addShortcut(chGraph, 0, 0, true, 0, 2);

--- a/core/src/test/java/com/graphhopper/routing/util/FootFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/FootFlagEncoderTest.java
@@ -67,10 +67,9 @@ public class FootFlagEncoderTest {
     @Test
     public void testCombined() {
         Graph g = new GraphBuilder(encodingManager).create();
-        FlagEncoder carEncoder = encodingManager.getEncoder("car");
         EdgeIteratorState edge = g.edge(0, 1);
-        edge.set(footAvSpeedEnc, 10.0).set(footAccessEnc, true).setReverse(footAccessEnc, true);
-        edge.set(carAvSpeedEnc, 100.0).set(carAccessEnc, true).setReverse(carAccessEnc, false);
+        edge.set(footAvSpeedEnc, 10.0).set(footAccessEnc, true, true);
+        edge.set(carAvSpeedEnc, 100.0).set(carAccessEnc, true, false);
 
         assertEquals(10, edge.get(footAvSpeedEnc), 1e-1);
         assertTrue(edge.get(footAccessEnc));
@@ -90,9 +89,9 @@ public class FootFlagEncoderTest {
     @Test
     public void testGraph() {
         Graph g = new GraphBuilder(encodingManager).create();
-        g.edge(0, 1).setDistance(10).set(footAvSpeedEnc, 10.0).set(footAccessEnc, true).setReverse(footAccessEnc, true);
-        g.edge(0, 2).setDistance(10).set(footAvSpeedEnc, 5.0).set(footAccessEnc, true).setReverse(footAccessEnc, true);
-        g.edge(1, 3).setDistance(10).set(footAvSpeedEnc, 10.0).set(footAccessEnc, true).setReverse(footAccessEnc, true);
+        g.edge(0, 1).setDistance(10).set(footAvSpeedEnc, 10.0).set(footAccessEnc, true, true);
+        g.edge(0, 2).setDistance(10).set(footAvSpeedEnc, 5.0).set(footAccessEnc, true, true);
+        g.edge(1, 3).setDistance(10).set(footAvSpeedEnc, 10.0).set(footAccessEnc, true, true);
         EdgeExplorer out = g.createEdgeExplorer(DefaultEdgeFilter.outEdges(footEncoder));
         assertEquals(GHUtility.asSet(1, 2), GHUtility.getNeighbors(out.setBaseNode(0)));
         assertEquals(GHUtility.asSet(0, 3), GHUtility.getNeighbors(out.setBaseNode(1)));

--- a/core/src/test/java/com/graphhopper/routing/util/FootFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/FootFlagEncoderTest.java
@@ -65,20 +65,6 @@ public class FootFlagEncoderTest {
     }
 
     @Test
-    public void testBasics() {
-        IntsRef edgeFlags = encodingManager.createEdgeFlags();
-        footEncoder.flagsDefault(edgeFlags, true, true);
-        assertEquals(FootFlagEncoder.MEAN_SPEED, footEncoder.getSpeed(edgeFlags), 1e-1);
-
-        IntsRef ef1 = encodingManager.createEdgeFlags();
-        footEncoder.flagsDefault(ef1, true, false);
-        IntsRef ef2 = encodingManager.createEdgeFlags();
-        footEncoder.flagsDefault(ef2, false, true);
-        assertEquals(footAccessEnc.getBool(false, ef1), footAccessEnc.getBool(true, ef2));
-        assertEquals(footEncoder.getSpeed(ef1), footEncoder.getSpeed(ef1), 1e-1);
-    }
-
-    @Test
     public void testCombined() {
         Graph g = new GraphBuilder(encodingManager).create();
         FlagEncoder carEncoder = encodingManager.getEncoder("car");

--- a/core/src/test/java/com/graphhopper/routing/util/MotorcycleFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/MotorcycleFlagEncoderTest.java
@@ -49,7 +49,7 @@ public class MotorcycleFlagEncoderTest {
                 setWayGeometry(Helper.createPointList3D(51.1, 12.0011, 49, 51.1, 12.0015, 55));
         edge.setDistance(100);
 
-        edge.set(accessEnc, true).setReverse(accessEnc, true).set(encoder.getAverageSpeedEnc(), 10.0).setReverse(encoder.getAverageSpeedEnc(), 15.0);
+        edge.set(accessEnc, true, true).set(encoder.getAverageSpeedEnc(), 10.0, 15.0);
         return gs;
     }
 

--- a/core/src/test/java/com/graphhopper/routing/util/MountainBikeFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/MountainBikeFlagEncoderTest.java
@@ -36,7 +36,7 @@ public class MountainBikeFlagEncoderTest extends AbstractBikeFlagEncoderTester {
 
     @Test
     public void testGetSpeed() {
-        IntsRef intsRef = GHUtility.setProperties(encodingManager.createEdgeFlags(), encoder, 10, true, false);
+        IntsRef intsRef = GHUtility.setSpeed(10, 0, encoder, encodingManager.createEdgeFlags());
         assertEquals(10, encoder.getSpeed(intsRef), 1e-1);
         ReaderWay way = new ReaderWay(1);
         way.setTag("highway", "primary");

--- a/core/src/test/java/com/graphhopper/routing/util/RacingBikeFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/RacingBikeFlagEncoderTest.java
@@ -94,7 +94,7 @@ public class RacingBikeFlagEncoderTest extends AbstractBikeFlagEncoderTester {
 
     @Test
     public void testGetSpeed() {
-        IntsRef intsRef = GHUtility.setProperties(encodingManager.createEdgeFlags(), encoder, 10, true, false);
+        IntsRef intsRef = GHUtility.setSpeed(10, 0, encoder, encodingManager.createEdgeFlags());
         assertEquals(10, encoder.getSpeed(intsRef), 1e-1);
         ReaderWay way = new ReaderWay(1);
         way.setTag("highway", "track");

--- a/core/src/test/java/com/graphhopper/routing/util/WheelchairFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/WheelchairFlagEncoderTest.java
@@ -55,8 +55,8 @@ public class WheelchairFlagEncoderTest {
         Graph g = new GraphBuilder(encodingManager).create();
         FlagEncoder carEncoder = encodingManager.getEncoder("car");
         EdgeIteratorState edge = g.edge(0, 1);
-        edge.set(wheelchairAvSpeedEnc, 10.0).set(wheelchairAccessEnc, true).setReverse(wheelchairAccessEnc, true);
-        edge.set(carAvSpeedEnc, 100.0).set(carAccessEnc, true).setReverse(carAccessEnc, false);
+        edge.set(wheelchairAvSpeedEnc, 10.0).set(wheelchairAccessEnc, true, true);
+        edge.set(carAvSpeedEnc, 100.0).set(carAccessEnc, true, false);
 
         assertEquals(10, edge.get(wheelchairAvSpeedEnc), .1);
         assertTrue(edge.get(wheelchairAccessEnc));
@@ -76,9 +76,9 @@ public class WheelchairFlagEncoderTest {
     @Test
     public void testGraph() {
         Graph g = new GraphBuilder(encodingManager).create();
-        g.edge(0, 1).setDistance(10).set(wheelchairAvSpeedEnc, 10.0).set(wheelchairAccessEnc, true).setReverse(wheelchairAccessEnc, true);
-        g.edge(0, 2).setDistance(10).set(wheelchairAvSpeedEnc, 5.0).set(wheelchairAccessEnc, true).setReverse(wheelchairAccessEnc, true);
-        g.edge(1, 3).setDistance(10).set(wheelchairAvSpeedEnc, 10.0).set(wheelchairAccessEnc, true).setReverse(wheelchairAccessEnc, true);
+        g.edge(0, 1).setDistance(10).set(wheelchairAvSpeedEnc, 10.0).set(wheelchairAccessEnc, true, true);
+        g.edge(0, 2).setDistance(10).set(wheelchairAvSpeedEnc, 5.0).set(wheelchairAccessEnc, true, true);
+        g.edge(1, 3).setDistance(10).set(wheelchairAvSpeedEnc, 10.0).set(wheelchairAccessEnc, true, true);
         EdgeExplorer out = g.createEdgeExplorer(DefaultEdgeFilter.outEdges(wheelchairEncoder));
         assertEquals(GHUtility.asSet(1, 2), GHUtility.getNeighbors(out.setBaseNode(0)));
         assertEquals(GHUtility.asSet(0, 3), GHUtility.getNeighbors(out.setBaseNode(1)));

--- a/core/src/test/java/com/graphhopper/routing/util/WheelchairFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/WheelchairFlagEncoderTest.java
@@ -51,20 +51,6 @@ public class WheelchairFlagEncoderTest {
     }
 
     @Test
-    public void testBasics() {
-        IntsRef edgeFlags = encodingManager.createEdgeFlags();
-        wheelchairEncoder.flagsDefault(edgeFlags, true, true);
-        assertEquals(FootFlagEncoder.MEAN_SPEED, wheelchairAvSpeedEnc.getDecimal(false, edgeFlags), .1);
-
-        IntsRef ef1 = encodingManager.createEdgeFlags();
-        wheelchairEncoder.flagsDefault(ef1, true, false);
-        IntsRef ef2 = encodingManager.createEdgeFlags();
-        wheelchairEncoder.flagsDefault(ef2, false, true);
-        assertEquals(wheelchairAccessEnc.getBool(false, ef1), wheelchairAccessEnc.getBool(true, ef2));
-        assertEquals(wheelchairAvSpeedEnc.getDecimal(false, ef1), wheelchairAvSpeedEnc.getDecimal(false, ef1), .1);
-    }
-
-    @Test
     public void testCombined() {
         Graph g = new GraphBuilder(encodingManager).create();
         FlagEncoder carEncoder = encodingManager.getEncoder("car");

--- a/core/src/test/java/com/graphhopper/routing/util/WheelchairFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/WheelchairFlagEncoderTest.java
@@ -504,14 +504,14 @@ public class WheelchairFlagEncoderTest {
         na.setNode(1, 51.1, 12.002, 55);
         EdgeIteratorState edge0 = gs.edge(0, 1).setWayGeometry(Helper.createPointList3D(51.1, 12.0011, 49, 51.1, 12.0015, 55));
         edge0.setDistance(100);
-        GHUtility.setProperties(edge0, wheelchairEncoder, 5, 5);
+        GHUtility.setSpeed(5, 5, wheelchairEncoder, edge0);
 
         // incline of 10% over all
         na.setNode(2, 51.2, 12.101, 50);
         na.setNode(3, 51.2, 12.102, 60);
         EdgeIteratorState edge1 = gs.edge(2, 3).setWayGeometry(Helper.createPointList3D(51.2, 12.1011, 49, 51.2, 12.1015, 55));
         edge1.setDistance(100);
-        GHUtility.setProperties(edge1, wheelchairEncoder, 5, 5);
+        GHUtility.setSpeed(5, 5, wheelchairEncoder, edge1);
         return gs;
     }
 

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMTurnRelationParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMTurnRelationParserTest.java
@@ -32,7 +32,7 @@ public class OSMTurnRelationParserTest {
 
         OSMTurnRelationParser parser = new OSMTurnRelationParser(encoder.toString(), 1, OSMRoadAccessParser.toOSMRestrictions(TransportationMode.CAR));
         GraphHopperStorage ghStorage = new GraphBuilder(new EncodingManager.Builder().add(encoder).addTurnCostParser(parser).build()).create();
-        EdgeBasedRoutingAlgorithmTest.initGraph(ghStorage);
+        EdgeBasedRoutingAlgorithmTest.initGraph(ghStorage, encoder);
         TurnCostParser.ExternalInternalMap map = new TurnCostParser.ExternalInternalMap() {
 
             @Override

--- a/core/src/test/java/com/graphhopper/routing/util/spatialrules/SpatialRuleLookupBuilderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/spatialrules/SpatialRuleLookupBuilderTest.java
@@ -163,10 +163,10 @@ public class SpatialRuleLookupBuilderTest {
 
         Graph graph = new GraphBuilder(em).create();
         FlagEncoder encoder = em.getEncoder("car");
-        EdgeIteratorState e1 = GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
-        EdgeIteratorState e2 = GHUtility.setProperties(graph.edge(0, 2).setDistance(1), encoder, 60, true, true);
-        EdgeIteratorState e3 = GHUtility.setProperties(graph.edge(0, 3).setDistance(1), encoder, 60, true, true);
-        EdgeIteratorState e4 = GHUtility.setProperties(graph.edge(0, 4).setDistance(1), encoder, 60, true, true);
+        EdgeIteratorState e1 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(1));
+        EdgeIteratorState e2 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 2).setDistance(1));
+        EdgeIteratorState e3 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 3).setDistance(1));
+        EdgeIteratorState e4 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 4).setDistance(1));
         updateDistancesFor(graph, 0, 0.00, 0.00);
         updateDistancesFor(graph, 1, 0.01, 0.01);
         updateDistancesFor(graph, 2, -0.01, -0.01);

--- a/core/src/test/java/com/graphhopper/routing/util/spatialrules/SpatialRuleLookupBuilderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/spatialrules/SpatialRuleLookupBuilderTest.java
@@ -23,6 +23,7 @@ import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.*;
 import com.graphhopper.routing.util.CarFlagEncoder;
 import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.routing.util.TransportationMode;
 import com.graphhopper.routing.util.parsers.SpatialRuleParser;
 import com.graphhopper.routing.util.spatialrules.countries.GermanySpatialRule;
@@ -30,6 +31,7 @@ import com.graphhopper.storage.Graph;
 import com.graphhopper.storage.GraphBuilder;
 import com.graphhopper.storage.IntsRef;
 import com.graphhopper.util.EdgeIteratorState;
+import com.graphhopper.util.GHUtility;
 import com.graphhopper.util.PMap;
 import com.graphhopper.util.shapes.GHPoint;
 import org.junit.Test;
@@ -58,11 +60,11 @@ public class SpatialRuleLookupBuilderTest {
     private static SpatialRuleLookup createLookup() throws IOException {
         return createLookup(new Envelope(-180, 180, -90, 90));
     }
-    
+
     private static SpatialRuleLookup createLookup(Envelope maxBounds) throws IOException {
         final FileReader reader = new FileReader(COUNTRIES_FILE);
         List<JsonFeatureCollection> feats = Collections.singletonList(
-                        Jackson.newObjectMapper().readValue(reader, JsonFeatureCollection.class));
+                Jackson.newObjectMapper().readValue(reader, JsonFeatureCollection.class));
         return SpatialRuleLookupBuilder.buildIndex(feats, "ISO3166-1:alpha3", new CountriesSpatialRuleFactory());
     }
 
@@ -142,7 +144,7 @@ public class SpatialRuleLookupBuilderTest {
                 }
                 return SpatialRuleSet.EMPTY;
             }
-            
+
             @Override
             public List<SpatialRule> getRules() {
                 return Collections.singletonList(germany);
@@ -160,10 +162,11 @@ public class SpatialRuleLookupBuilderTest {
         DecimalEncodedValue tmpCarMaxSpeedEnc = em.getDecimalEncodedValue(MaxSpeed.KEY);
 
         Graph graph = new GraphBuilder(em).create();
-        EdgeIteratorState e1 = graph.edge(0, 1, 1, true);
-        EdgeIteratorState e2 = graph.edge(0, 2, 1, true);
-        EdgeIteratorState e3 = graph.edge(0, 3, 1, true);
-        EdgeIteratorState e4 = graph.edge(0, 4, 1, true);
+        FlagEncoder encoder = em.getEncoder("car");
+        EdgeIteratorState e1 = GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
+        EdgeIteratorState e2 = GHUtility.setProperties(graph.edge(0, 2).setDistance(1), encoder, 60, true, true);
+        EdgeIteratorState e3 = GHUtility.setProperties(graph.edge(0, 3).setDistance(1), encoder, 60, true, true);
+        EdgeIteratorState e4 = GHUtility.setProperties(graph.edge(0, 4).setDistance(1), encoder, 60, true, true);
         updateDistancesFor(graph, 0, 0.00, 0.00);
         updateDistancesFor(graph, 1, 0.01, 0.01);
         updateDistancesFor(graph, 2, -0.01, -0.01);
@@ -184,7 +187,7 @@ public class SpatialRuleLookupBuilderTest {
         e2.setFlags(em.handleWayTags(way2, map, relFlags));
         assertEquals(RoadAccess.YES, e2.get(tmpRoadAccessEnc));
 
-        assertEquals(index.getRules().indexOf(germany), e1.get(countrySpatialIdEnc)-1);
+        assertEquals(index.getRules().indexOf(germany), e1.get(countrySpatialIdEnc) - 1);
         assertEquals(0, e2.get(countrySpatialIdEnc));
 
         ReaderWay livingStreet = new ReaderWay(29L);

--- a/core/src/test/java/com/graphhopper/routing/weighting/BlockAreaWeightingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/BlockAreaWeightingTest.java
@@ -36,7 +36,7 @@ public class BlockAreaWeightingTest {
         em = EncodingManager.create(Arrays.asList(encoder));
         graph = new GraphBuilder(em).create();
         // 0-1
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(1));
         updateDistancesFor(graph, 0, 0.00, 0.00);
         updateDistancesFor(graph, 1, 0.01, 0.01);
     }

--- a/core/src/test/java/com/graphhopper/routing/weighting/BlockAreaWeightingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/BlockAreaWeightingTest.java
@@ -14,6 +14,7 @@ import com.graphhopper.storage.index.LocationIndexTree;
 import com.graphhopper.storage.index.Snap;
 import com.graphhopper.util.EdgeIterator;
 import com.graphhopper.util.EdgeIteratorState;
+import com.graphhopper.util.GHUtility;
 import com.graphhopper.util.shapes.Circle;
 import org.junit.Before;
 import org.junit.Test;
@@ -35,7 +36,7 @@ public class BlockAreaWeightingTest {
         em = EncodingManager.create(Arrays.asList(encoder));
         graph = new GraphBuilder(em).create();
         // 0-1
-        graph.edge(0, 1, 1, true);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
         updateDistancesFor(graph, 0, 0.00, 0.00);
         updateDistancesFor(graph, 1, 0.01, 0.01);
     }

--- a/core/src/test/java/com/graphhopper/routing/weighting/CustomWeightingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/CustomWeightingTest.java
@@ -68,7 +68,7 @@ public class CustomWeightingTest {
     @Test
     public void speedOnly() {
         // 50km/h -> 72s per km, 100km/h -> 36s per km
-        EdgeIteratorState edge = GHUtility.setProperties(graph.edge(0, 1).setDistance(1000), carFE, 60, true, true)
+        EdgeIteratorState edge = GHUtility.setSpeed(60, true, true, carFE, graph.edge(0, 1).setDistance(1000))
                 .set(avSpeedEnc, 50).setReverse(avSpeedEnc, 100);
         assertEquals(72, createWeighting(new CustomModel().setDistanceInfluence(0)).calcEdgeWeight(edge, false), 1.e-6);
         assertEquals(36, createWeighting(new CustomModel().setDistanceInfluence(0)).calcEdgeWeight(edge, true), 1.e-6);
@@ -77,9 +77,9 @@ public class CustomWeightingTest {
     @Test
     public void withPriority() {
         // 25km/h -> 144s per km, 50km/h -> 72s per km, 100km/h -> 36s per km
-        EdgeIteratorState slow = GHUtility.setProperties(graph.edge(0, 1).setDistance(1000), carFE, 60, true, true).set(avSpeedEnc, 25).set(roadClassEnc, SECONDARY);
-        EdgeIteratorState medium = GHUtility.setProperties(graph.edge(0, 1).setDistance(1000), carFE, 60, true, true).set(avSpeedEnc, 50).set(roadClassEnc, SECONDARY);
-        EdgeIteratorState fast = GHUtility.setProperties(graph.edge(0, 1).setDistance(1000), carFE, 60, true, true).set(avSpeedEnc, 100).set(roadClassEnc, SECONDARY);
+        EdgeIteratorState slow = GHUtility.setSpeed(60, true, true, carFE, graph.edge(0, 1).setDistance(1000)).set(avSpeedEnc, 25).set(roadClassEnc, SECONDARY);
+        EdgeIteratorState medium = GHUtility.setSpeed(60, true, true, carFE, graph.edge(0, 1).setDistance(1000)).set(avSpeedEnc, 50).set(roadClassEnc, SECONDARY);
+        EdgeIteratorState fast = GHUtility.setSpeed(60, true, true, carFE, graph.edge(0, 1).setDistance(1000)).set(avSpeedEnc, 100).set(roadClassEnc, SECONDARY);
 
         // without priority costs fastest weighting is the same as custom weighting
         assertEquals(144, new FastestWeighting(carFE, NO_TURN_COST_PROVIDER).calcEdgeWeight(slow, false), .1);
@@ -124,9 +124,9 @@ public class CustomWeightingTest {
 
     @Test
     public void testBasic() {
-        EdgeIteratorState primary = GHUtility.setProperties(graph.edge(0, 1).setDistance(10), carFE, 60, true, true).
+        EdgeIteratorState primary = GHUtility.setSpeed(60, true, true, carFE, graph.edge(0, 1).setDistance(10)).
                 set(roadClassEnc, PRIMARY).set(avSpeedEnc, 80);
-        EdgeIteratorState secondary = GHUtility.setProperties(graph.edge(1, 2).setDistance(10), carFE, 60, true, true).
+        EdgeIteratorState secondary = GHUtility.setSpeed(60, true, true, carFE, graph.edge(1, 2).setDistance(10)).
                 set(roadClassEnc, SECONDARY).set(avSpeedEnc, 70);
 
         CustomModel vehicleModel = new CustomModel();
@@ -152,7 +152,7 @@ public class CustomWeightingTest {
 
     @Test
     public void testMaxSpeedMap() {
-        EdgeIteratorState primary = GHUtility.setProperties(graph.edge(0, 1).setDistance(10), carFE, 60, true, true).
+        EdgeIteratorState primary = GHUtility.setSpeed(60, true, true, carFE, graph.edge(0, 1).setDistance(10)).
                 set(roadClassEnc, PRIMARY).set(avSpeedEnc, 80);
         CustomModel vehicleModel = new CustomModel();
 
@@ -168,7 +168,7 @@ public class CustomWeightingTest {
 
     @Test
     public void testSpeedFactorBooleanEV() {
-        EdgeIteratorState edge = GHUtility.setProperties(graph.edge(0, 1).setDistance(10), carFE, 60, true, true).set(avSpeedEnc, 15);
+        EdgeIteratorState edge = GHUtility.setSpeed(60, true, true, carFE, graph.edge(0, 1).setDistance(10)).set(avSpeedEnc, 15);
         CustomModel vehicleModel = new CustomModel();
         assertEquals(3.1, createWeighting(vehicleModel).calcEdgeWeight(edge, false), 0.01);
         // here we increase weight for edges that are road class links
@@ -213,7 +213,7 @@ public class CustomWeightingTest {
         vehicleModel.getPriority().put(KEY, map);
         CustomWeighting weighting = createWeighting(vehicleModel);
 
-        EdgeIteratorState edge = GHUtility.setProperties(graph.edge(0, 1).setDistance(10), carFE, 60, true, true).set(avSpeedEnc, 15);
+        EdgeIteratorState edge = GHUtility.setSpeed(60, true, true, carFE, graph.edge(0, 1).setDistance(10)).set(avSpeedEnc, 15);
         assertEquals(3.1, weighting.calcEdgeWeight(edge, false), 0.01);
         // we increase weight for motorways
         edge.set(roadClassEnc, MOTORWAY);
@@ -228,8 +228,8 @@ public class CustomWeightingTest {
     @Test
     public void testAvoidHighSpeed() {
         CustomWeighting weighting = createWeighting(new CustomModel());
-        EdgeIteratorState slowEdge = GHUtility.setProperties(graph.edge(0, 1).setDistance(10), carFE, 60, true, true).set(avSpeedEnc, 15).set(maxSpeedEnc, 50);
-        EdgeIteratorState fastEdge = GHUtility.setProperties(graph.edge(1, 2).setDistance(10), carFE, 60, true, true).set(avSpeedEnc, 60).set(maxSpeedEnc, 70);
+        EdgeIteratorState slowEdge = GHUtility.setSpeed(60, true, true, carFE, graph.edge(0, 1).setDistance(10)).set(avSpeedEnc, 15).set(maxSpeedEnc, 50);
+        EdgeIteratorState fastEdge = GHUtility.setSpeed(60, true, true, carFE, graph.edge(1, 2).setDistance(10)).set(avSpeedEnc, 60).set(maxSpeedEnc, 70);
         assertEquals(3.10, weighting.calcEdgeWeight(slowEdge, false), 0.01);
         assertEquals(1.30, weighting.calcEdgeWeight(fastEdge, false), 0.01);
 
@@ -255,8 +255,8 @@ public class CustomWeightingTest {
     public void testIntEncodedValue() {
         // currently we have no inbuilt encoded value that requires int but it is not bad to have for e.g. lanes
         CustomWeighting weighting = createWeighting(new CustomModel());
-        EdgeIteratorState slowEdge = GHUtility.setProperties(graph.edge(0, 1).setDistance(10), carFE, 60, true, true).set(avSpeedEnc, 15).set(laneEnc, 0);
-        EdgeIteratorState fastEdge = GHUtility.setProperties(graph.edge(1, 2).setDistance(10), carFE, 60, true, true).set(avSpeedEnc, 60).set(laneEnc, 2);
+        EdgeIteratorState slowEdge = GHUtility.setSpeed(60, true, true, carFE, graph.edge(0, 1).setDistance(10)).set(avSpeedEnc, 15).set(laneEnc, 0);
+        EdgeIteratorState fastEdge = GHUtility.setSpeed(60, true, true, carFE, graph.edge(1, 2).setDistance(10)).set(avSpeedEnc, 60).set(laneEnc, 2);
         assertEquals(3.10, weighting.calcEdgeWeight(slowEdge, false), 0.01);
         assertEquals(1.30, weighting.calcEdgeWeight(fastEdge, false), 0.01);
 
@@ -300,11 +300,11 @@ public class CustomWeightingTest {
         // a bit in the north where my_area is:
         graph.getNodeAccess().setNode(2, 51.054506, 13.723432);
         graph.getNodeAccess().setNode(3, 51.053589, 13.730679);
-        EdgeIteratorState edge1 = GHUtility.setProperties(graph.edge(0, 1).setDistance(500), carFE, 60, true, true).set(avSpeedEnc, 15);
+        EdgeIteratorState edge1 = GHUtility.setSpeed(60, true, true, carFE, graph.edge(0, 1).setDistance(500)).set(avSpeedEnc, 15);
         assertEquals(120, weighting.calcEdgeWeight(edge1, false), 0.01);
 
         // intersect polygon => increase weight (it doubles, because distance influence is zero)
-        EdgeIteratorState edge2 = GHUtility.setProperties(graph.edge(2, 3).setDistance(500), carFE, 60, true, true).set(avSpeedEnc, 15);
+        EdgeIteratorState edge2 = GHUtility.setSpeed(60, true, true, carFE, graph.edge(2, 3).setDistance(500)).set(avSpeedEnc, 15);
         assertTrue(poly.intersects(edge2.fetchWayGeometry(FetchMode.ALL).toLineString(false)));
         assertEquals(240, weighting.calcEdgeWeight(edge2, false), 0.01);
     }

--- a/core/src/test/java/com/graphhopper/routing/weighting/CustomWeightingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/CustomWeightingTest.java
@@ -28,6 +28,7 @@ import com.graphhopper.storage.GraphBuilder;
 import com.graphhopper.storage.GraphHopperStorage;
 import com.graphhopper.util.EdgeIteratorState;
 import com.graphhopper.util.FetchMode;
+import com.graphhopper.util.GHUtility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;
@@ -45,7 +46,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class CustomWeightingTest {
 
-    GraphHopperStorage graphHopperStorage;
+    GraphHopperStorage graph;
     DecimalEncodedValue avSpeedEnc;
     DecimalEncodedValue maxSpeedEnc;
     IntEncodedValue laneEnc;
@@ -61,13 +62,13 @@ public class CustomWeightingTest {
         avSpeedEnc = carFE.getAverageSpeedEnc();
         maxSpeedEnc = encodingManager.getDecimalEncodedValue(MaxSpeed.KEY);
         roadClassEnc = encodingManager.getEnumEncodedValue(KEY, RoadClass.class);
-        graphHopperStorage = new GraphBuilder(encodingManager).create();
+        graph = new GraphBuilder(encodingManager).create();
     }
 
     @Test
     public void speedOnly() {
         // 50km/h -> 72s per km, 100km/h -> 36s per km
-        EdgeIteratorState edge = graphHopperStorage.edge(0, 1, 1000, true)
+        EdgeIteratorState edge = GHUtility.setProperties(graph.edge(0, 1).setDistance(1000), carFE, 60, true, true)
                 .set(avSpeedEnc, 50).setReverse(avSpeedEnc, 100);
         assertEquals(72, createWeighting(new CustomModel().setDistanceInfluence(0)).calcEdgeWeight(edge, false), 1.e-6);
         assertEquals(36, createWeighting(new CustomModel().setDistanceInfluence(0)).calcEdgeWeight(edge, true), 1.e-6);
@@ -76,9 +77,9 @@ public class CustomWeightingTest {
     @Test
     public void withPriority() {
         // 25km/h -> 144s per km, 50km/h -> 72s per km, 100km/h -> 36s per km
-        EdgeIteratorState slow = graphHopperStorage.edge(0, 1, 1000, true).set(avSpeedEnc, 25).set(roadClassEnc, SECONDARY);
-        EdgeIteratorState medium = graphHopperStorage.edge(0, 1, 1000, true).set(avSpeedEnc, 50).set(roadClassEnc, SECONDARY);
-        EdgeIteratorState fast = graphHopperStorage.edge(0, 1, 1000, true).set(avSpeedEnc, 100).set(roadClassEnc, SECONDARY);
+        EdgeIteratorState slow = GHUtility.setProperties(graph.edge(0, 1).setDistance(1000), carFE, 60, true, true).set(avSpeedEnc, 25).set(roadClassEnc, SECONDARY);
+        EdgeIteratorState medium = GHUtility.setProperties(graph.edge(0, 1).setDistance(1000), carFE, 60, true, true).set(avSpeedEnc, 50).set(roadClassEnc, SECONDARY);
+        EdgeIteratorState fast = GHUtility.setProperties(graph.edge(0, 1).setDistance(1000), carFE, 60, true, true).set(avSpeedEnc, 100).set(roadClassEnc, SECONDARY);
 
         // without priority costs fastest weighting is the same as custom weighting
         assertEquals(144, new FastestWeighting(carFE, NO_TURN_COST_PROVIDER).calcEdgeWeight(slow, false), .1);
@@ -103,7 +104,8 @@ public class CustomWeightingTest {
 
     @Test
     public void withDistanceInfluence() {
-        EdgeIteratorState edge = graphHopperStorage.edge(0, 1, 10_000, true).set(avSpeedEnc, 50);
+        BooleanEncodedValue accessEnc = carFE.getAccessEnc();
+        EdgeIteratorState edge = graph.edge(0, 1).setDistance(10_000).set(avSpeedEnc, 50).set(accessEnc, true).setReverse(accessEnc, true);
         assertEquals(720, createWeighting(new CustomModel().setDistanceInfluence(0)).calcEdgeWeight(edge, false), .1);
         assertEquals(720_000, createWeighting(new CustomModel().setDistanceInfluence(0)).calcEdgeMillis(edge, false), .1);
         // distance_influence=30 means that for every kilometer we get additional costs of 30s, so +300s here
@@ -112,7 +114,7 @@ public class CustomWeightingTest {
         assertEquals(720_000, createWeighting(new CustomModel().setDistanceInfluence(30)).calcEdgeMillis(edge, false), .1);
 
         // we can also imagine a shorter but slower road that takes the same time
-        edge = graphHopperStorage.edge(0, 1, 5_000, true).set(avSpeedEnc, 25);
+        edge = graph.edge(0, 1).setDistance(5_000).set(avSpeedEnc, 25).set(accessEnc, true).setReverse(accessEnc, true);
         assertEquals(720, createWeighting(new CustomModel().setDistanceInfluence(0)).calcEdgeWeight(edge, false), .1);
         assertEquals(720_000, createWeighting(new CustomModel().setDistanceInfluence(0)).calcEdgeMillis(edge, false), .1);
         // and if we include the distance influence the weight will be bigger but still smaller than what we got for
@@ -122,9 +124,9 @@ public class CustomWeightingTest {
 
     @Test
     public void testBasic() {
-        EdgeIteratorState primary = graphHopperStorage.edge(0, 1, 10, true).
+        EdgeIteratorState primary = GHUtility.setProperties(graph.edge(0, 1).setDistance(10), carFE, 60, true, true).
                 set(roadClassEnc, PRIMARY).set(avSpeedEnc, 80);
-        EdgeIteratorState secondary = graphHopperStorage.edge(1, 2, 10, true).
+        EdgeIteratorState secondary = GHUtility.setProperties(graph.edge(1, 2).setDistance(10), carFE, 60, true, true).
                 set(roadClassEnc, SECONDARY).set(avSpeedEnc, 70);
 
         CustomModel vehicleModel = new CustomModel();
@@ -150,7 +152,7 @@ public class CustomWeightingTest {
 
     @Test
     public void testMaxSpeedMap() {
-        EdgeIteratorState primary = graphHopperStorage.edge(0, 1, 10, true).
+        EdgeIteratorState primary = GHUtility.setProperties(graph.edge(0, 1).setDistance(10), carFE, 60, true, true).
                 set(roadClassEnc, PRIMARY).set(avSpeedEnc, 80);
         CustomModel vehicleModel = new CustomModel();
 
@@ -166,7 +168,7 @@ public class CustomWeightingTest {
 
     @Test
     public void testSpeedFactorBooleanEV() {
-        EdgeIteratorState edge = graphHopperStorage.edge(0, 1, 10, true).set(avSpeedEnc, 15);
+        EdgeIteratorState edge = GHUtility.setProperties(graph.edge(0, 1).setDistance(10), carFE, 60, true, true).set(avSpeedEnc, 15);
         CustomModel vehicleModel = new CustomModel();
         assertEquals(3.1, createWeighting(vehicleModel).calcEdgeWeight(edge, false), 0.01);
         // here we increase weight for edges that are road class links
@@ -185,10 +187,10 @@ public class CustomWeightingTest {
         BooleanEncodedValue specialEnc = new SimpleBooleanEncodedValue("special", true);
         encodingManager = new EncodingManager.Builder().add(carFE).add(specialEnc).build();
         avSpeedEnc = carFE.getAverageSpeedEnc();
-        graphHopperStorage = new GraphBuilder(encodingManager).create();
+        graph = new GraphBuilder(encodingManager).create();
 
         BooleanEncodedValue accessEnc = carFE.getAccessEnc();
-        EdgeIteratorState edge = graphHopperStorage.edge(0, 1).set(accessEnc, true).setReverse(accessEnc, true).
+        EdgeIteratorState edge = graph.edge(0, 1).set(accessEnc, true).setReverse(accessEnc, true).
                 set(avSpeedEnc, 15).set(specialEnc, false).setReverse(specialEnc, true).setDistance(10);
 
         CustomModel vehicleModel = new CustomModel();
@@ -211,13 +213,14 @@ public class CustomWeightingTest {
         vehicleModel.getPriority().put(KEY, map);
         CustomWeighting weighting = createWeighting(vehicleModel);
 
-        EdgeIteratorState edge = graphHopperStorage.edge(0, 1, 10, true).set(avSpeedEnc, 15);
+        EdgeIteratorState edge = GHUtility.setProperties(graph.edge(0, 1).setDistance(10), carFE, 60, true, true).set(avSpeedEnc, 15);
         assertEquals(3.1, weighting.calcEdgeWeight(edge, false), 0.01);
         // we increase weight for motorways
         edge.set(roadClassEnc, MOTORWAY);
         assertEquals(24.70, weighting.calcEdgeWeight(edge, false), 0.01);
         // the edge weight is proportional to the edge distance
-        edge = graphHopperStorage.edge(0, 1, 5 * 10, true).set(avSpeedEnc, 15);
+        BooleanEncodedValue accessEnc = carFE.getAccessEnc();
+        edge = graph.edge(0, 1).setDistance(5 * 10).set(avSpeedEnc, 15).set(accessEnc, true).setReverse(accessEnc, true);
         assertEquals(5 * 3.1, weighting.calcEdgeWeight(edge, false), 0.01);
         assertEquals(5 * 24.70, weighting.calcEdgeWeight(edge.set(roadClassEnc, MOTORWAY), false), 0.01);
     }
@@ -225,8 +228,8 @@ public class CustomWeightingTest {
     @Test
     public void testAvoidHighSpeed() {
         CustomWeighting weighting = createWeighting(new CustomModel());
-        EdgeIteratorState slowEdge = graphHopperStorage.edge(0, 1, 10, true).set(avSpeedEnc, 15).set(maxSpeedEnc, 50);
-        EdgeIteratorState fastEdge = graphHopperStorage.edge(1, 2, 10, true).set(avSpeedEnc, 60).set(maxSpeedEnc, 70);
+        EdgeIteratorState slowEdge = GHUtility.setProperties(graph.edge(0, 1).setDistance(10), carFE, 60, true, true).set(avSpeedEnc, 15).set(maxSpeedEnc, 50);
+        EdgeIteratorState fastEdge = GHUtility.setProperties(graph.edge(1, 2).setDistance(10), carFE, 60, true, true).set(avSpeedEnc, 60).set(maxSpeedEnc, 70);
         assertEquals(3.10, weighting.calcEdgeWeight(slowEdge, false), 0.01);
         assertEquals(1.30, weighting.calcEdgeWeight(fastEdge, false), 0.01);
 
@@ -252,8 +255,8 @@ public class CustomWeightingTest {
     public void testIntEncodedValue() {
         // currently we have no inbuilt encoded value that requires int but it is not bad to have for e.g. lanes
         CustomWeighting weighting = createWeighting(new CustomModel());
-        EdgeIteratorState slowEdge = graphHopperStorage.edge(0, 1, 10, true).set(avSpeedEnc, 15).set(laneEnc, 0);
-        EdgeIteratorState fastEdge = graphHopperStorage.edge(1, 2, 10, true).set(avSpeedEnc, 60).set(laneEnc, 2);
+        EdgeIteratorState slowEdge = GHUtility.setProperties(graph.edge(0, 1).setDistance(10), carFE, 60, true, true).set(avSpeedEnc, 15).set(laneEnc, 0);
+        EdgeIteratorState fastEdge = GHUtility.setProperties(graph.edge(1, 2).setDistance(10), carFE, 60, true, true).set(avSpeedEnc, 60).set(laneEnc, 2);
         assertEquals(3.10, weighting.calcEdgeWeight(slowEdge, false), 0.01);
         assertEquals(1.30, weighting.calcEdgeWeight(fastEdge, false), 0.01);
 
@@ -292,16 +295,16 @@ public class CustomWeightingTest {
         vehicleModel.setDistanceInfluence(0);
         CustomWeighting weighting = createWeighting(vehicleModel);
 
-        graphHopperStorage.getNodeAccess().setNode(0, 51.036213, 13.713684);
-        graphHopperStorage.getNodeAccess().setNode(1, 51.036591, 13.719864);
+        graph.getNodeAccess().setNode(0, 51.036213, 13.713684);
+        graph.getNodeAccess().setNode(1, 51.036591, 13.719864);
         // a bit in the north where my_area is:
-        graphHopperStorage.getNodeAccess().setNode(2, 51.054506, 13.723432);
-        graphHopperStorage.getNodeAccess().setNode(3, 51.053589, 13.730679);
-        EdgeIteratorState edge1 = graphHopperStorage.edge(0, 1, 500, true).set(avSpeedEnc, 15);
+        graph.getNodeAccess().setNode(2, 51.054506, 13.723432);
+        graph.getNodeAccess().setNode(3, 51.053589, 13.730679);
+        EdgeIteratorState edge1 = GHUtility.setProperties(graph.edge(0, 1).setDistance(500), carFE, 60, true, true).set(avSpeedEnc, 15);
         assertEquals(120, weighting.calcEdgeWeight(edge1, false), 0.01);
 
         // intersect polygon => increase weight (it doubles, because distance influence is zero)
-        EdgeIteratorState edge2 = graphHopperStorage.edge(2, 3, 500, true).set(avSpeedEnc, 15);
+        EdgeIteratorState edge2 = GHUtility.setProperties(graph.edge(2, 3).setDistance(500), carFE, 60, true, true).set(avSpeedEnc, 15);
         assertTrue(poly.intersects(edge2.fetchWayGeometry(FetchMode.ALL).toLineString(false)));
         assertEquals(240, weighting.calcEdgeWeight(edge2, false), 0.01);
     }

--- a/core/src/test/java/com/graphhopper/routing/weighting/CustomWeightingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/CustomWeightingTest.java
@@ -68,8 +68,8 @@ public class CustomWeightingTest {
     @Test
     public void speedOnly() {
         // 50km/h -> 72s per km, 100km/h -> 36s per km
-        EdgeIteratorState edge = GHUtility.setSpeed(60, true, true, carFE, graph.edge(0, 1).setDistance(1000))
-                .set(avSpeedEnc, 50).setReverse(avSpeedEnc, 100);
+        EdgeIteratorState edge;
+        GHUtility.setSpeed(50, 100, carFE, edge = graph.edge(0, 1).setDistance(1000));
         assertEquals(72, createWeighting(new CustomModel().setDistanceInfluence(0)).calcEdgeWeight(edge, false), 1.e-6);
         assertEquals(36, createWeighting(new CustomModel().setDistanceInfluence(0)).calcEdgeWeight(edge, true), 1.e-6);
     }
@@ -114,7 +114,7 @@ public class CustomWeightingTest {
         assertEquals(720_000, createWeighting(new CustomModel().setDistanceInfluence(30)).calcEdgeMillis(edge, false), .1);
 
         // we can also imagine a shorter but slower road that takes the same time
-        edge = graph.edge(0, 1).setDistance(5_000).set(avSpeedEnc, 25).set(accessEnc, true).setReverse(accessEnc, true);
+        edge = graph.edge(0, 1).setDistance(5_000).set(avSpeedEnc, 25).set(accessEnc, true, true);
         assertEquals(720, createWeighting(new CustomModel().setDistanceInfluence(0)).calcEdgeWeight(edge, false), .1);
         assertEquals(720_000, createWeighting(new CustomModel().setDistanceInfluence(0)).calcEdgeMillis(edge, false), .1);
         // and if we include the distance influence the weight will be bigger but still smaller than what we got for
@@ -190,8 +190,8 @@ public class CustomWeightingTest {
         graph = new GraphBuilder(encodingManager).create();
 
         BooleanEncodedValue accessEnc = carFE.getAccessEnc();
-        EdgeIteratorState edge = graph.edge(0, 1).set(accessEnc, true).setReverse(accessEnc, true).
-                set(avSpeedEnc, 15).set(specialEnc, false).setReverse(specialEnc, true).setDistance(10);
+        EdgeIteratorState edge = graph.edge(0, 1).set(accessEnc, true, true).
+                set(avSpeedEnc, 15).set(specialEnc, false, true).setDistance(10);
 
         CustomModel vehicleModel = new CustomModel();
         assertEquals(3.1, createWeighting(vehicleModel).calcEdgeWeight(edge, false), 0.01);

--- a/core/src/test/java/com/graphhopper/routing/weighting/FastestWeightingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/FastestWeightingTest.java
@@ -46,7 +46,7 @@ public class FastestWeightingTest {
     @Test
     public void testMinWeightHasSameUnitAs_getWeight() {
         Weighting instance = new FastestWeighting(encoder);
-        IntsRef flags = GHUtility.setProperties(encodingManager.createEdgeFlags(), encoder, encoder.getMaxSpeed(), true, false);
+        IntsRef flags = GHUtility.setSpeed(encoder.getMaxSpeed(), 0, encoder, encodingManager.createEdgeFlags());
         assertEquals(instance.getMinWeight(10), instance.calcEdgeWeight(createMockedEdgeIteratorState(10, flags), false), 1e-8);
     }
 
@@ -55,7 +55,7 @@ public class FastestWeightingTest {
         Weighting instance = new FastestWeighting(encoder, new PMap().putObject(Parameters.Routing.HEADING_PENALTY, 100));
 
         VirtualEdgeIteratorState virtEdge = new VirtualEdgeIteratorState(0, GHUtility.createEdgeKey(1, false), 1, 2, 10,
-                GHUtility.setProperties(encodingManager.createEdgeFlags(), encoder, 10, true, false), "test", Helper.createPointList(51, 0, 51, 1), false);
+                GHUtility.setSpeed(10, 0, encoder, encodingManager.createEdgeFlags()), "test", Helper.createPointList(51, 0, 51, 1), false);
         double time = instance.calcEdgeWeight(virtEdge, false);
 
         virtEdge.setUnfavored(true);
@@ -91,7 +91,7 @@ public class FastestWeightingTest {
         GraphHopperStorage g = new GraphBuilder(EncodingManager.create(tmpEnc)).create();
         Weighting w = new FastestWeighting(tmpEnc);
 
-        IntsRef edgeFlags = GHUtility.setProperties(g.getEncodingManager().createEdgeFlags(), tmpEnc, 15, true, true);
+        IntsRef edgeFlags = GHUtility.setSpeed(15, 15, tmpEnc, g.getEncodingManager().createEdgeFlags());
         tmpEnc.getAverageSpeedEnc().setDecimal(true, edgeFlags, 10.0);
 
         EdgeIteratorState edge = GHUtility.createMockedEdgeIteratorState(100000, edgeFlags);
@@ -106,8 +106,8 @@ public class FastestWeightingTest {
     public void calcWeightAndTime_withTurnCosts() {
         Graph graph = new GraphBuilder(encodingManager).create();
         Weighting weighting = new FastestWeighting(encoder, new DefaultTurnCostProvider(encoder, graph.getTurnCostStorage()));
-        GHUtility.setProperties(graph.edge(0,1).setDistance(100),encoder,60,true, true);
-        EdgeIteratorState edge = GHUtility.setProperties(graph.edge(1,2).setDistance(100),encoder,60,true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(100));
+        EdgeIteratorState edge = GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(100));
         // turn costs are given in seconds
         setTurnCost(graph, 0, 1, 2, 5);
         assertEquals(6 + 5, GHUtility.calcWeightWithTurnWeight(weighting, edge, false, 0), 1.e-6);
@@ -118,7 +118,7 @@ public class FastestWeightingTest {
     public void calcWeightAndTime_uTurnCosts() {
         Graph graph = new GraphBuilder(encodingManager).create();
         Weighting weighting = new FastestWeighting(encoder, new DefaultTurnCostProvider(encoder, graph.getTurnCostStorage(), 40));
-        EdgeIteratorState edge = GHUtility.setProperties(graph.edge(0,1).setDistance(100),encoder,60,true, true);
+        EdgeIteratorState edge = GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(100));
         assertEquals(6 + 40, GHUtility.calcWeightWithTurnWeight(weighting, edge, false, 0), 1.e-6);
         assertEquals((6 + 40) * 1000, GHUtility.calcMillisWithTurnMillis(weighting, edge, false, 0), 1.e-6);
     }
@@ -127,8 +127,8 @@ public class FastestWeightingTest {
     public void calcWeightAndTime_withTurnCosts_shortest() {
         Graph graph = new GraphBuilder(encodingManager).create();
         Weighting weighting = new ShortestWeighting(encoder, new DefaultTurnCostProvider(encoder, graph.getTurnCostStorage()));
-        GHUtility.setProperties(graph.edge(0,1).setDistance(100),encoder,60,true, true);
-        EdgeIteratorState edge = GHUtility.setProperties(graph.edge(1,2).setDistance(100),encoder,60,true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(100));
+        EdgeIteratorState edge = GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(100));
         // turn costs are given in seconds
         setTurnCost(graph, 0, 1, 2, 5);
         // todo: for the shortest weighting turn costs cannot be interpreted as seconds? at least when they are added

--- a/core/src/test/java/com/graphhopper/routing/weighting/FastestWeightingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/FastestWeightingTest.java
@@ -106,8 +106,8 @@ public class FastestWeightingTest {
     public void calcWeightAndTime_withTurnCosts() {
         Graph graph = new GraphBuilder(encodingManager).create();
         Weighting weighting = new FastestWeighting(encoder, new DefaultTurnCostProvider(encoder, graph.getTurnCostStorage()));
-        graph.edge(0, 1, 100, true);
-        EdgeIteratorState edge = graph.edge(1, 2, 100, true);
+        GHUtility.setProperties(graph.edge(0,1).setDistance(100),encoder,60,true, true);
+        EdgeIteratorState edge = GHUtility.setProperties(graph.edge(1,2).setDistance(100),encoder,60,true, true);
         // turn costs are given in seconds
         setTurnCost(graph, 0, 1, 2, 5);
         assertEquals(6 + 5, GHUtility.calcWeightWithTurnWeight(weighting, edge, false, 0), 1.e-6);
@@ -118,7 +118,7 @@ public class FastestWeightingTest {
     public void calcWeightAndTime_uTurnCosts() {
         Graph graph = new GraphBuilder(encodingManager).create();
         Weighting weighting = new FastestWeighting(encoder, new DefaultTurnCostProvider(encoder, graph.getTurnCostStorage(), 40));
-        EdgeIteratorState edge = graph.edge(0, 1, 100, true);
+        EdgeIteratorState edge = GHUtility.setProperties(graph.edge(0,1).setDistance(100),encoder,60,true, true);
         assertEquals(6 + 40, GHUtility.calcWeightWithTurnWeight(weighting, edge, false, 0), 1.e-6);
         assertEquals((6 + 40) * 1000, GHUtility.calcMillisWithTurnMillis(weighting, edge, false, 0), 1.e-6);
     }
@@ -127,8 +127,8 @@ public class FastestWeightingTest {
     public void calcWeightAndTime_withTurnCosts_shortest() {
         Graph graph = new GraphBuilder(encodingManager).create();
         Weighting weighting = new ShortestWeighting(encoder, new DefaultTurnCostProvider(encoder, graph.getTurnCostStorage()));
-        graph.edge(0, 1, 100, true);
-        EdgeIteratorState edge = graph.edge(1, 2, 100, true);
+        GHUtility.setProperties(graph.edge(0,1).setDistance(100),encoder,60,true, true);
+        EdgeIteratorState edge = GHUtility.setProperties(graph.edge(1,2).setDistance(100),encoder,60,true, true);
         // turn costs are given in seconds
         setTurnCost(graph, 0, 1, 2, 5);
         // todo: for the shortest weighting turn costs cannot be interpreted as seconds? at least when they are added

--- a/core/src/test/java/com/graphhopper/routing/weighting/ShortFastestWeightingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/ShortFastestWeightingTest.java
@@ -37,7 +37,7 @@ public class ShortFastestWeightingTest {
 
     @Test
     public void testShort() {
-        EdgeIteratorState edge = createMockedEdgeIteratorState(10, GHUtility.setProperties(encodingManager.createEdgeFlags(), encoder, 50, true, false));
+        EdgeIteratorState edge = createMockedEdgeIteratorState(10, GHUtility.setSpeed(50, 0, encoder, encodingManager.createEdgeFlags()));
         Weighting instance = new ShortFastestWeighting(encoder, 0.03);
         assertEquals(1.02, instance.calcEdgeWeight(edge, false), 1e-8);
 

--- a/core/src/test/java/com/graphhopper/routing/weighting/custom/PriorityCalculatorTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/custom/PriorityCalculatorTest.java
@@ -19,13 +19,15 @@
 package com.graphhopper.routing.weighting.custom;
 
 import com.graphhopper.routing.ev.*;
+import com.graphhopper.routing.util.CarFlagEncoder;
 import com.graphhopper.routing.util.CustomModel;
 import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.storage.GraphBuilder;
 import com.graphhopper.util.EdgeIteratorState;
+import com.graphhopper.util.GHUtility;
 import org.junit.jupiter.api.Test;
 
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -39,8 +41,9 @@ class PriorityCalculatorTest {
     PriorityCalculatorTest() {
         // in this test we use the same edge for every test and check the calculated priority for different custom models
         // and depending on additional properties of the edge we set in the tests
-        em = EncodingManager.create("car");
-        edge = new GraphBuilder(em).create().edge(0, 1, 1000, true);
+        FlagEncoder encoder = new CarFlagEncoder();
+        em = EncodingManager.create(encoder);
+        edge = GHUtility.setProperties(new GraphBuilder(em).create().edge(0, 1).setDistance(1000), encoder, 60, true, true);
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/routing/weighting/custom/PriorityCalculatorTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/custom/PriorityCalculatorTest.java
@@ -107,8 +107,7 @@ class PriorityCalculatorTest {
         EnumEncodedValue<RoadClass> roadClass = em.getEnumEncodedValue(RoadClass.KEY, RoadClass.class);
         DecimalEncodedValue maxSpeedEnc = em.getDecimalEncodedValue(MaxSpeed.KEY);
         edge.set(roadClass, RoadClass.PRIMARY);
-        edge.set(maxSpeedEnc, 110);
-        edge.setReverse(maxSpeedEnc, 50);
+        edge.set(maxSpeedEnc, 110, 50);
 
         Map<String, Object> maxSpeedMap = new LinkedHashMap<>();
         maxSpeedMap.put("<100", 0.5);

--- a/core/src/test/java/com/graphhopper/routing/weighting/custom/PriorityCalculatorTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/custom/PriorityCalculatorTest.java
@@ -43,7 +43,7 @@ class PriorityCalculatorTest {
         // and depending on additional properties of the edge we set in the tests
         FlagEncoder encoder = new CarFlagEncoder();
         em = EncodingManager.create(encoder);
-        edge = GHUtility.setProperties(new GraphBuilder(em).create().edge(0, 1).setDistance(1000), encoder, 60, true, true);
+        edge = GHUtility.setSpeed(60, true, true, encoder, new GraphBuilder(em).create().edge(0, 1).setDistance(1000));
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/routing/weighting/custom/SpeedCalculatorTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/custom/SpeedCalculatorTest.java
@@ -45,7 +45,7 @@ class SpeedCalculatorTest {
         // and depending on additional properties of the edge we set in the tests
         FlagEncoder encoder = new CarFlagEncoder();
         em = EncodingManager.create(encoder);
-        edge = GHUtility.setProperties(new GraphBuilder(em).create().edge(0, 1).setDistance(1000), encoder, 60, true, true);
+        edge = GHUtility.setSpeed(60, true, true, encoder, new GraphBuilder(em).create().edge(0, 1).setDistance(1000));
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/routing/weighting/custom/SpeedCalculatorTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/custom/SpeedCalculatorTest.java
@@ -21,14 +21,15 @@ package com.graphhopper.routing.weighting.custom;
 import com.graphhopper.routing.ev.EnumEncodedValue;
 import com.graphhopper.routing.ev.RoadClass;
 import com.graphhopper.routing.ev.RoadEnvironment;
+import com.graphhopper.routing.util.CarFlagEncoder;
 import com.graphhopper.routing.util.CustomModel;
 import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.storage.GraphBuilder;
 import com.graphhopper.util.EdgeIteratorState;
+import com.graphhopper.util.GHUtility;
 import org.junit.jupiter.api.Test;
 
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -42,8 +43,9 @@ class SpeedCalculatorTest {
     SpeedCalculatorTest() {
         // in this test we use the same edge for every test and check the calculated speed for different custom models
         // and depending on additional properties of the edge we set in the tests
-        em = EncodingManager.create("car");
-        edge = new GraphBuilder(em).create().edge(0, 1, 1000, true);
+        FlagEncoder encoder = new CarFlagEncoder();
+        em = EncodingManager.create(encoder);
+        edge = GHUtility.setProperties(new GraphBuilder(em).create().edge(0, 1).setDistance(1000), encoder, 60, true, true);
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/storage/AbstractGraphStorageTester.java
+++ b/core/src/test/java/com/graphhopper/storage/AbstractGraphStorageTester.java
@@ -760,7 +760,7 @@ public abstract class AbstractGraphStorageTester {
         });
         manager = EncodingManager.create(list);
         graph = new GraphHopperStorage(new RAMDirectory(), manager, false).create(defaultSize);
-        edgeIter = graph.edge(0, 1).set(access0Enc, true).setReverse(access0Enc, false);
+        edgeIter = graph.edge(0, 1).set(access0Enc, true, false);
         assertTrue(edgeIter.get(access0Enc));
         assertFalse(edgeIter.getReverse(access0Enc));
     }

--- a/core/src/test/java/com/graphhopper/storage/AbstractGraphStorageTester.java
+++ b/core/src/test/java/com/graphhopper/storage/AbstractGraphStorageTester.java
@@ -118,11 +118,11 @@ public abstract class AbstractGraphStorageTester {
         graph = createGHStorage();
 
         double maxDist = BaseGraph.MAX_DIST;
-        EdgeIteratorState edge1 = GHUtility.setProperties(graph.edge(0, 1).setDistance(maxDist), carEncoder, 60, true, true);
+        EdgeIteratorState edge1 = GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(0, 1).setDistance(maxDist));
         assertEquals(maxDist, edge1.getDistance(), 1);
 
         // max out should NOT lead to infinity as this leads fast to NaN! -> we set dist to the maximum if its larger than desired
-        EdgeIteratorState edge2 = GHUtility.setProperties(graph.edge(0, 2).setDistance(maxDist + 1), carEncoder, 60, true, true);
+        EdgeIteratorState edge2 = GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(0, 2).setDistance(maxDist + 1));
         assertEquals(maxDist, edge2.getDistance(), 1);
     }
 
@@ -133,8 +133,8 @@ public abstract class AbstractGraphStorageTester {
         for (int i = 0; i < defaultSize * 2; i++) {
             na.setNode(i, 2 * i, 3 * i);
         }
-        GHUtility.setProperties(graph.edge(defaultSize + 1, defaultSize + 2).setDistance(10), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(defaultSize + 1, defaultSize + 3).setDistance(10), carEncoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(defaultSize + 1, defaultSize + 2).setDistance(10));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(defaultSize + 1, defaultSize + 3).setDistance(10));
         assertEquals(2, getCountAll(defaultSize + 1));
     }
 
@@ -148,20 +148,20 @@ public abstract class AbstractGraphStorageTester {
     @Test
     public void testCreateLocation() {
         graph = createGHStorage();
-        GHUtility.setProperties(graph.edge(3, 1).setDistance(50), carEncoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(3, 1).setDistance(50));
         assertEquals(1, getCountOut(1));
 
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(100), carEncoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(1, 2).setDistance(100));
         assertEquals(2, getCountOut(1));
     }
 
     @Test
     public void testEdges() {
         graph = createGHStorage();
-        GHUtility.setProperties(graph.edge(2, 1).setDistance(12), carEncoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(2, 1).setDistance(12));
         assertEquals(1, getCountOut(2));
 
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(12), carEncoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(2, 3).setDistance(12));
         assertEquals(1, getCountOut(1));
         assertEquals(2, getCountOut(2));
         assertEquals(1, getCountOut(3));
@@ -171,11 +171,11 @@ public abstract class AbstractGraphStorageTester {
     public void testUnidirectional() {
         graph = createGHStorage();
 
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(12), carEncoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 11).setDistance(12), carEncoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(11, 1).setDistance(12), carEncoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 12).setDistance(12), carEncoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 2).setDistance(112), carEncoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(1, 2).setDistance(12));
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(1, 11).setDistance(12));
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(11, 1).setDistance(12));
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(1, 12).setDistance(12));
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(3, 2).setDistance(112));
         EdgeIterator i = carOutExplorer.setBaseNode(2);
         assertFalse(i.next());
 
@@ -204,11 +204,11 @@ public abstract class AbstractGraphStorageTester {
     public void testUnidirectionalEdgeFilter() {
         graph = createGHStorage();
 
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(12), carEncoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 11).setDistance(12), carEncoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(11, 1).setDistance(12), carEncoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 12).setDistance(12), carEncoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 2).setDistance(112), carEncoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(1, 2).setDistance(12));
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(1, 11).setDistance(12));
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(11, 1).setDistance(12));
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(1, 12).setDistance(12));
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(3, 2).setDistance(112));
         EdgeIterator i = carOutExplorer.setBaseNode(2);
         assertFalse(i.next());
 
@@ -239,8 +239,8 @@ public abstract class AbstractGraphStorageTester {
     public void testUpdateUnidirectional() {
         graph = createGHStorage();
 
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(12), carEncoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 2).setDistance(112), carEncoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(1, 2).setDistance(12));
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(3, 2).setDistance(112));
         EdgeIterator i = carOutExplorer.setBaseNode(2);
         assertFalse(i.next());
         i = carOutExplorer.setBaseNode(3);
@@ -248,7 +248,7 @@ public abstract class AbstractGraphStorageTester {
         assertEquals(2, i.getAdjNode());
         assertFalse(i.next());
 
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(112), carEncoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(2, 3).setDistance(112));
         i = carOutExplorer.setBaseNode(2);
         assertTrue(i.next());
         assertEquals(3, i.getAdjNode());
@@ -261,18 +261,18 @@ public abstract class AbstractGraphStorageTester {
     @Test
     public void testClone() {
         graph = createGHStorage();
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(10), carEncoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(1, 2).setDistance(10));
         NodeAccess na = graph.getNodeAccess();
         na.setNode(0, 12, 23);
         na.setNode(1, 8, 13);
         na.setNode(2, 2, 10);
         na.setNode(3, 5, 9);
-        GHUtility.setProperties(graph.edge(1, 3).setDistance(10), carEncoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(1, 3).setDistance(10));
 
         Graph cloneGraph = graph.copyTo(AbstractGraphStorageTester.this.createGHStorage(locationParent + "/clone", false));
         assertEquals(graph.getNodes(), cloneGraph.getNodes());
         assertEquals(getCountOut(1), count(cloneGraph.createEdgeExplorer(carOutFilter).setBaseNode(1)));
-        GHUtility.setProperties(cloneGraph.edge(1, 4).setDistance(10), carEncoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, carEncoder, cloneGraph.edge(1, 4).setDistance(10));
         assertEquals(3, count(cloneGraph.createEdgeExplorer(carOutFilter).setBaseNode(1)));
         assertEquals(graph.getBounds(), cloneGraph.getBounds());
         Helper.close((Closeable) cloneGraph);
@@ -281,9 +281,9 @@ public abstract class AbstractGraphStorageTester {
     @Test
     public void testCopyProperties() {
         graph = createGHStorage();
-        EdgeIteratorState edge = GHUtility.setProperties(graph.edge(1, 3).setDistance(10), carEncoder, 60, true, false).setName("testing").setWayGeometry(Helper.createPointList(1, 2));
+        EdgeIteratorState edge = GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(1, 3).setDistance(10)).setName("testing").setWayGeometry(Helper.createPointList(1, 2));
 
-        EdgeIteratorState newEdge = GHUtility.setProperties(graph.edge(1, 3).setDistance(10), carEncoder, 60, true, false);
+        EdgeIteratorState newEdge = GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(1, 3).setDistance(10));
         newEdge.copyPropertiesFrom(edge);
         assertEquals(edge.getName(), newEdge.getName());
         assertEquals(edge.getDistance(), newEdge.getDistance(), 1e-7);
@@ -299,10 +299,10 @@ public abstract class AbstractGraphStorageTester {
         na.setNode(1, 22, 23);
         assertEquals(2, graph.getNodes());
 
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(10), carEncoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(0, 1).setDistance(10));
         assertEquals(2, graph.getNodes());
 
-        GHUtility.setProperties(graph.edge(0, 2).setDistance(10), carEncoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(0, 2).setDistance(10));
         assertEquals(3, graph.getNodes());
         Helper.close(graph);
 
@@ -340,11 +340,11 @@ public abstract class AbstractGraphStorageTester {
         na.setNode(3, 78, 89);
         na.setNode(4, 2, 1);
         na.setNode(5, 7, 5);
-        GHUtility.setProperties(g.edge(0, 1).setDistance(12), carEncoder, 60, true, true);
-        GHUtility.setProperties(g.edge(0, 2).setDistance(212), carEncoder, 60, true, true);
-        GHUtility.setProperties(g.edge(0, 3).setDistance(212), carEncoder, 60, true, true);
-        GHUtility.setProperties(g.edge(0, 4).setDistance(212), carEncoder, 60, true, true);
-        GHUtility.setProperties(g.edge(0, 5).setDistance(212), carEncoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(0, 1).setDistance(12));
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(0, 2).setDistance(212));
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(0, 3).setDistance(212));
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(0, 4).setDistance(212));
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(0, 5).setDistance(212));
     }
 
     private void checkExampleGraph(Graph graph) {
@@ -374,11 +374,11 @@ public abstract class AbstractGraphStorageTester {
     @Test
     public void testDirectional() {
         graph = createGHStorage();
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(12), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(12), carEncoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(12), carEncoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 5).setDistance(12), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(6, 3).setDistance(12), carEncoder, 60, true, false);
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(1, 2).setDistance(12));
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(2, 3).setDistance(12));
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(3, 4).setDistance(12));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(3, 5).setDistance(12));
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(6, 3).setDistance(12));
 
         assertEquals(1, getCountAll(1));
         assertEquals(1, getCountIn(1));
@@ -404,29 +404,29 @@ public abstract class AbstractGraphStorageTester {
     @Test
     public void testDozendEdges() {
         graph = createGHStorage();
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(12), carEncoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(1, 2).setDistance(12));
         int nn = 1;
         assertEquals(1, getCountAll(nn));
 
-        GHUtility.setProperties(graph.edge(1, 3).setDistance(13), carEncoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(1, 3).setDistance(13));
         assertEquals(2, getCountAll(1));
 
-        GHUtility.setProperties(graph.edge(1, 4).setDistance(14), carEncoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(1, 4).setDistance(14));
         assertEquals(3, getCountAll(1));
 
-        GHUtility.setProperties(graph.edge(1, 5).setDistance(15), carEncoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(1, 5).setDistance(15));
         assertEquals(4, getCountAll(1));
 
-        GHUtility.setProperties(graph.edge(1, 6).setDistance(16), carEncoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(1, 6).setDistance(16));
         assertEquals(5, getCountAll(1));
 
-        GHUtility.setProperties(graph.edge(1, 7).setDistance(16), carEncoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(1, 7).setDistance(16));
         assertEquals(6, getCountAll(1));
 
-        GHUtility.setProperties(graph.edge(1, 8).setDistance(16), carEncoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(1, 8).setDistance(16));
         assertEquals(7, getCountAll(1));
 
-        GHUtility.setProperties(graph.edge(1, 9).setDistance(16), carEncoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(1, 9).setDistance(16));
         assertEquals(8, getCountAll(1));
         assertEquals(8, getCountOut(1));
 
@@ -439,7 +439,7 @@ public abstract class AbstractGraphStorageTester {
         graph = createGHStorage();
 
         assertEquals(0, getCountAll(1));
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(12), carEncoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(0, 1).setDistance(12));
         assertEquals(1, getCountAll(1));
     }
 
@@ -473,8 +473,8 @@ public abstract class AbstractGraphStorageTester {
     @Test
     public void testFlags() {
         graph = createGHStorage();
-        GHUtility.setProperties(graph.edge(0, 1), carEncoder, 100, true, true).setDistance(10);
-        GHUtility.setProperties(graph.edge(2, 3), carEncoder, 10, true, false).setDistance(10);
+        GHUtility.setSpeed(100, true, true, carEncoder, graph.edge(0, 1)).setDistance(10);
+        GHUtility.setSpeed(10, true, false, carEncoder, graph.edge(2, 3)).setDistance(10);
 
         EdgeIterator iter = carAllExplorer.setBaseNode(0);
         assertTrue(iter.next());
@@ -498,8 +498,8 @@ public abstract class AbstractGraphStorageTester {
     @Test
     public void testEdgeProperties() {
         graph = createGHStorage();
-        EdgeIteratorState iter1 = GHUtility.setProperties(graph.edge(0, 1).setDistance(10), carEncoder, 60, true, true);
-        EdgeIteratorState iter2 = GHUtility.setProperties(graph.edge(0, 2).setDistance(20), carEncoder, 60, true, true);
+        EdgeIteratorState iter1 = GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(0, 1).setDistance(10));
+        EdgeIteratorState iter2 = GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(0, 2).setDistance(20));
 
         int edgeId = iter1.getEdge();
         EdgeIteratorState iter = graph.getEdgeIteratorState(edgeId, 0);
@@ -527,9 +527,9 @@ public abstract class AbstractGraphStorageTester {
     @Test
     public void testCreateDuplicateEdges() {
         graph = createGHStorage();
-        GHUtility.setProperties(graph.edge(2, 1).setDistance(12), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(12), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(13), carEncoder, 60, true, false);
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(2, 1).setDistance(12));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(2, 3).setDistance(12));
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(2, 3).setDistance(13));
         assertEquals(3, getCountOut(2));
 
         // no exception
@@ -561,22 +561,22 @@ public abstract class AbstractGraphStorageTester {
         assertFalse(oneIter.get(carAccessEnc));
         assertTrue(oneIter.getReverse(carAccessEnc));
 
-        GHUtility.setProperties(graph.edge(3, 2).setDistance(14), carEncoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(3, 2).setDistance(14));
         assertEquals(4, getCountOut(2));
     }
 
     @Test
     public void testIdenticalNodes() {
         graph = createGHStorage();
-        GHUtility.setProperties(graph.edge(0, 0).setDistance(100), carEncoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(0, 0).setDistance(100));
         assertEquals(1, getCountAll(0));
     }
 
     @Test
     public void testIdenticalNodes2() {
         graph = createGHStorage();
-        GHUtility.setProperties(graph.edge(0, 0).setDistance(100), carEncoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(0, 0).setDistance(100), carEncoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(0, 0).setDistance(100));
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(0, 0).setDistance(100));
         assertEquals(2, getCountAll(0));
     }
 
@@ -584,11 +584,11 @@ public abstract class AbstractGraphStorageTester {
     public void testEdgeReturn() {
         graph = createGHStorage();
         EdgeIteratorState iter = graph.edge(4, 10).setDistance(100);
-        GHUtility.setProperties(iter, carEncoder, 10, true, false);
+        GHUtility.setSpeed(10, true, false, carEncoder, iter);
         assertEquals(4, iter.getBaseNode());
         assertEquals(10, iter.getAdjNode());
         iter = graph.edge(14, 10).setDistance(100);
-        GHUtility.setProperties(iter, carEncoder, 10, true, false);
+        GHUtility.setSpeed(10, true, false, carEncoder, iter);
         assertEquals(14, iter.getBaseNode());
         assertEquals(10, iter.getAdjNode());
     }
@@ -604,13 +604,13 @@ public abstract class AbstractGraphStorageTester {
 
         PointList pointList = Helper.createPointList(1, 1, 1, 2, 1, 3);
         EdgeIteratorState edge = graph.edge(0, 4).setDistance(100).setWayGeometry(pointList);
-        GHUtility.setProperties(edge, carEncoder, 10, true, false);
+        GHUtility.setSpeed(10, true, false, carEncoder, edge);
         pointList = Helper.createPointList(1, 5, 1, 6, 1, 7, 1, 8, 1, 9);
         edge = graph.edge(4, 10).setDistance(100).setWayGeometry(pointList);
-        GHUtility.setProperties(edge, carEncoder, 10, true, false);
+        GHUtility.setSpeed(10, true, false, carEncoder, edge);
         pointList = Helper.createPointList(1, 13, 1, 12, 1, 11);
         edge = graph.edge(14, 0).setDistance(100).setWayGeometry(pointList);
-        GHUtility.setProperties(edge, carEncoder, 10, true, false);
+        GHUtility.setSpeed(10, true, false, carEncoder, edge);
 
         EdgeIterator iter = carAllExplorer.setBaseNode(0);
         assertTrue(iter.next());
@@ -648,11 +648,11 @@ public abstract class AbstractGraphStorageTester {
     @Test
     public void testFootMix() {
         graph = createGHStorage();
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(10), footEncoder, 10, true, true);
-        GHUtility.setProperties(graph.edge(0, 2).setDistance(10), carEncoder, 10, true, true);
+        GHUtility.setSpeed(10, true, true, footEncoder, graph.edge(0, 1).setDistance(10));
+        GHUtility.setSpeed(10, true, true, carEncoder, graph.edge(0, 2).setDistance(10));
         EdgeIteratorState edge = graph.edge(0, 3).setDistance(10);
-        GHUtility.setProperties(edge, footEncoder, 10, true, true);
-        GHUtility.setProperties(edge, carEncoder, 10, true, true);
+        GHUtility.setSpeed(10, true, true, footEncoder, edge);
+        GHUtility.setSpeed(10, true, true, carEncoder, edge);
         EdgeExplorer footOutExplorer = graph.createEdgeExplorer(DefaultEdgeFilter.outEdges(footEncoder));
         assertEquals(GHUtility.asSet(3, 1), GHUtility.getNeighbors(footOutExplorer.setBaseNode(0)));
         assertEquals(GHUtility.asSet(3, 2), GHUtility.getNeighbors(carOutExplorer.setBaseNode(0)));
@@ -661,9 +661,9 @@ public abstract class AbstractGraphStorageTester {
     @Test
     public void testGetAllEdges() {
         graph = createGHStorage();
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(2), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(3, 1).setDistance(1), carEncoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(3, 2).setDistance(1), carEncoder, 60, true, false);
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(0, 1).setDistance(2));
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(3, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(3, 2).setDistance(1));
 
         EdgeIterator iter = graph.getAllEdges();
         assertTrue(iter.next());
@@ -688,10 +688,10 @@ public abstract class AbstractGraphStorageTester {
     @Test
     public void testStringIndex() {
         graph = createGHStorage();
-        EdgeIteratorState iter1 = GHUtility.setProperties(graph.edge(0, 1).setDistance(10), carEncoder, 60, true, true);
+        EdgeIteratorState iter1 = GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(0, 1).setDistance(10));
         iter1.setName("named street1");
 
-        EdgeIteratorState iter2 = GHUtility.setProperties(graph.edge(0, 1).setDistance(10), carEncoder, 60, true, true);
+        EdgeIteratorState iter2 = GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(0, 1).setDistance(10));
         iter2.setName("named street2");
 
         assertEquals("named street1", graph.getEdgeIteratorState(iter1.getEdge(), iter1.getAdjNode()).getName());
@@ -728,14 +728,14 @@ public abstract class AbstractGraphStorageTester {
         BooleanEncodedValue access1Enc = manager.getBooleanEncodedValue(getKey("car", "access"));
 
         edge = graph.edge(0, 1);
-        GHUtility.setProperties(edge, list.get(0), 99.123, true, true);
+        GHUtility.setSpeed(99.123, true, true, list.get(0), edge);
         assertEquals(99.123, edge.get(avSpeed0Enc), 1e-3);
         EdgeIteratorState edgeIter = GHUtility.getEdge(graph, 1, 0);
         assertEquals(99.123, edgeIter.get(avSpeed0Enc), 1e-3);
         assertTrue(edgeIter.get(access0Enc));
         assertTrue(edgeIter.getReverse(access0Enc));
         edge = graph.edge(2, 3);
-        GHUtility.setProperties(edge, list.get(1), 44.123, true, false);
+        GHUtility.setSpeed(44.123, true, false, list.get(1), edge);
         assertEquals(44.123, edge.get(avSpeed1Enc), 1e-3);
 
         edgeIter = GHUtility.getEdge(graph, 3, 2);
@@ -790,7 +790,7 @@ public abstract class AbstractGraphStorageTester {
         na.setNode(1, 11, 20, 1);
         na.setNode(2, 12, 12, 0.4);
 
-        EdgeIteratorState iter2 = GHUtility.setProperties(graph.edge(0, 1).setDistance(100), carEncoder, 60, true, true);
+        EdgeIteratorState iter2 = GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(0, 1).setDistance(100));
         final BaseGraph baseGraph = (BaseGraph) graph.getBaseGraph();
         assertEquals(4, baseGraph.getMaxGeoRef());
         iter2.setWayGeometry(Helper.createPointList3D(1, 2, 3, 3, 4, 5, 5, 6, 7, 7, 8, 9));
@@ -803,7 +803,7 @@ public abstract class AbstractGraphStorageTester {
         assertEquals(4 + (1 + 12), baseGraph.getMaxGeoRef());
         iter2.setWayGeometry(Helper.createPointList3D(1.5, 1, 0, 2, 3, 0));
         assertEquals(4 + (1 + 12) + (1 + 6), baseGraph.getMaxGeoRef());
-        EdgeIteratorState iter1 = GHUtility.setProperties(graph.edge(0, 2).setDistance(200), carEncoder, 60, true, true);
+        EdgeIteratorState iter1 = GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(0, 2).setDistance(200));
         iter1.setWayGeometry(Helper.createPointList3D(3.5, 4.5, 0, 5, 6, 0));
         assertEquals(4 + (1 + 12) + (1 + 6) + (1 + 6), baseGraph.getMaxGeoRef());
     }
@@ -811,10 +811,10 @@ public abstract class AbstractGraphStorageTester {
     @Test
     public void testDetachEdge() {
         graph = createGHStorage();
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(2), carEncoder, 60, true, true);
-        GHUtility.setProperties(GHUtility.setProperties(graph.edge(0, 2).setDistance(2), carEncoder, 60, true, true).setWayGeometry(Helper.createPointList(1, 2, 3, 4)),
-                carEncoder, 10, true, false);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(2), carEncoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(0, 1).setDistance(2));
+        GHUtility.setSpeed(10, true, false, carEncoder, GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(0, 2).setDistance(2)).setWayGeometry(Helper.createPointList(1, 2, 3, 4))
+        );
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(1, 2).setDistance(2));
 
         EdgeIterator iter = graph.createEdgeExplorer().setBaseNode(0);
         try {
@@ -849,7 +849,7 @@ public abstract class AbstractGraphStorageTester {
         assertEquals(3, edgeState20.fetchWayGeometry(FetchMode.PILLAR_ONLY).getLatitude(0), 1e-1);
 
         // #162 a directed self referencing edge should be able to reverse its state too
-        GHUtility.setProperties(GHUtility.setProperties(graph.edge(3, 3).setDistance(2), carEncoder, 60, true, true), carEncoder, 10, true, false);
+        GHUtility.setSpeed(10, true, false, carEncoder, GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(3, 3).setDistance(2)));
         EdgeIterator edgeState33 = graph.createEdgeExplorer().setBaseNode(3);
         edgeState33.next();
         assertEquals(3, edgeState33.getBaseNode());

--- a/core/src/test/java/com/graphhopper/storage/AbstractGraphStorageTester.java
+++ b/core/src/test/java/com/graphhopper/storage/AbstractGraphStorageTester.java
@@ -118,11 +118,11 @@ public abstract class AbstractGraphStorageTester {
         graph = createGHStorage();
 
         double maxDist = BaseGraph.MAX_DIST;
-        EdgeIteratorState edge1 = graph.edge(0, 1, maxDist, true);
+        EdgeIteratorState edge1 = GHUtility.setProperties(graph.edge(0, 1).setDistance(maxDist), carEncoder, 60, true, true);
         assertEquals(maxDist, edge1.getDistance(), 1);
 
         // max out should NOT lead to infinity as this leads fast to NaN! -> we set dist to the maximum if its larger than desired
-        EdgeIteratorState edge2 = graph.edge(0, 2, maxDist + 1, true);
+        EdgeIteratorState edge2 = GHUtility.setProperties(graph.edge(0, 2).setDistance(maxDist + 1), carEncoder, 60, true, true);
         assertEquals(maxDist, edge2.getDistance(), 1);
     }
 
@@ -133,8 +133,8 @@ public abstract class AbstractGraphStorageTester {
         for (int i = 0; i < defaultSize * 2; i++) {
             na.setNode(i, 2 * i, 3 * i);
         }
-        graph.edge(defaultSize + 1, defaultSize + 2, 10, true);
-        graph.edge(defaultSize + 1, defaultSize + 3, 10, true);
+        GHUtility.setProperties(graph.edge(defaultSize + 1, defaultSize + 2).setDistance(10), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(defaultSize + 1, defaultSize + 3).setDistance(10), carEncoder, 60, true, true);
         assertEquals(2, getCountAll(defaultSize + 1));
     }
 
@@ -148,20 +148,20 @@ public abstract class AbstractGraphStorageTester {
     @Test
     public void testCreateLocation() {
         graph = createGHStorage();
-        graph.edge(3, 1, 50, true);
+        GHUtility.setProperties(graph.edge(3, 1).setDistance(50), carEncoder, 60, true, true);
         assertEquals(1, getCountOut(1));
 
-        graph.edge(1, 2, 100, true);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(100), carEncoder, 60, true, true);
         assertEquals(2, getCountOut(1));
     }
 
     @Test
     public void testEdges() {
         graph = createGHStorage();
-        graph.edge(2, 1, 12, true);
+        GHUtility.setProperties(graph.edge(2, 1).setDistance(12), carEncoder, 60, true, true);
         assertEquals(1, getCountOut(2));
 
-        graph.edge(2, 3, 12, true);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(12), carEncoder, 60, true, true);
         assertEquals(1, getCountOut(1));
         assertEquals(2, getCountOut(2));
         assertEquals(1, getCountOut(3));
@@ -171,11 +171,11 @@ public abstract class AbstractGraphStorageTester {
     public void testUnidirectional() {
         graph = createGHStorage();
 
-        graph.edge(1, 2, 12, false);
-        graph.edge(1, 11, 12, false);
-        graph.edge(11, 1, 12, false);
-        graph.edge(1, 12, 12, false);
-        graph.edge(3, 2, 112, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(12), carEncoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 11).setDistance(12), carEncoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(11, 1).setDistance(12), carEncoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 12).setDistance(12), carEncoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 2).setDistance(112), carEncoder, 60, true, false);
         EdgeIterator i = carOutExplorer.setBaseNode(2);
         assertFalse(i.next());
 
@@ -204,11 +204,11 @@ public abstract class AbstractGraphStorageTester {
     public void testUnidirectionalEdgeFilter() {
         graph = createGHStorage();
 
-        graph.edge(1, 2, 12, false);
-        graph.edge(1, 11, 12, false);
-        graph.edge(11, 1, 12, false);
-        graph.edge(1, 12, 12, false);
-        graph.edge(3, 2, 112, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(12), carEncoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 11).setDistance(12), carEncoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(11, 1).setDistance(12), carEncoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 12).setDistance(12), carEncoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 2).setDistance(112), carEncoder, 60, true, false);
         EdgeIterator i = carOutExplorer.setBaseNode(2);
         assertFalse(i.next());
 
@@ -239,8 +239,8 @@ public abstract class AbstractGraphStorageTester {
     public void testUpdateUnidirectional() {
         graph = createGHStorage();
 
-        graph.edge(1, 2, 12, false);
-        graph.edge(3, 2, 112, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(12), carEncoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 2).setDistance(112), carEncoder, 60, true, false);
         EdgeIterator i = carOutExplorer.setBaseNode(2);
         assertFalse(i.next());
         i = carOutExplorer.setBaseNode(3);
@@ -248,7 +248,7 @@ public abstract class AbstractGraphStorageTester {
         assertEquals(2, i.getAdjNode());
         assertFalse(i.next());
 
-        graph.edge(2, 3, 112, false);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(112), carEncoder, 60, true, false);
         i = carOutExplorer.setBaseNode(2);
         assertTrue(i.next());
         assertEquals(3, i.getAdjNode());
@@ -261,18 +261,18 @@ public abstract class AbstractGraphStorageTester {
     @Test
     public void testClone() {
         graph = createGHStorage();
-        graph.edge(1, 2, 10, true);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(10), carEncoder, 60, true, true);
         NodeAccess na = graph.getNodeAccess();
         na.setNode(0, 12, 23);
         na.setNode(1, 8, 13);
         na.setNode(2, 2, 10);
         na.setNode(3, 5, 9);
-        graph.edge(1, 3, 10, true);
+        GHUtility.setProperties(graph.edge(1, 3).setDistance(10), carEncoder, 60, true, true);
 
         Graph cloneGraph = graph.copyTo(AbstractGraphStorageTester.this.createGHStorage(locationParent + "/clone", false));
         assertEquals(graph.getNodes(), cloneGraph.getNodes());
         assertEquals(getCountOut(1), count(cloneGraph.createEdgeExplorer(carOutFilter).setBaseNode(1)));
-        cloneGraph.edge(1, 4, 10, true);
+        GHUtility.setProperties(cloneGraph.edge(1, 4).setDistance(10), carEncoder, 60, true, true);
         assertEquals(3, count(cloneGraph.createEdgeExplorer(carOutFilter).setBaseNode(1)));
         assertEquals(graph.getBounds(), cloneGraph.getBounds());
         Helper.close((Closeable) cloneGraph);
@@ -281,9 +281,9 @@ public abstract class AbstractGraphStorageTester {
     @Test
     public void testCopyProperties() {
         graph = createGHStorage();
-        EdgeIteratorState edge = graph.edge(1, 3, 10, false).setName("testing").setWayGeometry(Helper.createPointList(1, 2));
+        EdgeIteratorState edge = GHUtility.setProperties(graph.edge(1, 3).setDistance(10), carEncoder, 60, true, false).setName("testing").setWayGeometry(Helper.createPointList(1, 2));
 
-        EdgeIteratorState newEdge = graph.edge(1, 3, 10, false);
+        EdgeIteratorState newEdge = GHUtility.setProperties(graph.edge(1, 3).setDistance(10), carEncoder, 60, true, false);
         newEdge.copyPropertiesFrom(edge);
         assertEquals(edge.getName(), newEdge.getName());
         assertEquals(edge.getDistance(), newEdge.getDistance(), 1e-7);
@@ -299,10 +299,10 @@ public abstract class AbstractGraphStorageTester {
         na.setNode(1, 22, 23);
         assertEquals(2, graph.getNodes());
 
-        graph.edge(0, 1, 10, true);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(10), carEncoder, 60, true, true);
         assertEquals(2, graph.getNodes());
 
-        graph.edge(0, 2, 10, true);
+        GHUtility.setProperties(graph.edge(0, 2).setDistance(10), carEncoder, 60, true, true);
         assertEquals(3, graph.getNodes());
         Helper.close(graph);
 
@@ -340,11 +340,11 @@ public abstract class AbstractGraphStorageTester {
         na.setNode(3, 78, 89);
         na.setNode(4, 2, 1);
         na.setNode(5, 7, 5);
-        g.edge(0, 1, 12, true);
-        g.edge(0, 2, 212, true);
-        g.edge(0, 3, 212, true);
-        g.edge(0, 4, 212, true);
-        g.edge(0, 5, 212, true);
+        GHUtility.setProperties(g.edge(0, 1).setDistance(12), carEncoder, 60, true, true);
+        GHUtility.setProperties(g.edge(0, 2).setDistance(212), carEncoder, 60, true, true);
+        GHUtility.setProperties(g.edge(0, 3).setDistance(212), carEncoder, 60, true, true);
+        GHUtility.setProperties(g.edge(0, 4).setDistance(212), carEncoder, 60, true, true);
+        GHUtility.setProperties(g.edge(0, 5).setDistance(212), carEncoder, 60, true, true);
     }
 
     private void checkExampleGraph(Graph graph) {
@@ -374,11 +374,11 @@ public abstract class AbstractGraphStorageTester {
     @Test
     public void testDirectional() {
         graph = createGHStorage();
-        graph.edge(1, 2, 12, true);
-        graph.edge(2, 3, 12, false);
-        graph.edge(3, 4, 12, false);
-        graph.edge(3, 5, 12, true);
-        graph.edge(6, 3, 12, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(12), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(12), carEncoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(12), carEncoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 5).setDistance(12), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(6, 3).setDistance(12), carEncoder, 60, true, false);
 
         assertEquals(1, getCountAll(1));
         assertEquals(1, getCountIn(1));
@@ -404,29 +404,29 @@ public abstract class AbstractGraphStorageTester {
     @Test
     public void testDozendEdges() {
         graph = createGHStorage();
-        graph.edge(1, 2, 12, true);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(12), carEncoder, 60, true, true);
         int nn = 1;
         assertEquals(1, getCountAll(nn));
 
-        graph.edge(1, 3, 13, false);
+        GHUtility.setProperties(graph.edge(1, 3).setDistance(13), carEncoder, 60, true, false);
         assertEquals(2, getCountAll(1));
 
-        graph.edge(1, 4, 14, false);
+        GHUtility.setProperties(graph.edge(1, 4).setDistance(14), carEncoder, 60, true, false);
         assertEquals(3, getCountAll(1));
 
-        graph.edge(1, 5, 15, false);
+        GHUtility.setProperties(graph.edge(1, 5).setDistance(15), carEncoder, 60, true, false);
         assertEquals(4, getCountAll(1));
 
-        graph.edge(1, 6, 16, false);
+        GHUtility.setProperties(graph.edge(1, 6).setDistance(16), carEncoder, 60, true, false);
         assertEquals(5, getCountAll(1));
 
-        graph.edge(1, 7, 16, false);
+        GHUtility.setProperties(graph.edge(1, 7).setDistance(16), carEncoder, 60, true, false);
         assertEquals(6, getCountAll(1));
 
-        graph.edge(1, 8, 16, false);
+        GHUtility.setProperties(graph.edge(1, 8).setDistance(16), carEncoder, 60, true, false);
         assertEquals(7, getCountAll(1));
 
-        graph.edge(1, 9, 16, false);
+        GHUtility.setProperties(graph.edge(1, 9).setDistance(16), carEncoder, 60, true, false);
         assertEquals(8, getCountAll(1));
         assertEquals(8, getCountOut(1));
 
@@ -439,7 +439,7 @@ public abstract class AbstractGraphStorageTester {
         graph = createGHStorage();
 
         assertEquals(0, getCountAll(1));
-        graph.edge(0, 1, 12, true);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(12), carEncoder, 60, true, true);
         assertEquals(1, getCountAll(1));
     }
 
@@ -498,8 +498,8 @@ public abstract class AbstractGraphStorageTester {
     @Test
     public void testEdgeProperties() {
         graph = createGHStorage();
-        EdgeIteratorState iter1 = graph.edge(0, 1, 10, true);
-        EdgeIteratorState iter2 = graph.edge(0, 2, 20, true);
+        EdgeIteratorState iter1 = GHUtility.setProperties(graph.edge(0, 1).setDistance(10), carEncoder, 60, true, true);
+        EdgeIteratorState iter2 = GHUtility.setProperties(graph.edge(0, 2).setDistance(20), carEncoder, 60, true, true);
 
         int edgeId = iter1.getEdge();
         EdgeIteratorState iter = graph.getEdgeIteratorState(edgeId, 0);
@@ -527,9 +527,9 @@ public abstract class AbstractGraphStorageTester {
     @Test
     public void testCreateDuplicateEdges() {
         graph = createGHStorage();
-        graph.edge(2, 1, 12, true);
-        graph.edge(2, 3, 12, true);
-        graph.edge(2, 3, 13, false);
+        GHUtility.setProperties(graph.edge(2, 1).setDistance(12), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(12), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(13), carEncoder, 60, true, false);
         assertEquals(3, getCountOut(2));
 
         // no exception
@@ -561,22 +561,22 @@ public abstract class AbstractGraphStorageTester {
         assertFalse(oneIter.get(carAccessEnc));
         assertTrue(oneIter.getReverse(carAccessEnc));
 
-        graph.edge(3, 2, 14, true);
+        GHUtility.setProperties(graph.edge(3, 2).setDistance(14), carEncoder, 60, true, true);
         assertEquals(4, getCountOut(2));
     }
 
     @Test
     public void testIdenticalNodes() {
         graph = createGHStorage();
-        graph.edge(0, 0, 100, true);
+        GHUtility.setProperties(graph.edge(0, 0).setDistance(100), carEncoder, 60, true, true);
         assertEquals(1, getCountAll(0));
     }
 
     @Test
     public void testIdenticalNodes2() {
         graph = createGHStorage();
-        graph.edge(0, 0, 100, false);
-        graph.edge(0, 0, 100, false);
+        GHUtility.setProperties(graph.edge(0, 0).setDistance(100), carEncoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(0, 0).setDistance(100), carEncoder, 60, true, false);
         assertEquals(2, getCountAll(0));
     }
 
@@ -661,9 +661,9 @@ public abstract class AbstractGraphStorageTester {
     @Test
     public void testGetAllEdges() {
         graph = createGHStorage();
-        graph.edge(0, 1, 2, true);
-        graph.edge(3, 1, 1, false);
-        graph.edge(3, 2, 1, false);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(2), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(3, 1).setDistance(1), carEncoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(3, 2).setDistance(1), carEncoder, 60, true, false);
 
         EdgeIterator iter = graph.getAllEdges();
         assertTrue(iter.next());
@@ -688,10 +688,10 @@ public abstract class AbstractGraphStorageTester {
     @Test
     public void testStringIndex() {
         graph = createGHStorage();
-        EdgeIteratorState iter1 = graph.edge(0, 1, 10, true);
+        EdgeIteratorState iter1 = GHUtility.setProperties(graph.edge(0, 1).setDistance(10), carEncoder, 60, true, true);
         iter1.setName("named street1");
 
-        EdgeIteratorState iter2 = graph.edge(0, 1, 10, true);
+        EdgeIteratorState iter2 = GHUtility.setProperties(graph.edge(0, 1).setDistance(10), carEncoder, 60, true, true);
         iter2.setName("named street2");
 
         assertEquals("named street1", graph.getEdgeIteratorState(iter1.getEdge(), iter1.getAdjNode()).getName());
@@ -790,7 +790,7 @@ public abstract class AbstractGraphStorageTester {
         na.setNode(1, 11, 20, 1);
         na.setNode(2, 12, 12, 0.4);
 
-        EdgeIteratorState iter2 = graph.edge(0, 1, 100, true);
+        EdgeIteratorState iter2 = GHUtility.setProperties(graph.edge(0, 1).setDistance(100), carEncoder, 60, true, true);
         final BaseGraph baseGraph = (BaseGraph) graph.getBaseGraph();
         assertEquals(4, baseGraph.getMaxGeoRef());
         iter2.setWayGeometry(Helper.createPointList3D(1, 2, 3, 3, 4, 5, 5, 6, 7, 7, 8, 9));
@@ -803,7 +803,7 @@ public abstract class AbstractGraphStorageTester {
         assertEquals(4 + (1 + 12), baseGraph.getMaxGeoRef());
         iter2.setWayGeometry(Helper.createPointList3D(1.5, 1, 0, 2, 3, 0));
         assertEquals(4 + (1 + 12) + (1 + 6), baseGraph.getMaxGeoRef());
-        EdgeIteratorState iter1 = graph.edge(0, 2, 200, true);
+        EdgeIteratorState iter1 = GHUtility.setProperties(graph.edge(0, 2).setDistance(200), carEncoder, 60, true, true);
         iter1.setWayGeometry(Helper.createPointList3D(3.5, 4.5, 0, 5, 6, 0));
         assertEquals(4 + (1 + 12) + (1 + 6) + (1 + 6), baseGraph.getMaxGeoRef());
     }
@@ -811,10 +811,10 @@ public abstract class AbstractGraphStorageTester {
     @Test
     public void testDetachEdge() {
         graph = createGHStorage();
-        graph.edge(0, 1, 2, true);
-        GHUtility.setProperties(graph.edge(0, 2, 2, true).setWayGeometry(Helper.createPointList(1, 2, 3, 4)),
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(2), carEncoder, 60, true, true);
+        GHUtility.setProperties(GHUtility.setProperties(graph.edge(0, 2).setDistance(2), carEncoder, 60, true, true).setWayGeometry(Helper.createPointList(1, 2, 3, 4)),
                 carEncoder, 10, true, false);
-        graph.edge(1, 2, 2, true);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(2), carEncoder, 60, true, true);
 
         EdgeIterator iter = graph.createEdgeExplorer().setBaseNode(0);
         try {
@@ -849,7 +849,7 @@ public abstract class AbstractGraphStorageTester {
         assertEquals(3, edgeState20.fetchWayGeometry(FetchMode.PILLAR_ONLY).getLatitude(0), 1e-1);
 
         // #162 a directed self referencing edge should be able to reverse its state too
-        GHUtility.setProperties(graph.edge(3, 3, 2, true), carEncoder, 10, true, false);
+        GHUtility.setProperties(GHUtility.setProperties(graph.edge(3, 3).setDistance(2), carEncoder, 60, true, true), carEncoder, 10, true, false);
         EdgeIterator edgeState33 = graph.createEdgeExplorer().setBaseNode(3);
         edgeState33.next();
         assertEquals(3, edgeState33.getBaseNode());

--- a/core/src/test/java/com/graphhopper/storage/GraphEdgeIdFinderTest.java
+++ b/core/src/test/java/com/graphhopper/storage/GraphEdgeIdFinderTest.java
@@ -20,6 +20,7 @@ package com.graphhopper.storage;
 import com.graphhopper.routing.util.*;
 import com.graphhopper.storage.index.LocationIndex;
 import com.graphhopper.storage.index.LocationIndexTree;
+import com.graphhopper.util.GHUtility;
 import org.junit.Test;
 
 import java.util.Set;
@@ -42,11 +43,11 @@ public class GraphEdgeIdFinderTest {
         // 0-1-2
         // | |
         // 3-4
-        graph.edge(0, 1, 1, true);
-        graph.edge(1, 2, 1, true);
-        graph.edge(3, 4, 1, true);
-        graph.edge(0, 3, 1, true);
-        graph.edge(1, 4, 1, true);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(0, 3).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 4).setDistance(1), encoder, 60, true, true);
         updateDistancesFor(graph, 0, 0.01, 0.00);
         updateDistancesFor(graph, 1, 0.01, 0.01);
         updateDistancesFor(graph, 2, 0.01, 0.02);
@@ -77,19 +78,19 @@ public class GraphEdgeIdFinderTest {
         // 04-05-06-07
         // |  |
         // 08-09-10-11
-        graph.edge(0, 1, 1, true); // 0
-        graph.edge(1, 2, 1, true); // 1
-        graph.edge(2, 3, 1, true); // 2
-        graph.edge(0, 4, 1, true); // 3
-        graph.edge(1, 5, 1, true); // 4
-        graph.edge(4, 5, 1, true); // 5
-        graph.edge(5, 6, 1, true); // 6
-        graph.edge(6, 7, 1, true); // 7
-        graph.edge(4, 8, 1, true); // 8
-        graph.edge(5, 9, 1, true); // 9
-        graph.edge(8, 9, 1, true); // 10
-        graph.edge(9, 10, 1, true); // 11
-        graph.edge(10, 11, 1, true); // 12
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true); // 0
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, true); // 1
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, true); // 2
+        GHUtility.setProperties(graph.edge(0, 4).setDistance(1), encoder, 60, true, true); // 3
+        GHUtility.setProperties(graph.edge(1, 5).setDistance(1), encoder, 60, true, true); // 4
+        GHUtility.setProperties(graph.edge(4, 5).setDistance(1), encoder, 60, true, true); // 5
+        GHUtility.setProperties(graph.edge(5, 6).setDistance(1), encoder, 60, true, true); // 6
+        GHUtility.setProperties(graph.edge(6, 7).setDistance(1), encoder, 60, true, true); // 7
+        GHUtility.setProperties(graph.edge(4, 8).setDistance(1), encoder, 60, true, true); // 8
+        GHUtility.setProperties(graph.edge(5, 9).setDistance(1), encoder, 60, true, true); // 9
+        GHUtility.setProperties(graph.edge(8, 9).setDistance(1), encoder, 60, true, true); // 10
+        GHUtility.setProperties(graph.edge(9, 10).setDistance(1), encoder, 60, true, true); // 11
+        GHUtility.setProperties(graph.edge(10, 11).setDistance(1), encoder, 60, true, true); // 12
 
         updateDistancesFor(graph, 0, 2, 0);
         updateDistancesFor(graph, 1, 2, 1);

--- a/core/src/test/java/com/graphhopper/storage/GraphEdgeIdFinderTest.java
+++ b/core/src/test/java/com/graphhopper/storage/GraphEdgeIdFinderTest.java
@@ -43,11 +43,11 @@ public class GraphEdgeIdFinderTest {
         // 0-1-2
         // | |
         // 3-4
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(0, 3).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 4).setDistance(1), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 4).setDistance(1));
         updateDistancesFor(graph, 0, 0.01, 0.00);
         updateDistancesFor(graph, 1, 0.01, 0.01);
         updateDistancesFor(graph, 2, 0.01, 0.02);
@@ -78,19 +78,19 @@ public class GraphEdgeIdFinderTest {
         // 04-05-06-07
         // |  |
         // 08-09-10-11
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true); // 0
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, true); // 1
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, true); // 2
-        GHUtility.setProperties(graph.edge(0, 4).setDistance(1), encoder, 60, true, true); // 3
-        GHUtility.setProperties(graph.edge(1, 5).setDistance(1), encoder, 60, true, true); // 4
-        GHUtility.setProperties(graph.edge(4, 5).setDistance(1), encoder, 60, true, true); // 5
-        GHUtility.setProperties(graph.edge(5, 6).setDistance(1), encoder, 60, true, true); // 6
-        GHUtility.setProperties(graph.edge(6, 7).setDistance(1), encoder, 60, true, true); // 7
-        GHUtility.setProperties(graph.edge(4, 8).setDistance(1), encoder, 60, true, true); // 8
-        GHUtility.setProperties(graph.edge(5, 9).setDistance(1), encoder, 60, true, true); // 9
-        GHUtility.setProperties(graph.edge(8, 9).setDistance(1), encoder, 60, true, true); // 10
-        GHUtility.setProperties(graph.edge(9, 10).setDistance(1), encoder, 60, true, true); // 11
-        GHUtility.setProperties(graph.edge(10, 11).setDistance(1), encoder, 60, true, true); // 12
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(1)); // 0
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(1)); // 1
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 3).setDistance(1)); // 2
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 4).setDistance(1)); // 3
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 5).setDistance(1)); // 4
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 5).setDistance(1)); // 5
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(5, 6).setDistance(1)); // 6
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(6, 7).setDistance(1)); // 7
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 8).setDistance(1)); // 8
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(5, 9).setDistance(1)); // 9
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(8, 9).setDistance(1)); // 10
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(9, 10).setDistance(1)); // 11
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(10, 11).setDistance(1)); // 12
 
         updateDistancesFor(graph, 0, 2, 0);
         updateDistancesFor(graph, 1, 2, 1);

--- a/core/src/test/java/com/graphhopper/storage/GraphHopperStorageCHTest.java
+++ b/core/src/test/java/com/graphhopper/storage/GraphHopperStorageCHTest.java
@@ -129,7 +129,7 @@ public class GraphHopperStorageCHTest extends GraphHopperStorageTest {
         //            3  2
         graph = createGHStorage();
         EdgeExplorer baseCarOutExplorer = graph.createEdgeExplorer(carOutFilter);
-        graph.edge(4, 1, 30, true);
+        GHUtility.setProperties(graph.edge(4, 1).setDistance(30), carEncoder, 60, true, true);
         graph.freeze();
 
         CHGraph lg = getGraph(graph);
@@ -222,8 +222,8 @@ public class GraphHopperStorageCHTest extends GraphHopperStorageTest {
     public void weightExact() {
         graph = createGHStorage();
         CHGraph chGraph = getGraph(graph);
-        graph.edge(0, 1, 1, false);
-        graph.edge(1, 2, 1, false);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), carEncoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), carEncoder, 60, true, false);
         graph.freeze();
         setIdentityLevels(chGraph);
 
@@ -295,8 +295,8 @@ public class GraphHopperStorageCHTest extends GraphHopperStorageTest {
     @Test
     public void testSimpleShortcutCreationAndTraversal() {
         graph = createGHStorage();
-        graph.edge(1, 3, 10, true);
-        graph.edge(3, 4, 10, true);
+        GHUtility.setProperties(graph.edge(1, 3).setDistance(10), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(10), carEncoder, 60, true, true);
         graph.freeze();
 
         CHGraph lg = getGraph(graph);
@@ -312,8 +312,8 @@ public class GraphHopperStorageCHTest extends GraphHopperStorageTest {
     @Test
     public void testAddShortcutSkippedEdgesWriteRead() {
         graph = createGHStorage();
-        final EdgeIteratorState edge1 = graph.edge(1, 3, 10, true);
-        final EdgeIteratorState edge2 = graph.edge(3, 4, 10, true);
+        final EdgeIteratorState edge1 = GHUtility.setProperties(graph.edge(1, 3).setDistance(10), carEncoder, 60, true, true);
+        final EdgeIteratorState edge2 = GHUtility.setProperties(graph.edge(3, 4).setDistance(10), carEncoder, 60, true, true);
         graph.freeze();
 
         CHGraph lg = getGraph(graph);
@@ -333,8 +333,8 @@ public class GraphHopperStorageCHTest extends GraphHopperStorageTest {
     @Test
     public void testAddShortcutSkippedEdgesWriteRead_writeWithCHEdgeIterator() {
         graph = createGHStorage();
-        final EdgeIteratorState edge1 = graph.edge(1, 3, 10, true);
-        final EdgeIteratorState edge2 = graph.edge(3, 4, 10, true);
+        final EdgeIteratorState edge1 = GHUtility.setProperties(graph.edge(1, 3).setDistance(10), carEncoder, 60, true, true);
+        final EdgeIteratorState edge2 = GHUtility.setProperties(graph.edge(3, 4).setDistance(10), carEncoder, 60, true, true);
         graph.freeze();
 
         CHGraph lg = getGraph(graph);
@@ -353,8 +353,8 @@ public class GraphHopperStorageCHTest extends GraphHopperStorageTest {
     @Test(expected = IllegalStateException.class)
     public void testAddShortcut_edgeBased_throwsIfNotConfiguredForEdgeBased() {
         graph = newGHStorage(false, false);
-        graph.edge(0, 1, 1, false);
-        graph.edge(1, 2, 1, false);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), carEncoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), carEncoder, 60, true, false);
         graph.freeze();
         addShortcut(getGraph(graph), 0, 2, true, 0, 1, 0, 1, 2);
     }
@@ -363,8 +363,8 @@ public class GraphHopperStorageCHTest extends GraphHopperStorageTest {
     public void testAddShortcut_edgeBased() {
         // 0 -> 1 -> 2
         graph = newGHStorage(false, true);
-        graph.edge(0, 1, 1, false);
-        graph.edge(1, 2, 3, false);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), carEncoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(3), carEncoder, 60, true, false);
         graph.freeze();
         CHGraph lg = getGraph(this.graph);
         setIdentityLevels(lg);
@@ -380,8 +380,8 @@ public class GraphHopperStorageCHTest extends GraphHopperStorageTest {
     @Test
     public void testGetEdgeIterator() {
         graph = newGHStorage(false, true);
-        graph.edge(0, 1, 1, false);
-        graph.edge(1, 2, 1, false);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), carEncoder, 60, true, false);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), carEncoder, 60, true, false);
         graph.freeze();
         CHGraph lg = getGraph(graph);
         setIdentityLevels(lg);

--- a/core/src/test/java/com/graphhopper/storage/GraphHopperStorageCHTest.java
+++ b/core/src/test/java/com/graphhopper/storage/GraphHopperStorageCHTest.java
@@ -129,7 +129,7 @@ public class GraphHopperStorageCHTest extends GraphHopperStorageTest {
         //            3  2
         graph = createGHStorage();
         EdgeExplorer baseCarOutExplorer = graph.createEdgeExplorer(carOutFilter);
-        GHUtility.setProperties(graph.edge(4, 1).setDistance(30), carEncoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(4, 1).setDistance(30));
         graph.freeze();
 
         CHGraph lg = getGraph(graph);
@@ -222,8 +222,8 @@ public class GraphHopperStorageCHTest extends GraphHopperStorageTest {
     public void weightExact() {
         graph = createGHStorage();
         CHGraph chGraph = getGraph(graph);
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), carEncoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), carEncoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(1, 2).setDistance(1));
         graph.freeze();
         setIdentityLevels(chGraph);
 
@@ -295,8 +295,8 @@ public class GraphHopperStorageCHTest extends GraphHopperStorageTest {
     @Test
     public void testSimpleShortcutCreationAndTraversal() {
         graph = createGHStorage();
-        GHUtility.setProperties(graph.edge(1, 3).setDistance(10), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(10), carEncoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(1, 3).setDistance(10));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(3, 4).setDistance(10));
         graph.freeze();
 
         CHGraph lg = getGraph(graph);
@@ -312,8 +312,8 @@ public class GraphHopperStorageCHTest extends GraphHopperStorageTest {
     @Test
     public void testAddShortcutSkippedEdgesWriteRead() {
         graph = createGHStorage();
-        final EdgeIteratorState edge1 = GHUtility.setProperties(graph.edge(1, 3).setDistance(10), carEncoder, 60, true, true);
-        final EdgeIteratorState edge2 = GHUtility.setProperties(graph.edge(3, 4).setDistance(10), carEncoder, 60, true, true);
+        final EdgeIteratorState edge1 = GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(1, 3).setDistance(10));
+        final EdgeIteratorState edge2 = GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(3, 4).setDistance(10));
         graph.freeze();
 
         CHGraph lg = getGraph(graph);
@@ -333,8 +333,8 @@ public class GraphHopperStorageCHTest extends GraphHopperStorageTest {
     @Test
     public void testAddShortcutSkippedEdgesWriteRead_writeWithCHEdgeIterator() {
         graph = createGHStorage();
-        final EdgeIteratorState edge1 = GHUtility.setProperties(graph.edge(1, 3).setDistance(10), carEncoder, 60, true, true);
-        final EdgeIteratorState edge2 = GHUtility.setProperties(graph.edge(3, 4).setDistance(10), carEncoder, 60, true, true);
+        final EdgeIteratorState edge1 = GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(1, 3).setDistance(10));
+        final EdgeIteratorState edge2 = GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(3, 4).setDistance(10));
         graph.freeze();
 
         CHGraph lg = getGraph(graph);
@@ -353,8 +353,8 @@ public class GraphHopperStorageCHTest extends GraphHopperStorageTest {
     @Test(expected = IllegalStateException.class)
     public void testAddShortcut_edgeBased_throwsIfNotConfiguredForEdgeBased() {
         graph = newGHStorage(false, false);
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), carEncoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), carEncoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(1, 2).setDistance(1));
         graph.freeze();
         addShortcut(getGraph(graph), 0, 2, true, 0, 1, 0, 1, 2);
     }
@@ -363,8 +363,8 @@ public class GraphHopperStorageCHTest extends GraphHopperStorageTest {
     public void testAddShortcut_edgeBased() {
         // 0 -> 1 -> 2
         graph = newGHStorage(false, true);
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), carEncoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(3), carEncoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(1, 2).setDistance(3));
         graph.freeze();
         CHGraph lg = getGraph(this.graph);
         setIdentityLevels(lg);
@@ -380,8 +380,8 @@ public class GraphHopperStorageCHTest extends GraphHopperStorageTest {
     @Test
     public void testGetEdgeIterator() {
         graph = newGHStorage(false, true);
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), carEncoder, 60, true, false);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), carEncoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(1, 2).setDistance(1));
         graph.freeze();
         CHGraph lg = getGraph(graph);
         setIdentityLevels(lg);
@@ -426,8 +426,8 @@ public class GraphHopperStorageCHTest extends GraphHopperStorageTest {
         BooleanEncodedValue tmpCarAccessEnc = tmpCar.getAccessEnc();
 
         graph = new GraphBuilder(em).setCHConfigs(chConfigs).create();
-        IntsRef edgeFlags = GHUtility.setProperties(em.createEdgeFlags(), tmpCar, 100, true, false);
-        graph.edge(0, 1).setDistance(10).setFlags(GHUtility.setProperties(edgeFlags, tmpBike, 10, true, true));
+        IntsRef edgeFlags = GHUtility.setSpeed(100, 0, tmpCar, em.createEdgeFlags());
+        graph.edge(0, 1).setDistance(10).setFlags(GHUtility.setSpeed(10, 10, tmpBike, edgeFlags));
         graph.edge(1, 2).setDistance(10).setFlags(edgeFlags);
 
         graph.freeze();

--- a/core/src/test/java/com/graphhopper/storage/GraphHopperStorageLMTest.java
+++ b/core/src/test/java/com/graphhopper/storage/GraphHopperStorageLMTest.java
@@ -31,7 +31,7 @@ public class GraphHopperStorageLMTest {
         way_0_1.setTag("highway", "primary");
         way_0_1.setTag("maxheight", "4.4");
 
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), carFlagEncoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, carFlagEncoder, graph.edge(0, 1).setDistance(1));
         updateDistancesFor(graph, 0, 0.00, 0.00);
         updateDistancesFor(graph, 1, 0.01, 0.01);
         graph.getEdgeIteratorState(0, 1).setFlags(
@@ -42,7 +42,7 @@ public class GraphHopperStorageLMTest {
         way_1_2.setTag("highway", "primary");
         way_1_2.setTag("maxweight", "45");
 
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), carFlagEncoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, carFlagEncoder, graph.edge(1, 2).setDistance(1));
         updateDistancesFor(graph, 2, 0.02, 0.02);
         graph.getEdgeIteratorState(1, 2).setFlags(
                 carFlagEncoder.handleWayTags(encodingManager.createEdgeFlags(), way_1_2, Access.WAY));

--- a/core/src/test/java/com/graphhopper/storage/GraphHopperStorageLMTest.java
+++ b/core/src/test/java/com/graphhopper/storage/GraphHopperStorageLMTest.java
@@ -7,6 +7,7 @@ import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.util.CarFlagEncoder;
 import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.routing.util.EncodingManager.Access;
+import com.graphhopper.util.GHUtility;
 import com.graphhopper.util.Helper;
 import org.junit.Test;
 
@@ -30,7 +31,7 @@ public class GraphHopperStorageLMTest {
         way_0_1.setTag("highway", "primary");
         way_0_1.setTag("maxheight", "4.4");
 
-        graph.edge(0, 1, 1, true);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), carFlagEncoder, 60, true, true);
         updateDistancesFor(graph, 0, 0.00, 0.00);
         updateDistancesFor(graph, 1, 0.01, 0.01);
         graph.getEdgeIteratorState(0, 1).setFlags(
@@ -41,7 +42,7 @@ public class GraphHopperStorageLMTest {
         way_1_2.setTag("highway", "primary");
         way_1_2.setTag("maxweight", "45");
 
-        graph.edge(1, 2, 1, true);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), carFlagEncoder, 60, true, true);
         updateDistancesFor(graph, 2, 0.02, 0.02);
         graph.getEdgeIteratorState(1, 2).setFlags(
                 carFlagEncoder.handleWayTags(encodingManager.createEdgeFlags(), way_1_2, Access.WAY));

--- a/core/src/test/java/com/graphhopper/storage/GraphHopperStorageTest.java
+++ b/core/src/test/java/com/graphhopper/storage/GraphHopperStorageTest.java
@@ -75,13 +75,13 @@ public class GraphHopperStorageTest extends AbstractGraphStorageTester {
         na.setNode(1, 11, 20, 1);
         na.setNode(2, 12, 12, 0.4);
 
-        EdgeIteratorState iter2 = GHUtility.setProperties(graph.edge(0, 1).setDistance(100), carEncoder, 60, true, true);
+        EdgeIteratorState iter2 = GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(0, 1).setDistance(100));
         iter2.setWayGeometry(Helper.createPointList3D(1.5, 1, 0, 2, 3, 0));
-        EdgeIteratorState iter1 = GHUtility.setProperties(graph.edge(0, 2).setDistance(200), carEncoder, 60, true, true);
+        EdgeIteratorState iter1 = GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(0, 2).setDistance(200));
         iter1.setWayGeometry(Helper.createPointList3D(3.5, 4.5, 0, 5, 6, 0));
-        GHUtility.setProperties(graph.edge(9, 10).setDistance(200), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(9, 11).setDistance(200), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(120), carEncoder, 60, true, false);
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(9, 10).setDistance(200));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(9, 11).setDistance(200));
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(1, 2).setDistance(120));
 
         iter1.setName("named street1");
         iter2.setName("named street2");
@@ -98,7 +98,7 @@ public class GraphHopperStorageTest extends AbstractGraphStorageTester {
 
         assertEquals("named street1", graph.getEdgeIteratorState(iter1.getEdge(), iter1.getAdjNode()).getName());
         assertEquals("named street2", graph.getEdgeIteratorState(iter2.getEdge(), iter2.getAdjNode()).getName());
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(123), carEncoder, 60, true, true).
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(3, 4).setDistance(123)).
                 setWayGeometry(Helper.createPointList3D(4.4, 5.5, 0, 6.6, 7.7, 0));
         checkGraph(graph);
     }
@@ -192,8 +192,8 @@ public class GraphHopperStorageTest extends AbstractGraphStorageTester {
         // a typical usage where we create independent EdgeIteratorState's BUT due to the IntsRef reference they are no more independent
         GraphHopperStorage storage = createGHStorage();
         Graph graph = storage.getBaseGraph();
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(10), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(10), carEncoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(0, 1).setDistance(10));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(1, 2).setDistance(10));
 
         EdgeIteratorState edge0 = graph.getEdgeIteratorState(0, Integer.MIN_VALUE);
         EdgeIteratorState edge1 = graph.getEdgeIteratorState(1, Integer.MIN_VALUE);
@@ -230,9 +230,9 @@ public class GraphHopperStorageTest extends AbstractGraphStorageTester {
         Graph graph = storage.getBaseGraph();
         IntsRef ref = encodingManager.createEdgeFlags();
         ref.ints[0] = 12;
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(10), carEncoder, 60, true, true).setFlags(ref);
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(1, 2).setDistance(10)).setFlags(ref);
         ref.ints[0] = 13;
-        GHUtility.setProperties(graph.edge(1, 3).setDistance(10), carEncoder, 60, true, true).setFlags(ref);
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(1, 3).setDistance(10)).setFlags(ref);
 
         EdgeIterator iter = graph.createEdgeExplorer().setBaseNode(1);
         assertTrue(iter.next());
@@ -256,8 +256,8 @@ public class GraphHopperStorageTest extends AbstractGraphStorageTester {
         na.setNode(1, 8, 13);
         na.setNode(2, 2, 10);
         na.setNode(3, 5, 9);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(10), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 3).setDistance(10), carEncoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(1, 2).setDistance(10));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(1, 3).setDistance(10));
         int nodes = graph.getNodes();
         int edges = graph.getAllEdges().length();
         graph.flush();
@@ -295,7 +295,7 @@ public class GraphHopperStorageTest extends AbstractGraphStorageTester {
     @Test
     public void testEdgeKey() {
         GraphHopperStorage g = new GraphBuilder(encodingManager).create();
-        GHUtility.setProperties(g.edge(0, 1).setDistance(10), carEncoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(0, 1).setDistance(10));
         // storage direction
         assertEdge(g.getEdgeIteratorState(0, Integer.MIN_VALUE), 0, 1, false, 0, 0);
         // reverse direction
@@ -309,7 +309,7 @@ public class GraphHopperStorageTest extends AbstractGraphStorageTester {
     @Test
     public void testEdgeKey_loop() {
         GraphHopperStorage g = new GraphBuilder(encodingManager).create();
-        GHUtility.setProperties(g.edge(0, 0).setDistance(10), carEncoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(0, 0).setDistance(10));
         // storage direction
         assertEdge(g.getEdgeIteratorState(0, Integer.MIN_VALUE), 0, 0, false, 0, 0);
         // reverse direction cannot be retrieved, we get forward direction anyway

--- a/core/src/test/java/com/graphhopper/storage/GraphHopperStorageTest.java
+++ b/core/src/test/java/com/graphhopper/storage/GraphHopperStorageTest.java
@@ -75,13 +75,13 @@ public class GraphHopperStorageTest extends AbstractGraphStorageTester {
         na.setNode(1, 11, 20, 1);
         na.setNode(2, 12, 12, 0.4);
 
-        EdgeIteratorState iter2 = graph.edge(0, 1, 100, true);
+        EdgeIteratorState iter2 = GHUtility.setProperties(graph.edge(0, 1).setDistance(100), carEncoder, 60, true, true);
         iter2.setWayGeometry(Helper.createPointList3D(1.5, 1, 0, 2, 3, 0));
-        EdgeIteratorState iter1 = graph.edge(0, 2, 200, true);
+        EdgeIteratorState iter1 = GHUtility.setProperties(graph.edge(0, 2).setDistance(200), carEncoder, 60, true, true);
         iter1.setWayGeometry(Helper.createPointList3D(3.5, 4.5, 0, 5, 6, 0));
-        graph.edge(9, 10, 200, true);
-        graph.edge(9, 11, 200, true);
-        graph.edge(1, 2, 120, false);
+        GHUtility.setProperties(graph.edge(9, 10).setDistance(200), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(9, 11).setDistance(200), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(120), carEncoder, 60, true, false);
 
         iter1.setName("named street1");
         iter2.setName("named street2");
@@ -98,7 +98,8 @@ public class GraphHopperStorageTest extends AbstractGraphStorageTester {
 
         assertEquals("named street1", graph.getEdgeIteratorState(iter1.getEdge(), iter1.getAdjNode()).getName());
         assertEquals("named street2", graph.getEdgeIteratorState(iter2.getEdge(), iter2.getAdjNode()).getName());
-        graph.edge(3, 4, 123, true).setWayGeometry(Helper.createPointList3D(4.4, 5.5, 0, 6.6, 7.7, 0));
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(123), carEncoder, 60, true, true).
+                setWayGeometry(Helper.createPointList3D(4.4, 5.5, 0, 6.6, 7.7, 0));
         checkGraph(graph);
     }
 
@@ -191,8 +192,8 @@ public class GraphHopperStorageTest extends AbstractGraphStorageTester {
         // a typical usage where we create independent EdgeIteratorState's BUT due to the IntsRef reference they are no more independent
         GraphHopperStorage storage = createGHStorage();
         Graph graph = storage.getBaseGraph();
-        graph.edge(0, 1, 10, true);
-        graph.edge(1, 2, 10, true);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(10), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(10), carEncoder, 60, true, true);
 
         EdgeIteratorState edge0 = graph.getEdgeIteratorState(0, Integer.MIN_VALUE);
         EdgeIteratorState edge1 = graph.getEdgeIteratorState(1, Integer.MIN_VALUE);
@@ -229,9 +230,9 @@ public class GraphHopperStorageTest extends AbstractGraphStorageTester {
         Graph graph = storage.getBaseGraph();
         IntsRef ref = encodingManager.createEdgeFlags();
         ref.ints[0] = 12;
-        graph.edge(1, 2, 10, true).setFlags(ref);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(10), carEncoder, 60, true, true).setFlags(ref);
         ref.ints[0] = 13;
-        graph.edge(1, 3, 10, true).setFlags(ref);
+        GHUtility.setProperties(graph.edge(1, 3).setDistance(10), carEncoder, 60, true, true).setFlags(ref);
 
         EdgeIterator iter = graph.createEdgeExplorer().setBaseNode(1);
         assertTrue(iter.next());
@@ -255,8 +256,8 @@ public class GraphHopperStorageTest extends AbstractGraphStorageTester {
         na.setNode(1, 8, 13);
         na.setNode(2, 2, 10);
         na.setNode(3, 5, 9);
-        graph.edge(1, 2, 10, true);
-        graph.edge(1, 3, 10, true);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(10), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 3).setDistance(10), carEncoder, 60, true, true);
         int nodes = graph.getNodes();
         int edges = graph.getAllEdges().length();
         graph.flush();
@@ -294,7 +295,7 @@ public class GraphHopperStorageTest extends AbstractGraphStorageTester {
     @Test
     public void testEdgeKey() {
         GraphHopperStorage g = new GraphBuilder(encodingManager).create();
-        g.edge(0, 1, 10, true);
+        GHUtility.setProperties(g.edge(0, 1).setDistance(10), carEncoder, 60, true, true);
         // storage direction
         assertEdge(g.getEdgeIteratorState(0, Integer.MIN_VALUE), 0, 1, false, 0, 0);
         // reverse direction
@@ -308,7 +309,7 @@ public class GraphHopperStorageTest extends AbstractGraphStorageTester {
     @Test
     public void testEdgeKey_loop() {
         GraphHopperStorage g = new GraphBuilder(encodingManager).create();
-        g.edge(0, 0, 10, true);
+        GHUtility.setProperties(g.edge(0, 0).setDistance(10), carEncoder, 60, true, true);
         // storage direction
         assertEdge(g.getEdgeIteratorState(0, Integer.MIN_VALUE), 0, 0, false, 0, 0);
         // reverse direction cannot be retrieved, we get forward direction anyway

--- a/core/src/test/java/com/graphhopper/storage/GraphHopperStorageTest.java
+++ b/core/src/test/java/com/graphhopper/storage/GraphHopperStorageTest.java
@@ -197,8 +197,8 @@ public class GraphHopperStorageTest extends AbstractGraphStorageTester {
 
         EdgeIteratorState edge0 = graph.getEdgeIteratorState(0, Integer.MIN_VALUE);
         EdgeIteratorState edge1 = graph.getEdgeIteratorState(1, Integer.MIN_VALUE);
-        edge0.set(carAccessEnc, true).setReverse(carAccessEnc, false);
-        edge1.set(carAccessEnc, false).setReverse(carAccessEnc, true);
+        edge0.set(carAccessEnc, true, false);
+        edge1.set(carAccessEnc, false, true);
 
         assertFalse(edge1.get(carAccessEnc));
         assertTrue(edge1.getReverse(carAccessEnc));

--- a/core/src/test/java/com/graphhopper/storage/GraphHopperStorageWithTurnCostsTest.java
+++ b/core/src/test/java/com/graphhopper/storage/GraphHopperStorageWithTurnCostsTest.java
@@ -59,13 +59,13 @@ public class GraphHopperStorageWithTurnCostsTest extends GraphHopperStorageTest 
         na.setNode(1, 11, 20, 1);
         na.setNode(2, 12, 12, 0.4);
 
-        EdgeIteratorState iter2 = GHUtility.setProperties(graph.edge(0, 1).setDistance(100), carEncoder, 60, true, true);
+        EdgeIteratorState iter2 = GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(0, 1).setDistance(100));
         iter2.setWayGeometry(Helper.createPointList3D(1.5, 1, 0, 2, 3, 0));
-        EdgeIteratorState iter1 = GHUtility.setProperties(graph.edge(0, 2).setDistance(200), carEncoder, 60, true, true);
+        EdgeIteratorState iter1 = GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(0, 2).setDistance(200));
         iter1.setWayGeometry(Helper.createPointList3D(3.5, 4.5, 0, 5, 6, 0));
-        GHUtility.setProperties(graph.edge(9, 10).setDistance(200), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(9, 11).setDistance(200), carEncoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(120), carEncoder, 60, true, false);
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(9, 10).setDistance(200));
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(9, 11).setDistance(200));
+        GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(1, 2).setDistance(120));
 
         setTurnCost(iter1.getEdge(), 0, iter2.getEdge(), 1337);
         setTurnCost(iter2.getEdge(), 0, iter1.getEdge(), 666);
@@ -92,7 +92,7 @@ public class GraphHopperStorageWithTurnCostsTest extends GraphHopperStorageTest 
         assertEquals(815, getTurnCost(iter2, 1, iter1), .1);
         assertEquals(0, getTurnCost(iter2, 3, iter1), .1);
 
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(123), carEncoder, 60, true, true).
+        GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(3, 4).setDistance(123)).
                 setWayGeometry(Helper.createPointList3D(4.4, 5.5, 0, 6.6, 7.7, 0));
         checkGraph(graph);
     }
@@ -118,10 +118,10 @@ public class GraphHopperStorageWithTurnCostsTest extends GraphHopperStorageTest 
 
         // Make node 50 the 'center' node
         for (int nodeId = 51; nodeId < 100; nodeId++) {
-            GHUtility.setProperties(graph.edge(50, nodeId).setDistance(r.nextDouble()), carEncoder, 60, true, true);
+            GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(50, nodeId).setDistance(r.nextDouble()));
         }
         for (int nodeId = 0; nodeId < 50; nodeId++) {
-            GHUtility.setProperties(graph.edge(nodeId, 50).setDistance(r.nextDouble()), carEncoder, 60, true, true);
+            GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(nodeId, 50).setDistance(r.nextDouble()));
         }
 
         // add 100 turn cost entries around node 50

--- a/core/src/test/java/com/graphhopper/storage/GraphHopperStorageWithTurnCostsTest.java
+++ b/core/src/test/java/com/graphhopper/storage/GraphHopperStorageWithTurnCostsTest.java
@@ -21,6 +21,7 @@ import com.graphhopper.routing.ev.EncodedValueLookup;
 import com.graphhopper.routing.ev.TurnCost;
 import com.graphhopper.routing.util.CarFlagEncoder;
 import com.graphhopper.util.EdgeIteratorState;
+import com.graphhopper.util.GHUtility;
 import com.graphhopper.util.Helper;
 import org.junit.Test;
 
@@ -58,13 +59,13 @@ public class GraphHopperStorageWithTurnCostsTest extends GraphHopperStorageTest 
         na.setNode(1, 11, 20, 1);
         na.setNode(2, 12, 12, 0.4);
 
-        EdgeIteratorState iter2 = graph.edge(0, 1, 100, true);
+        EdgeIteratorState iter2 = GHUtility.setProperties(graph.edge(0, 1).setDistance(100), carEncoder, 60, true, true);
         iter2.setWayGeometry(Helper.createPointList3D(1.5, 1, 0, 2, 3, 0));
-        EdgeIteratorState iter1 = graph.edge(0, 2, 200, true);
+        EdgeIteratorState iter1 = GHUtility.setProperties(graph.edge(0, 2).setDistance(200), carEncoder, 60, true, true);
         iter1.setWayGeometry(Helper.createPointList3D(3.5, 4.5, 0, 5, 6, 0));
-        graph.edge(9, 10, 200, true);
-        graph.edge(9, 11, 200, true);
-        graph.edge(1, 2, 120, false);
+        GHUtility.setProperties(graph.edge(9, 10).setDistance(200), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(9, 11).setDistance(200), carEncoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(120), carEncoder, 60, true, false);
 
         setTurnCost(iter1.getEdge(), 0, iter2.getEdge(), 1337);
         setTurnCost(iter2.getEdge(), 0, iter1.getEdge(), 666);
@@ -91,7 +92,8 @@ public class GraphHopperStorageWithTurnCostsTest extends GraphHopperStorageTest 
         assertEquals(815, getTurnCost(iter2, 1, iter1), .1);
         assertEquals(0, getTurnCost(iter2, 3, iter1), .1);
 
-        graph.edge(3, 4, 123, true).setWayGeometry(Helper.createPointList3D(4.4, 5.5, 0, 6.6, 7.7, 0));
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(123), carEncoder, 60, true, true).
+                setWayGeometry(Helper.createPointList3D(4.4, 5.5, 0, 6.6, 7.7, 0));
         checkGraph(graph);
     }
 
@@ -116,10 +118,10 @@ public class GraphHopperStorageWithTurnCostsTest extends GraphHopperStorageTest 
 
         // Make node 50 the 'center' node
         for (int nodeId = 51; nodeId < 100; nodeId++) {
-            graph.edge(50, nodeId, r.nextDouble(), true);
+            GHUtility.setProperties(graph.edge(50, nodeId).setDistance(r.nextDouble()), carEncoder, 60, true, true);
         }
         for (int nodeId = 0; nodeId < 50; nodeId++) {
-            graph.edge(nodeId, 50, r.nextDouble(), true);
+            GHUtility.setProperties(graph.edge(nodeId, 50).setDistance(r.nextDouble()), carEncoder, 60, true, true);
         }
 
         // add 100 turn cost entries around node 50

--- a/core/src/test/java/com/graphhopper/storage/ShortcutUnpackerTest.java
+++ b/core/src/test/java/com/graphhopper/storage/ShortcutUnpackerTest.java
@@ -61,12 +61,12 @@ public class ShortcutUnpackerTest {
         DecimalEncodedValue speedEnc = encoder.getAverageSpeedEnc();
         double fwdSpeed = 60;
         double bwdSpeed = 30;
-        GHUtility.setProperties(graph.edge(0,1).setDistance(1),encoder,60,true, true).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
-        GHUtility.setProperties(graph.edge(1,2).setDistance(1),encoder,60,true, true).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
-        GHUtility.setProperties(graph.edge(2,3).setDistance(1),encoder,60,true, true).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
-        GHUtility.setProperties(graph.edge(3,4).setDistance(1),encoder,60,true, true).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
-        GHUtility.setProperties(graph.edge(4,5).setDistance(1),encoder,60,true, true).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
-        GHUtility.setProperties(graph.edge(5,6).setDistance(1),encoder,60,true, true).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed); // edge 5
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(1)).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(1)).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 3).setDistance(1)).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 4).setDistance(1)).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 5).setDistance(1)).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(5, 6).setDistance(1)).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed); // edge 5
         graph.freeze();
 
         setCHLevels(1, 3, 5, 4, 2, 0, 6);
@@ -156,12 +156,12 @@ public class ShortcutUnpackerTest {
         DecimalEncodedValue speedEnc = encoder.getAverageSpeedEnc();
         double fwdSpeed = 60;
         double bwdSpeed = 30;
-        GHUtility.setProperties(graph.edge(0,1).setDistance(1),encoder,60,true, true).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
-        GHUtility.setProperties(graph.edge(1,2).setDistance(1),encoder,60,true, true).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
-        GHUtility.setProperties(graph.edge(2,3).setDistance(1),encoder,60,true, true).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
-        GHUtility.setProperties(graph.edge(3,4).setDistance(1),encoder,60,true, true).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
-        GHUtility.setProperties(graph.edge(4,1).setDistance(1),encoder,60,true, true).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
-        GHUtility.setProperties(graph.edge(1,5).setDistance(1),encoder,60,true, true).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(1)).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(1)).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 3).setDistance(1)).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 4).setDistance(1)).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 1).setDistance(1)).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 5).setDistance(1)).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
         graph.freeze();
 
         setCHLevels(2, 4, 3, 1, 5, 0);
@@ -233,12 +233,12 @@ public class ShortcutUnpackerTest {
         DecimalEncodedValue speedEnc = encoder.getAverageSpeedEnc();
         double fwdSpeed = 60;
         double bwdSpeed = 30;
-        EdgeIteratorState edge0 = GHUtility.setProperties(graph.edge(0,1).setDistance(1),encoder,60,true, true).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
-        EdgeIteratorState edge1 = GHUtility.setProperties(graph.edge(1,2).setDistance(1),encoder,60,true, true).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
-        EdgeIteratorState edge2 = GHUtility.setProperties(graph.edge(2,3).setDistance(1),encoder,60,true, true).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
-        EdgeIteratorState edge3 = GHUtility.setProperties(graph.edge(3,4).setDistance(1),encoder,60,true, true).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
-        EdgeIteratorState edge4 = GHUtility.setProperties(graph.edge(4,5).setDistance(1),encoder,60,true, true).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
-        EdgeIteratorState edge5 = GHUtility.setProperties(graph.edge(5,6).setDistance(1),encoder,60,true, true).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
+        EdgeIteratorState edge0 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(1)).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
+        EdgeIteratorState edge1 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(1)).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
+        EdgeIteratorState edge2 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 3).setDistance(1)).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
+        EdgeIteratorState edge3 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 4).setDistance(1)).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
+        EdgeIteratorState edge4 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 5).setDistance(1)).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
+        EdgeIteratorState edge5 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(5, 6).setDistance(1)).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
         graph.freeze();
 
         // turn costs ->

--- a/core/src/test/java/com/graphhopper/storage/ShortcutUnpackerTest.java
+++ b/core/src/test/java/com/graphhopper/storage/ShortcutUnpackerTest.java
@@ -61,12 +61,12 @@ public class ShortcutUnpackerTest {
         DecimalEncodedValue speedEnc = encoder.getAverageSpeedEnc();
         double fwdSpeed = 60;
         double bwdSpeed = 30;
-        graph.edge(0, 1, 1, true).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
-        graph.edge(1, 2, 1, true).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
-        graph.edge(2, 3, 1, true).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
-        graph.edge(3, 4, 1, true).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
-        graph.edge(4, 5, 1, true).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
-        graph.edge(5, 6, 1, true).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed); // edge 5
+        GHUtility.setProperties(graph.edge(0,1).setDistance(1),encoder,60,true, true).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
+        GHUtility.setProperties(graph.edge(1,2).setDistance(1),encoder,60,true, true).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
+        GHUtility.setProperties(graph.edge(2,3).setDistance(1),encoder,60,true, true).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
+        GHUtility.setProperties(graph.edge(3,4).setDistance(1),encoder,60,true, true).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
+        GHUtility.setProperties(graph.edge(4,5).setDistance(1),encoder,60,true, true).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
+        GHUtility.setProperties(graph.edge(5,6).setDistance(1),encoder,60,true, true).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed); // edge 5
         graph.freeze();
 
         setCHLevels(1, 3, 5, 4, 2, 0, 6);
@@ -156,12 +156,12 @@ public class ShortcutUnpackerTest {
         DecimalEncodedValue speedEnc = encoder.getAverageSpeedEnc();
         double fwdSpeed = 60;
         double bwdSpeed = 30;
-        graph.edge(0, 1, 1, true).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
-        graph.edge(1, 2, 1, true).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
-        graph.edge(2, 3, 1, true).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
-        graph.edge(3, 4, 1, true).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
-        graph.edge(4, 1, 1, true).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
-        graph.edge(1, 5, 1, true).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
+        GHUtility.setProperties(graph.edge(0,1).setDistance(1),encoder,60,true, true).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
+        GHUtility.setProperties(graph.edge(1,2).setDistance(1),encoder,60,true, true).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
+        GHUtility.setProperties(graph.edge(2,3).setDistance(1),encoder,60,true, true).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
+        GHUtility.setProperties(graph.edge(3,4).setDistance(1),encoder,60,true, true).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
+        GHUtility.setProperties(graph.edge(4,1).setDistance(1),encoder,60,true, true).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
+        GHUtility.setProperties(graph.edge(1,5).setDistance(1),encoder,60,true, true).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
         graph.freeze();
 
         setCHLevels(2, 4, 3, 1, 5, 0);
@@ -233,12 +233,12 @@ public class ShortcutUnpackerTest {
         DecimalEncodedValue speedEnc = encoder.getAverageSpeedEnc();
         double fwdSpeed = 60;
         double bwdSpeed = 30;
-        EdgeIteratorState edge0 = graph.edge(0, 1, 1, true).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
-        EdgeIteratorState edge1 = graph.edge(1, 2, 1, true).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
-        EdgeIteratorState edge2 = graph.edge(2, 3, 1, true).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
-        EdgeIteratorState edge3 = graph.edge(3, 4, 1, true).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
-        EdgeIteratorState edge4 = graph.edge(4, 5, 1, true).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
-        EdgeIteratorState edge5 = graph.edge(5, 6, 1, true).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
+        EdgeIteratorState edge0 = GHUtility.setProperties(graph.edge(0,1).setDistance(1),encoder,60,true, true).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
+        EdgeIteratorState edge1 = GHUtility.setProperties(graph.edge(1,2).setDistance(1),encoder,60,true, true).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
+        EdgeIteratorState edge2 = GHUtility.setProperties(graph.edge(2,3).setDistance(1),encoder,60,true, true).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
+        EdgeIteratorState edge3 = GHUtility.setProperties(graph.edge(3,4).setDistance(1),encoder,60,true, true).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
+        EdgeIteratorState edge4 = GHUtility.setProperties(graph.edge(4,5).setDistance(1),encoder,60,true, true).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
+        EdgeIteratorState edge5 = GHUtility.setProperties(graph.edge(5,6).setDistance(1),encoder,60,true, true).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
         graph.freeze();
 
         // turn costs ->

--- a/core/src/test/java/com/graphhopper/storage/ShortcutUnpackerTest.java
+++ b/core/src/test/java/com/graphhopper/storage/ShortcutUnpackerTest.java
@@ -4,7 +4,6 @@ import com.carrotsearch.hppc.DoubleArrayList;
 import com.carrotsearch.hppc.IntArrayList;
 import com.graphhopper.routing.ch.PrepareEncoder;
 import com.graphhopper.routing.ch.ShortcutUnpacker;
-import com.graphhopper.routing.ev.DecimalEncodedValue;
 import com.graphhopper.routing.ev.EncodedValueLookup;
 import com.graphhopper.routing.ev.TurnCost;
 import com.graphhopper.routing.util.CarFlagEncoder;
@@ -58,15 +57,14 @@ public class ShortcutUnpackerTest {
     @Test
     public void testUnpacking() {
         // 0-1-2-3-4-5-6
-        DecimalEncodedValue speedEnc = encoder.getAverageSpeedEnc();
-        double fwdSpeed = 60;
-        double bwdSpeed = 30;
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(1)).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(1)).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 3).setDistance(1)).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 4).setDistance(1)).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 5).setDistance(1)).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(5, 6).setDistance(1)).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed); // edge 5
+        GHUtility.setSpeed(60, 30, encoder,
+                graph.edge(0, 1).setDistance(1),
+                graph.edge(1, 2).setDistance(1),
+                graph.edge(2, 3).setDistance(1),
+                graph.edge(3, 4).setDistance(1),
+                graph.edge(4, 5).setDistance(1),
+                graph.edge(5, 6).setDistance(1) // edge 5
+        );
         graph.freeze();
 
         setCHLevels(1, 3, 5, 4, 2, 0, 6);
@@ -153,15 +151,13 @@ public class ShortcutUnpackerTest {
         //   2   4
         //    \ /
         // 0 - 1 - 5
-        DecimalEncodedValue speedEnc = encoder.getAverageSpeedEnc();
-        double fwdSpeed = 60;
-        double bwdSpeed = 30;
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(1)).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(1)).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 3).setDistance(1)).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 4).setDistance(1)).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 1).setDistance(1)).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 5).setDistance(1)).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
+        GHUtility.setSpeed(60, 30, encoder,
+                graph.edge(0, 1).setDistance(1),
+                graph.edge(1, 2).setDistance(1),
+                graph.edge(2, 3).setDistance(1),
+                graph.edge(3, 4).setDistance(1),
+                graph.edge(4, 1).setDistance(1),
+                graph.edge(1, 5).setDistance(1));
         graph.freeze();
 
         setCHLevels(2, 4, 3, 1, 5, 0);
@@ -230,15 +226,14 @@ public class ShortcutUnpackerTest {
         //      2 5 3 2 1 4 6      turn costs ->
         // prev 0-1-2-3-4-5-6 next
         //      1 0 1 4 2 3 2      turn costs <-
-        DecimalEncodedValue speedEnc = encoder.getAverageSpeedEnc();
-        double fwdSpeed = 60;
-        double bwdSpeed = 30;
-        EdgeIteratorState edge0 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(1)).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
-        EdgeIteratorState edge1 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(1)).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
-        EdgeIteratorState edge2 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 3).setDistance(1)).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
-        EdgeIteratorState edge3 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 4).setDistance(1)).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
-        EdgeIteratorState edge4 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 5).setDistance(1)).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
-        EdgeIteratorState edge5 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(5, 6).setDistance(1)).set(speedEnc, fwdSpeed).setReverse(speedEnc, bwdSpeed);
+        EdgeIteratorState edge0, edge1, edge2, edge3, edge4, edge5;
+        GHUtility.setSpeed(60, 30, encoder,
+                edge0 = graph.edge(0, 1).setDistance(1),
+                edge1 = graph.edge(1, 2).setDistance(1),
+                edge2 = graph.edge(2, 3).setDistance(1),
+                edge3 = graph.edge(3, 4).setDistance(1),
+                edge4 = graph.edge(4, 5).setDistance(1),
+                edge5 = graph.edge(5, 6).setDistance(1));
         graph.freeze();
 
         // turn costs ->

--- a/core/src/test/java/com/graphhopper/storage/TurnCostStorageTest.java
+++ b/core/src/test/java/com/graphhopper/storage/TurnCostStorageTest.java
@@ -54,12 +54,12 @@ public class TurnCostStorageTest {
     // |
     // 4
     public static void initGraph(GraphHopperStorage g) {
-        GHUtility.setProperties(Arrays.asList(
+        GHUtility.setSpeed(60, 60, g.getEncodingManager().getEncoder("car"),
                 g.edge(0, 1).setDistance(3),
                 g.edge(0, 2).setDistance(1),
                 g.edge(1, 3).setDistance(1),
                 g.edge(2, 3).setDistance(1),
-                g.edge(2, 4).setDistance(1)), g.getEncodingManager(), true, true);
+                g.edge(2, 4).setDistance(1));
     }
 
     /**

--- a/core/src/test/java/com/graphhopper/storage/TurnCostStorageTest.java
+++ b/core/src/test/java/com/graphhopper/storage/TurnCostStorageTest.java
@@ -24,6 +24,7 @@ import com.graphhopper.routing.util.BikeFlagEncoder;
 import com.graphhopper.routing.util.CarFlagEncoder;
 import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.routing.util.FlagEncoder;
+import com.graphhopper.util.GHUtility;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -52,12 +53,13 @@ public class TurnCostStorageTest {
     // 2--3
     // |
     // 4
-    public static void initGraph(Graph g) {
-        g.edge(0, 1, 3, true);
-        g.edge(0, 2, 1, true);
-        g.edge(1, 3, 1, true);
-        g.edge(2, 3, 1, true);
-        g.edge(2, 4, 1, true);
+    public static void initGraph(GraphHopperStorage g) {
+        GHUtility.setProperties(Arrays.asList(
+                g.edge(0, 1).setDistance(3),
+                g.edge(0, 2).setDistance(1),
+                g.edge(1, 3).setDistance(1),
+                g.edge(2, 3).setDistance(1),
+                g.edge(2, 4).setDistance(1)), g.getEncodingManager(), true, true);
     }
 
     /**

--- a/core/src/test/java/com/graphhopper/storage/index/AbstractLocationIndexTester.java
+++ b/core/src/test/java/com/graphhopper/storage/index/AbstractLocationIndexTester.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import java.io.Closeable;
 import java.io.File;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
@@ -111,14 +112,18 @@ public abstract class AbstractLocationIndexTester {
         na.setNode(4, 6, 1);
         na.setNode(5, 4, 4);
         na.setNode(6, 4.5, -0.5);
-        GHUtility.setProperties(Arrays.asList(g.edge(0, 1).setDistance(3.5),
+        List<EdgeIteratorState> list = Arrays.asList(g.edge(0, 1).setDistance(3.5),
                 g.edge(0, 2).setDistance(2.5),
                 g.edge(2, 3).setDistance(1),
                 g.edge(3, 4).setDistance(3.2),
                 g.edge(1, 4).setDistance(2.4),
                 g.edge(3, 5).setDistance(1.5),
                 // make sure 6 is connected
-                g.edge(6, 4).setDistance(1.2)), em, true, true);
+                g.edge(6, 4).setDistance(1.2));
+        for (FlagEncoder encoder : em.fetchEdgeEncoders()) {
+            double speed = encoder.getMaxSpeed() / 2;
+            GHUtility.setSpeed(speed, speed, encoder, list);
+        }
     }
 
     @Test
@@ -151,7 +156,7 @@ public abstract class AbstractLocationIndexTester {
 
         idx = createIndex(g, -1);
         // if we would use less array entries then some points gets the same key so avoid that for this test
-        // e.g. for 16 we get "expected 6 but was 9" i.e 6 was overwritten by node j9 which is a bit closer to the grid center        
+        // e.g. for 16 we get "expected 6 but was 9" i.e 6 was overwritten by node j9 which is a bit closer to the grid center
         // go through every point of the graph if all points are reachable
         NodeAccess na = g.getNodeAccess();
         for (int i = 0; i < locs; i++) {
@@ -302,26 +307,26 @@ public abstract class AbstractLocationIndexTester {
         // => 17 locations
 
         FlagEncoder encoder = encodingManager.getEncoder("car");
-        GHUtility.setProperties(graph.edge(a0, b1).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(c2, b1).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(c2, d3).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(f5, b1).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(e4, f5).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(m12, d3).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(e4, k10).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(f5, d3).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(f5, i8).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(f5, j9).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(k10, g6).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(j9, l11).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(i8, l11).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(i8, h7).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(k10, n13).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(k10, o14).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(l11, p15).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(m12, p15).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(q16, p15).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(q16, m12).setDistance(1), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(a0, b1).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(c2, b1).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(c2, d3).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(f5, b1).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(e4, f5).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(m12, d3).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(e4, k10).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(f5, d3).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(f5, i8).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(f5, j9).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(k10, g6).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(j9, l11).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(i8, l11).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(i8, h7).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(k10, n13).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(k10, o14).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(l11, p15).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(m12, p15).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(q16, p15).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(q16, m12).setDistance(1));
         return graph;
     }
 

--- a/core/src/test/java/com/graphhopper/storage/index/AbstractLocationIndexTester.java
+++ b/core/src/test/java/com/graphhopper/storage/index/AbstractLocationIndexTester.java
@@ -343,7 +343,7 @@ public abstract class AbstractLocationIndexTester {
         FlagEncoder encoder = encodingManager.getEncoder("foot");
         BooleanEncodedValue accessEnc = encoder.getAccessEnc();
         while (iter.next()) {
-            iter.set(accessEnc, false).setReverse(accessEnc, false);
+            iter.set(accessEnc, false, false);
         }
         idx.close();
 

--- a/core/src/test/java/com/graphhopper/storage/index/AbstractLocationIndexTester.java
+++ b/core/src/test/java/com/graphhopper/storage/index/AbstractLocationIndexTester.java
@@ -20,16 +20,14 @@ package com.graphhopper.storage.index;
 import com.graphhopper.routing.ev.BooleanEncodedValue;
 import com.graphhopper.routing.util.*;
 import com.graphhopper.storage.*;
-import com.graphhopper.util.DistanceCalc;
-import com.graphhopper.util.DistanceCalcEarth;
-import com.graphhopper.util.EdgeIterator;
-import com.graphhopper.util.Helper;
+import com.graphhopper.util.*;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.Closeable;
 import java.io.File;
+import java.util.Arrays;
 import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
@@ -74,8 +72,9 @@ public abstract class AbstractLocationIndexTester {
 
     @Test
     public void testSimpleGraph() {
-        Graph g = AbstractLocationIndexTester.this.createGHStorage(EncodingManager.create("car"));
-        initSimpleGraph(g);
+        EncodingManager em = EncodingManager.create("car");
+        Graph g = AbstractLocationIndexTester.this.createGHStorage(em);
+        initSimpleGraph(g, em);
 
         idx = createIndex(g, -1);
         assertEquals(4, findID(idx, 5, 2));
@@ -91,7 +90,7 @@ public abstract class AbstractLocationIndexTester {
         Helper.close((Closeable) g);
     }
 
-    public void initSimpleGraph(Graph g) {
+    public static void initSimpleGraph(Graph g, EncodingManager em) {
         //  6 |       4
         //  5 |           
         //    |     6
@@ -112,20 +111,21 @@ public abstract class AbstractLocationIndexTester {
         na.setNode(4, 6, 1);
         na.setNode(5, 4, 4);
         na.setNode(6, 4.5, -0.5);
-        g.edge(0, 1, 3.5, true);
-        g.edge(0, 2, 2.5, true);
-        g.edge(2, 3, 1, true);
-        g.edge(3, 4, 3.2, true);
-        g.edge(1, 4, 2.4, true);
-        g.edge(3, 5, 1.5, true);
-        // make sure 6 is connected
-        g.edge(6, 4, 1.2, true);
+        GHUtility.setProperties(Arrays.asList(g.edge(0, 1).setDistance(3.5),
+                g.edge(0, 2).setDistance(2.5),
+                g.edge(2, 3).setDistance(1),
+                g.edge(3, 4).setDistance(3.2),
+                g.edge(1, 4).setDistance(2.4),
+                g.edge(3, 5).setDistance(1.5),
+                // make sure 6 is connected
+                g.edge(6, 4).setDistance(1.2)), em, true, true);
     }
 
     @Test
     public void testSimpleGraph2() {
-        Graph g = AbstractLocationIndexTester.this.createGHStorage(EncodingManager.create("car"));
-        initSimpleGraph(g);
+        EncodingManager em = EncodingManager.create("car");
+        Graph g = AbstractLocationIndexTester.this.createGHStorage(em);
+        initSimpleGraph(g, em);
 
         idx = createIndex(g, -1);
         assertEquals(4, findID(idx, 5, 2));
@@ -301,26 +301,27 @@ public abstract class AbstractLocationIndexTester {
         na.setNode(16, 5, 5);
         // => 17 locations
 
-        graph.edge(a0, b1, 1, true);
-        graph.edge(c2, b1, 1, true);
-        graph.edge(c2, d3, 1, true);
-        graph.edge(f5, b1, 1, true);
-        graph.edge(e4, f5, 1, true);
-        graph.edge(m12, d3, 1, true);
-        graph.edge(e4, k10, 1, true);
-        graph.edge(f5, d3, 1, true);
-        graph.edge(f5, i8, 1, true);
-        graph.edge(f5, j9, 1, true);
-        graph.edge(k10, g6, 1, true);
-        graph.edge(j9, l11, 1, true);
-        graph.edge(i8, l11, 1, true);
-        graph.edge(i8, h7, 1, true);
-        graph.edge(k10, n13, 1, true);
-        graph.edge(k10, o14, 1, true);
-        graph.edge(l11, p15, 1, true);
-        graph.edge(m12, p15, 1, true);
-        graph.edge(q16, p15, 1, true);
-        graph.edge(q16, m12, 1, true);
+        FlagEncoder encoder = encodingManager.getEncoder("car");
+        GHUtility.setProperties(graph.edge(a0, b1).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(c2, b1).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(c2, d3).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(f5, b1).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(e4, f5).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(m12, d3).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(e4, k10).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(f5, d3).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(f5, i8).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(f5, j9).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(k10, g6).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(j9, l11).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(i8, l11).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(i8, h7).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(k10, n13).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(k10, o14).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(l11, p15).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(m12, p15).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(q16, p15).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(q16, m12).setDistance(1), encoder, 60, true, true);
         return graph;
     }
 
@@ -328,7 +329,7 @@ public abstract class AbstractLocationIndexTester {
     public void testDifferentVehicles() {
         final EncodingManager encodingManager = EncodingManager.create("car,foot");
         Graph g = AbstractLocationIndexTester.this.createGHStorage(encodingManager);
-        initSimpleGraph(g);
+        initSimpleGraph(g, encodingManager);
         idx = createIndex(g, -1);
         assertEquals(1, findID(idx, 1, -1));
 

--- a/core/src/test/java/com/graphhopper/storage/index/LocationIndexTreeTest.java
+++ b/core/src/test/java/com/graphhopper/storage/index/LocationIndexTreeTest.java
@@ -76,13 +76,13 @@ public class LocationIndexTreeTest extends AbstractLocationIndexTester {
         na.setNode(2, -1, -1);
         na.setNode(3, -0.4, 0.9);
         na.setNode(4, -0.6, 1.6);
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(0, 2).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(0, 4).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 3).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 4).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 4).setDistance(1));
         return graph;
     }
 
@@ -249,9 +249,9 @@ public class LocationIndexTreeTest extends AbstractLocationIndexTester {
         na.setNode(2, 51.2, 9.4);
         na.setNode(3, 49, 10);
 
-        GHUtility.setProperties(graph.edge(1, 0).setDistance(1000), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(0, 2).setDistance(1000), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(0, 3).setDistance(1000), encoder, 60, true, true).setWayGeometry(Helper.createPointList(51.21, 9.43));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 0).setDistance(1000));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 2).setDistance(1000));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 3).setDistance(1000)).setWayGeometry(Helper.createPointList(51.21, 9.43));
         LocationIndex index = createIndex(graph, -1);
         assertEquals(2, findID(index, 51.2, 9.4));
     }
@@ -274,14 +274,14 @@ public class LocationIndexTreeTest extends AbstractLocationIndexTester {
         na.setNode(2, -1, -1);
         na.setNode(3, -0.4, 0.9);
         na.setNode(4, -0.6, 1.6);
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(0, 2).setDistance(1), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 2).setDistance(1));
         // insert A and B, without this we would get 0 for 0,0
-        GHUtility.setProperties(graph.edge(0, 4).setDistance(1), encoder, 60, true, true).setWayGeometry(Helper.createPointList(1, 1));
-        GHUtility.setProperties(graph.edge(1, 3).setDistance(1), encoder, 60, true, true).setWayGeometry(Helper.createPointList(0, 0));
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 4).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 4).setDistance(1)).setWayGeometry(Helper.createPointList(1, 1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 3).setDistance(1)).setWayGeometry(Helper.createPointList(0, 0));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 4).setDistance(1));
         return graph;
     }
 
@@ -304,9 +304,9 @@ public class LocationIndexTreeTest extends AbstractLocationIndexTester {
         na.setNode(20, 52, 9);
         na.setNode(30, 51.2, 9.4);
         na.setNode(50, 49, 10);
-        GHUtility.setProperties(g.edge(20, 50).setDistance(1), encoder, 60, true, true).setWayGeometry(Helper.createPointList(51.25, 9.43));
-        GHUtility.setProperties(g.edge(10, 20).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(20, 30).setDistance(1), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(20, 50).setDistance(1)).setWayGeometry(Helper.createPointList(51.25, 9.43));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(10, 20).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(20, 30).setDistance(1));
 
         LocationIndex index = createIndex(g, 2000);
         assertEquals(20, findID(index, 51.25, 9.43));
@@ -381,44 +381,44 @@ public class LocationIndexTreeTest extends AbstractLocationIndexTester {
         // top right
         na.setNode(101, 49.96053, 11.58814);
 
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(10), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(10), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(10), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(3, 4).setDistance(10), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(4, 5).setDistance(10), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(6, 7).setDistance(10), encoder, 60, true, true);
+        GHUtility.setSpeed(60, 60, encoder,
+                graph.edge(0, 1).setDistance(10),
+                graph.edge(1, 2).setDistance(10),
+                graph.edge(2, 3).setDistance(10),
+                graph.edge(3, 4).setDistance(10),
+                graph.edge(4, 5).setDistance(10),
+                graph.edge(6, 7).setDistance(10),
+                graph.edge(2, 8).setDistance(10),
+                graph.edge(2, 9).setDistance(10),
+                graph.edge(3, 10).setDistance(10),
+                graph.edge(4, 11).setDistance(10),
+                graph.edge(5, 12).setDistance(10),
+                graph.edge(6, 13).setDistance(10),
 
-        GHUtility.setProperties(graph.edge(2, 8).setDistance(10), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 9).setDistance(10), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(3, 10).setDistance(10), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(4, 11).setDistance(10), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(5, 12).setDistance(10), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(6, 13).setDistance(10), encoder, 60, true, true);
+                graph.edge(1, 14).setDistance(10),
+                graph.edge(2, 15).setDistance(10),
+                graph.edge(5, 16).setDistance(10),
+                graph.edge(14, 15).setDistance(10),
+                graph.edge(16, 17).setDistance(10),
+                graph.edge(16, 20).setDistance(10),
+                graph.edge(16, 25).setDistance(10),
 
-        GHUtility.setProperties(graph.edge(1, 14).setDistance(10), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 15).setDistance(10), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(5, 16).setDistance(10), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(14, 15).setDistance(10), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(16, 17).setDistance(10), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(16, 20).setDistance(10), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(16, 25).setDistance(10), encoder, 60, true, true);
+                graph.edge(18, 14).setDistance(10),
+                graph.edge(18, 19).setDistance(10),
+                graph.edge(18, 21).setDistance(10),
+                graph.edge(19, 21).setDistance(10),
+                graph.edge(21, 24).setDistance(10),
+                graph.edge(23, 24).setDistance(10),
+                graph.edge(24, 25).setDistance(10),
+                graph.edge(26, 27).setDistance(10),
+                graph.edge(27, 28).setDistance(10),
+                graph.edge(28, 29).setDistance(10),
 
-        GHUtility.setProperties(graph.edge(18, 14).setDistance(10), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(18, 19).setDistance(10), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(18, 21).setDistance(10), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(19, 21).setDistance(10), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(21, 24).setDistance(10), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(23, 24).setDistance(10), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(24, 25).setDistance(10), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(26, 27).setDistance(10), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(27, 28).setDistance(10), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(28, 29).setDistance(10), encoder, 60, true, true);
-
-        GHUtility.setProperties(graph.edge(24, 30).setDistance(10), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(24, 31).setDistance(10), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(26, 32).setDistance(10), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(27, 33).setDistance(10), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(28, 34).setDistance(10), encoder, 60, true, true);
+                graph.edge(24, 30).setDistance(10),
+                graph.edge(24, 31).setDistance(10),
+                graph.edge(26, 32).setDistance(10),
+                graph.edge(27, 33).setDistance(10),
+                graph.edge(28, 34).setDistance(10));
         return graph;
     }
 
@@ -469,10 +469,10 @@ public class LocationIndexTreeTest extends AbstractLocationIndexTester {
                 int index = lonIdx * 10 + latIdx;
                 na.setNode(index, 0.01 * latIdx, 0.01 * lonIdx);
                 if (latIdx < MAX - 1)
-                    GHUtility.setProperties(graph.edge(index, index + 1).setDistance(1000), carEncoder, 60, true, true);
+                    GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(index, index + 1).setDistance(1000));
 
                 if (lonIdx < MAX - 1)
-                    GHUtility.setProperties(graph.edge(index, index + 10).setDistance(1000), carEncoder, 60, true, true);
+                    GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(index, index + 10).setDistance(1000));
             }
         }
 
@@ -519,22 +519,23 @@ public class LocationIndexTreeTest extends AbstractLocationIndexTester {
         na.setNode(7, 0, -179.5);
 
         // just use 1 as distance which is incorrect but does not matter in this unit case
-        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(0, 4).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(1, 5).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(4, 5).setDistance(1), encoder, 60, true, true);
+        GHUtility.setSpeed(60, 60, encoder,
+                graph.edge(0, 1).setDistance(1),
+                graph.edge(0, 4).setDistance(1),
+                graph.edge(1, 5).setDistance(1),
+                graph.edge(4, 5).setDistance(1),
 
-        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(2, 6).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(3, 7).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(graph.edge(6, 7).setDistance(1), encoder, 60, true, true);
+                graph.edge(2, 3).setDistance(1),
+                graph.edge(2, 6).setDistance(1),
+                graph.edge(3, 7).setDistance(1),
+                graph.edge(6, 7).setDistance(1));
 
         // as last edges: create cross boundary edges
         // See #667 where the recommendation is to adjust the import and introduce two pillar nodes 
         // where the connection is cross boundary and would be okay if ignored as real length is 0
-        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, true).setWayGeometry(Helper.createPointList(0, 180, 0, -180));
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(1)).setWayGeometry(Helper.createPointList(0, 180, 0, -180));
         // but this unit test succeeds even without this adjusted import:
-        GHUtility.setProperties(graph.edge(5, 6).setDistance(1), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, graph.edge(5, 6).setDistance(1));
 
         LocationIndexTree index = createIndexNoPrepare(graph, 500);
         index.prepareIndex();

--- a/core/src/test/java/com/graphhopper/storage/index/LocationIndexTreeTest.java
+++ b/core/src/test/java/com/graphhopper/storage/index/LocationIndexTreeTest.java
@@ -68,6 +68,7 @@ public class LocationIndexTreeTest extends AbstractLocationIndexTester {
     // |____/   4
     // 2-------/
     Graph createTestGraph(EncodingManager em) {
+        FlagEncoder encoder = em.getEncoder("car");
         Graph graph = createGHStorage(new RAMDirectory(), em, false);
         NodeAccess na = graph.getNodeAccess();
         na.setNode(0, 0.5, -0.5);
@@ -75,13 +76,13 @@ public class LocationIndexTreeTest extends AbstractLocationIndexTester {
         na.setNode(2, -1, -1);
         na.setNode(3, -0.4, 0.9);
         na.setNode(4, -0.6, 1.6);
-        graph.edge(0, 1, 1, true);
-        graph.edge(0, 2, 1, true);
-        graph.edge(0, 4, 1, true);
-        graph.edge(1, 3, 1, true);
-        graph.edge(2, 3, 1, true);
-        graph.edge(2, 4, 1, true);
-        graph.edge(3, 4, 1, true);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(0, 2).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(0, 4).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 3).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 4).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, true);
         return graph;
     }
 
@@ -240,16 +241,17 @@ public class LocationIndexTreeTest extends AbstractLocationIndexTester {
 
     @Test
     public void testMoreReal() {
-        Graph graph = createGHStorage(EncodingManager.create("car"));
+        FlagEncoder encoder = new CarFlagEncoder();
+        Graph graph = createGHStorage(EncodingManager.create(encoder));
         NodeAccess na = graph.getNodeAccess();
         na.setNode(1, 51.2492152, 9.4317166);
         na.setNode(0, 52, 9);
         na.setNode(2, 51.2, 9.4);
         na.setNode(3, 49, 10);
 
-        graph.edge(1, 0, 1000, true);
-        graph.edge(0, 2, 1000, true);
-        graph.edge(0, 3, 1000, true).setWayGeometry(Helper.createPointList(51.21, 9.43));
+        GHUtility.setProperties(graph.edge(1, 0).setDistance(1000), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(0, 2).setDistance(1000), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(0, 3).setDistance(1000), encoder, 60, true, true).setWayGeometry(Helper.createPointList(51.21, 9.43));
         LocationIndex index = createIndex(graph, -1);
         assertEquals(2, findID(index, 51.2, 9.4));
     }
@@ -265,20 +267,21 @@ public class LocationIndexTreeTest extends AbstractLocationIndexTester {
     //  |
     private Graph createTestGraphWithWayGeometry() {
         Graph graph = createGHStorage(encodingManager);
+        FlagEncoder encoder = encodingManager.getEncoder("car");
         NodeAccess na = graph.getNodeAccess();
         na.setNode(0, 0.5, -0.5);
         na.setNode(1, -0.5, -0.5);
         na.setNode(2, -1, -1);
         na.setNode(3, -0.4, 0.9);
         na.setNode(4, -0.6, 1.6);
-        graph.edge(0, 1, 1, true);
-        graph.edge(0, 2, 1, true);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(0, 2).setDistance(1), encoder, 60, true, true);
         // insert A and B, without this we would get 0 for 0,0
-        graph.edge(0, 4, 1, true).setWayGeometry(Helper.createPointList(1, 1));
-        graph.edge(1, 3, 1, true).setWayGeometry(Helper.createPointList(0, 0));
-        graph.edge(2, 3, 1, true);
-        graph.edge(2, 4, 1, true);
-        graph.edge(3, 4, 1, true);
+        GHUtility.setProperties(graph.edge(0, 4).setDistance(1), encoder, 60, true, true).setWayGeometry(Helper.createPointList(1, 1));
+        GHUtility.setProperties(graph.edge(1, 3).setDistance(1), encoder, 60, true, true).setWayGeometry(Helper.createPointList(0, 0));
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 4).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(1), encoder, 60, true, true);
         return graph;
     }
 
@@ -295,14 +298,15 @@ public class LocationIndexTreeTest extends AbstractLocationIndexTester {
     @Test
     public void testFindingWayGeometry() {
         Graph g = createGHStorage(encodingManager);
+        FlagEncoder encoder = encodingManager.getEncoder("car");
         NodeAccess na = g.getNodeAccess();
         na.setNode(10, 51.2492152, 9.4317166);
         na.setNode(20, 52, 9);
         na.setNode(30, 51.2, 9.4);
         na.setNode(50, 49, 10);
-        g.edge(20, 50, 1, true).setWayGeometry(Helper.createPointList(51.25, 9.43));
-        g.edge(10, 20, 1, true);
-        g.edge(20, 30, 1, true);
+        GHUtility.setProperties(g.edge(20, 50).setDistance(1), encoder, 60, true, true).setWayGeometry(Helper.createPointList(51.25, 9.43));
+        GHUtility.setProperties(g.edge(10, 20).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(20, 30).setDistance(1), encoder, 60, true, true);
 
         LocationIndex index = createIndex(g, 2000);
         assertEquals(20, findID(index, 51.25, 9.43));
@@ -324,6 +328,7 @@ public class LocationIndexTreeTest extends AbstractLocationIndexTester {
 
     // see testgraph2.jpg
     Graph createTestGraph2() {
+        FlagEncoder encoder = encodingManager.getEncoder("car");
         Graph graph = createGHStorage(new RAMDirectory(), encodingManager, false);
         NodeAccess na = graph.getNodeAccess();
         na.setNode(8, 49.94553, 11.57214);
@@ -376,44 +381,44 @@ public class LocationIndexTreeTest extends AbstractLocationIndexTester {
         // top right
         na.setNode(101, 49.96053, 11.58814);
 
-        graph.edge(0, 1, 10, true);
-        graph.edge(1, 2, 10, true);
-        graph.edge(2, 3, 10, true);
-        graph.edge(3, 4, 10, true);
-        graph.edge(4, 5, 10, true);
-        graph.edge(6, 7, 10, true);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(10), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(10), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(10), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(3, 4).setDistance(10), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(4, 5).setDistance(10), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(6, 7).setDistance(10), encoder, 60, true, true);
 
-        graph.edge(2, 8, 10, true);
-        graph.edge(2, 9, 10, true);
-        graph.edge(3, 10, 10, true);
-        graph.edge(4, 11, 10, true);
-        graph.edge(5, 12, 10, true);
-        graph.edge(6, 13, 10, true);
+        GHUtility.setProperties(graph.edge(2, 8).setDistance(10), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 9).setDistance(10), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(3, 10).setDistance(10), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(4, 11).setDistance(10), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(5, 12).setDistance(10), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(6, 13).setDistance(10), encoder, 60, true, true);
 
-        graph.edge(1, 14, 10, true);
-        graph.edge(2, 15, 10, true);
-        graph.edge(5, 16, 10, true);
-        graph.edge(14, 15, 10, true);
-        graph.edge(16, 17, 10, true);
-        graph.edge(16, 20, 10, true);
-        graph.edge(16, 25, 10, true);
+        GHUtility.setProperties(graph.edge(1, 14).setDistance(10), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 15).setDistance(10), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(5, 16).setDistance(10), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(14, 15).setDistance(10), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(16, 17).setDistance(10), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(16, 20).setDistance(10), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(16, 25).setDistance(10), encoder, 60, true, true);
 
-        graph.edge(18, 14, 10, true);
-        graph.edge(18, 19, 10, true);
-        graph.edge(18, 21, 10, true);
-        graph.edge(19, 21, 10, true);
-        graph.edge(21, 24, 10, true);
-        graph.edge(23, 24, 10, true);
-        graph.edge(24, 25, 10, true);
-        graph.edge(26, 27, 10, true);
-        graph.edge(27, 28, 10, true);
-        graph.edge(28, 29, 10, true);
+        GHUtility.setProperties(graph.edge(18, 14).setDistance(10), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(18, 19).setDistance(10), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(18, 21).setDistance(10), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(19, 21).setDistance(10), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(21, 24).setDistance(10), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(23, 24).setDistance(10), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(24, 25).setDistance(10), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(26, 27).setDistance(10), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(27, 28).setDistance(10), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(28, 29).setDistance(10), encoder, 60, true, true);
 
-        graph.edge(24, 30, 10, true);
-        graph.edge(24, 31, 10, true);
-        graph.edge(26, 32, 10, true);
-        graph.edge(27, 33, 10, true);
-        graph.edge(28, 34, 10, true);
+        GHUtility.setProperties(graph.edge(24, 30).setDistance(10), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(24, 31).setDistance(10), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(26, 32).setDistance(10), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(27, 33).setDistance(10), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(28, 34).setDistance(10), encoder, 60, true, true);
         return graph;
     }
 
@@ -464,10 +469,10 @@ public class LocationIndexTreeTest extends AbstractLocationIndexTester {
                 int index = lonIdx * 10 + latIdx;
                 na.setNode(index, 0.01 * latIdx, 0.01 * lonIdx);
                 if (latIdx < MAX - 1)
-                    graph.edge(index, index + 1, 1000, true);
+                    GHUtility.setProperties(graph.edge(index, index + 1).setDistance(1000), carEncoder, 60, true, true);
 
                 if (lonIdx < MAX - 1)
-                    graph.edge(index, index + 10, 1000, true);
+                    GHUtility.setProperties(graph.edge(index, index + 10).setDistance(1000), carEncoder, 60, true, true);
             }
         }
 
@@ -501,6 +506,7 @@ public class LocationIndexTreeTest extends AbstractLocationIndexTester {
     // 4--5--6--7
     @Test
     public void testCrossBoundaryNetwork_issue667() {
+        FlagEncoder encoder = encodingManager.getEncoder("car");
         Graph graph = createGHStorage(new RAMDirectory(), encodingManager, false);
         NodeAccess na = graph.getNodeAccess();
         na.setNode(0, 0.1, 179.5);
@@ -513,22 +519,22 @@ public class LocationIndexTreeTest extends AbstractLocationIndexTester {
         na.setNode(7, 0, -179.5);
 
         // just use 1 as distance which is incorrect but does not matter in this unit case
-        graph.edge(0, 1, 1, true);
-        graph.edge(0, 4, 1, true);
-        graph.edge(1, 5, 1, true);
-        graph.edge(4, 5, 1, true);
+        GHUtility.setProperties(graph.edge(0, 1).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(0, 4).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(1, 5).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(4, 5).setDistance(1), encoder, 60, true, true);
 
-        graph.edge(2, 3, 1, true);
-        graph.edge(2, 6, 1, true);
-        graph.edge(3, 7, 1, true);
-        graph.edge(6, 7, 1, true);
+        GHUtility.setProperties(graph.edge(2, 3).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(2, 6).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(3, 7).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(graph.edge(6, 7).setDistance(1), encoder, 60, true, true);
 
         // as last edges: create cross boundary edges
         // See #667 where the recommendation is to adjust the import and introduce two pillar nodes 
         // where the connection is cross boundary and would be okay if ignored as real length is 0
-        graph.edge(1, 2, 1, true).setWayGeometry(Helper.createPointList(0, 180, 0, -180));
+        GHUtility.setProperties(graph.edge(1, 2).setDistance(1), encoder, 60, true, true).setWayGeometry(Helper.createPointList(0, 180, 0, -180));
         // but this unit test succeeds even without this adjusted import:
-        graph.edge(5, 6, 1, true);
+        GHUtility.setProperties(graph.edge(5, 6).setDistance(1), encoder, 60, true, true);
 
         LocationIndexTree index = createIndexNoPrepare(graph, 500);
         index.prepareIndex();

--- a/core/src/test/java/com/graphhopper/storage/index/LocationIndexTreeTest.java
+++ b/core/src/test/java/com/graphhopper/storage/index/LocationIndexTreeTest.java
@@ -480,10 +480,10 @@ public class LocationIndexTreeTest extends AbstractLocationIndexTester {
         AllEdgesIterator iter = graph.getAllEdges();
         BooleanEncodedValue accessEnc = bikeEncoder.getAccessEnc();
         while (iter.next()) {
-            iter.set(accessEnc, false).setReverse(accessEnc, false);
+            iter.set(accessEnc, false, false);
         }
         for (EdgeIteratorState edge : Arrays.asList(GHUtility.getEdge(graph, 0, 1), GHUtility.getEdge(graph, 1, 2))) {
-            edge.set(accessEnc, true).setReverse(accessEnc, true);
+            edge.set(accessEnc, true, true);
         }
 
         LocationIndexTree index = createIndexNoPrepare(graph, 500);

--- a/core/src/test/java/com/graphhopper/util/BreadthFirstSearchTest.java
+++ b/core/src/test/java/com/graphhopper/util/BreadthFirstSearchTest.java
@@ -65,18 +65,18 @@ public class BreadthFirstSearchTest {
 
         FlagEncoder encoder = new CarFlagEncoder();
         Graph g = new GraphBuilder(EncodingManager.create(encoder)).create();
-        GHUtility.setProperties(g.edge(0, 1).setDistance(85), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(0, 2).setDistance(217), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(0, 3).setDistance(173), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(0, 5).setDistance(173), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(1, 6).setDistance(75), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(2, 7).setDistance(51), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(3, 8).setDistance(23), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(4, 8).setDistance(793), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(8, 10).setDistance(343), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(6, 9).setDistance(72), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(9, 10).setDistance(8), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(5, 10).setDistance(1), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(0, 1).setDistance(85));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(0, 2).setDistance(217));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(0, 3).setDistance(173));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(0, 5).setDistance(173));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(1, 6).setDistance(75));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(2, 7).setDistance(51));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(3, 8).setDistance(23));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(4, 8).setDistance(793));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(8, 10).setDistance(343));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(6, 9).setDistance(72));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(9, 10).setDistance(8));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(5, 10).setDistance(1));
 
         bfs.start(g.createEdgeExplorer(), 0);
 
@@ -105,12 +105,12 @@ public class BreadthFirstSearchTest {
 
         FlagEncoder encoder = new CarFlagEncoder();
         Graph g = new GraphBuilder(EncodingManager.create(encoder)).create();
-        GHUtility.setProperties(g.edge(1, 2).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(g.edge(2, 3).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(g.edge(3, 4).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(g.edge(1, 5).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(g.edge(5, 6).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(g.edge(6, 4).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(2, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(3, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(1, 5).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(5, 6).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(6, 4).setDistance(1));
 
         bfs.start(g.createEdgeExplorer(), 1);
 

--- a/core/src/test/java/com/graphhopper/util/BreadthFirstSearchTest.java
+++ b/core/src/test/java/com/graphhopper/util/BreadthFirstSearchTest.java
@@ -21,7 +21,9 @@ import com.carrotsearch.hppc.IntArrayList;
 import com.graphhopper.coll.GHBitSet;
 import com.graphhopper.coll.GHIntHashSet;
 import com.graphhopper.coll.GHTBitSet;
+import com.graphhopper.routing.util.CarFlagEncoder;
 import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.storage.Graph;
 import com.graphhopper.storage.GraphBuilder;
 import org.junit.Before;
@@ -61,19 +63,20 @@ public class BreadthFirstSearchTest {
             }
         };
 
-        Graph g = new GraphBuilder(EncodingManager.create("car")).create();
-        g.edge(0, 1, 85, true);
-        g.edge(0, 2, 217, true);
-        g.edge(0, 3, 173, true);
-        g.edge(0, 5, 173, true);
-        g.edge(1, 6, 75, true);
-        g.edge(2, 7, 51, true);
-        g.edge(3, 8, 23, true);
-        g.edge(4, 8, 793, true);
-        g.edge(8, 10, 343, true);
-        g.edge(6, 9, 72, true);
-        g.edge(9, 10, 8, true);
-        g.edge(5, 10, 1, true);
+        FlagEncoder encoder = new CarFlagEncoder();
+        Graph g = new GraphBuilder(EncodingManager.create(encoder)).create();
+        GHUtility.setProperties(g.edge(0, 1).setDistance(85), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(0, 2).setDistance(217), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(0, 3).setDistance(173), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(0, 5).setDistance(173), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(1, 6).setDistance(75), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(2, 7).setDistance(51), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(3, 8).setDistance(23), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(4, 8).setDistance(793), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(8, 10).setDistance(343), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(6, 9).setDistance(72), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(9, 10).setDistance(8), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(5, 10).setDistance(1), encoder, 60, true, true);
 
         bfs.start(g.createEdgeExplorer(), 0);
 
@@ -100,13 +103,14 @@ public class BreadthFirstSearchTest {
             }
         };
 
-        Graph g = new GraphBuilder(EncodingManager.create("car")).create();
-        g.edge(1, 2, 1, false);
-        g.edge(2, 3, 1, false);
-        g.edge(3, 4, 1, false);
-        g.edge(1, 5, 1, false);
-        g.edge(5, 6, 1, false);
-        g.edge(6, 4, 1, false);
+        FlagEncoder encoder = new CarFlagEncoder();
+        Graph g = new GraphBuilder(EncodingManager.create(encoder)).create();
+        GHUtility.setProperties(g.edge(1, 2).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(g.edge(2, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(g.edge(3, 4).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(g.edge(1, 5).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(g.edge(5, 6).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(g.edge(6, 4).setDistance(1), encoder, 60, true, false);
 
         bfs.start(g.createEdgeExplorer(), 1);
 

--- a/core/src/test/java/com/graphhopper/util/CHEdgeIteratorTest.java
+++ b/core/src/test/java/com/graphhopper/util/CHEdgeIteratorTest.java
@@ -45,8 +45,8 @@ public class CHEdgeIteratorTest {
         GraphHopperStorage g = new GraphBuilder(encodingManager).setCHConfigs(CHConfig.nodeBased("p", weighting)).create();
         BooleanEncodedValue accessEnc = carFlagEncoder.getAccessEnc();
         DecimalEncodedValue avSpeedEnc = carFlagEncoder.getAverageSpeedEnc();
-        g.edge(0, 1).setDistance(12).set(accessEnc, true).setReverse(accessEnc, true).set(avSpeedEnc, 10.0);
-        g.edge(0, 2).setDistance(13).set(accessEnc, true).setReverse(accessEnc, true).set(avSpeedEnc, 20.0);
+        g.edge(0, 1).setDistance(12).set(accessEnc, true, true).set(avSpeedEnc, 10.0);
+        g.edge(0, 2).setDistance(13).set(accessEnc, true, true).set(avSpeedEnc, 20.0);
         g.freeze();
 
         CHGraph lg = g.getCHGraph();
@@ -60,7 +60,7 @@ public class CHEdgeIteratorTest {
         assertEquals(10.0, iter.getReverse(avSpeedEnc), .1);
 
         // update setProperties
-        iter.set(accessEnc, true).setReverse(accessEnc, false).set(avSpeedEnc, 20.0);
+        iter.set(accessEnc, true, false).set(avSpeedEnc, 20.0);
         assertEquals(12, iter.getDistance(), 1e-4);
 
         // update distance

--- a/core/src/test/java/com/graphhopper/util/DepthFirstSearchTest.java
+++ b/core/src/test/java/com/graphhopper/util/DepthFirstSearchTest.java
@@ -67,13 +67,13 @@ public class DepthFirstSearchTest {
         EncodingManager em = EncodingManager.create("car");
         FlagEncoder encoder = em.getEncoder("car");
         Graph g = new GraphBuilder(em).create();
-        GHUtility.setProperties(g.edge(1, 2).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(g.edge(1, 5).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(g.edge(1, 4).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(g.edge(2, 3).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(g.edge(3, 4).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(g.edge(5, 6).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(g.edge(6, 4).setDistance(1), encoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(1, 5).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(1, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(2, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(3, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(5, 6).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(6, 4).setDistance(1));
 
         dfs.start(g.createEdgeExplorer(DefaultEdgeFilter.outEdges(encoder)), 1);
 
@@ -102,11 +102,11 @@ public class DepthFirstSearchTest {
         EncodingManager em = EncodingManager.create("car");
         FlagEncoder encoder = em.getEncoder("car");
         Graph g = new GraphBuilder(em).create();
-        GHUtility.setProperties(g.edge(1, 2).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(g.edge(1, 4).setDistance(1), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(1, 3).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(g.edge(2, 3).setDistance(1), encoder, 60, true, false);
-        GHUtility.setProperties(g.edge(4, 3).setDistance(1), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(1, 2).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(1, 4).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(1, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(2, 3).setDistance(1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(4, 3).setDistance(1));
 
         dfs.start(g.createEdgeExplorer(DefaultEdgeFilter.outEdges(encoder)), 1);
 

--- a/core/src/test/java/com/graphhopper/util/DepthFirstSearchTest.java
+++ b/core/src/test/java/com/graphhopper/util/DepthFirstSearchTest.java
@@ -65,17 +65,17 @@ public class DepthFirstSearchTest {
         };
 
         EncodingManager em = EncodingManager.create("car");
-        FlagEncoder fe = em.getEncoder("car");
+        FlagEncoder encoder = em.getEncoder("car");
         Graph g = new GraphBuilder(em).create();
-        g.edge(1, 2, 1, false);
-        g.edge(1, 5, 1, false);
-        g.edge(1, 4, 1, false);
-        g.edge(2, 3, 1, false);
-        g.edge(3, 4, 1, false);
-        g.edge(5, 6, 1, false);
-        g.edge(6, 4, 1, false);
+        GHUtility.setProperties(g.edge(1, 2).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(g.edge(1, 5).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(g.edge(1, 4).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(g.edge(2, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(g.edge(3, 4).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(g.edge(5, 6).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(g.edge(6, 4).setDistance(1), encoder, 60, true, false);
 
-        dfs.start(g.createEdgeExplorer(DefaultEdgeFilter.outEdges(fe)), 1);
+        dfs.start(g.createEdgeExplorer(DefaultEdgeFilter.outEdges(encoder)), 1);
 
         assertTrue(counter > 0);
         assertEquals("[1, 2, 3, 4, 5, 6]", list.toString());
@@ -100,15 +100,15 @@ public class DepthFirstSearchTest {
         };
 
         EncodingManager em = EncodingManager.create("car");
-        FlagEncoder fe = em.getEncoder("car");
+        FlagEncoder encoder = em.getEncoder("car");
         Graph g = new GraphBuilder(em).create();
-        g.edge(1, 2, 1, false);
-        g.edge(1, 4, 1, true);
-        g.edge(1, 3, 1, false);
-        g.edge(2, 3, 1, false);
-        g.edge(4, 3, 1, true);
+        GHUtility.setProperties(g.edge(1, 2).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(g.edge(1, 4).setDistance(1), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(1, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(g.edge(2, 3).setDistance(1), encoder, 60, true, false);
+        GHUtility.setProperties(g.edge(4, 3).setDistance(1), encoder, 60, true, true);
 
-        dfs.start(g.createEdgeExplorer(DefaultEdgeFilter.outEdges(fe)), 1);
+        dfs.start(g.createEdgeExplorer(DefaultEdgeFilter.outEdges(encoder)), 1);
 
         assertTrue(counter > 0);
         assertEquals("[1, 2, 3, 4]", list.toString());

--- a/core/src/test/java/com/graphhopper/util/GHUtilityTest.java
+++ b/core/src/test/java/com/graphhopper/util/GHUtilityTest.java
@@ -59,12 +59,12 @@ public class GHUtilityTest {
         na.setNode(6, 2.3, 2.2);
         na.setNode(7, 5, 1.5);
         na.setNode(8, 4.6, 4);
-        GHUtility.setProperties(g.edge(8, 2).setDistance(0.5), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(7, 3).setDistance(2.1), encoder, 60, true, false);
-        GHUtility.setProperties(g.edge(1, 0).setDistance(3.9), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(7, 5).setDistance(0.7), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(1, 2).setDistance(1.9), encoder, 60, true, true);
-        GHUtility.setProperties(g.edge(8, 1).setDistance(2.05), encoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(8, 2).setDistance(0.5));
+        GHUtility.setSpeed(60, true, false, encoder, g.edge(7, 3).setDistance(2.1));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(1, 0).setDistance(3.9));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(7, 5).setDistance(0.7));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(1, 2).setDistance(1.9));
+        GHUtility.setSpeed(60, true, true, encoder, g.edge(8, 1).setDistance(2.05));
         return g;
     }
 
@@ -117,15 +117,15 @@ public class GHUtilityTest {
         na.setNode(0, 0, 1);
         na.setNode(1, 2.5, 2);
         na.setNode(2, 3.5, 3);
-        GHUtility.setProperties(g.edge(0, 1).setDistance(1.1), carEncoder, 60, true, false);
-        GHUtility.setProperties(g.edge(2, 1).setDistance(1.1), carEncoder, 60, true, false);
+        GHUtility.setSpeed(60, true, false, carEncoder, g.edge(0, 1).setDistance(1.1));
+        GHUtility.setSpeed(60, true, false, carEncoder, g.edge(2, 1).setDistance(1.1));
         GHUtility.sortDFS(g, createGraph());
     }
 
     @Test
     public void testCopyWithSelfRef() {
         Graph g = initUnsorted(createGraph(), carEncoder);
-        GHUtility.setProperties(g.edge(0, 0).setDistance(11), carEncoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(0, 0).setDistance(11));
 
         Graph g2 = new GraphBuilder(encodingManager).create();
         GHUtility.copyTo(g, g2);
@@ -136,7 +136,7 @@ public class GHUtilityTest {
     @Test
     public void testCopy() {
         Graph g = initUnsorted(createGraph(), carEncoder);
-        EdgeIteratorState edgeState = GHUtility.setProperties(g.edge(6, 5).setDistance(11), carEncoder, 60, true, true);
+        EdgeIteratorState edgeState = GHUtility.setSpeed(60, true, true, carEncoder, g.edge(6, 5).setDistance(11));
         edgeState.setWayGeometry(Helper.createPointList(12, 10, -1, 3));
 
         GraphHopperStorage newStore = new GraphBuilder(encodingManager).setCHConfigs(CHConfig.nodeBased("p2", new FastestWeighting(carEncoder))).create();

--- a/core/src/test/java/com/graphhopper/util/GHUtilityTest.java
+++ b/core/src/test/java/com/graphhopper/util/GHUtilityTest.java
@@ -48,7 +48,7 @@ public class GHUtilityTest {
     //   6     \1
     //   ______/
     // 0/
-    Graph initUnsorted(Graph g) {
+    Graph initUnsorted(Graph g, FlagEncoder encoder) {
         NodeAccess na = g.getNodeAccess();
         na.setNode(0, 0, 1);
         na.setNode(1, 2.5, 4.5);
@@ -59,12 +59,12 @@ public class GHUtilityTest {
         na.setNode(6, 2.3, 2.2);
         na.setNode(7, 5, 1.5);
         na.setNode(8, 4.6, 4);
-        g.edge(8, 2, 0.5, true);
-        g.edge(7, 3, 2.1, false);
-        g.edge(1, 0, 3.9, true);
-        g.edge(7, 5, 0.7, true);
-        g.edge(1, 2, 1.9, true);
-        g.edge(8, 1, 2.05, true);
+        GHUtility.setProperties(g.edge(8, 2).setDistance(0.5), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(7, 3).setDistance(2.1), encoder, 60, true, false);
+        GHUtility.setProperties(g.edge(1, 0).setDistance(3.9), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(7, 5).setDistance(0.7), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(1, 2).setDistance(1.9), encoder, 60, true, true);
+        GHUtility.setProperties(g.edge(8, 1).setDistance(2.05), encoder, 60, true, true);
         return g;
     }
 
@@ -83,7 +83,7 @@ public class GHUtilityTest {
 
     @Test
     public void testSort() {
-        Graph g = initUnsorted(createGraph());
+        Graph g = initUnsorted(createGraph(), carEncoder);
         Graph newG = GHUtility.sortDFS(g, createGraph());
         assertEquals(g.getNodes(), newG.getNodes());
         assertEquals(g.getEdges(), newG.getEdges());
@@ -117,15 +117,15 @@ public class GHUtilityTest {
         na.setNode(0, 0, 1);
         na.setNode(1, 2.5, 2);
         na.setNode(2, 3.5, 3);
-        g.edge(0, 1, 1.1, false);
-        g.edge(2, 1, 1.1, false);
+        GHUtility.setProperties(g.edge(0, 1).setDistance(1.1), carEncoder, 60, true, false);
+        GHUtility.setProperties(g.edge(2, 1).setDistance(1.1), carEncoder, 60, true, false);
         GHUtility.sortDFS(g, createGraph());
     }
 
     @Test
     public void testCopyWithSelfRef() {
-        Graph g = initUnsorted(createGraph());
-        g.edge(0, 0, 11, true);
+        Graph g = initUnsorted(createGraph(), carEncoder);
+        GHUtility.setProperties(g.edge(0, 0).setDistance(11), carEncoder, 60, true, true);
 
         Graph g2 = new GraphBuilder(encodingManager).create();
         GHUtility.copyTo(g, g2);
@@ -135,8 +135,8 @@ public class GHUtilityTest {
 
     @Test
     public void testCopy() {
-        Graph g = initUnsorted(createGraph());
-        EdgeIteratorState edgeState = g.edge(6, 5, 11, true);
+        Graph g = initUnsorted(createGraph(), carEncoder);
+        EdgeIteratorState edgeState = GHUtility.setProperties(g.edge(6, 5).setDistance(11), carEncoder, 60, true, true);
         edgeState.setWayGeometry(Helper.createPointList(12, 10, -1, 3));
 
         GraphHopperStorage newStore = new GraphBuilder(encodingManager).setCHConfigs(CHConfig.nodeBased("p2", new FastestWeighting(carEncoder))).create();

--- a/core/src/test/java/com/graphhopper/util/InstructionListTest.java
+++ b/core/src/test/java/com/graphhopper/util/InstructionListTest.java
@@ -21,16 +21,11 @@ import com.carrotsearch.hppc.IntArrayList;
 import com.graphhopper.routing.Dijkstra;
 import com.graphhopper.routing.InstructionsFromEdges;
 import com.graphhopper.routing.Path;
-import com.graphhopper.routing.ev.EnumEncodedValue;
-import com.graphhopper.routing.ev.RoadAccess;
-import com.graphhopper.routing.ev.RoadEnvironment;
 import com.graphhopper.routing.util.CarFlagEncoder;
 import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.routing.util.TraversalMode;
-import com.graphhopper.routing.weighting.FastestWeighting;
 import com.graphhopper.routing.weighting.ShortestWeighting;
-import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.Graph;
 import com.graphhopper.storage.GraphBuilder;
 import com.graphhopper.storage.NodeAccess;
@@ -92,27 +87,27 @@ public class InstructionListTest {
         na.setNode(6, 1.0, 1.0);
         na.setNode(7, 1.0, 1.1);
         na.setNode(8, 1.0, 1.2);
-        g.edge(0, 1, 10000, true).setName("0-1");
-        g.edge(1, 2, 11000, true).setName("1-2");
+        GHUtility.setProperties(g.edge(0, 1).setDistance(10000), carEncoder, 60, true, true).setName("0-1");
+        GHUtility.setProperties(g.edge(1, 2).setDistance(11000), carEncoder, 60, true, true).setName("1-2");
 
-        g.edge(0, 3, 11000, true);
-        g.edge(1, 4, 10000, true).setName("1-4");
-        g.edge(2, 5, 11000, true).setName("5-2");
+        GHUtility.setProperties(g.edge(0, 3).setDistance(11000), carEncoder, 60, true, true);
+        GHUtility.setProperties(g.edge(1, 4).setDistance(10000), carEncoder, 60, true, true).setName("1-4");
+        GHUtility.setProperties(g.edge(2, 5).setDistance(11000), carEncoder, 60, true, true).setName("5-2");
 
-        g.edge(3, 6, 11000, true).setName("3-6");
-        g.edge(4, 7, 10000, true).setName("4-7");
-        g.edge(5, 8, 10000, true).setName("5-8");
+        GHUtility.setProperties(g.edge(3, 6).setDistance(11000), carEncoder, 60, true, true).setName("3-6");
+        GHUtility.setProperties(g.edge(4, 7).setDistance(10000), carEncoder, 60, true, true).setName("4-7");
+        GHUtility.setProperties(g.edge(5, 8).setDistance(10000), carEncoder, 60, true, true).setName("5-8");
 
-        g.edge(6, 7, 11000, true).setName("6-7");
-        EdgeIteratorState iter = g.edge(7, 8, 10000, true);
+        GHUtility.setProperties(g.edge(6, 7).setDistance(11000), carEncoder, 60, true, true).setName("6-7");
+        EdgeIteratorState iter = GHUtility.setProperties(g.edge(7, 8).setDistance(10000), carEncoder, 60, true, true);
         PointList list = new PointList();
         list.add(1.0, 1.15);
         list.add(1.0, 1.16);
         iter.setWayGeometry(list);
         iter.setName("7-8");
         // missing edge name
-        g.edge(9, 10, 10000, true);
-        EdgeIteratorState iter2 = g.edge(8, 9, 20000, true);
+        GHUtility.setProperties(g.edge(9, 10).setDistance(10000), carEncoder, 60, true, true);
+        EdgeIteratorState iter2 = GHUtility.setProperties(g.edge(8, 9).setDistance(20000), carEncoder, 60, true, true);
         list.clear();
         list.add(1.0, 1.3);
         iter2.setName("8-9");
@@ -184,10 +179,10 @@ public class InstructionListTest {
         na.setNode(3, 10.0, 10.08);
         na.setNode(4, 10.1, 10.10);
         na.setNode(5, 10.2, 10.13);
-        g.edge(3, 4, 100, true).setName("3-4");
-        g.edge(4, 5, 100, true).setName("4-5");
+        GHUtility.setProperties(g.edge(3, 4).setDistance(100), carEncoder, 60, true, true).setName("3-4");
+        GHUtility.setProperties(g.edge(4, 5).setDistance(100), carEncoder, 60, true, true).setName("4-5");
 
-        EdgeIteratorState iter = g.edge(2, 4, 100, true);
+        EdgeIteratorState iter = GHUtility.setProperties(g.edge(2, 4).setDistance(100), carEncoder, 60, true, true);
         iter.setName("2-4");
         PointList list = new PointList();
         list.add(10.20, 10.05);
@@ -224,10 +219,10 @@ public class InstructionListTest {
         na.setNode(3, 10.0, 10.05);
         na.setNode(4, 10.1, 10.10);
         na.setNode(5, 10.2, 10.15);
-        g.edge(3, 4, 100, true).setName("street");
-        g.edge(4, 5, 100, true).setName("4-5");
+        GHUtility.setProperties(g.edge(3, 4).setDistance(100), carEncoder, 60, true, true).setName("street");
+        GHUtility.setProperties(g.edge(4, 5).setDistance(100), carEncoder, 60, true, true).setName("4-5");
 
-        EdgeIteratorState iter = g.edge(2, 4, 100, true);
+        EdgeIteratorState iter = GHUtility.setProperties(g.edge(2, 4).setDistance(100), carEncoder, 60, true, true);
         iter.setName("street");
         PointList list = new PointList();
         list.add(10.20, 10.05);
@@ -258,9 +253,9 @@ public class InstructionListTest {
         na.setNode(2, 51.73458, 9.225442);
         na.setNode(3, 51.734643, 9.22541);
         na.setNode(4, 51.734451, 9.225436);
-        g.edge(1, 2, 10, true);
-        g.edge(2, 3, 10, true);
-        g.edge(2, 4, 10, true);
+        GHUtility.setProperties(g.edge(1, 2).setDistance(10), carEncoder, 60, true, true);
+        GHUtility.setProperties(g.edge(2, 3).setDistance(10), carEncoder, 60, true, true);
+        GHUtility.setProperties(g.edge(2, 4).setDistance(10), carEncoder, 60, true, true);
 
         ShortestWeighting weighting = new ShortestWeighting(carEncoder);
         Path p = new Dijkstra(g, weighting, tMode).calcPath(1, 3);
@@ -287,9 +282,9 @@ public class InstructionListTest {
         na.setNode(2, 48.748577, 9.322152);
         na.setNode(3, 48.748776, 9.321889);
         na.setNode(4, 48.74847, 9.322299);
-        g.edge(1, 2, 10, true);
-        g.edge(2, 3, 10, true);
-        g.edge(2, 4, 10, true);
+        GHUtility.setProperties(g.edge(1, 2).setDistance(10), carEncoder, 60, true, true);
+        GHUtility.setProperties(g.edge(2, 3).setDistance(10), carEncoder, 60, true, true);
+        GHUtility.setProperties(g.edge(2, 4).setDistance(10), carEncoder, 60, true, true);
 
         ShortestWeighting weighting = new ShortestWeighting(carEncoder);
         Path p = new Dijkstra(g, weighting, tMode).calcPath(1, 3);
@@ -326,12 +321,12 @@ public class InstructionListTest {
         na.setNode(6, 15.1, 10.1);
         na.setNode(7, 15.1, 9.8);
 
-        g.edge(1, 2, 10000, true).setName("1-2");
-        g.edge(2, 3, 10000, true).setName("2-3");
-        g.edge(2, 6, 10000, true).setName("2-6");
-        g.edge(3, 4, 10000, true).setName("3-4").setWayGeometry(waypoint);
-        g.edge(3, 7, 10000, true).setName("3-7");
-        g.edge(4, 5, 10000, true).setName("4-5");
+        GHUtility.setProperties(g.edge(1, 2).setDistance(10000), carEncoder, 60, true, true).setName("1-2");
+        GHUtility.setProperties(g.edge(2, 3).setDistance(10000), carEncoder, 60, true, true).setName("2-3");
+        GHUtility.setProperties(g.edge(2, 6).setDistance(10000), carEncoder, 60, true, true).setName("2-6");
+        GHUtility.setProperties(g.edge(3, 4).setDistance(10000), carEncoder, 60, true, true).setName("3-4").setWayGeometry(waypoint);
+        GHUtility.setProperties(g.edge(3, 7).setDistance(10000), carEncoder, 60, true, true).setName("3-7");
+        GHUtility.setProperties(g.edge(4, 5).setDistance(10000), carEncoder, 60, true, true).setName("4-5");
 
         ShortestWeighting weighting = new ShortestWeighting(carEncoder);
         Path p = new Dijkstra(g, weighting, tMode).calcPath(1, 5);

--- a/core/src/test/java/com/graphhopper/util/InstructionListTest.java
+++ b/core/src/test/java/com/graphhopper/util/InstructionListTest.java
@@ -87,27 +87,27 @@ public class InstructionListTest {
         na.setNode(6, 1.0, 1.0);
         na.setNode(7, 1.0, 1.1);
         na.setNode(8, 1.0, 1.2);
-        GHUtility.setProperties(g.edge(0, 1).setDistance(10000), carEncoder, 60, true, true).setName("0-1");
-        GHUtility.setProperties(g.edge(1, 2).setDistance(11000), carEncoder, 60, true, true).setName("1-2");
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(0, 1).setDistance(10000)).setName("0-1");
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(1, 2).setDistance(11000)).setName("1-2");
 
-        GHUtility.setProperties(g.edge(0, 3).setDistance(11000), carEncoder, 60, true, true);
-        GHUtility.setProperties(g.edge(1, 4).setDistance(10000), carEncoder, 60, true, true).setName("1-4");
-        GHUtility.setProperties(g.edge(2, 5).setDistance(11000), carEncoder, 60, true, true).setName("5-2");
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(0, 3).setDistance(11000));
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(1, 4).setDistance(10000)).setName("1-4");
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(2, 5).setDistance(11000)).setName("5-2");
 
-        GHUtility.setProperties(g.edge(3, 6).setDistance(11000), carEncoder, 60, true, true).setName("3-6");
-        GHUtility.setProperties(g.edge(4, 7).setDistance(10000), carEncoder, 60, true, true).setName("4-7");
-        GHUtility.setProperties(g.edge(5, 8).setDistance(10000), carEncoder, 60, true, true).setName("5-8");
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(3, 6).setDistance(11000)).setName("3-6");
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(4, 7).setDistance(10000)).setName("4-7");
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(5, 8).setDistance(10000)).setName("5-8");
 
-        GHUtility.setProperties(g.edge(6, 7).setDistance(11000), carEncoder, 60, true, true).setName("6-7");
-        EdgeIteratorState iter = GHUtility.setProperties(g.edge(7, 8).setDistance(10000), carEncoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(6, 7).setDistance(11000)).setName("6-7");
+        EdgeIteratorState iter = GHUtility.setSpeed(60, true, true, carEncoder, g.edge(7, 8).setDistance(10000));
         PointList list = new PointList();
         list.add(1.0, 1.15);
         list.add(1.0, 1.16);
         iter.setWayGeometry(list);
         iter.setName("7-8");
         // missing edge name
-        GHUtility.setProperties(g.edge(9, 10).setDistance(10000), carEncoder, 60, true, true);
-        EdgeIteratorState iter2 = GHUtility.setProperties(g.edge(8, 9).setDistance(20000), carEncoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(9, 10).setDistance(10000));
+        EdgeIteratorState iter2 = GHUtility.setSpeed(60, true, true, carEncoder, g.edge(8, 9).setDistance(20000));
         list.clear();
         list.add(1.0, 1.3);
         iter2.setName("8-9");
@@ -179,10 +179,10 @@ public class InstructionListTest {
         na.setNode(3, 10.0, 10.08);
         na.setNode(4, 10.1, 10.10);
         na.setNode(5, 10.2, 10.13);
-        GHUtility.setProperties(g.edge(3, 4).setDistance(100), carEncoder, 60, true, true).setName("3-4");
-        GHUtility.setProperties(g.edge(4, 5).setDistance(100), carEncoder, 60, true, true).setName("4-5");
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(3, 4).setDistance(100)).setName("3-4");
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(4, 5).setDistance(100)).setName("4-5");
 
-        EdgeIteratorState iter = GHUtility.setProperties(g.edge(2, 4).setDistance(100), carEncoder, 60, true, true);
+        EdgeIteratorState iter = GHUtility.setSpeed(60, true, true, carEncoder, g.edge(2, 4).setDistance(100));
         iter.setName("2-4");
         PointList list = new PointList();
         list.add(10.20, 10.05);
@@ -219,10 +219,10 @@ public class InstructionListTest {
         na.setNode(3, 10.0, 10.05);
         na.setNode(4, 10.1, 10.10);
         na.setNode(5, 10.2, 10.15);
-        GHUtility.setProperties(g.edge(3, 4).setDistance(100), carEncoder, 60, true, true).setName("street");
-        GHUtility.setProperties(g.edge(4, 5).setDistance(100), carEncoder, 60, true, true).setName("4-5");
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(3, 4).setDistance(100)).setName("street");
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(4, 5).setDistance(100)).setName("4-5");
 
-        EdgeIteratorState iter = GHUtility.setProperties(g.edge(2, 4).setDistance(100), carEncoder, 60, true, true);
+        EdgeIteratorState iter = GHUtility.setSpeed(60, true, true, carEncoder, g.edge(2, 4).setDistance(100));
         iter.setName("street");
         PointList list = new PointList();
         list.add(10.20, 10.05);
@@ -253,9 +253,9 @@ public class InstructionListTest {
         na.setNode(2, 51.73458, 9.225442);
         na.setNode(3, 51.734643, 9.22541);
         na.setNode(4, 51.734451, 9.225436);
-        GHUtility.setProperties(g.edge(1, 2).setDistance(10), carEncoder, 60, true, true);
-        GHUtility.setProperties(g.edge(2, 3).setDistance(10), carEncoder, 60, true, true);
-        GHUtility.setProperties(g.edge(2, 4).setDistance(10), carEncoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(1, 2).setDistance(10));
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(2, 3).setDistance(10));
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(2, 4).setDistance(10));
 
         ShortestWeighting weighting = new ShortestWeighting(carEncoder);
         Path p = new Dijkstra(g, weighting, tMode).calcPath(1, 3);
@@ -282,9 +282,9 @@ public class InstructionListTest {
         na.setNode(2, 48.748577, 9.322152);
         na.setNode(3, 48.748776, 9.321889);
         na.setNode(4, 48.74847, 9.322299);
-        GHUtility.setProperties(g.edge(1, 2).setDistance(10), carEncoder, 60, true, true);
-        GHUtility.setProperties(g.edge(2, 3).setDistance(10), carEncoder, 60, true, true);
-        GHUtility.setProperties(g.edge(2, 4).setDistance(10), carEncoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(1, 2).setDistance(10));
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(2, 3).setDistance(10));
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(2, 4).setDistance(10));
 
         ShortestWeighting weighting = new ShortestWeighting(carEncoder);
         Path p = new Dijkstra(g, weighting, tMode).calcPath(1, 3);
@@ -321,12 +321,12 @@ public class InstructionListTest {
         na.setNode(6, 15.1, 10.1);
         na.setNode(7, 15.1, 9.8);
 
-        GHUtility.setProperties(g.edge(1, 2).setDistance(10000), carEncoder, 60, true, true).setName("1-2");
-        GHUtility.setProperties(g.edge(2, 3).setDistance(10000), carEncoder, 60, true, true).setName("2-3");
-        GHUtility.setProperties(g.edge(2, 6).setDistance(10000), carEncoder, 60, true, true).setName("2-6");
-        GHUtility.setProperties(g.edge(3, 4).setDistance(10000), carEncoder, 60, true, true).setName("3-4").setWayGeometry(waypoint);
-        GHUtility.setProperties(g.edge(3, 7).setDistance(10000), carEncoder, 60, true, true).setName("3-7");
-        GHUtility.setProperties(g.edge(4, 5).setDistance(10000), carEncoder, 60, true, true).setName("4-5");
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(1, 2).setDistance(10000)).setName("1-2");
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(2, 3).setDistance(10000)).setName("2-3");
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(2, 6).setDistance(10000)).setName("2-6");
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(3, 4).setDistance(10000)).setName("3-4").setWayGeometry(waypoint);
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(3, 7).setDistance(10000)).setName("3-7");
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(4, 5).setDistance(10000)).setName("4-5");
 
         ShortestWeighting weighting = new ShortestWeighting(carEncoder);
         Path p = new Dijkstra(g, weighting, tMode).calcPath(1, 5);

--- a/core/src/test/java/com/graphhopper/util/PathSimplificationTest.java
+++ b/core/src/test/java/com/graphhopper/util/PathSimplificationTest.java
@@ -88,33 +88,33 @@ public class PathSimplificationTest {
 
         IntsRef relFlags = carManager.createRelationFlags();
         EdgeIteratorState tmpEdge;
-        tmpEdge = g.edge(0, 1, 10000, true).setName("0-1");
+        tmpEdge = GHUtility.setProperties(g.edge(0, 1).setDistance(10000), carEncoder, 60, true, true).setName("0-1");
         EncodingManager.AcceptWay map = new EncodingManager.AcceptWay();
         assertTrue(carManager.acceptWay(w, map));
         tmpEdge.setFlags(carManager.handleWayTags(w, map, relFlags));
-        tmpEdge = g.edge(1, 2, 11000, true).setName("1-2");
+        tmpEdge = GHUtility.setProperties(g.edge(1, 2).setDistance(11000), carEncoder, 60, true, true).setName("1-2");
         tmpEdge.setFlags(carManager.handleWayTags(w, map, relFlags));
 
         w.setTag("maxspeed", "20");
-        tmpEdge = g.edge(0, 3, 11000, true);
+        tmpEdge = GHUtility.setProperties(g.edge(0, 3).setDistance(11000), carEncoder, 60, true, true);
         tmpEdge.setFlags(carManager.handleWayTags(w, map, relFlags));
-        tmpEdge = g.edge(1, 4, 10000, true).setName("1-4");
+        tmpEdge = GHUtility.setProperties(g.edge(1, 4).setDistance(10000), carEncoder, 60, true, true).setName("1-4");
         tmpEdge.setFlags(carManager.handleWayTags(w, map, relFlags));
-        tmpEdge = g.edge(2, 5, 11000, true).setName("5-2");
+        tmpEdge = GHUtility.setProperties(g.edge(2, 5).setDistance(11000), carEncoder, 60, true, true).setName("5-2");
         tmpEdge.setFlags(carManager.handleWayTags(w, map, relFlags));
 
         w.setTag("maxspeed", "30");
-        tmpEdge = g.edge(3, 6, 11000, true).setName("3-6");
+        tmpEdge = GHUtility.setProperties(g.edge(3, 6).setDistance(11000), carEncoder, 60, true, true).setName("3-6");
         tmpEdge.setFlags(carManager.handleWayTags(w, map, relFlags));
-        tmpEdge = g.edge(4, 7, 10000, true).setName("4-7");
+        tmpEdge = GHUtility.setProperties(g.edge(4, 7).setDistance(10000), carEncoder, 60, true, true).setName("4-7");
         tmpEdge.setFlags(carManager.handleWayTags(w, map, relFlags));
-        tmpEdge = g.edge(5, 8, 10000, true).setName("5-8");
+        tmpEdge = GHUtility.setProperties(g.edge(5, 8).setDistance(10000), carEncoder, 60, true, true).setName("5-8");
         tmpEdge.setFlags(carManager.handleWayTags(w, map, relFlags));
 
         w.setTag("maxspeed", "40");
-        tmpEdge = g.edge(6, 7, 11000, true).setName("6-7");
+        tmpEdge = GHUtility.setProperties(g.edge(6, 7).setDistance(11000), carEncoder, 60, true, true).setName("6-7");
         tmpEdge.setFlags(carManager.handleWayTags(w, map, relFlags));
-        tmpEdge = g.edge(7, 8, 10000, true);
+        tmpEdge = GHUtility.setProperties(g.edge(7, 8).setDistance(10000), carEncoder, 60, true, true);
         PointList list = new PointList();
         list.add(1.0, 1.15);
         list.add(1.0, 1.16);
@@ -124,9 +124,9 @@ public class PathSimplificationTest {
 
         w.setTag("maxspeed", "50");
         // missing edge name
-        tmpEdge = g.edge(9, 10, 10000, true);
+        tmpEdge = GHUtility.setProperties(g.edge(9, 10).setDistance(10000), carEncoder, 60, true, true);
         tmpEdge.setFlags(carManager.handleWayTags(w, map, relFlags));
-        tmpEdge = g.edge(8, 9, 20000, true);
+        tmpEdge = GHUtility.setProperties(g.edge(8, 9).setDistance(20000), carEncoder, 60, true, true);
         list.clear();
         list.add(1.0, 1.3);
         list.add(1.0, 1.3001);

--- a/core/src/test/java/com/graphhopper/util/PathSimplificationTest.java
+++ b/core/src/test/java/com/graphhopper/util/PathSimplificationTest.java
@@ -88,33 +88,33 @@ public class PathSimplificationTest {
 
         IntsRef relFlags = carManager.createRelationFlags();
         EdgeIteratorState tmpEdge;
-        tmpEdge = GHUtility.setProperties(g.edge(0, 1).setDistance(10000), carEncoder, 60, true, true).setName("0-1");
+        tmpEdge = GHUtility.setSpeed(60, true, true, carEncoder, g.edge(0, 1).setDistance(10000)).setName("0-1");
         EncodingManager.AcceptWay map = new EncodingManager.AcceptWay();
         assertTrue(carManager.acceptWay(w, map));
         tmpEdge.setFlags(carManager.handleWayTags(w, map, relFlags));
-        tmpEdge = GHUtility.setProperties(g.edge(1, 2).setDistance(11000), carEncoder, 60, true, true).setName("1-2");
+        tmpEdge = GHUtility.setSpeed(60, true, true, carEncoder, g.edge(1, 2).setDistance(11000)).setName("1-2");
         tmpEdge.setFlags(carManager.handleWayTags(w, map, relFlags));
 
         w.setTag("maxspeed", "20");
-        tmpEdge = GHUtility.setProperties(g.edge(0, 3).setDistance(11000), carEncoder, 60, true, true);
+        tmpEdge = GHUtility.setSpeed(60, true, true, carEncoder, g.edge(0, 3).setDistance(11000));
         tmpEdge.setFlags(carManager.handleWayTags(w, map, relFlags));
-        tmpEdge = GHUtility.setProperties(g.edge(1, 4).setDistance(10000), carEncoder, 60, true, true).setName("1-4");
+        tmpEdge = GHUtility.setSpeed(60, true, true, carEncoder, g.edge(1, 4).setDistance(10000)).setName("1-4");
         tmpEdge.setFlags(carManager.handleWayTags(w, map, relFlags));
-        tmpEdge = GHUtility.setProperties(g.edge(2, 5).setDistance(11000), carEncoder, 60, true, true).setName("5-2");
+        tmpEdge = GHUtility.setSpeed(60, true, true, carEncoder, g.edge(2, 5).setDistance(11000)).setName("5-2");
         tmpEdge.setFlags(carManager.handleWayTags(w, map, relFlags));
 
         w.setTag("maxspeed", "30");
-        tmpEdge = GHUtility.setProperties(g.edge(3, 6).setDistance(11000), carEncoder, 60, true, true).setName("3-6");
+        tmpEdge = GHUtility.setSpeed(60, true, true, carEncoder, g.edge(3, 6).setDistance(11000)).setName("3-6");
         tmpEdge.setFlags(carManager.handleWayTags(w, map, relFlags));
-        tmpEdge = GHUtility.setProperties(g.edge(4, 7).setDistance(10000), carEncoder, 60, true, true).setName("4-7");
+        tmpEdge = GHUtility.setSpeed(60, true, true, carEncoder, g.edge(4, 7).setDistance(10000)).setName("4-7");
         tmpEdge.setFlags(carManager.handleWayTags(w, map, relFlags));
-        tmpEdge = GHUtility.setProperties(g.edge(5, 8).setDistance(10000), carEncoder, 60, true, true).setName("5-8");
+        tmpEdge = GHUtility.setSpeed(60, true, true, carEncoder, g.edge(5, 8).setDistance(10000)).setName("5-8");
         tmpEdge.setFlags(carManager.handleWayTags(w, map, relFlags));
 
         w.setTag("maxspeed", "40");
-        tmpEdge = GHUtility.setProperties(g.edge(6, 7).setDistance(11000), carEncoder, 60, true, true).setName("6-7");
+        tmpEdge = GHUtility.setSpeed(60, true, true, carEncoder, g.edge(6, 7).setDistance(11000)).setName("6-7");
         tmpEdge.setFlags(carManager.handleWayTags(w, map, relFlags));
-        tmpEdge = GHUtility.setProperties(g.edge(7, 8).setDistance(10000), carEncoder, 60, true, true);
+        tmpEdge = GHUtility.setSpeed(60, true, true, carEncoder, g.edge(7, 8).setDistance(10000));
         PointList list = new PointList();
         list.add(1.0, 1.15);
         list.add(1.0, 1.16);
@@ -124,9 +124,9 @@ public class PathSimplificationTest {
 
         w.setTag("maxspeed", "50");
         // missing edge name
-        tmpEdge = GHUtility.setProperties(g.edge(9, 10).setDistance(10000), carEncoder, 60, true, true);
+        tmpEdge = GHUtility.setSpeed(60, true, true, carEncoder, g.edge(9, 10).setDistance(10000));
         tmpEdge.setFlags(carManager.handleWayTags(w, map, relFlags));
-        tmpEdge = GHUtility.setProperties(g.edge(8, 9).setDistance(20000), carEncoder, 60, true, true);
+        tmpEdge = GHUtility.setSpeed(60, true, true, carEncoder, g.edge(8, 9).setDistance(20000));
         list.clear();
         list.add(1.0, 1.3);
         list.add(1.0, 1.3001);

--- a/isochrone/src/test/java/com/graphhopper/isochrone/algorithm/ShortestPathTreeTest.java
+++ b/isochrone/src/test/java/com/graphhopper/isochrone/algorithm/ShortestPathTreeTest.java
@@ -77,27 +77,27 @@ public class ShortestPathTreeTest {
         // 4-5-- |
         // |/ \--7
         // 6----/
-        GHUtility.setProperties(((Graph) graph).edge(0, 1).setDistance(70), carEncoder, 10, true, false);
-        GHUtility.setProperties(((Graph) graph).edge(0, 4).setDistance(50), carEncoder, 20, true, false);
+        GHUtility.setSpeed(10, true, false, carEncoder, ((Graph) graph).edge(0, 1).setDistance(70));
+        GHUtility.setSpeed(20, true, false, carEncoder, ((Graph) graph).edge(0, 4).setDistance(50));
 
-        GHUtility.setProperties(((Graph) graph).edge(1, 4).setDistance(70), carEncoder, 10, true, true);
-        GHUtility.setProperties(((Graph) graph).edge(1, 5).setDistance(70), carEncoder, 10, true, true);
-        GHUtility.setProperties(((Graph) graph).edge(1, 2).setDistance(200), carEncoder, 10, true, true);
+        GHUtility.setSpeed(10, true, true, carEncoder, ((Graph) graph).edge(1, 4).setDistance(70));
+        GHUtility.setSpeed(10, true, true, carEncoder, ((Graph) graph).edge(1, 5).setDistance(70));
+        GHUtility.setSpeed(10, true, true, carEncoder, ((Graph) graph).edge(1, 2).setDistance(200));
 
-        GHUtility.setProperties(((Graph) graph).edge(5, 2).setDistance(50), carEncoder, 10, true, false);
-        GHUtility.setProperties(((Graph) graph).edge(2, 3).setDistance(50), carEncoder, 10, true, false);
+        GHUtility.setSpeed(10, true, false, carEncoder, ((Graph) graph).edge(5, 2).setDistance(50));
+        GHUtility.setSpeed(10, true, false, carEncoder, ((Graph) graph).edge(2, 3).setDistance(50));
 
-        GHUtility.setProperties(((Graph) graph).edge(5, 3).setDistance(110), carEncoder, 20, true, false);
-        GHUtility.setProperties(((Graph) graph).edge(3, 7).setDistance(70), carEncoder, 10, true, false);
+        GHUtility.setSpeed(20, true, false, carEncoder, ((Graph) graph).edge(5, 3).setDistance(110));
+        GHUtility.setSpeed(10, true, false, carEncoder, ((Graph) graph).edge(3, 7).setDistance(70));
 
-        GHUtility.setProperties(((Graph) graph).edge(4, 6).setDistance(50), carEncoder, 20, true, false);
-        GHUtility.setProperties(((Graph) graph).edge(5, 4).setDistance(70), carEncoder, 10, true, false);
+        GHUtility.setSpeed(20, true, false, carEncoder, ((Graph) graph).edge(4, 6).setDistance(50));
+        GHUtility.setSpeed(10, true, false, carEncoder, ((Graph) graph).edge(5, 4).setDistance(70));
 
-        GHUtility.setProperties(((Graph) graph).edge(5, 6).setDistance(70), carEncoder, 10, true, false);
-        GHUtility.setProperties(((Graph) graph).edge(7, 5).setDistance(50), carEncoder, 20, true, false);
+        GHUtility.setSpeed(10, true, false, carEncoder, ((Graph) graph).edge(5, 6).setDistance(70));
+        GHUtility.setSpeed(20, true, false, carEncoder, ((Graph) graph).edge(7, 5).setDistance(50));
 
-        GHUtility.setProperties(((Graph) graph).edge(6, 7).setDistance(50), carEncoder, 20, true, true);
-        GHUtility.setProperties(((Graph) graph).edge(3, 8).setDistance(25), carEncoder, 20, true, true);
+        GHUtility.setSpeed(20, true, true, carEncoder, ((Graph) graph).edge(6, 7).setDistance(50));
+        GHUtility.setSpeed(20, true, true, carEncoder, ((Graph) graph).edge(3, 8).setDistance(25));
     }
 
     private int countDirectedEdges(GraphHopperStorage graph) {

--- a/reader-gtfs/src/main/java/com/graphhopper/gtfs/RealtimeFeed.java
+++ b/reader-gtfs/src/main/java/com/graphhopper/gtfs/RealtimeFeed.java
@@ -213,11 +213,6 @@ public class RealtimeFeed {
             }
 
             @Override
-            public EdgeIteratorState edge(int a, int b, double distance, boolean bothDirections) {
-                return null;
-            }
-
-            @Override
             public EdgeIteratorState getEdgeIteratorState(int edgeId, int adjNode) {
                 return null;
             }

--- a/reader-gtfs/src/main/java/com/graphhopper/gtfs/WrapperGraph.java
+++ b/reader-gtfs/src/main/java/com/graphhopper/gtfs/WrapperGraph.java
@@ -209,6 +209,11 @@ public class WrapperGraph implements Graph {
             }
 
             @Override
+            public EdgeIteratorState set(BooleanEncodedValue property, boolean fwd, boolean bwd) {
+                return this;
+            }
+
+            @Override
             public int get(IntEncodedValue property) {
                 throw new UnsupportedOperationException();
             }
@@ -225,6 +230,11 @@ public class WrapperGraph implements Graph {
 
             @Override
             public EdgeIteratorState setReverse(IntEncodedValue property, int value) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public EdgeIteratorState set(IntEncodedValue property, int fwd, int bwd) {
                 throw new UnsupportedOperationException();
             }
 
@@ -249,6 +259,11 @@ public class WrapperGraph implements Graph {
             }
 
             @Override
+            public EdgeIteratorState set(DecimalEncodedValue property, double fwd, double bwd) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
             public <T extends Enum> T get(EnumEncodedValue<T> property) {
                 throw new UnsupportedOperationException();
             }
@@ -265,6 +280,11 @@ public class WrapperGraph implements Graph {
 
             @Override
             public <T extends Enum> EdgeIteratorState setReverse(EnumEncodedValue<T> property, T value) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public <T extends Enum> EdgeIteratorState set(EnumEncodedValue<T> property, T fwd, T bwd) {
                 throw new UnsupportedOperationException();
             }
 
@@ -304,6 +324,7 @@ public class WrapperGraph implements Graph {
 
                     EdgeIteratorState current = null;
                     EdgeIterator baseGraphEdgeIterator = baseGraphIterator();
+
                     private EdgeIterator baseGraphIterator() {
                         if (baseNode < mainGraph.getNodes()) {
                             return baseGraphEdgeExplorer.setBaseNode(baseNode);
@@ -322,7 +343,7 @@ public class WrapperGraph implements Graph {
                                 baseGraphEdgeIterator = null;
                             }
                         }
-                        while(iterator.hasNext()) {
+                        while (iterator.hasNext()) {
                             current = iterator.next();
                             if (filter.accept(current)) {
                                 return true;
@@ -417,6 +438,12 @@ public class WrapperGraph implements Graph {
                     }
 
                     @Override
+                    public EdgeIteratorState set(BooleanEncodedValue property, boolean fwd, boolean bwd) {
+                        current.set(property, fwd, bwd);
+                        return this;
+                    }
+
+                    @Override
                     public int get(IntEncodedValue property) {
                         return current.get(property);
                     }
@@ -435,6 +462,12 @@ public class WrapperGraph implements Graph {
                     @Override
                     public EdgeIteratorState setReverse(IntEncodedValue property, int value) {
                         current.setReverse(property, value);
+                        return this;
+                    }
+
+                    @Override
+                    public EdgeIteratorState set(IntEncodedValue property, int fwd, int bwd) {
+                        current.set(property, fwd, bwd);
                         return this;
                     }
 
@@ -461,6 +494,12 @@ public class WrapperGraph implements Graph {
                     }
 
                     @Override
+                    public EdgeIteratorState set(DecimalEncodedValue property, double fwd, double bwd) {
+                        current.set(property, fwd, bwd);
+                        return this;
+                    }
+
+                    @Override
                     public <T extends Enum> T get(EnumEncodedValue<T> property) {
                         return current.get(property);
                     }
@@ -479,6 +518,12 @@ public class WrapperGraph implements Graph {
                     @Override
                     public <T extends Enum> EdgeIteratorState setReverse(EnumEncodedValue<T> property, T value) {
                         current.setReverse(property, value);
+                        return this;
+                    }
+
+                    @Override
+                    public <T extends Enum> EdgeIteratorState set(EnumEncodedValue<T> property, T fwd, T bwd) {
+                        current.set(property, fwd, bwd);
                         return this;
                     }
 

--- a/reader-gtfs/src/main/java/com/graphhopper/gtfs/WrapperGraph.java
+++ b/reader-gtfs/src/main/java/com/graphhopper/gtfs/WrapperGraph.java
@@ -98,11 +98,6 @@ public class WrapperGraph implements Graph {
     }
 
     @Override
-    public EdgeIteratorState edge(int a, int b, double distance, boolean bothDirections) {
-        throw new RuntimeException();
-    }
-
-    @Override
     public EdgeIteratorState getEdgeIteratorState(int edgeId, int adjNode) {
         EdgeIteratorState edgeIteratorState = extraEdges.get(edgeId);
         if (edgeIteratorState != null) {

--- a/reader-osm/src/test/java/com/graphhopper/reader/osm/GraphHopperOSMTest.java
+++ b/reader-osm/src/test/java/com/graphhopper/reader/osm/GraphHopperOSMTest.java
@@ -899,19 +899,19 @@ public class GraphHopperOSMTest {
         na.setNode(7, 0.000, 0.001);
         na.setNode(8, 0.001, 0.001);
 
-        GHUtility.setProperties(g.edge(0, 1).setDistance(100), carEncoder, 60, true, true);
-        GHUtility.setProperties(g.edge(1, 2).setDistance(100), carEncoder, 60, true, true);
-        GHUtility.setProperties(g.edge(2, 3).setDistance(100), carEncoder, 60, true, true);
-        GHUtility.setProperties(g.edge(3, 4).setDistance(100), carEncoder, 60, true, true);
-        GHUtility.setProperties(g.edge(4, 5).setDistance(100), carEncoder, 60, true, true);
-        GHUtility.setProperties(g.edge(5, 6).setDistance(100), carEncoder, 60, true, true);
-        GHUtility.setProperties(g.edge(6, 7).setDistance(100), carEncoder, 60, true, true);
-        GHUtility.setProperties(g.edge(7, 0).setDistance(100), carEncoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(0, 1).setDistance(100));
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(1, 2).setDistance(100));
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(2, 3).setDistance(100));
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(3, 4).setDistance(100));
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(4, 5).setDistance(100));
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(5, 6).setDistance(100));
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(6, 7).setDistance(100));
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(7, 0).setDistance(100));
 
-        GHUtility.setProperties(g.edge(1, 8).setDistance(110), carEncoder, 60, true, true);
-        GHUtility.setProperties(g.edge(3, 8).setDistance(110), carEncoder, 60, true, true);
-        GHUtility.setProperties(g.edge(5, 8).setDistance(110), carEncoder, 60, true, true);
-        GHUtility.setProperties(g.edge(7, 8).setDistance(110), carEncoder, 60, true, true);
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(1, 8).setDistance(110));
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(3, 8).setDistance(110));
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(5, 8).setDistance(110));
+        GHUtility.setSpeed(60, true, true, carEncoder, g.edge(7, 8).setDistance(110));
 
         GraphHopper tmp = new GraphHopperOSM().
                 setEncodingManager(encodingManager).

--- a/reader-osm/src/test/java/com/graphhopper/reader/osm/GraphHopperOSMTest.java
+++ b/reader-osm/src/test/java/com/graphhopper/reader/osm/GraphHopperOSMTest.java
@@ -899,26 +899,25 @@ public class GraphHopperOSMTest {
         na.setNode(7, 0.000, 0.001);
         na.setNode(8, 0.001, 0.001);
 
-        g.edge(0, 1, 100, true);
-        g.edge(1, 2, 100, true);
-        g.edge(2, 3, 100, true);
-        g.edge(3, 4, 100, true);
-        g.edge(4, 5, 100, true);
-        g.edge(5, 6, 100, true);
-        g.edge(6, 7, 100, true);
-        g.edge(7, 0, 100, true);
+        GHUtility.setProperties(g.edge(0, 1).setDistance(100), carEncoder, 60, true, true);
+        GHUtility.setProperties(g.edge(1, 2).setDistance(100), carEncoder, 60, true, true);
+        GHUtility.setProperties(g.edge(2, 3).setDistance(100), carEncoder, 60, true, true);
+        GHUtility.setProperties(g.edge(3, 4).setDistance(100), carEncoder, 60, true, true);
+        GHUtility.setProperties(g.edge(4, 5).setDistance(100), carEncoder, 60, true, true);
+        GHUtility.setProperties(g.edge(5, 6).setDistance(100), carEncoder, 60, true, true);
+        GHUtility.setProperties(g.edge(6, 7).setDistance(100), carEncoder, 60, true, true);
+        GHUtility.setProperties(g.edge(7, 0).setDistance(100), carEncoder, 60, true, true);
 
-        g.edge(1, 8, 110, true);
-        g.edge(3, 8, 110, true);
-        g.edge(5, 8, 110, true);
-        g.edge(7, 8, 110, true);
+        GHUtility.setProperties(g.edge(1, 8).setDistance(110), carEncoder, 60, true, true);
+        GHUtility.setProperties(g.edge(3, 8).setDistance(110), carEncoder, 60, true, true);
+        GHUtility.setProperties(g.edge(5, 8).setDistance(110), carEncoder, 60, true, true);
+        GHUtility.setProperties(g.edge(7, 8).setDistance(110), carEncoder, 60, true, true);
 
         GraphHopper tmp = new GraphHopperOSM().
                 setEncodingManager(encodingManager).
                 setProfiles(new Profile("profile").setVehicle("car").setWeighting("fastest"));
         tmp.setGraphHopperStorage(g);
         tmp.postProcessing();
-
         return tmp;
     }
 

--- a/reader-osm/src/test/java/com/graphhopper/routing/RoutingAlgorithmWithOSMTest.java
+++ b/reader-osm/src/test/java/com/graphhopper/routing/RoutingAlgorithmWithOSMTest.java
@@ -774,7 +774,7 @@ public class RoutingAlgorithmWithOSMTest {
         final GraphHopperStorage graph = new GraphBuilder(eManager).create();
 
         String bigFile = "10000EWD.txt.gz";
-        new PrincetonReader(graph).setStream(new GZIPInputStream(PrincetonReader.class.getResourceAsStream(bigFile))).read();
+        new PrincetonReader(graph, eManager.getEncoder("car")).setStream(new GZIPInputStream(PrincetonReader.class.getResourceAsStream(bigFile))).read();
         GraphHopper hopper = new GraphHopper() {
             {
                 setEncodingManager(eManager);

--- a/web-bundle/src/test/java/com/graphhopper/util/gpx/GpxFromInstructionsTest.java
+++ b/web-bundle/src/test/java/com/graphhopper/util/gpx/GpxFromInstructionsTest.java
@@ -18,7 +18,6 @@
 
 package com.graphhopper.util.gpx;
 
-import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.Dijkstra;
 import com.graphhopper.routing.InstructionsFromEdges;
 import com.graphhopper.routing.Path;
@@ -29,7 +28,6 @@ import com.graphhopper.routing.util.TraversalMode;
 import com.graphhopper.routing.weighting.ShortestWeighting;
 import com.graphhopper.storage.Graph;
 import com.graphhopper.storage.GraphBuilder;
-import com.graphhopper.storage.IntsRef;
 import com.graphhopper.storage.NodeAccess;
 import com.graphhopper.util.*;
 import org.junit.Before;
@@ -79,12 +77,12 @@ public class GpxFromInstructionsTest {
         na.setNode(6, 15.1, 10.1);
         na.setNode(7, 15.1, 9.8);
 
-        g.edge(1, 2, 7000, true).setName("1-2").setFlags(flagsForSpeed(carManager, 70));
-        g.edge(2, 3, 8000, true).setName("2-3").setFlags(flagsForSpeed(carManager, 80));
-        g.edge(2, 6, 10000, true).setName("2-6").setFlags(flagsForSpeed(carManager, 10));
-        g.edge(3, 4, 9000, true).setName("3-4").setFlags(flagsForSpeed(carManager, 90));
-        g.edge(3, 7, 10000, true).setName("3-7").setFlags(flagsForSpeed(carManager, 10));
-        g.edge(4, 5, 10000, true).setName("4-5").setFlags(flagsForSpeed(carManager, 100));
+        GHUtility.setProperties(g.edge(1, 2).setDistance(7000).setName("1-2"), carEncoder, 63, true, true);
+        GHUtility.setProperties(g.edge(2, 3).setDistance(8000).setName("2-3"), carEncoder, 72, true, true);
+        GHUtility.setProperties(g.edge(2, 6).setDistance(10000).setName("2-6"), carEncoder, 9, true, true);
+        GHUtility.setProperties(g.edge(3, 4).setDistance(9000).setName("3-4"), carEncoder, 81, true, true);
+        GHUtility.setProperties(g.edge(3, 7).setDistance(10000).setName("3-7"), carEncoder, 9, true, true);
+        GHUtility.setProperties(g.edge(4, 5).setDistance(10000).setName("4-5"), carEncoder, 90, true, true);
 
         ShortestWeighting weighting = new ShortestWeighting(carEncoder);
         Path p = new Dijkstra(g, weighting, TraversalMode.NODE_BASED).calcPath(1, 5);
@@ -200,15 +198,6 @@ public class GpxFromInstructionsTest {
         assertEquals("_", GpxFromInstructions.simpleXMLEscape("<"));
         assertEquals("_blup_", GpxFromInstructions.simpleXMLEscape("<blup>"));
         assertEquals("a&amp;b", GpxFromInstructions.simpleXMLEscape("a&b"));
-    }
-
-    private IntsRef flagsForSpeed(EncodingManager encodingManager, int speedKmPerHour) {
-        ReaderWay way = new ReaderWay(1);
-        way.setTag("highway", "motorway");
-        way.setTag("maxspeed", String.format("%d km/h", speedKmPerHour));
-        EncodingManager.AcceptWay map = new EncodingManager.AcceptWay();
-        encodingManager.acceptWay(way, map);
-        return encodingManager.handleWayTags(way, map, encodingManager.createRelationFlags());
     }
 
     private void verifyGPX(String gpx) {

--- a/web-bundle/src/test/java/com/graphhopper/util/gpx/GpxFromInstructionsTest.java
+++ b/web-bundle/src/test/java/com/graphhopper/util/gpx/GpxFromInstructionsTest.java
@@ -77,12 +77,12 @@ public class GpxFromInstructionsTest {
         na.setNode(6, 15.1, 10.1);
         na.setNode(7, 15.1, 9.8);
 
-        GHUtility.setProperties(g.edge(1, 2).setDistance(7000).setName("1-2"), carEncoder, 63, true, true);
-        GHUtility.setProperties(g.edge(2, 3).setDistance(8000).setName("2-3"), carEncoder, 72, true, true);
-        GHUtility.setProperties(g.edge(2, 6).setDistance(10000).setName("2-6"), carEncoder, 9, true, true);
-        GHUtility.setProperties(g.edge(3, 4).setDistance(9000).setName("3-4"), carEncoder, 81, true, true);
-        GHUtility.setProperties(g.edge(3, 7).setDistance(10000).setName("3-7"), carEncoder, 9, true, true);
-        GHUtility.setProperties(g.edge(4, 5).setDistance(10000).setName("4-5"), carEncoder, 90, true, true);
+        GHUtility.setSpeed(63, true, true, carEncoder, g.edge(1, 2).setDistance(7000).setName("1-2"));
+        GHUtility.setSpeed(72, true, true, carEncoder, g.edge(2, 3).setDistance(8000).setName("2-3"));
+        GHUtility.setSpeed(9, true, true, carEncoder, g.edge(2, 6).setDistance(10000).setName("2-6"));
+        GHUtility.setSpeed(81, true, true, carEncoder, g.edge(3, 4).setDistance(9000).setName("3-4"));
+        GHUtility.setSpeed(9, true, true, carEncoder, g.edge(3, 7).setDistance(10000).setName("3-7"));
+        GHUtility.setSpeed(90, true, true, carEncoder, g.edge(4, 5).setDistance(10000).setName("4-5"));
 
         ShortestWeighting weighting = new ShortestWeighting(carEncoder);
         Path p = new Dijkstra(g, weighting, TraversalMode.NODE_BASED).calcPath(1, 5);


### PR DESCRIPTION
It took a bit time, but finally I got rid of this method :) (usage was approx 2000 times). This will likely make it easier to move average_speed and access parsing into a separate TagParser.

My best friend was regex replace functionality of IntelliJ ala:

`graph.edge\((\d+)..(\d+)..(\d+),` (or variations with `(\d+.\d+)` or `(\w+)`)
`GHUtility.setProperties(graph.edge($1,$2).setDistance($3),encoder,60,true,`

The new mechanism is a bit clumsy, but if you think about this then it is really necessary to initialize the edge with a specific speed (and vehicle). And in production we do not use this method, only for tests.

TODO: replace more single method calls of GHUtility with the new `GHUtility.setProperties(List<EdgeIteratorState>)`?