### PR TITLE
Keep elevation diagram selection between requests

### DIFF
--- a/web-bundle/package.json
+++ b/web-bundle/package.json
@@ -30,7 +30,7 @@
     "leaflet": "1.5.1",
     "leaflet-contextmenu": "1.4.0",
     "leaflet-loading": "0.1.24",
-    "leaflet.heightgraph": "0.2.0",
+    "leaflet.heightgraph": "1.4.0",
     "leaflet.vectorgrid": "1.3.0",
     "moment": "2.22.1"
   },

--- a/web-bundle/src/main/resources/com/graphhopper/maps/index.html
+++ b/web-bundle/src/main/resources/com/graphhopper/maps/index.html
@@ -36,7 +36,7 @@
         <link rel="stylesheet" href="css/codemirror/lib/codemirror.css?v=5.59.2">
         <link rel="stylesheet" href="css/codemirror/addon/hint/show-hint.css?v=5.59.2">
         <link rel="stylesheet" href="css/codemirror/addon/lint/lint.css?v=5.59.2">
-        <script type="text/javascript" src="js/main.js?v=0.11.2"></script>
+        <script type="text/javascript" src="js/main.js?v=3.0-SNAPSHOT"></script>
         <link rel="stylesheet" type="text/css" href="css/style.css" />
     </head>
     <body>

