### PR TITLE
CustomModelParser can handle multiple areas

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -78,6 +78,7 @@ Here is an overview:
  * vvikas, ideas for many to many improvements and #616
  * zstadler, multiple fixes and car4wd
  * samruston, improved point hint matching
+ * GProbo, fixes like #2241
 
 ## Translations
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -32,7 +32,8 @@ Here is an overview:
  * elibar, fix for alternative route calculation
  * fbonzon, several UI improvements like #615
  * florent-morel, improvements regarding fords, #320
- * fredao, translations 
+ * fredao, translations
+ * GProbo, fixes like #2241
  * HarelM, improvements regarding elevation
  * HelgeKrueger, modularization of javascript, #590
  * henningvs, doc improvements
@@ -78,7 +79,6 @@ Here is an overview:
  * vvikas, ideas for many to many improvements and #616
  * zstadler, multiple fixes and car4wd
  * samruston, improved point hint matching
- * GProbo, fixes like #2241
 
 ## Translations
 

--- a/core/src/main/java/com/graphhopper/routing/weighting/custom/CustomModelParser.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/custom/CustomModelParser.java
@@ -259,8 +259,8 @@ public class CustomModelParser {
                 if (!customModel.getAreas().containsKey(id))
                     throw new IllegalArgumentException("Area '" + id + "' wasn't found");
                 classSourceCode.append("protected " + Polygon.class.getSimpleName() + " " + arg + ";\n");
-                initSourceCode.append("JsonFeature feature = (JsonFeature) areas.get(\"" + id + "\");\n");
-                initSourceCode.append("this." + arg + " = new Polygon(new PreparedGeometryFactory().create(feature.getGeometry()));\n");
+                initSourceCode.append("JsonFeature feature_" + id + " = (JsonFeature) areas.get(\"" + id + "\");\n");
+                initSourceCode.append("this." + arg + " = new Polygon(new PreparedGeometryFactory().create(feature_" + id + ".getGeometry()));\n");
             } else {
                 if (!isValidVariableName(arg))
                     throw new IllegalArgumentException("Variable not supported: " + arg);


### PR DESCRIPTION
Solving issue #2240 
CustomModelParser used to create a Java file with a JsonFeature called feature. In case of multiple areas the JsonFeature was created twice.

The following is the code created by CustomModelParser.
  @Override
   public void init(EncodedValueLookup lookup, com.graphhopper.routing.ev.DecimalEncodedValue avgSpeedEnc, Map<String, com.graphhopper.util.JsonFeature> areas) {
this.avg_speed_enc = avgSpeedEnc;
JsonFeature feature = (JsonFeature) areas.get("milano");
this.in_area_milano = new Polygon(new PreparedGeometryFactory().create(feature.getGeometry()));
JsonFeature feature = (JsonFeature) areas.get("modena");
this.in_area_modena = new Polygon(new PreparedGeometryFactory().create(feature.getGeometry()));
if (lookup.hasEncodedValue("road_class")) this.road_class_enc = (EnumEncodedValue) lookup.getEncodedValue("road_class", EncodedValue.class);
   }

I added in CustomModelParser.createClassTemplate an id to the JsonFeature feature.
Now CustomModelParser create the following code:
 @Override
   public void init(EncodedValueLookup lookup, com.graphhopper.routing.ev.DecimalEncodedValue avgSpeedEnc, Map<String, com.graphhopper.util.JsonFeature> areas) {
this.avg_speed_enc = avgSpeedEnc;
JsonFeature feature_milano = (JsonFeature) areas.get("milano");
this.in_area_milano = new Polygon(new PreparedGeometryFactory().create(feature_milano.getGeometry()));
JsonFeature feature_modena = (JsonFeature) areas.get("modena");
this.in_area_modena = new Polygon(new PreparedGeometryFactory().create(feature_modena.getGeometry()));
if (lookup.hasEncodedValue("road_class")) this.road_class_enc = (EnumEncodedValue) lookup.getEncodedValue("road_class", EncodedValue.class);
   }