### PR TITLE
Custom weighting helper cleanup

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/DefaultWeightingFactory.java
+++ b/core/src/main/java/com/graphhopper/routing/DefaultWeightingFactory.java
@@ -76,7 +76,7 @@ public class DefaultWeightingFactory implements WeightingFactory {
             CustomProfile customProfile = (CustomProfile) profile;
             queryCustomModel = queryCustomModel == null ?
                     customProfile.getCustomModel() : CustomModel.merge(customProfile.getCustomModel(), queryCustomModel);
-            weighting = new CustomWeighting(encoder, encodingManager, turnCostProvider, queryCustomModel);
+            weighting = CustomWeighting.create(encoder, encodingManager, turnCostProvider, queryCustomModel);
         } else if ("shortest".equalsIgnoreCase(weightingStr)) {
             weighting = new ShortestWeighting(encoder, turnCostProvider);
         } else if ("fastest".equalsIgnoreCase(weightingStr)) {

--- a/core/src/main/java/com/graphhopper/routing/weighting/custom/CustomWeighting.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/custom/CustomWeighting.java
@@ -93,14 +93,12 @@ public final class CustomWeighting extends AbstractWeighting {
                                          CustomModel customModel) {
         if (customModel == null)
             throw new IllegalStateException("CustomModel cannot be null");
-        double distanceInfluence = customModel.getDistanceInfluence();
-        double headingPenaltySeconds = customModel.getHeadingPenalty();
         if (customModel.getMaxSpeedFallback() != null && customModel.getMaxSpeedFallback() > baseFlagEncoder.getMaxSpeed())
             throw new IllegalArgumentException("max_speed_fallback cannot be bigger than max_speed " + baseFlagEncoder.getMaxSpeed());
         double maxSpeedTmp = customModel.getMaxSpeedFallback() == null ? baseFlagEncoder.getMaxSpeed() : customModel.getMaxSpeedFallback();
-        CustomWeightingHelper cwHelper = ExpressionBuilder.create(customModel, lookup, baseFlagEncoder.getMaxSpeed(), maxSpeedTmp, baseFlagEncoder.getAverageSpeedEnc());
-        Parameters parameters = new Parameters(cwHelper::getSpeed, cwHelper::getPriority, maxSpeedTmp, distanceInfluence, headingPenaltySeconds);
-
+        SpeedAndAccessProvider speedAndAccessProvider = ExpressionBuilder.create(customModel, lookup, baseFlagEncoder.getMaxSpeed(), maxSpeedTmp, baseFlagEncoder.getAverageSpeedEnc());
+        Parameters parameters = new Parameters(speedAndAccessProvider::getSpeed, speedAndAccessProvider::getPriority,
+                maxSpeedTmp, customModel.getDistanceInfluence(), customModel.getHeadingPenalty());
         return new CustomWeighting(baseFlagEncoder, turnCostProvider, parameters);
     }
 

--- a/core/src/main/java/com/graphhopper/routing/weighting/custom/CustomWeighting.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/custom/CustomWeighting.java
@@ -130,7 +130,7 @@ public final class CustomWeighting extends AbstractWeighting {
         double distanceCosts = distance * distanceInfluence;
         if (Double.isInfinite(distanceCosts))
             return Double.POSITIVE_INFINITY;
-        double priority = edgeToPriorityMapping.apply(edgeState, reverse);
+        double priority = edgeToPriorityMapping.get(edgeState, reverse);
         return seconds / priority + distanceCosts;
     }
 
@@ -143,7 +143,7 @@ public final class CustomWeighting extends AbstractWeighting {
         if (reverse ? !edgeState.getReverse(baseVehicleAccessEnc) : !edgeState.get(baseVehicleAccessEnc))
             return Double.POSITIVE_INFINITY;
 
-        double speed = edgeToSpeedMapping.apply(edgeState, reverse);
+        double speed = edgeToSpeedMapping.get(edgeState, reverse);
         if (speed == 0)
             return Double.POSITIVE_INFINITY;
         if (speed < 0)
@@ -168,7 +168,7 @@ public final class CustomWeighting extends AbstractWeighting {
 
     @FunctionalInterface
     public interface EdgeToDoubleMapping {
-        double apply(EdgeIteratorState edge, boolean reverse);
+        double get(EdgeIteratorState edge, boolean reverse);
     }
 
     private static class Parameters {

--- a/core/src/main/java/com/graphhopper/routing/weighting/custom/CustomWeighting.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/custom/CustomWeighting.java
@@ -88,24 +88,17 @@ public final class CustomWeighting extends AbstractWeighting {
     private final double headingPenaltySeconds;
     private final CustomWeightingHelper cwHelper;
 
-    public CustomWeighting(FlagEncoder baseFlagEncoder, EncodedValueLookup lookup, TurnCostProvider turnCostProvider,
-                           CustomModel customModel) {
-        super(baseFlagEncoder, turnCostProvider);
+    public static CustomWeighting create(FlagEncoder baseFlagEncoder, EncodedValueLookup lookup, TurnCostProvider turnCostProvider,
+                                         CustomModel customModel) {
         if (customModel == null)
             throw new IllegalStateException("CustomModel cannot be null");
-
-        headingPenaltySeconds = customModel.getHeadingPenalty();
-        baseVehicleAccessEnc = baseFlagEncoder.getAccessEnc();
+        double distanceInfluence = customModel.getDistanceInfluence();
+        double headingPenaltySeconds = customModel.getHeadingPenalty();
         if (customModel.getMaxSpeedFallback() != null && customModel.getMaxSpeedFallback() > baseFlagEncoder.getMaxSpeed())
             throw new IllegalArgumentException("max_speed_fallback cannot be bigger than max_speed " + baseFlagEncoder.getMaxSpeed());
         double maxSpeedTmp = customModel.getMaxSpeedFallback() == null ? baseFlagEncoder.getMaxSpeed() : customModel.getMaxSpeedFallback();
-        cwHelper = ExpressionBuilder.create(customModel, lookup, baseFlagEncoder.getMaxSpeed(), maxSpeedTmp, baseFlagEncoder.getAverageSpeedEnc());
-        maxSpeed = maxSpeedTmp / SPEED_CONV;
-
-        // given unit is s/km -> convert to s/m
-        this.distanceInfluence = customModel.getDistanceInfluence() / 1000.0;
-        if (this.distanceInfluence < 0)
-            throw new IllegalArgumentException("distance_influence cannot be negative " + this.distanceInfluence);
+        CustomWeightingHelper cwHelper = ExpressionBuilder.create(customModel, lookup, baseFlagEncoder.getMaxSpeed(), maxSpeedTmp, baseFlagEncoder.getAverageSpeedEnc());
+        return new CustomWeighting(baseFlagEncoder, turnCostProvider, cwHelper, maxSpeedTmp, distanceInfluence, headingPenaltySeconds);
     }
 
     public CustomWeighting(FlagEncoder baseFlagEncoder, TurnCostProvider turnCostProvider, CustomWeightingHelper cwHelper,

--- a/core/src/main/java/com/graphhopper/routing/weighting/custom/CustomWeightingHelper.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/custom/CustomWeightingHelper.java
@@ -32,7 +32,7 @@ import java.util.Map;
  * This class is for internal usage only. It is subclassed by Janino, then special expressions are injected into init,
  * getSpeed and getPriority. At the end an instance is created and used in CustomWeighting.
  */
-public class CustomWeightingHelper {
+public class CustomWeightingHelper implements SpeedAndAccessProvider {
     protected DecimalEncodedValue avg_speed_enc;
     protected static boolean DEFAULT = true;
 
@@ -43,10 +43,12 @@ public class CustomWeightingHelper {
         this.avg_speed_enc = avgSpeedEnc;
     }
 
+    @Override
     public double getPriority(EdgeIteratorState edge, boolean reverse) {
         return 1;
     }
 
+    @Override
     public double getSpeed(EdgeIteratorState edge, boolean reverse) {
         return getRawSpeed(edge, reverse);
     }

--- a/core/src/main/java/com/graphhopper/routing/weighting/custom/ExpressionBuilder.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/custom/ExpressionBuilder.java
@@ -66,12 +66,16 @@ class ExpressionBuilder {
                 }
             });
 
+    private ExpressionBuilder() {
+        // utility class
+    }
+
     /**
      * This method compiles a new subclass of CustomWeightingHelper composed from the provided CustomModel caches this
      * and returns an instance.
      */
-    static CustomWeightingHelper create(CustomModel customModel, EncodedValueLookup lookup,
-                                        double globalMaxSpeed, double maxSpeedFallback, DecimalEncodedValue avgSpeedEnc) {
+    static SpeedAndAccessProvider create(CustomModel customModel, EncodedValueLookup lookup,
+                                         double globalMaxSpeed, double maxSpeedFallback, DecimalEncodedValue avgSpeedEnc) {
         Java.CompilationUnit cu;
         try {
             String key = customModel.toString() + ",global:" + globalMaxSpeed + ",fallback:" + maxSpeedFallback;
@@ -304,6 +308,7 @@ class ExpressionBuilder {
         cu = new DeepCopier() {
             boolean speedInjected = false;
             boolean priorityInjected = false;
+
             @Override
             public Java.FieldDeclaration copyFieldDeclaration(Java.FieldDeclaration subject) throws CompileException {
                 // for https://github.com/janino-compiler/janino/issues/135

--- a/core/src/main/java/com/graphhopper/routing/weighting/custom/SpeedAndAccessProvider.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/custom/SpeedAndAccessProvider.java
@@ -1,0 +1,27 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.graphhopper.routing.weighting.custom;
+
+import com.graphhopper.util.EdgeIteratorState;
+
+interface SpeedAndAccessProvider {
+    double getSpeed(EdgeIteratorState edge, boolean reverse);
+
+    double getPriority(EdgeIteratorState edge, boolean reverse);
+}

--- a/core/src/test/java/com/graphhopper/routing/weighting/custom/CustomWeightingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/custom/CustomWeightingTest.java
@@ -302,6 +302,6 @@ class CustomWeightingTest {
     }
 
     private Weighting createWeighting(CustomModel vehicleModel) {
-        return new CustomWeighting(carFE, encodingManager, NO_TURN_COST_PROVIDER, vehicleModel);
+        return CustomWeighting.create(carFE, encodingManager, NO_TURN_COST_PROVIDER, vehicleModel);
     }
 }

--- a/core/src/test/java/com/graphhopper/routing/weighting/custom/ExpressionBuilderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/custom/ExpressionBuilderTest.java
@@ -1,0 +1,52 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.graphhopper.routing.weighting.custom;
+
+import com.graphhopper.routing.ev.EnumEncodedValue;
+import com.graphhopper.routing.ev.RoadClass;
+import com.graphhopper.routing.util.CarFlagEncoder;
+import com.graphhopper.routing.util.CustomModel;
+import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.storage.GraphBuilder;
+import com.graphhopper.storage.GraphHopperStorage;
+import com.graphhopper.util.EdgeIteratorState;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ExpressionBuilderTest {
+    @Test
+    void setPriorityForRoadClass() {
+        CarFlagEncoder encoder = new CarFlagEncoder();
+        EncodingManager encodingManager = EncodingManager.create(encoder);
+        CustomModel customModel = new CustomModel();
+        customModel.getPriority().put("road_class == PRIMARY", 0.5);
+        // todo: can we get rid of this line here?
+        double maxSpeedFallback = customModel.getMaxSpeedFallback() == null ? encoder.getMaxSpeed() : customModel.getMaxSpeedFallback();
+        SpeedAndAccessProvider speedAndAccessProvider = ExpressionBuilder.create(customModel, encodingManager, encoder.getMaxSpeed(), maxSpeedFallback, encoder.getAverageSpeedEnc());
+
+        EnumEncodedValue<RoadClass> roadClassEnc = encodingManager.getEnumEncodedValue(RoadClass.KEY, RoadClass.class);
+        GraphHopperStorage graph = new GraphBuilder(encodingManager).create();
+        EdgeIteratorState edge1 = graph.edge(0, 1).setDistance(100).set(roadClassEnc, RoadClass.PRIMARY);
+        EdgeIteratorState edge2 = graph.edge(1, 2).setDistance(100).set(roadClassEnc, RoadClass.SECONDARY);
+
+        assertEquals(0.5, speedAndAccessProvider.getPriority(edge1, false), 1.e-6);
+        assertEquals(1.0, speedAndAccessProvider.getPriority(edge2, false), 1.e-6);
+    }
+}


### PR DESCRIPTION
Here I tried separating the custom model parsing from the custom weighting creation a bit, such that e.g. we can test extracting speeds and priorities from the custom model definition without creating a `CustomWeighting`.

Follow-up of this comment: https://github.com/graphhopper/graphhopper/pull/2209/files#r541899846

