### PR TITLE
Change of non-shared EncodedValue

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/EncodingManager.java
+++ b/core/src/main/java/com/graphhopper/routing/util/EncodingManager.java
@@ -794,10 +794,10 @@ public class EncodingManager implements EncodedValueLookup {
         return (T) ev;
     }
 
-    private static final String SPECIAL_SEPARATOR = ".";
+    private static final String SPECIAL_SEPARATOR = "__";
 
     public static boolean isSharedEncodedValues(EncodedValue ev) {
-        return !ev.getName().contains(SPECIAL_SEPARATOR);
+        return isValidEncodedValue(ev.getName()) && !ev.getName().contains(SPECIAL_SEPARATOR);
     }
 
     /**
@@ -840,11 +840,13 @@ public class EncodingManager implements EncodedValueLookup {
         int dotCount = 0;
         for (int i = 1; i < name.length(); i++) {
             char c = name.charAt(i);
-            if (c == '.') {
-                if (dotCount > 0) return false;
+            if (c == '_') {
+                if (dotCount > 1) return false;
                 dotCount++;
-            } else if (!isLowerLetter(c) && !isNumber(c) && c != '_' && c != '$') {
+            } else if (!isLowerLetter(c) && !isNumber(c)) {
                 return false;
+            } else {
+                dotCount = 0;
             }
         }
         return true;

--- a/core/src/main/java/com/graphhopper/routing/util/EncodingManager.java
+++ b/core/src/main/java/com/graphhopper/routing/util/EncodingManager.java
@@ -794,7 +794,7 @@ public class EncodingManager implements EncodedValueLookup {
         return (T) ev;
     }
 
-    private static final String SPECIAL_SEPARATOR = "__";
+    private static final String SPECIAL_SEPARATOR = "$";
 
     public static boolean isSharedEncodedValues(EncodedValue ev) {
         return isValidEncodedValue(ev.getName()) && !ev.getName().contains(SPECIAL_SEPARATOR);
@@ -837,16 +837,19 @@ public class EncodingManager implements EncodedValueLookup {
         // first character must be a lower case letter
         if (name.isEmpty() || !isLowerLetter(name.charAt(0)) || KEYWORDS.contains(name)) return false;
 
-        int dotCount = 0;
+        int dollarCount = 0, underscoreCount = 0;
         for (int i = 1; i < name.length(); i++) {
             char c = name.charAt(i);
-            if (c == '_') {
-                if (dotCount > 1) return false;
-                dotCount++;
+            if (c == '$') {
+                if (dollarCount > 0) return false;
+                dollarCount++;
+            } else if (c == '_') {
+                if (underscoreCount > 0) return false;
+                underscoreCount++;
             } else if (!isLowerLetter(c) && !isNumber(c)) {
                 return false;
             } else {
-                dotCount = 0;
+                underscoreCount = 0;
             }
         }
         return true;

--- a/core/src/test/java/com/graphhopper/routing/util/EncodingManagerTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/EncodingManagerTest.java
@@ -280,12 +280,12 @@ public class EncodingManagerTest {
 
     @Test
     public void validEV() {
-        for (String str : Arrays.asList("blup_test", "test", "test12", "car__test", "car_test_test", "small_truck__average_speed")) {
+        for (String str : Arrays.asList("blup_test", "test", "test12", "tes$0", "car_test_test", "small_car$average_speed")) {
             assertTrue(str, EncodingManager.isValidEncodedValue(str));
         }
 
-        for (String str : Arrays.asList("Test", "12test", "test|3", "tes$0", "blup_te.st_", "car___test", "test{34",
-                "blup.test", "test,21", "täst", "blup.two.three", "blup..test")) {
+        for (String str : Arrays.asList("Test", "12test", "test|3", "car__test", "blup_te.st_", "car___test", "car$$access",
+                "test{34", "truck__average_speed", "blup.test", "test,21", "täst", "blup.two.three", "blup..test")) {
             assertFalse(str, EncodingManager.isValidEncodedValue(str));
         }
 

--- a/core/src/test/java/com/graphhopper/routing/util/EncodingManagerTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/EncodingManagerTest.java
@@ -280,11 +280,12 @@ public class EncodingManagerTest {
 
     @Test
     public void validEV() {
-        for (String str : Arrays.asList("blup_test", "test", "test12", "tes$0", "blup.test", "blup_te.st_")) {
+        for (String str : Arrays.asList("blup_test", "test", "test12", "car__test", "car_test_test", "small_truck__average_speed")) {
             assertTrue(str, EncodingManager.isValidEncodedValue(str));
         }
 
-        for (String str : Arrays.asList("Test", "12test", "test|3", "test{34", "test,21", "täst", "blup.two.three", "blup..test")) {
+        for (String str : Arrays.asList("Test", "12test", "test|3", "tes$0", "blup_te.st_", "car___test", "test{34",
+                "blup.test", "test,21", "täst", "blup.two.three", "blup..test")) {
             assertFalse(str, EncodingManager.isValidEncodedValue(str));
         }
 


### PR DESCRIPTION
With #2198 we have stricter naming but we still allow `.` although this is not allowed in a Java variable.

This is a bit ugly as we can currently use the non-shared EncodedValues like `car.access` or `car.average_speed` or `bike.access` in the CustomWeighting. They are "non-shared" because the FlagEncoder creates and populates them - this will be moved into a separate TagParser in the future, but for now we have to detect it as a special case because these EncodedValues should be excluded when storing+loading all encoded values. This will disappear when FlagEncoders dissolve. 

This change is basically a change to make master forward compatible with the janino_scripting branch, i.e. also allow non-shared EncodedValues in the new CustomWeighting with janino scripting. As variables with `.` introduce a problem as e.g. `car.access` would need special handling. Either we introduce a class+object per flagEncoder (ala `class Car { BooleanEncodedValue access; DecimalEncodedValue average_speed; }` etc) so that the expression becomes a valid Java expression or we replace the dot with a character like `$` before creating the script, so that this is a valid Java variable and does not need special handling. Both solutions make the scripting creation more complex and error-prone, which I would like to avoid especially as we already plan to deprecate this `x.y` notation (when it is moved to TagParser).

Why `$` and not something else? I didn't find a better character that is suited as a separator character and is also allowed in a Java variable.