### PR TITLE
Use MaxSpeed EV in the AbstractFlagEncoder

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/CarFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/CarFlagEncoder.java
@@ -241,7 +241,7 @@ public class CarFlagEncoder extends AbstractFlagEncoder {
         if (!accept.isFerry()) {
             // get assumed speed from highway type
             double speed = getSpeed(way);
-            speed = applyMaxSpeed(way, speed);
+            speed = applyMaxSpeed(edgeFlags, speed);
 
             speed = applyBadSurfaceSpeed(way, speed);
 

--- a/core/src/main/java/com/graphhopper/routing/util/FootFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/FootFlagEncoder.java
@@ -242,7 +242,7 @@ public class FootFlagEncoder extends AbstractFlagEncoder {
             setSpeed(edgeFlags, true, true, ferrySpeed);
         }
 
-        priorityWayEncoder.setDecimal(false, edgeFlags, PriorityCode.getFactor(handlePriority(way, priorityFromRelation)));
+        priorityWayEncoder.setDecimal(false, edgeFlags, PriorityCode.getFactor(handlePriority(edgeFlags, way, priorityFromRelation)));
         return edgeFlags;
     }
 
@@ -255,14 +255,14 @@ public class FootFlagEncoder extends AbstractFlagEncoder {
             avgSpeedEnc.setDecimal(true, edgeFlags, speed);
     }
 
-    int handlePriority(ReaderWay way, Integer priorityFromRelation) {
+    int handlePriority(IntsRef edgeFlags, ReaderWay way, Integer priorityFromRelation) {
         TreeMap<Double, Integer> weightToPrioMap = new TreeMap<>();
         if (priorityFromRelation == null)
             weightToPrioMap.put(0d, UNCHANGED.getValue());
         else
             weightToPrioMap.put(110d, priorityFromRelation);
 
-        collect(way, weightToPrioMap);
+        collect(edgeFlags, way, weightToPrioMap);
 
         // pick priority with biggest order value
         return weightToPrioMap.lastEntry().getValue();
@@ -272,12 +272,12 @@ public class FootFlagEncoder extends AbstractFlagEncoder {
      * @param weightToPrioMap associate a weight with every priority. This sorted map allows
      *                        subclasses to 'insert' more important priorities as well as overwrite determined priorities.
      */
-    void collect(ReaderWay way, TreeMap<Double, Integer> weightToPrioMap) {
+    void collect(IntsRef edgeFlags, ReaderWay way, TreeMap<Double, Integer> weightToPrioMap) {
         String highway = way.getTag("highway");
         if (way.hasTag("foot", "designated"))
             weightToPrioMap.put(100d, PREFER.getValue());
 
-        double maxSpeed = getMaxSpeed(way);
+        double maxSpeed = getMaxSpeed(edgeFlags);
         if (safeHighwayTags.contains(highway) || (isValidSpeed(maxSpeed) && maxSpeed <= 20)) {
             weightToPrioMap.put(40d, PREFER.getValue());
             if (way.hasTag("tunnel", intendedValues)) {

--- a/core/src/main/java/com/graphhopper/routing/util/HikeFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/HikeFlagEncoder.java
@@ -67,12 +67,12 @@ public class HikeFlagEncoder extends FootFlagEncoder {
     }
 
     @Override
-    void collect(ReaderWay way, TreeMap<Double, Integer> weightToPrioMap) {
+    void collect(IntsRef edgeFlags, ReaderWay way, TreeMap<Double, Integer> weightToPrioMap) {
         String highway = way.getTag("highway");
         if (way.hasTag("foot", "designated"))
             weightToPrioMap.put(100d, PREFER.getValue());
 
-        double maxSpeed = getMaxSpeed(way);
+        double maxSpeed = getMaxSpeed(edgeFlags);
         if (safeHighwayTags.contains(highway) || (isValidSpeed(maxSpeed) && maxSpeed <= 20)) {
             weightToPrioMap.put(40d, PREFER.getValue());
             if (way.hasTag("tunnel", intendedValues)) {

--- a/core/src/main/java/com/graphhopper/routing/util/MotorcycleFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/MotorcycleFlagEncoder.java
@@ -20,7 +20,6 @@ package com.graphhopper.routing.util;
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.DecimalEncodedValue;
 import com.graphhopper.routing.ev.EncodedValue;
-import com.graphhopper.routing.ev.MaxSpeed;
 import com.graphhopper.routing.ev.UnsignedDecimalEncodedValue;
 import com.graphhopper.routing.util.parsers.helpers.OSMValueExtractor;
 import com.graphhopper.routing.weighting.CurvatureWeighting;
@@ -174,7 +173,7 @@ public class MotorcycleFlagEncoder extends CarFlagEncoder {
         if (!accept.isFerry()) {
             // get assumed speed from highway type
             double speed = getSpeed(way);
-            speed = applyMaxSpeed(way, speed);
+            speed = applyMaxSpeed(edgeFlags, speed);
 
             double maxMCSpeed = OSMValueExtractor.stringToKmh(way.getTag("maxspeed:motorcycle"));
             if (isValidSpeed(maxMCSpeed) && maxMCSpeed < speed)

--- a/core/src/main/java/com/graphhopper/routing/util/MountainBikeFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/MountainBikeFlagEncoder.java
@@ -18,6 +18,7 @@
 package com.graphhopper.routing.util;
 
 import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.storage.IntsRef;
 import com.graphhopper.util.PMap;
 
 import java.util.TreeMap;
@@ -138,8 +139,8 @@ public class MountainBikeFlagEncoder extends BikeCommonFlagEncoder {
     }
 
     @Override
-    void collect(ReaderWay way, double wayTypeSpeed, TreeMap<Double, Integer> weightToPrioMap) {
-        super.collect(way, wayTypeSpeed, weightToPrioMap);
+    void collect(IntsRef edgeFlags, ReaderWay way, double wayTypeSpeed, TreeMap<Double, Integer> weightToPrioMap) {
+        super.collect(edgeFlags, way, wayTypeSpeed, weightToPrioMap);
 
         String highway = way.getTag("highway");
         if ("track".equals(highway)) {

--- a/core/src/main/java/com/graphhopper/routing/util/RacingBikeFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/RacingBikeFlagEncoder.java
@@ -18,6 +18,7 @@
 package com.graphhopper.routing.util;
 
 import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.storage.IntsRef;
 import com.graphhopper.util.PMap;
 
 import java.util.TreeMap;
@@ -125,8 +126,8 @@ public class RacingBikeFlagEncoder extends BikeCommonFlagEncoder {
     }
 
     @Override
-    void collect(ReaderWay way, double wayTypeSpeed, TreeMap<Double, Integer> weightToPrioMap) {
-        super.collect(way, wayTypeSpeed, weightToPrioMap);
+    void collect(IntsRef edgeFlags, ReaderWay way, double wayTypeSpeed, TreeMap<Double, Integer> weightToPrioMap) {
+        super.collect(edgeFlags, way, wayTypeSpeed, weightToPrioMap);
 
         String highway = way.getTag("highway");
         if ("service".equals(highway)) {

--- a/core/src/main/java/com/graphhopper/routing/util/WheelchairFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/WheelchairFlagEncoder.java
@@ -264,10 +264,10 @@ public class WheelchairFlagEncoder extends FootFlagEncoder {
      * @return a priority for the given way
      */
     @Override
-    protected int handlePriority(ReaderWay way, Integer priorityFromRelation) {
+    protected int handlePriority(IntsRef edgeFlags, ReaderWay way, Integer priorityFromRelation) {
         TreeMap<Double, Integer> weightToPrioMap = new TreeMap<>();
 
-        weightToPrioMap.put(100d, super.handlePriority(way, priorityFromRelation));
+        weightToPrioMap.put(100d, super.handlePriority(edgeFlags, way, priorityFromRelation));
 
         if (way.hasTag("wheelchair", "designated")) {
             weightToPrioMap.put(102d, VERY_NICE.getValue());

--- a/core/src/main/java/com/graphhopper/routing/util/spatialrules/countries/AustriaSpatialRule.java
+++ b/core/src/main/java/com/graphhopper/routing/util/spatialrules/countries/AustriaSpatialRule.java
@@ -60,7 +60,7 @@ public class AustriaSpatialRule extends AbstractSpatialRule {
         case RESIDENTIAL:
             return 50;
         case LIVING_STREET:
-            return 20;
+            return 5;
         default:
             return Double.NaN;
         }

--- a/core/src/main/java/com/graphhopper/routing/util/spatialrules/countries/GermanySpatialRule.java
+++ b/core/src/main/java/com/graphhopper/routing/util/spatialrules/countries/GermanySpatialRule.java
@@ -59,13 +59,10 @@ public class GermanySpatialRule extends AbstractSpatialRule {
             case PRIMARY:
                 return 100;
             case SECONDARY:
-                return 100;
             case TERTIARY:
-                return 100;
             case UNCLASSIFIED:
-                return 100;
             case RESIDENTIAL:
-                return 100;
+                return 50;
             case LIVING_STREET:
                 return 4;
             default:

--- a/core/src/test/java/com/graphhopper/routing/ev/DecimalEncodedValueTest.java
+++ b/core/src/test/java/com/graphhopper/routing/ev/DecimalEncodedValueTest.java
@@ -25,12 +25,14 @@ public class DecimalEncodedValueTest {
         CarFlagEncoder carEncoder = new CarFlagEncoder(10, 0.5, 0);
         EncodingManager em = EncodingManager.create(carEncoder);
         DecimalEncodedValue carAverageSpeedEnc = em.getDecimalEncodedValue(EncodingManager.getKey(carEncoder, "average_speed"));
+        DecimalEncodedValue maxSpeedEnc = em.getDecimalEncodedValue(MaxSpeed.KEY);
 
         ReaderWay way = new ReaderWay(1);
         way.setTag("highway", "motorway_link");
-        way.setTag("maxspeed", "70 mph");
-        IntsRef flags = carEncoder.handleWayTags(em.createEdgeFlags(), way, carEncoder.getAccess(way));
-        assertEquals(101.5, carAverageSpeedEnc.getDecimal(true, flags), 1e-1);
+        IntsRef flags = em.createEdgeFlags();
+        maxSpeedEnc.setDecimal(false, flags, 110);
+        carEncoder.handleWayTags(flags, way, carEncoder.getAccess(way));
+        assertEquals(99, carAverageSpeedEnc.getDecimal(true, flags), 1e-1);
 
         DecimalEncodedValue instance1 = new UnsignedDecimalEncodedValue("test1", 8, 0.5, false);
         instance1.init(new EncodedValue.InitializerConfig());

--- a/core/src/test/java/com/graphhopper/routing/util/AbstractBikeFlagEncoderTester.java
+++ b/core/src/test/java/com/graphhopper/routing/util/AbstractBikeFlagEncoderTester.java
@@ -44,6 +44,7 @@ public abstract class AbstractBikeFlagEncoderTester {
     protected BooleanEncodedValue roundaboutEnc;
     protected DecimalEncodedValue priorityEnc;
     protected DecimalEncodedValue avgSpeedEnc;
+    protected DecimalEncodedValue maxSpeedEnc;
     protected EncodingManager.AcceptWay accessMap;
 
     @Before
@@ -52,6 +53,7 @@ public abstract class AbstractBikeFlagEncoderTester {
         roundaboutEnc = encodingManager.getBooleanEncodedValue(Roundabout.KEY);
         priorityEnc = encodingManager.getDecimalEncodedValue(EncodingManager.getKey(encoder, "priority"));
         avgSpeedEnc = encoder.getAverageSpeedEnc();
+        maxSpeedEnc = encodingManager.getDecimalEncodedValue(MaxSpeed.KEY);
         accessMap = new EncodingManager.AcceptWay().put(encoder.toString(), WAY);
     }
 
@@ -328,9 +330,9 @@ public abstract class AbstractBikeFlagEncoderTester {
 
     @Test
     public void testReduceToMaxSpeed() {
-        ReaderWay way = new ReaderWay(12);
-        way.setTag("maxspeed", "90");
-        assertEquals(12, encoder.applyMaxSpeed(way, 12), 1e-2);
+        IntsRef edgeFlags = encodingManager.createEdgeFlags();
+        maxSpeedEnc.setDecimal(false, edgeFlags, 90);
+        assertEquals(12, encoder.applyMaxSpeed(edgeFlags, 12), 1e-2);
     }
 
     @Test
@@ -338,7 +340,7 @@ public abstract class AbstractBikeFlagEncoderTester {
         ReaderWay osmWay = new ReaderWay(1);
         osmWay.setTag("highway", "tertiary");
         IntsRef edgeFlags = encodingManager.createEdgeFlags();
-        avgSpeedEnc.setDecimal(false, edgeFlags, encoder.applyMaxSpeed(osmWay, 49));
+        avgSpeedEnc.setDecimal(false, edgeFlags, encoder.applyMaxSpeed(edgeFlags, 49));
         assertEquals(30, avgSpeedEnc.getDecimal(false, edgeFlags), 1e-1);
         assertPriority(PREFER.getValue(), osmWay);
     }

--- a/core/src/test/java/com/graphhopper/routing/util/BikeFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/BikeFlagEncoderTest.java
@@ -545,7 +545,8 @@ public class BikeFlagEncoderTest extends AbstractBikeFlagEncoderTester {
         way.setTag("highway", "tertiary");
         way.setTag("maxspeed", "90");
         edgeFlags = encodingManager.createEdgeFlags();
-        encoder.setSpeed(false, edgeFlags, encoder.applyMaxSpeed(way, 20));
+        maxSpeedEnc.setDecimal(false, edgeFlags, 90);
+        encoder.setSpeed(false, edgeFlags, encoder.applyMaxSpeed(edgeFlags, 20));
         assertEquals(20, avgSpeedEnc.getDecimal(false, edgeFlags), 1e-1);
         assertPriority(UNCHANGED.getValue(), way);
 
@@ -553,7 +554,8 @@ public class BikeFlagEncoderTest extends AbstractBikeFlagEncoderTester {
         way.setTag("highway", "track");
         way.setTag("maxspeed", "90");
         edgeFlags = encodingManager.createEdgeFlags();
-        encoder.setSpeed(false, edgeFlags, encoder.applyMaxSpeed(way, 20));
+        maxSpeedEnc.setDecimal(false, edgeFlags, 90);
+        encoder.setSpeed(false, edgeFlags, encoder.applyMaxSpeed(edgeFlags, 20));
         assertEquals(20, avgSpeedEnc.getDecimal(false, edgeFlags), 1e-1);
         assertPriority(UNCHANGED.getValue(), way);
 
@@ -561,7 +563,8 @@ public class BikeFlagEncoderTest extends AbstractBikeFlagEncoderTester {
         way.setTag("highway", "residential");
         way.setTag("maxspeed", "15");
         edgeFlags = encodingManager.createEdgeFlags();
-        encoder.setSpeed(false, edgeFlags, encoder.applyMaxSpeed(way, 15));
+        maxSpeedEnc.setDecimal(false, edgeFlags, 15);
+        encoder.setSpeed(false, edgeFlags, encoder.applyMaxSpeed(edgeFlags, 15));
         assertEquals(15, avgSpeedEnc.getDecimal(false, edgeFlags), 1.0);
         edgeFlags = encodingManager.handleWayTags(way, accessMap, encodingManager.createRelationFlags());
         assertEquals(15, avgSpeedEnc.getDecimal(false, edgeFlags), 1.0);

--- a/core/src/test/java/com/graphhopper/routing/util/FootFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/FootFlagEncoderTest.java
@@ -274,53 +274,54 @@ public class FootFlagEncoderTest {
 
     @Test
     public void testPriority() {
+        IntsRef edgeFlags = encodingManager.createEdgeFlags();
         ReaderWay way = new ReaderWay(1);
         way.setTag("highway", "cycleway");
-        assertEquals(PriorityCode.UNCHANGED.getValue(), footEncoder.handlePriority(way, null));
+        assertEquals(PriorityCode.UNCHANGED.getValue(), footEncoder.handlePriority(edgeFlags, way, null));
 
         way.setTag("highway", "primary");
-        assertEquals(PriorityCode.AVOID_IF_POSSIBLE.getValue(), footEncoder.handlePriority(way, null));
+        assertEquals(PriorityCode.AVOID_IF_POSSIBLE.getValue(), footEncoder.handlePriority(edgeFlags, way, null));
 
         way.setTag("highway", "track");
         way.setTag("bicycle", "official");
-        assertEquals(PriorityCode.AVOID_IF_POSSIBLE.getValue(), footEncoder.handlePriority(way, null));
+        assertEquals(PriorityCode.AVOID_IF_POSSIBLE.getValue(), footEncoder.handlePriority(edgeFlags, way, null));
 
         way.setTag("highway", "track");
         way.setTag("bicycle", "designated");
-        assertEquals(PriorityCode.AVOID_IF_POSSIBLE.getValue(), footEncoder.handlePriority(way, null));
+        assertEquals(PriorityCode.AVOID_IF_POSSIBLE.getValue(), footEncoder.handlePriority(edgeFlags, way, null));
 
         way.setTag("highway", "cycleway");
         way.setTag("bicycle", "designated");
         way.setTag("foot", "designated");
-        assertEquals(PriorityCode.PREFER.getValue(), footEncoder.handlePriority(way, null));
+        assertEquals(PriorityCode.PREFER.getValue(), footEncoder.handlePriority(edgeFlags, way, null));
 
         way.clearTags();
         way.setTag("highway", "primary");
         way.setTag("sidewalk", "yes");
-        assertEquals(PriorityCode.UNCHANGED.getValue(), footEncoder.handlePriority(way, null));
+        assertEquals(PriorityCode.UNCHANGED.getValue(), footEncoder.handlePriority(edgeFlags, way, null));
 
         way.clearTags();
         way.setTag("highway", "cycleway");
         way.setTag("sidewalk", "no");
-        assertEquals(PriorityCode.UNCHANGED.getValue(), footEncoder.handlePriority(way, null));
+        assertEquals(PriorityCode.UNCHANGED.getValue(), footEncoder.handlePriority(edgeFlags, way, null));
 
         way.clearTags();
         way.setTag("highway", "road");
         way.setTag("bicycle", "official");
         way.setTag("sidewalk", "no");
-        assertEquals(PriorityCode.AVOID_IF_POSSIBLE.getValue(), footEncoder.handlePriority(way, null));
+        assertEquals(PriorityCode.AVOID_IF_POSSIBLE.getValue(), footEncoder.handlePriority(edgeFlags, way, null));
 
         way.clearTags();
         way.setTag("highway", "trunk");
         way.setTag("sidewalk", "no");
-        assertEquals(PriorityCode.AVOID_IF_POSSIBLE.getValue(), footEncoder.handlePriority(way, null));
+        assertEquals(PriorityCode.AVOID_IF_POSSIBLE.getValue(), footEncoder.handlePriority(edgeFlags, way, null));
         way.setTag("sidewalk", "none");
-        assertEquals(PriorityCode.AVOID_IF_POSSIBLE.getValue(), footEncoder.handlePriority(way, null));
+        assertEquals(PriorityCode.AVOID_IF_POSSIBLE.getValue(), footEncoder.handlePriority(edgeFlags, way, null));
 
         way.clearTags();
         way.setTag("highway", "residential");
         way.setTag("sidewalk", "yes");
-        assertEquals(PriorityCode.PREFER.getValue(), footEncoder.handlePriority(way, null));
+        assertEquals(PriorityCode.PREFER.getValue(), footEncoder.handlePriority(edgeFlags, way, null));
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/routing/util/HikeFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/HikeFlagEncoderTest.java
@@ -18,10 +18,11 @@
 package com.graphhopper.routing.util;
 
 import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.storage.IntsRef;
+
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -43,53 +44,54 @@ public class HikeFlagEncoderTest {
 
     @Test
     public void testPriority() {
+        IntsRef edgeFlags = encodingManager.createEdgeFlags();
         ReaderWay way = new ReaderWay(1);
         way.setTag("highway", "cycleway");
-        assertEquals(PriorityCode.UNCHANGED.getValue(), hikeEncoder.handlePriority(way, null));
+        assertEquals(PriorityCode.UNCHANGED.getValue(), hikeEncoder.handlePriority(edgeFlags, way, null));
 
         way.setTag("highway", "primary");
-        assertEquals(PriorityCode.REACH_DEST.getValue(), hikeEncoder.handlePriority(way, null));
+        assertEquals(PriorityCode.REACH_DEST.getValue(), hikeEncoder.handlePriority(edgeFlags, way, null));
 
         way.setTag("highway", "track");
         way.setTag("bicycle", "official");
-        assertEquals(PriorityCode.AVOID_IF_POSSIBLE.getValue(), hikeEncoder.handlePriority(way, null));
+        assertEquals(PriorityCode.AVOID_IF_POSSIBLE.getValue(), hikeEncoder.handlePriority(edgeFlags, way, null));
 
         way.setTag("highway", "track");
         way.setTag("bicycle", "designated");
-        assertEquals(PriorityCode.AVOID_IF_POSSIBLE.getValue(), hikeEncoder.handlePriority(way, null));
+        assertEquals(PriorityCode.AVOID_IF_POSSIBLE.getValue(), hikeEncoder.handlePriority(edgeFlags, way, null));
 
         way.setTag("highway", "cycleway");
         way.setTag("bicycle", "designated");
         way.setTag("foot", "designated");
-        assertEquals(PriorityCode.PREFER.getValue(), hikeEncoder.handlePriority(way, null));
+        assertEquals(PriorityCode.PREFER.getValue(), hikeEncoder.handlePriority(edgeFlags, way, null));
 
         way.clearTags();
         way.setTag("highway", "primary");
         way.setTag("sidewalk", "yes");
-        assertEquals(PriorityCode.REACH_DEST.getValue(), hikeEncoder.handlePriority(way, null));
+        assertEquals(PriorityCode.REACH_DEST.getValue(), hikeEncoder.handlePriority(edgeFlags, way, null));
 
         way.clearTags();
         way.setTag("highway", "cycleway");
         way.setTag("sidewalk", "no");
-        assertEquals(PriorityCode.UNCHANGED.getValue(), hikeEncoder.handlePriority(way, null));
+        assertEquals(PriorityCode.UNCHANGED.getValue(), hikeEncoder.handlePriority(edgeFlags, way, null));
 
         way.clearTags();
         way.setTag("highway", "road");
         way.setTag("bicycle", "official");
         way.setTag("sidewalk", "no");
-        assertEquals(PriorityCode.AVOID_IF_POSSIBLE.getValue(), hikeEncoder.handlePriority(way, null));
+        assertEquals(PriorityCode.AVOID_IF_POSSIBLE.getValue(), hikeEncoder.handlePriority(edgeFlags, way, null));
 
         way.clearTags();
         way.setTag("highway", "trunk");
         way.setTag("sidewalk", "no");
-        assertEquals(PriorityCode.WORST.getValue(), hikeEncoder.handlePriority(way, null));
+        assertEquals(PriorityCode.WORST.getValue(), hikeEncoder.handlePriority(edgeFlags, way, null));
         way.setTag("sidewalk", "none");
-        assertEquals(PriorityCode.WORST.getValue(), hikeEncoder.handlePriority(way, null));
+        assertEquals(PriorityCode.WORST.getValue(), hikeEncoder.handlePriority(edgeFlags, way, null));
 
         way.clearTags();
         way.setTag("highway", "residential");
         way.setTag("sidewalk", "yes");
-        assertEquals(PriorityCode.PREFER.getValue(), hikeEncoder.handlePriority(way, null));
+        assertEquals(PriorityCode.PREFER.getValue(), hikeEncoder.handlePriority(edgeFlags, way, null));
     }
 
 }

--- a/core/src/test/java/com/graphhopper/routing/util/RacingBikeFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/RacingBikeFlagEncoderTest.java
@@ -179,37 +179,37 @@ public class RacingBikeFlagEncoderTest extends AbstractBikeFlagEncoderTester {
         osmWay.setTag("highway", "tertiary");
         osmWay.setTag("maxspeed", "50");
         IntsRef intsRef = encodingManager.createEdgeFlags();
-        encoder.setSpeed(false, intsRef, encoder.applyMaxSpeed(osmWay, 20));
+        encoder.setSpeed(false, intsRef, encoder.applyMaxSpeed(intsRef, 20));
         assertEquals(20, avgSpeedEnc.getDecimal(false, intsRef), 1e-1);
         assertPriority(PREFER.getValue(), osmWay);
 
         osmWay.setTag("maxspeed", "60");
-        encoder.setSpeed(false, intsRef, encoder.applyMaxSpeed(osmWay, 20));
+        encoder.setSpeed(false, intsRef, encoder.applyMaxSpeed(intsRef, 20));
         assertEquals(20, avgSpeedEnc.getDecimal(false, intsRef), 1e-1);
         assertPriority(PREFER.getValue(), osmWay);
 
         osmWay.setTag("maxspeed", "80");
-        encoder.setSpeed(false, intsRef, encoder.applyMaxSpeed(osmWay, 20));
+        encoder.setSpeed(false, intsRef, encoder.applyMaxSpeed(intsRef, 20));
         assertEquals(20, avgSpeedEnc.getDecimal(false, intsRef), 1e-1);
         assertPriority(PREFER.getValue(), osmWay);
 
         osmWay.setTag("maxspeed", "90");
-        encoder.setSpeed(false, intsRef, encoder.applyMaxSpeed(osmWay, 20));
+        encoder.setSpeed(false, intsRef, encoder.applyMaxSpeed(intsRef, 20));
         assertEquals(20, avgSpeedEnc.getDecimal(false, intsRef), 1e-1);
         assertPriority(UNCHANGED.getValue(), osmWay);
 
         osmWay.setTag("maxspeed", "120");
-        encoder.setSpeed(false, intsRef, encoder.applyMaxSpeed(osmWay, 20));
+        encoder.setSpeed(false, intsRef, encoder.applyMaxSpeed(intsRef, 20));
         assertEquals(20, avgSpeedEnc.getDecimal(false, intsRef), 1e-1);
         assertPriority(UNCHANGED.getValue(), osmWay);
 
         osmWay.setTag("highway", "motorway");
-        encoder.setSpeed(false, intsRef, encoder.applyMaxSpeed(osmWay, 20));
+        encoder.setSpeed(false, intsRef, encoder.applyMaxSpeed(intsRef, 20));
         assertEquals(20, avgSpeedEnc.getDecimal(false, intsRef), 1e-1);
         assertPriority(REACH_DEST.getValue(), osmWay);
 
         osmWay.setTag("tunnel", "yes");
-        encoder.setSpeed(false, intsRef, encoder.applyMaxSpeed(osmWay, 20));
+        encoder.setSpeed(false, intsRef, encoder.applyMaxSpeed(intsRef, 20));
         assertEquals(20, avgSpeedEnc.getDecimal(false, intsRef), 1e-1);
         assertPriority(AVOID_AT_ALL_COSTS.getValue(), osmWay);
 
@@ -217,7 +217,7 @@ public class RacingBikeFlagEncoderTest extends AbstractBikeFlagEncoderTester {
         osmWay.setTag("highway", "motorway");
         osmWay.setTag("tunnel", "yes");
         osmWay.setTag("maxspeed", "80");
-        encoder.setSpeed(false, intsRef, encoder.applyMaxSpeed(osmWay, 20));
+        encoder.setSpeed(false, intsRef, encoder.applyMaxSpeed(intsRef, 20));
         assertEquals(20, avgSpeedEnc.getDecimal(false, intsRef), 1e-1);
         assertPriority(AVOID_AT_ALL_COSTS.getValue(), osmWay);
 
@@ -225,7 +225,7 @@ public class RacingBikeFlagEncoderTest extends AbstractBikeFlagEncoderTester {
         osmWay.setTag("highway", "motorway");
         osmWay.setTag("tunnel", "yes");
         osmWay.setTag("maxspeed", "120");
-        encoder.setSpeed(false, intsRef, encoder.applyMaxSpeed(osmWay, 20));
+        encoder.setSpeed(false, intsRef, encoder.applyMaxSpeed(intsRef, 20));
         assertEquals(20, avgSpeedEnc.getDecimal(false, intsRef), 1e-1);
         assertPriority(AVOID_AT_ALL_COSTS.getValue(), osmWay);
 
@@ -233,14 +233,14 @@ public class RacingBikeFlagEncoderTest extends AbstractBikeFlagEncoderTester {
         osmWay.setTag("highway", "notdefined");
         osmWay.setTag("tunnel", "yes");
         osmWay.setTag("maxspeed", "120");
-        encoder.setSpeed(false, intsRef, encoder.applyMaxSpeed(osmWay, 20));
+        encoder.setSpeed(false, intsRef, encoder.applyMaxSpeed(intsRef, 20));
         assertEquals(20, avgSpeedEnc.getDecimal(false, intsRef), 1e-1);
         assertPriority(AVOID_AT_ALL_COSTS.getValue(), osmWay);
 
         osmWay.clearTags();
         osmWay.setTag("highway", "notdefined");
         osmWay.setTag("maxspeed", "50");
-        encoder.setSpeed(false, intsRef, encoder.applyMaxSpeed(osmWay, 20));
+        encoder.setSpeed(false, intsRef, encoder.applyMaxSpeed(intsRef, 20));
         assertEquals(20, avgSpeedEnc.getDecimal(false, intsRef), 1e-1);
         assertPriority(UNCHANGED.getValue(), osmWay);
     }

--- a/core/src/test/java/com/graphhopper/routing/util/WheelchairFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/WheelchairFlagEncoderTest.java
@@ -294,65 +294,66 @@ public class WheelchairFlagEncoderTest {
 
     @Test
     public void testPriority() {
+        IntsRef edgeFlags = encodingManager.createEdgeFlags();
         ReaderWay way = new ReaderWay(1);
         way.setTag("highway", "cycleway");
-        assertEquals(PriorityCode.UNCHANGED.getValue(), wheelchairEncoder.handlePriority(way, null));
+        assertEquals(PriorityCode.UNCHANGED.getValue(), wheelchairEncoder.handlePriority(edgeFlags, way, null));
 
         way.setTag("highway", "primary");
-        assertEquals(PriorityCode.AVOID_IF_POSSIBLE.getValue(), wheelchairEncoder.handlePriority(way, null));
+        assertEquals(PriorityCode.AVOID_IF_POSSIBLE.getValue(), wheelchairEncoder.handlePriority(edgeFlags, way, null));
 
         way.setTag("highway", "track");
         way.setTag("bicycle", "official");
-        assertEquals(PriorityCode.AVOID_IF_POSSIBLE.getValue(), wheelchairEncoder.handlePriority(way, null));
+        assertEquals(PriorityCode.AVOID_IF_POSSIBLE.getValue(), wheelchairEncoder.handlePriority(edgeFlags, way, null));
 
         way.setTag("highway", "track");
         way.setTag("bicycle", "designated");
-        assertEquals(PriorityCode.AVOID_IF_POSSIBLE.getValue(), wheelchairEncoder.handlePriority(way, null));
+        assertEquals(PriorityCode.AVOID_IF_POSSIBLE.getValue(), wheelchairEncoder.handlePriority(edgeFlags, way, null));
 
         way.setTag("highway", "cycleway");
         way.setTag("bicycle", "designated");
         way.setTag("foot", "designated");
-        assertEquals(PriorityCode.PREFER.getValue(), wheelchairEncoder.handlePriority(way, null));
+        assertEquals(PriorityCode.PREFER.getValue(), wheelchairEncoder.handlePriority(edgeFlags, way, null));
 
         way.clearTags();
         way.setTag("highway", "primary");
         way.setTag("sidewalk", "yes");
-        assertEquals(PriorityCode.UNCHANGED.getValue(), wheelchairEncoder.handlePriority(way, null));
+        assertEquals(PriorityCode.UNCHANGED.getValue(), wheelchairEncoder.handlePriority(edgeFlags, way, null));
 
         way.clearTags();
         way.setTag("highway", "cycleway");
         way.setTag("sidewalk", "no");
-        assertEquals(PriorityCode.UNCHANGED.getValue(), wheelchairEncoder.handlePriority(way, null));
+        assertEquals(PriorityCode.UNCHANGED.getValue(), wheelchairEncoder.handlePriority(edgeFlags, way, null));
 
         way.clearTags();
         way.setTag("highway", "road");
         way.setTag("bicycle", "official");
         way.setTag("sidewalk", "no");
-        assertEquals(PriorityCode.AVOID_IF_POSSIBLE.getValue(), wheelchairEncoder.handlePriority(way, null));
+        assertEquals(PriorityCode.AVOID_IF_POSSIBLE.getValue(), wheelchairEncoder.handlePriority(edgeFlags, way, null));
 
         way.clearTags();
         way.setTag("highway", "trunk");
         way.setTag("sidewalk", "no");
-        assertEquals(PriorityCode.AVOID_IF_POSSIBLE.getValue(), wheelchairEncoder.handlePriority(way, null));
+        assertEquals(PriorityCode.AVOID_IF_POSSIBLE.getValue(), wheelchairEncoder.handlePriority(edgeFlags, way, null));
         way.setTag("sidewalk", "none");
-        assertEquals(PriorityCode.AVOID_IF_POSSIBLE.getValue(), wheelchairEncoder.handlePriority(way, null));
+        assertEquals(PriorityCode.AVOID_IF_POSSIBLE.getValue(), wheelchairEncoder.handlePriority(edgeFlags, way, null));
 
         way.clearTags();
         way.setTag("highway", "residential");
         way.setTag("sidewalk", "yes");
-        assertEquals(PriorityCode.PREFER.getValue(), wheelchairEncoder.handlePriority(way, null));
+        assertEquals(PriorityCode.PREFER.getValue(), wheelchairEncoder.handlePriority(edgeFlags, way, null));
 
         way.clearTags();
         way.setTag("highway", "footway");
-        assertEquals(PriorityCode.PREFER.getValue(), wheelchairEncoder.handlePriority(way, null));
+        assertEquals(PriorityCode.PREFER.getValue(), wheelchairEncoder.handlePriority(edgeFlags, way, null));
         way.setTag("wheelchair", "designated");
-        assertEquals(PriorityCode.VERY_NICE.getValue(), wheelchairEncoder.handlePriority(way, null));
+        assertEquals(PriorityCode.VERY_NICE.getValue(), wheelchairEncoder.handlePriority(edgeFlags, way, null));
 
         way.clearTags();
         way.setTag("highway", "footway");
-        assertEquals(PriorityCode.PREFER.getValue(), wheelchairEncoder.handlePriority(way, null));
+        assertEquals(PriorityCode.PREFER.getValue(), wheelchairEncoder.handlePriority(edgeFlags, way, null));
         way.setTag("wheelchair", "limited");
-        assertEquals(PriorityCode.REACH_DEST.getValue(), wheelchairEncoder.handlePriority(way, null));
+        assertEquals(PriorityCode.REACH_DEST.getValue(), wheelchairEncoder.handlePriority(edgeFlags, way, null));
     }
 
     @Test


### PR DESCRIPTION
Fixes #2266 

* avoids parsing the max speed tags multiple times by using the encoded value
* respects SpatialRules as they are used in the OSMMaxSpeedParser
* lowered some max speed fallback values for Germany and Austria to match the limits of urban areas
* adapted unittests