### PR TITLE
Replace some usages of DefaultEdgeFilter in PT, leave some open questions

### DIFF
--- a/reader-gtfs/src/main/java/com/graphhopper/gtfs/GraphHopperGtfs.java
+++ b/reader-gtfs/src/main/java/com/graphhopper/gtfs/GraphHopperGtfs.java
@@ -24,7 +24,6 @@ import com.graphhopper.GraphHopper;
 import com.graphhopper.GraphHopperConfig;
 import com.graphhopper.routing.ev.EnumEncodedValue;
 import com.graphhopper.routing.querygraph.QueryGraph;
-import com.graphhopper.routing.util.DefaultEdgeFilter;
 import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.routing.weighting.FastestWeighting;
 import com.graphhopper.storage.Directory;
@@ -163,8 +162,8 @@ public class GraphHopperGtfs extends GraphHopper {
                     EdgeIteratorState edgeIteratorState = graphHopperStorage.getEdgeIteratorState(label.edge, label.adjNode);
                     if (edgeIteratorState.get(ptEncodedValues.getTypeEnc()) == GtfsStorage.EdgeType.EXIT_PT) {
                         GtfsStorageI.PlatformDescriptor fromPlatformDescriptor = getGtfsStorage().getPlatformDescriptorByEdge().get(label.edge);
-                        DefaultEdgeFilter filter = DefaultEdgeFilter.outEdges(ptEncodedValues.getAccessEnc());
-                        EdgeExplorer edgeExplorer = graphHopperStorage.createEdgeExplorer(filter);
+                        // todo: maybe no need for an edge filter because we filter for ENTER_PT below anyway?!
+                        EdgeExplorer edgeExplorer = graphHopperStorage.createEdgeExplorer(edge -> edge.get(ptEncodedValues.getAccessEnc()));
                         EdgeIterator edgeIterator = edgeExplorer.setBaseNode(stationNode);
                         while (edgeIterator.next()) {
                             if (edgeIterator.get(ptEncodedValues.getTypeEnc()) == GtfsStorage.EdgeType.ENTER_PT) {


### PR DESCRIPTION
I took a look at the usage of access flags in PT. We are currently trying to move access flags into the weighting as much as possible (#1835). The biggest issue I ran into here seems to be that PT uses the `Weighting` but does not call `calcEdgeWeight`, but only `calcEdgeMillis` *and* `FastestWeighting` returns infinite weight in case speed is zero, but not infinite time *and* PT does not set speeds, for example for the `VirtualEdgeIteratorStates` that are created in the overlayGraph in `RealtimeFeed`.

Maybe we can get rid of some edge filter usages entirely, because in a few cases we first filter by access flags, but then pick only certain PT edge types right after anyway. See the comments in the code.

It would be probably best to consider some of the changes in the `pt_graph` branch first before we make changes here. For example it moves all instances where PT edges are created to a common method.