--- a/web-bundle/src/main/resources/com/graphhopper/maps/js/graphhopper/GHRequest.js
+++ b/web-bundle/src/main/resources/com/graphhopper/maps/js/graphhopper/GHRequest.js
@@ -60,7 +60,7 @@ var GHRequest = function (host, api_key) {
 
 GHRequest.prototype.init = function (params) {
     for (var key in params) {
-        if (key === "point" || key === "mathRandom" || key === "do_zoom" || key === "layer" || key === "use_miles")
+        if (key === "point" || key === "mathRandom" || key === "do_zoom" || key === "layer" || key === "use_miles" || key === "selected_detail")
             continue;
 
         var val = params[key];
@@ -77,6 +77,9 @@ GHRequest.prototype.init = function (params) {
 
     if ('use_miles' in params)
         this.useMiles = params.use_miles;
+
+    if ('selected_detail' in params)
+        this.selectedDetail = params.selected_detail;
 
     if (!this.api_params.profile)
         this.api_params.profile = this.profiles[0].profile_name
@@ -194,7 +197,7 @@ GHRequest.prototype.createGPXURL = function (withRoute, withTrack, withWayPoints
 
 GHRequest.prototype.createHistoryURL = function () {
     var skip = {"key": true};
-    return this.createPath("?" + this.createPointParams(true), skip) + "&use_miles=" + !!this.useMiles;
+    return this.createPath("?" + this.createPointParams(true), skip) + "&use_miles=" + !!this.useMiles + (this.selectedDetail ? "&selected_detail=" + this.selectedDetail : "");
 };
 
 GHRequest.prototype.createPointParams = function (useRawInput) {

--- a/web-bundle/src/main/resources/com/graphhopper/maps/js/main-template.js
+++ b/web-bundle/src/main/resources/com/graphhopper/maps/js/main-template.js
@@ -681,7 +681,7 @@ function createRouteCallback(request, routeResultsDiv, urlForHistory, doZoom) {
            return;
        }
 
-       function createClickHandler(geoJsons, currentLayerIndex, tabHeader, oneTab, hasElevation, details) {
+       function createClickHandler(geoJsons, currentLayerIndex, tabHeader, oneTab, hasElevation, details, selectedDetail, detailSelected) {
            return function () {
 
                var currentGeoJson = geoJsons[currentLayerIndex];
@@ -700,7 +700,7 @@ function createRouteCallback(request, routeResultsDiv, urlForHistory, doZoom) {
 
                if (hasElevation) {
                    mapLayer.clearElevation();
-                   mapLayer.addElevation(currentGeoJson, details);
+                   mapLayer.addElevation(currentGeoJson, details, selectedDetail, detailSelected);
                }
 
                headerTabs.find("li").removeClass("current");
@@ -766,7 +766,10 @@ function createRouteCallback(request, routeResultsDiv, urlForHistory, doZoom) {
            mapLayer.addDataToRoutingLayer(geojsonFeature);
            var oneTab = $("<div class='route_result_tab'>");
            routeResultsDiv.append(oneTab);
-           tabHeader.click(createClickHandler(geoJsons, pathIndex, tabHeader, oneTab, request.hasElevation(), path.details));
+           var detailSelected = function (id, type) {
+               ghRequest.selectedDetail = type.text;
+           }
+           tabHeader.click(createClickHandler(geoJsons, pathIndex, tabHeader, oneTab, request.hasElevation(), path.details, request.selectedDetail, detailSelected));
 
            var routeInfo = $("<div class='route_description'>");
            if (path.description && path.description.length > 0) {

--- a/web-bundle/src/main/resources/com/graphhopper/maps/js/map.js
+++ b/web-bundle/src/main/resources/com/graphhopper/maps/js/map.js
@@ -302,6 +302,7 @@ module.exports.addElevation = function (geoJsonFeature, details, selectedDetail,
     var selectedDetailIdx = -1;
     for (var detailKey in details) {
         detailIdx++;
+        console.log(detailIdx, detailKey);
         if (detailKey === selectedDetail)
             selectedDetailIdx = detailIdx;
         GHFeatureCollection.push(sliceFeatureCollection(details[detailKey], detailKey, geoJsonFeature))

--- a/web-bundle/src/main/resources/com/graphhopper/maps/js/map.js
+++ b/web-bundle/src/main/resources/com/graphhopper/maps/js/map.js
@@ -302,6 +302,8 @@ module.exports.addElevation = function (geoJsonFeature, details, selectedDetail,
     var selectedDetailIdx = -1;
     for (var detailKey in details) {
         detailIdx++;
+        // strangely without this console.log the detail-selection does not work (tried FF and Chrome)
+        // no idea, just keeping it for now...
         console.log(detailIdx, detailKey);
         if (detailKey === selectedDetail)
             selectedDetailIdx = detailIdx;

--- a/web-bundle/src/main/resources/com/graphhopper/maps/js/map.js
+++ b/web-bundle/src/main/resources/com/graphhopper/maps/js/map.js
@@ -273,7 +273,7 @@ module.exports.focus = focus;
 module.exports.initMap = initMap;
 module.exports.adjustMapSize = adjustMapSize;
 
-module.exports.addElevation = function (geoJsonFeature, details) {
+module.exports.addElevation = function (geoJsonFeature, details, selectedDetail, detailSelected) {
 
     // TODO no option to switch to miles yet
     var options = {
@@ -291,14 +291,23 @@ module.exports.addElevation = function (geoJsonFeature, details) {
         expand: expandElevationDiagram,
         expandCallback: function (expand) {
             expandElevationDiagram = expand;
-        }
+        },
+        selectedAttributeIdx: 0,
+        chooseSelectionCallback: detailSelected
     };
 
     var GHFeatureCollection = [];
 
+    var detailIdx = -1;
+    var selectedDetailIdx = -1;
     for (var detailKey in details) {
+        detailIdx++;
+        if (detailKey === selectedDetail)
+            selectedDetailIdx = detailIdx;
         GHFeatureCollection.push(sliceFeatureCollection(details[detailKey], detailKey, geoJsonFeature))
     }
+    if (selectedDetailIdx >= 0)
+        options.selectedAttributeIdx = selectedDetailIdx;
 
     if(GHFeatureCollection.length === 0) {
         // No Path Details => Show only elevation

--- a/web-bundle/src/main/resources/com/graphhopper/maps/js/map.js
+++ b/web-bundle/src/main/resources/com/graphhopper/maps/js/map.js
@@ -285,8 +285,8 @@ module.exports.addElevation = function (geoJsonFeature, details) {
             bottom: 55,
             left: 50
         },
-        xTicks: 6,
-        yTicks: 6,
+        xTicks: 3,
+        yTicks: 3,
         position: "bottomright",
         expand: expandElevationDiagram,
         expandCallback: function (expand) {


### PR DESCRIPTION
I added a new `selected_detail` url parameter to the maps UI. It stores the selected detail in the elevation diagram so we can keep the selection in between requests (e.g. when we shift the markers or update the custom model).

This PR depends on #2257 