### PR TITLE
Update leaflet.heightgraph 0.2.0 -> 1.4.0

### DIFF
--- a/web-bundle/package.json
+++ b/web-bundle/package.json
@@ -30,7 +30,7 @@
     "leaflet": "1.5.1",
     "leaflet-contextmenu": "1.4.0",
     "leaflet-loading": "0.1.24",
-    "leaflet.heightgraph": "0.2.0",
+    "leaflet.heightgraph": "1.4.0",
     "leaflet.vectorgrid": "1.3.0",
     "moment": "2.22.1"
   },

--- a/web-bundle/src/main/resources/com/graphhopper/maps/js/map.js
+++ b/web-bundle/src/main/resources/com/graphhopper/maps/js/map.js
@@ -285,8 +285,8 @@ module.exports.addElevation = function (geoJsonFeature, details) {
             bottom: 55,
             left: 50
         },
-        xTicks: 6,
-        yTicks: 6,
+        xTicks: 3,
+        yTicks: 3,
         position: "bottomright",
         expand: expandElevationDiagram,
         expandCallback: function (expand) {


### PR DESCRIPTION
I updated the heightgraph version. One thing I noticed is that in master the 'elevation highlighting' is not updated while moving the slider (on the right y-axis of the diagram) and after moving it it annoyingly jumps back to zero when I try to move it again. But this seems fixed with the new version. (Update: Yes this was: https://github.com/GIScience/Leaflet.Heightgraph/issues/42). Also with 1.4.0 it is possible to use a continuous color scale for numeric path details like average_speed or time. Will do this in a follow-up PR.

@boldtrn Thanks for developing the elevation diagram. Do you think there is an issue with this update? I already adjusted the x-ticks (they were too frequent, probably since 0.4.1) and checked the css file (its the same except a folder name img/images).