### PR TITLE
Remove configurable-assets-bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ android/libs/graphhopper-*-android.jar
 .idea/
 *iml
 /web/src/main/resources/assets/js/config/options_prod.js
+/web/src/main/resources/assets/js/main.js
 /web/dependency-reduced-pom.xml
 /web/node
 *.pbf

--- a/config-example.yml
+++ b/config-example.yml
@@ -172,15 +172,6 @@ graphhopper:
   # Having less rules, might result in a smaller graph. The line below contains the world-wide bounding box, uncomment and adapt to your need.
   # spatial_rules.max_bbox: -180,180,-90,90
 
-
-# Uncomment the following to point /maps to the source directory in the filesystem instead of
-# the Java resource path. Helpful for development of the web client.
-# Assumes that the web module is the working directory.
-#
-# assets:
-#  overrides:
-#    /maps: web/target/classes/assets/
-
 # Dropwizard server configuration
 server:
   application_connectors:

--- a/docs/core/quickstart-from-source.md
+++ b/docs/core/quickstart-from-source.md
@@ -96,15 +96,6 @@ as those versions are not in maven central:
 
 ### JavaScript
 
-When developing the UI for GraphHopper you need to enable serving files
-directly from local disc via your config.yml:
-
-```yml
-assets:
-  overrides:
-    /maps: web/src/main/resources/assets/
-```
-
 To setup the JavaScript development environment install the [node package
 manager](https://github.com/nvm-sh/nvm):
 
@@ -122,7 +113,7 @@ production:
 ```bash
 cd web
 
-# For development just use watchify and all changes will be available on refresh:
+# For development just use watchify and all changes (except those in index.html) will be available on refresh:
 npm run watch
 
 # bundle creates the main file

--- a/docs/core/quickstart-from-source.md
+++ b/docs/core/quickstart-from-source.md
@@ -113,7 +113,12 @@ production:
 ```bash
 cd web
 
-# For development just use watchify and all changes (except those in index.html) will be available on refresh:
+# For development just use watchify, which updates the main.js file whenever you change one of the .js files:
+# To see your changes in the browser without restarting the server you can either run the GH server in debug mode from
+# IntelliJ and use `Run->Debugging Actions->Reload Changed Classes` (and refresh your browser window). Or you serve
+# GH maps from the web/src/main/resources/assets folder directly using e.g. `live-server` (npm install -g live-server).
+# For the latter case make sure GH maps points to your running GH instance (set the routing host in js/config/options.js
+# to e.g. http://localhost:8989/).
 npm run watch
 
 # bundle creates the main file

--- a/docs/core/quickstart-from-source.md
+++ b/docs/core/quickstart-from-source.md
@@ -94,33 +94,38 @@ as those versions are not in maven central:
     </repositories>
 ```
 
-### JavaScript
+### Web UI (JavaScript)
 
 To setup the JavaScript development environment install the [node package
-manager](https://github.com/nvm-sh/nvm):
+manager](https://github.com/nvm-sh/nvm#install--update-script). For windows use [nvm-windows](https://github.com/coreybutler/nvm-windows).
 
-```bash
-wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | bash && \. $HOME/.nvm/nvm.sh && nvm install
-# create main.js via npm
-cd web && npm install && npm run bundleProduction && cd ..
-```
-
-For windows use [nvm-windows](https://github.com/coreybutler/nvm-windows).
-
-There are more npm commands to e.g. change the main.js on the fly or create an uglified main.js for
-production:
+To develop the web UI you need to rebuild the bundled main.js on every change. npm does this for you automatically:
 
 ```bash
 cd web
-
-# For development just use watchify, which updates the main.js file whenever you change one of the .js files:
-# To see your changes in the browser without restarting the server you can either run the GH server in debug mode from
-# IntelliJ and use `Run->Debugging Actions->Reload Changed Classes` (and refresh your browser window). Or you serve
-# GH maps from the web/src/main/resources/assets folder directly using e.g. `live-server` (npm install -g live-server).
-# For the latter case make sure GH maps points to your running GH instance (set the routing host in js/config/options.js
-# to e.g. http://localhost:8989/).
 npm run watch
+```
 
+To see your changes in the browser without restarting the server you can either run the GH server in debug mode from
+IntelliJ (use `Run->Debugging Actions->Reload Changed Classes` and refresh your browser window). 
+
+Or you start a separate server. For this you need to change the routing.host property in src/main/resources/assets/js/config/options.js:
+```js
+...
+  routing: {host: 'http://localhost:8989', api_key: ''},
+...
+```
+
+And then in a second shell do:
+
+```
+npm install -g live-server
+live-server --open=src/main/resources/assets/
+```
+
+Other npm commands e.g. to produce a bundled main.js for production:
+
+```bash
 # bundle creates the main file
 npm run bundle
 

--- a/pom.xml
+++ b/pom.xml
@@ -90,15 +90,9 @@
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-dependencies</artifactId>
-                <!-- make sure the dropwizard version is compatible to the below dropwizard-configurable-assets-bundle version -->
                 <version>2.0.16</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>io.dropwizard-bundles</groupId>
-                <artifactId>dropwizard-configurable-assets-bundle</artifactId>
-                <version>1.3.5</version>
             </dependency>
             <dependency>
                 <groupId>com.graphhopper.external</groupId>

--- a/web/package.json
+++ b/web/package.json
@@ -6,10 +6,10 @@
   "license": "Apache-2.0",
   "main": "main.js",
   "scripts": {
-    "watch": "watchify src/main/resources/assets/js/main-template.js -o target/classes/assets/js/main.js --debug --verbose",
-    "bundle": "browserify src/main/resources/assets/js/main-template.js -o target/classes/assets/js/main.js",
-    "bundleDebug": "browserify src/main/resources/assets/js/main-template.js --debug -o target/classes/assets/js/main.js",
-    "bundleProduction": "browserify -g uglifyify src/main/resources/assets/js/main-template.js -o target/classes/assets/js/main.js",
+    "watch": "watchify src/main/resources/assets/js/main-template.js -o src/main/resources/assets/js/main.js --debug --verbose",
+    "bundle": "browserify src/main/resources/assets/js/main-template.js -o src/main/resources/assets/js/main.js",
+    "bundleDebug": "browserify src/main/resources/assets/js/main-template.js --debug -o src/main/resources/assets/js/main.js",
+    "bundleProduction": "browserify -g uglifyify src/main/resources/assets/js/main-template.js -o src/main/resources/assets/js/main.js",
     "test": "JASMINE_CONFIG_PATH=src/test/resources/assets/spec/jasmine.json jasmine",
     "lint": "jshint src/main/resources/assets/js/"
   },

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -24,6 +24,10 @@
             <artifactId>dropwizard-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-assets</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.graphhopper</groupId>
             <artifactId>graphhopper-web-bundle</artifactId>
             <version>${project.parent.version}</version>
@@ -32,10 +36,6 @@
             <groupId>com.graphhopper</groupId>
             <artifactId>graphhopper-nav</artifactId>
             <version>${project.parent.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.dropwizard-bundles</groupId>
-            <artifactId>dropwizard-configurable-assets-bundle</artifactId>
         </dependency>
 
         <!-- Pt and/or map-matching and/or isochrone web client dependencies-->

--- a/web/src/main/java/com/graphhopper/http/CORSFilter.java
+++ b/web/src/main/java/com/graphhopper/http/CORSFilter.java
@@ -30,7 +30,7 @@ public class CORSFilter implements Filter {
         HttpServletResponse rsp = (HttpServletResponse) response;
         rsp.setHeader("Access-Control-Allow-Methods", "GET, POST, HEAD, OPTIONS");
         rsp.setHeader("Access-Control-Allow-Headers", "Origin,Accept,X-Requested-With,"
-                + "Content-Type,Access-Control-Request-Method,Access-Control-Request-Headers,Range");
+                + "Content-Type,Access-Control-Request-Method,Access-Control-Request-Headers,Range,gh-client");
         rsp.setHeader("Access-Control-Allow-Origin", "*");
 
         chain.doFilter(request, response);

--- a/web/src/main/java/com/graphhopper/http/GraphHopperApplication.java
+++ b/web/src/main/java/com/graphhopper/http/GraphHopperApplication.java
@@ -42,6 +42,8 @@ public final class GraphHopperApplication extends Application<GraphHopperServerC
         bootstrap.addCommand(new ImportCommand());
         bootstrap.addCommand(new MatchCommand());
         bootstrap.addBundle(new AssetsBundle("/assets/", "/maps/", "index.html"));
+        // see this link even though its outdated?! // https://www.webjars.org/documentation#dropwizard
+        bootstrap.addBundle(new AssetsBundle("/META-INF/resources/webjars", "/webjars/", null, "webjars"));
     }
 
     @Override

--- a/web/src/main/java/com/graphhopper/http/GraphHopperApplication.java
+++ b/web/src/main/java/com/graphhopper/http/GraphHopperApplication.java
@@ -22,14 +22,12 @@ import com.graphhopper.http.cli.MatchCommand;
 import com.graphhopper.http.resources.RootResource;
 import com.graphhopper.navigation.NavigateResource;
 import io.dropwizard.Application;
-import io.dropwizard.bundles.assets.ConfiguredAssetsBundle;
+import io.dropwizard.assets.AssetsBundle;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 
 import javax.servlet.DispatcherType;
 import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.Map;
 
 public final class GraphHopperApplication extends Application<GraphHopperServerConfiguration> {
 
@@ -43,11 +41,7 @@ public final class GraphHopperApplication extends Application<GraphHopperServerC
         bootstrap.addBundle(new RealtimeBundle());
         bootstrap.addCommand(new ImportCommand());
         bootstrap.addCommand(new MatchCommand());
-
-        Map<String, String> resourceToURIMappings = new HashMap<>();
-        resourceToURIMappings.put("/assets/", "/maps/");
-        resourceToURIMappings.put("/META-INF/resources/webjars", "/webjars"); // https://www.webjars.org/documentation#dropwizard
-        bootstrap.addBundle(new ConfiguredAssetsBundle(resourceToURIMappings, "index.html"));
+        bootstrap.addBundle(new AssetsBundle("/assets/", "/maps/", "index.html"));
     }
 
     @Override

--- a/web/src/main/java/com/graphhopper/http/GraphHopperServerConfiguration.java
+++ b/web/src/main/java/com/graphhopper/http/GraphHopperServerConfiguration.java
@@ -20,21 +20,14 @@ package com.graphhopper.http;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.graphhopper.GraphHopperConfig;
 import io.dropwizard.Configuration;
-import io.dropwizard.bundles.assets.AssetsBundleConfiguration;
-import io.dropwizard.bundles.assets.AssetsConfiguration;
 
-import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
-public class GraphHopperServerConfiguration extends Configuration implements GraphHopperBundleConfiguration, RealtimeBundleConfiguration, AssetsBundleConfiguration {
+public class GraphHopperServerConfiguration extends Configuration implements GraphHopperBundleConfiguration, RealtimeBundleConfiguration {
 
     @NotNull
     @JsonProperty
     private final GraphHopperConfig graphhopper = new GraphHopperConfig();
-
-    @Valid
-    @JsonProperty
-    private final AssetsConfiguration assets = AssetsConfiguration.builder().build();
 
     @JsonProperty
     private final RealtimeConfiguration gtfsRealtime = new RealtimeConfiguration();
@@ -45,11 +38,6 @@ public class GraphHopperServerConfiguration extends Configuration implements Gra
     @Override
     public GraphHopperConfig getGraphHopperConfiguration() {
         return graphhopper;
-    }
-
-    @Override
-    public AssetsConfiguration getAssetsConfiguration() {
-        return assets;
     }
 
     @Override

--- a/web/src/main/resources/assets/js/config/options.js
+++ b/web/src/main/resources/assets/js/config/options.js
@@ -11,6 +11,8 @@
 exports.options = {
     with_tiles: true,
     environment: "development",
+    // for local development use this (assuming your GH server is running on the standard port)
+    // routing: {host: 'http://localhost:8989', api_key: ''},
     routing: {host: '', api_key: ''},
     geocoding: {host: '', api_key: ''},
     thunderforest: {api_key: ''},

--- a/web/src/main/resources/assets/js/config/options.js
+++ b/web/src/main/resources/assets/js/config/options.js
@@ -5,7 +5,7 @@
 // Misuse of API keys that you don't own is prohibited and you'll be blocked.
 ////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-// Easily replace this options.js with an additional file that you prodive as options_prod.js activate via:
+// Easily replace this options.js with an additional file that you provide as options_prod.js activate via:
 // BROWSERIFYSWAP_ENV='production' npm run watch
 // see also package.json and https://github.com/thlorenz/browserify-swap
 exports.options = {

--- a/web/src/main/resources/assets/js/graphhopper/GHRequest.js
+++ b/web/src/main/resources/assets/js/graphhopper/GHRequest.js
@@ -256,8 +256,7 @@ GHRequest.prototype.doRequest = function (url, callback) {
         timeout: 30000,
         url: url,
         beforeSend: function(request) {
-            request.setRequestHeader("gh-client", "web-ui")
-            request.setRequestHeader("gh-client-version", "1.0")
+            request.setRequestHeader("gh-client", "web-ui 3.0")
         },
         success: function (json) {
             if (json.paths) {


### PR DESCRIPTION
The configurable-assets-bundle was used so we can edit the maps JavaScript code while the server is running(?). However, we were already pointing the bundle override into web/target/classes in config-example.yml and if we change the files there our changes will be reflected in the browser already without the configurable-assets-bundle. Therefore I do not see why we need this?

With this PR we (still) can edit main-template.js or any of the other javascript files of the map client and see the changes after a page reload byrunning `npm run watch` which will browserify all the files and copy the resulting `main.js` file to web/target/classes/assets whenever we make a change. Changes to `index.html` are not reflected and we would need some mechanism that updates `index.html` in the target folder after making a change to achieve the same effect. In any cas the configurable-resource-bundle would only be beneficial if we pointed it to web/src/main/resources/assets, but I could not make this work and apparently config-example.yml was changed to point to the target folder (maybe for the same reason).