### PR TITLE
No more contributor license agreement

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,6 @@
+Make sure you read and followed [our contributing guide](https://github.com/graphhopper/graphhopper/blob/master/CONTRIBUTING.md) before you submit a pull request. E.g. that all unit tests should still pass.
+
+Your contribution will fall under the Apache License and you agree to our
+<a href="https://graphhopper.com/agreements/cccoc.html">contributor covenant code of conduct</a>.
+
+Your first contribution should include a change where you add yourself to the CONTRIBUTORS.md file.

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,6 +1,3 @@
-Make sure you read and followed [our contributing guide](https://github.com/graphhopper/graphhopper/blob/master/CONTRIBUTING.md) before you submit a pull request. E.g. that all unit tests should still pass.
-
-Your contribution will fall under the Apache License and you agree to our
-<a href="https://graphhopper.com/agreements/cccoc.html">contributor covenant code of conduct</a>.
+Please read [our contributing guide](https://github.com/graphhopper/graphhopper/blob/master/CONTRIBUTING.md) and note that also your contribution falls under the Apache License 2.0 as outlined there.
 
 Your first contribution should include a change where you add yourself to the CONTRIBUTORS.md file.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ appear on your fork its github page afterwards.
 
 ## License Agreement
 
-Your contributions like pull requests, bug fixes, documentation changes and translations will fall under the Apache License and you agree to our
+All contributions like pull requests, bug fixes, documentation changes and translations fall under the Apache License and contributors agree to our
 <a href="https://www.graphhopper.com/code-of-conduct/">contributor covenant code of conduct</a>.
 
 ## Code formatting

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,19 +25,8 @@ appear on your fork its github page afterwards.
 
 ## License Agreement
 
-For contributions like pull requests, bug fixes and translations please read 
-the <a href="https://graphhopper.com/agreements/individual-cla.html">GraphHopper License Agreement</a>, which includes our
-<a href="https://graphhopper.com/agreements/cccoc.html">contributor covenant code of conduct</a>.
-<a href="https://graphhopper.com/#contact">Send us</a> an email with the signed print out of this CLA. Or, if you prefer
-the faster electronically method via signaturit.com, please send us an email with a request for this - 
-keep in mind that this requires storing your Email there.
-
-For companies that would like that their developers work for us, we need an additional [corporate CLA signed](https://graphhopper.com/agreements/corporate-cla.html).
-
-Note, our CLA does not influence your rights on your contribution but it makes sure for others that you agree to the Apache License, Version 2.
-After this you'll appear in the <a href="CONTRIBUTORS.md">contributors list</a> and your pull request can also be discussed technically.
-
-Read more in [this issue](https://github.com/graphhopper/graphhopper/pull/1129#issuecomment-375820168) why it is not that easy to make this CLA-signing process simpler for first-time contributors and maintainers.
+You contributions like pull requests, bug fixes, documentation changes and translations will fall under the Apache License and you agree also to our
+<a href="https://graphhopper.com/agreements/cccoc.html">contributor covenant code of conduct</a>. Your first contribution should include a change where you add yourself to the CONTRIBUTORS.md file.
 
 ## Code formatting
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,8 +25,8 @@ appear on your fork its github page afterwards.
 
 ## License Agreement
 
-Your contributions like pull requests, bug fixes, documentation changes and translations will fall under the Apache License and you agree also to our
-<a href="https://graphhopper.com/agreements/cccoc.html">contributor covenant code of conduct</a>. Your first contribution should include a change where you add yourself to the CONTRIBUTORS.md file.
+Your contributions like pull requests, bug fixes, documentation changes and translations will fall under the Apache License and you agree to our
+<a href="https://www.graphhopper.com/code-of-conduct/">contributor covenant code of conduct</a>.
 
 ## Code formatting
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ appear on your fork its github page afterwards.
 
 ## License Agreement
 
-You contributions like pull requests, bug fixes, documentation changes and translations will fall under the Apache License and you agree also to our
+Your contributions like pull requests, bug fixes, documentation changes and translations will fall under the Apache License and you agree also to our
 <a href="https://graphhopper.com/agreements/cccoc.html">contributor covenant code of conduct</a>. Your first contribution should include a change where you add yourself to the CONTRIBUTORS.md file.
 
 ## Code formatting

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,9 +1,6 @@
 # Contributors
 
-Most of the contributors are mentioned at Github as [Members](https://github.com/graphhopper?tab=members) or [Contributors](https://github.com/graphhopper/graphhopper/contributors). 
-
-Contributors that agree to the [project its CLA](https://www.graphhopper.com/individual-contributor-license-agreement/)
-state this as a comment via a separate, signed commit.
+Most of the contributors are mentioned at Github as [Members](https://github.com/graphhopper?tab=members) or [Contributors](https://github.com/graphhopper/graphhopper/contributors).
 
 Here is an overview:
 


### PR DESCRIPTION
I propose to remove the requirement of a CLA.

We never used the CLA to take away ownership or had the right to relicense the code, but still this requirement added a lot of friction. And so other companies like Chef or Amazon do not require CLA.

IMO we can safely assume that everyone who contributes understands that this project is Apache licensed and so the contribution will be under the same license.