### PR TITLE
Extend the list of restricted encoded value names

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/EncodingManager.java
+++ b/core/src/main/java/com/graphhopper/routing/util/EncodingManager.java
@@ -820,17 +820,19 @@ public class EncodingManager implements EncodedValueLookup {
             "case", "catch", "char", "class", "const", "continue",
             "default", "do", "double",
             "else", "enum", "extends",
-            "final", "finally", "float", "for",
+            "false", "final", "finally", "float", "for",
             "goto",
             "if", "implements", "import", "instanceof", "int", "interface",
             "long",
-            "native", "new",
-            "package", "private", "protected", "public",
-            "return",
-            "short", "static", "strictfp", "super", "switch", "synchronized",
-            "this", "throw", "throws", "transient", "try",
-            "void", "volatile",
-            "while"
+            "native", "new", "non-sealed", "null",
+            "package", "permits", "private", "protected", "public",
+            "record", "return",
+            "sealed", "short", "static", "strictfp", "super", "switch", "synchronized",
+            "this", "throw", "throws", "transient", "true", "try",
+            "var", "void", "volatile",
+            "while",
+            "yield",
+            "_"
     ));
 
     public static boolean isValidEncodedValue(String name) {


### PR DESCRIPTION
Added the following entries: 

- `_` (underscore is a keyword since Java 9)
- false, true
- null
- sealed, non-sealed, permits (JEP 360)
- record (JEP 395)
- var, yield (restricted identifiers)

https://docs.oracle.com/javase/specs/jls/se15/html/jls-3.html#jls-3.9