### PR TITLE
Log MultiException properly

### DIFF
--- a/web-bundle/src/main/java/com/graphhopper/http/MultiExceptionMapper.java
+++ b/web-bundle/src/main/java/com/graphhopper/http/MultiExceptionMapper.java
@@ -33,7 +33,9 @@ public class MultiExceptionMapper implements ExceptionMapper<MultiException> {
 
     @Override
     public Response toResponse(MultiException e) {
-        logger.info("bad request: " + (Helper.isEmpty(e.getMessage()) ? "unknown reason" : e.getErrors()));
+        logger.info("bad request: " + (Helper.isEmpty(e.getMessage())
+                ? (e.getErrors().isEmpty() ? "unknown reason" : e.getErrors().toString())
+                : e.getErrors()));
         return Response.status(Response.Status.BAD_REQUEST)
                 .entity(e)
                 .build();


### PR DESCRIPTION
Our `MultiException` constructor calls the default `RuntimeException` constructor , so the `detailsMessage` field in `Throwable` is always `null`. Therefore we log `unknown reason` for many errors. I changed this so we see more details on e.g. 400 errors like this:

```
# before
com.graphhopper.http.MultiExceptionMapper: bad request: unknown reason

# after
com.graphhopper.http.MultiExceptionMapper: bad request: [java.lang.IllegalArgumentException: The 'heading' parameter is currently not supported for speed mode, you need to disable speed mode with `ch.disable=true`. See issue #483]
```

Not sure, we could also properly set the message in `MultiException` and skip `java.lang.IllegalArgumentException` for the output, but this seemed like the minimal fix..