### PR TITLE
remove GraphHopper.setEncodingManager 

### DIFF
--- a/config-example.yml
+++ b/config-example.yml
@@ -10,7 +10,7 @@ graphhopper:
 
   # More options: foot,hike,bike,bike2,mtb,racingbike,motorcycle,car4wd,wheelchair (comma separated)
   # bike2 takes elevation data into account (like up-hill is slower than down-hill) and requires enabling graph.elevation.provider below.
-  graph.flag_encoders: car
+  # graph.flag_encoders: car
 
   # Enable turn restrictions for car or motorcycle.
   # graph.flag_encoders: car|turn_costs=true

--- a/config-example.yml
+++ b/config-example.yml
@@ -123,7 +123,7 @@ graphhopper:
 
   # In many cases the road network consists of independent components without any routes going in between. In
   # the most simple case you can imagine an island without a bridge or ferry connection. The following parameter
-  # allows setting a minimum size (number of nodes) for such detached components. This can be used to reduce the number
+  # allows setting a minimum size (number of edges) for such detached components. This can be used to reduce the number
   # of cases where a connection between locations might not be found.
   prepare.min_network_size: 200
 

--- a/core/files/changelog.txt
+++ b/core/files/changelog.txt
@@ -1,4 +1,5 @@
 3.0
+    removed setEncodingManager use setProfiles instead or for more custom requirements overwrite GraphHopper.customizeEncodingManager
     CustomWeighting language breaks old format but is more powerful and easier to read; it also allows factors >1 for server-side CustomModels
     renamed GHUtilities.setProperties to setSpeed
     Helper.createFormatter is using the ENGLISH Locale instead of UK, see #2186

--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -1106,7 +1106,7 @@ public class GraphHopper implements GraphHopperAPI {
                 TurnCostProvider turnCostProvider = new DefaultTurnCostProvider(encoder, ghStorage.getTurnCostStorage(), 0);
                 jobs.add(new PrepareJob(encoder.toString(), encoder.getAccessEnc(), turnCostProvider));
             } else {
-                jobs.add(new PrepareJob(encoder.toString(), encoder.getAccessEnc(), null));
+                jobs.add(new PrepareJob(encoder.toString(), encoder.getAccessEnc(), TurnCostProvider.NO_TURN_COST_PROVIDER));
             }
         }
         return jobs;

--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -462,7 +462,7 @@ public class GraphHopper implements GraphHopperAPI {
         removeZipped = ghConfig.getBool("graph.remove_zipped", removeZipped);
 
         if (encodingManager != null)
-            throw new IllegalStateException("Cannot overwrite EncodingManager in init");
+            throw new IllegalStateException("Cannot call init twice. EncodingManager was already initialized.");
 
         emBuilder.setEnableInstructions(ghConfig.getBool("datareader.instructions", true));
         emBuilder.setPreferredLanguage(ghConfig.getString("datareader.preferred_language", ""));

--- a/core/src/main/java/com/graphhopper/routing/util/DefaultFlagEncoderFactory.java
+++ b/core/src/main/java/com/graphhopper/routing/util/DefaultFlagEncoderFactory.java
@@ -57,6 +57,6 @@ public class DefaultFlagEncoderFactory implements FlagEncoderFactory {
         if (name.equals(WHEELCHAIR))
             return new WheelchairFlagEncoder(configuration);
 
-        throw new IllegalArgumentException("entry in encoder list not supported " + name);
+        throw new IllegalArgumentException("entry in encoder list not supported: " + name);
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/util/EncodingManager.java
+++ b/core/src/main/java/com/graphhopper/routing/util/EncodingManager.java
@@ -31,6 +31,7 @@ import com.graphhopper.util.PMap;
 
 import java.util.*;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static com.graphhopper.util.Helper.toLowerCase;
 
@@ -58,22 +59,18 @@ public class EncodingManager implements EncodedValueLookup {
 
     /**
      * Instantiate manager with the given list of encoders. The manager knows several default
-     * encoders ignoring case.
-     *
-     * @param flagEncodersStr comma delimited list of encoders. The order does not matter.
+     * encoders using DefaultFlagEncoderFactory.
      */
-    public static EncodingManager create(String flagEncodersStr) {
-        return create(new DefaultFlagEncoderFactory(), flagEncodersStr);
+    public static EncodingManager create(String flagEncoders) {
+        return create(new DefaultFlagEncoderFactory(), Arrays.asList(flagEncoders.split(",")));
     }
 
-    public static EncodingManager create(FlagEncoderFactory factory, String flagEncodersStr) {
-        return createBuilder(parseEncoderString(factory, flagEncodersStr)).build();
+    public static EncodingManager create(FlagEncoderFactory factory, List<String> flagEncoderStrings) {
+        return createBuilder(flagEncoderStrings.stream().map(s -> parseEncoderString(factory, s)).collect(Collectors.toList())).build();
     }
 
     /**
      * Instantiate manager with the given list of encoders.
-     *
-     * @param flagEncoders comma delimited list of encoders. The order does not matter.
      */
     public static EncodingManager create(FlagEncoder... flagEncoders) {
         return create(Arrays.asList(flagEncoders));
@@ -81,8 +78,6 @@ public class EncodingManager implements EncodedValueLookup {
 
     /**
      * Instantiate manager with the given list of encoders.
-     *
-     * @param flagEncoders comma delimited list of encoders. The order does not matter.
      */
     public static EncodingManager create(List<? extends FlagEncoder> flagEncoders) {
         return createBuilder(flagEncoders).build();
@@ -96,29 +91,34 @@ public class EncodingManager implements EncodedValueLookup {
         return builder;
     }
 
+    public static StorableProperties loadProperties(String ghLoc) {
+        Directory dir = new RAMDirectory(ghLoc, true);
+        StorableProperties properties = new StorableProperties(dir);
+        if (!properties.loadExisting())
+            return null;
+//            throw new IllegalStateException("Cannot load properties to fetch EncodingManager configuration at: " + dir.getLocation());
+        String encodedValuesStr = properties.get("graph.encoded_values");
+        String flagEncoderValuesStr = properties.get("graph.flag_encoders");
+        if (Helper.isEmpty(flagEncoderValuesStr) && Helper.isEmpty(encodedValuesStr))
+            return null;
+//            throw new IllegalStateException("EncodingManager was not found in the graph location: " + properties.getLocation());
+        return properties;
+    }
+
     /**
      * Create the EncodingManager from the provided GraphHopper location. Throws an
      * IllegalStateException if it fails. Used if no EncodingManager specified on load.
      */
-    public static EncodingManager create(EncodedValueFactory evFactory, FlagEncoderFactory flagEncoderFactory, String ghLoc) {
-        Directory dir = new RAMDirectory(ghLoc, true);
-        StorableProperties properties = new StorableProperties(dir);
-        if (!properties.loadExisting())
-            throw new IllegalStateException("Cannot load properties to fetch EncodingManager configuration at: "
-                    + dir.getLocation());
-
+    public static EncodingManager create(EncodedValueFactory evFactory, FlagEncoderFactory flagEncoderFactory, StorableProperties properties) {
         EncodingManager.Builder builder = new EncodingManager.Builder();
         String encodedValuesStr = properties.get("graph.encoded_values");
-        if (!Helper.isEmpty(encodedValuesStr))
-            builder.addAll(evFactory, encodedValuesStr);
+        for (String evString : encodedValuesStr.split(",")) {
+            builder.addIfAbsent(evFactory, evString);
+        }
         String flagEncoderValuesStr = properties.get("graph.flag_encoders");
-        if (!Helper.isEmpty(flagEncoderValuesStr))
-            builder.addAll(flagEncoderFactory, flagEncoderValuesStr);
-
-        if (Helper.isEmpty(flagEncoderValuesStr) && Helper.isEmpty(encodedValuesStr))
-            throw new IllegalStateException("EncodingManager was not configured. And no one was found in the graph: "
-                    + dir.getLocation());
-
+        for (String encoderString : flagEncoderValuesStr.split(",")) {
+            builder.addIfAbsent(flagEncoderFactory, encoderString);
+        }
         return builder.build();
     }
 
@@ -144,9 +144,9 @@ public class EncodingManager implements EncodedValueLookup {
     public static class Builder {
         private EncodingManager em;
         private DateRangeParser dateRangeParser;
-        private final List<AbstractFlagEncoder> flagEncoderList = new ArrayList<>();
-        private final List<EncodedValue> encodedValueList = new ArrayList<>();
-        private final List<TagParser> tagParsers = new ArrayList<>();
+        private final Map<String, AbstractFlagEncoder> flagEncoderMap = new LinkedHashMap<>();
+        private final Map<String, EncodedValue> encodedValueMap = new LinkedHashMap<>();
+        private final Set<TagParser> tagParserSet = new LinkedHashSet<>();
         private final List<TurnCostParser> turnCostParsers = new ArrayList<>();
         private final List<RelationTagParser> relationTagParsers = new ArrayList<>();
 
@@ -181,27 +181,35 @@ public class EncodingManager implements EncodedValueLookup {
             return this;
         }
 
-        /**
-         * For backward compatibility provide a way to add multiple FlagEncoders
-         */
-        public Builder addAll(FlagEncoderFactory factory, String flagEncodersStr) {
+        public boolean addIfAbsent(FlagEncoderFactory factory, String flagEncoderString) {
             check();
-            for (FlagEncoder fe : parseEncoderString(factory, flagEncodersStr)) {
-                flagEncoderList.add((AbstractFlagEncoder) fe);
-            }
-            return this;
+            String key = flagEncoderString.split("\\|")[0].trim();
+            if (flagEncoderMap.containsKey(key))
+                return false;
+            FlagEncoder fe = parseEncoderString(factory, flagEncoderString);
+            if (!fe.toString().equals(key)) throw new IllegalStateException("not equal " + key + ", " + fe.toString());
+            flagEncoderMap.put(fe.toString(), (AbstractFlagEncoder) fe);
+            return true;
         }
 
-        public Builder addAll(EncodedValueFactory factory, String encodedValueString) {
+        public boolean addIfAbsent(EncodedValueFactory factory, String encodedValueString) {
             check();
-            em.add(encodedValueList, factory, encodedValueString);
-            return this;
+            String key = encodedValueString.split("\\|")[0].trim();
+            if (encodedValueMap.containsKey(key))
+                return false;
+            EncodedValue ev = parseEncodedValueString(factory, encodedValueString);
+            if (!ev.getName().equals(key)) throw new IllegalStateException("not equal " + key + ", " + ev.getName());
+            encodedValueMap.put(ev.getName(), ev);
+            return true;
         }
 
-        public Builder addAll(TagParserFactory factory, String tagParserString) {
+        public boolean addIfAbsent(TagParserFactory factory, String tagParserString) {
             check();
-            em.add(tagParsers, factory, tagParserString);
-            return this;
+            tagParserString = tagParserString.trim();
+            if (tagParserString.isEmpty()) return false;
+
+            TagParser tagParser = em.parseEncodedValueString(factory, tagParserString);
+            return tagParserSet.add(tagParser);
         }
 
         public Builder addTurnCostParser(TurnCostParser parser) {
@@ -218,13 +226,17 @@ public class EncodingManager implements EncodedValueLookup {
 
         public Builder add(FlagEncoder encoder) {
             check();
-            flagEncoderList.add((AbstractFlagEncoder) encoder);
+            if (flagEncoderMap.containsKey(encoder.toString()))
+                throw new IllegalArgumentException("Encoder already exists: " + encoder);
+            flagEncoderMap.put(encoder.toString(), (AbstractFlagEncoder) encoder);
             return this;
         }
 
         public Builder add(EncodedValue encodedValue) {
             check();
-            encodedValueList.add(encodedValue);
+            if (encodedValueMap.containsKey(encodedValue.getName()))
+                throw new IllegalArgumentException("EncodedValue already exists: " + encodedValue.getName());
+            encodedValueMap.put(encodedValue.getName(), encodedValue);
             return this;
         }
 
@@ -240,7 +252,7 @@ public class EncodingManager implements EncodedValueLookup {
          */
         public Builder add(TagParser tagParser) {
             check();
-            tagParsers.add(tagParser);
+            tagParserSet.add(tagParser);
             return this;
         }
 
@@ -296,7 +308,7 @@ public class EncodingManager implements EncodedValueLookup {
             }
 
             List<SpatialRuleParser> insertLater = new ArrayList<>();
-            for (TagParser tagParser : tagParsers) {
+            for (TagParser tagParser : tagParserSet) {
                 if (SpatialRuleParser.class.isAssignableFrom(tagParser.getClass())) {
                     insertLater.add((SpatialRuleParser) tagParser);
                 } else {
@@ -304,7 +316,7 @@ public class EncodingManager implements EncodedValueLookup {
                 }
             }
 
-            for (EncodedValue ev : encodedValueList) {
+            for (EncodedValue ev : encodedValueMap.values()) {
                 em.addEncodedValue(ev, false);
             }
 
@@ -333,7 +345,7 @@ public class EncodingManager implements EncodedValueLookup {
             if (dateRangeParser == null)
                 dateRangeParser = new DateRangeParser(DateRangeParser.createCalendar());
 
-            for (AbstractFlagEncoder encoder : flagEncoderList) {
+            for (AbstractFlagEncoder encoder : flagEncoderMap.values()) {
                 if (encoder instanceof BikeCommonFlagEncoder) {
                     if (!em.hasEncodedValue(RouteNetwork.key("bike")))
                         _addRelationTagParser(new OSMBikeNetworkTagParser());
@@ -346,7 +358,7 @@ public class EncodingManager implements EncodedValueLookup {
                 }
             }
 
-            for (AbstractFlagEncoder encoder : flagEncoderList) {
+            for (AbstractFlagEncoder encoder : flagEncoderMap.values()) {
                 encoder.init(dateRangeParser);
                 em.addEncoder(encoder);
             }
@@ -356,7 +368,7 @@ public class EncodingManager implements EncodedValueLookup {
             }
 
             // FlagEncoder can demand TurnCostParsers => add them after the explicitly added ones
-            for (AbstractFlagEncoder encoder : flagEncoderList) {
+            for (AbstractFlagEncoder encoder : flagEncoderMap.values()) {
                 if (encoder.supportsTurnCosts() && !em.turnCostParsers.containsKey(encoder.toString()))
                     _addTurnCostParser(new OSMTurnRelationParser(encoder.toString(), encoder.getMaxTurnCosts(),
                             OSMRoadAccessParser.toOSMRestrictions(encoder.getTransportationMode())));
@@ -371,62 +383,44 @@ public class EncodingManager implements EncodedValueLookup {
         }
     }
 
-    static List<FlagEncoder> parseEncoderString(FlagEncoderFactory factory, String encoderList) {
-        if (encoderList.contains(":"))
-            throw new IllegalArgumentException("EncodingManager does no longer use reflection instantiate encoders directly.");
+    static FlagEncoder parseEncoderString(FlagEncoderFactory factory, String encoderString) {
+        if (!encoderString.equals(toLowerCase(encoderString)))
+            throw new IllegalArgumentException("Since 0.7 EncodingManager does no longer accept upper case profiles: " + encoderString);
 
-        if (!encoderList.equals(toLowerCase(encoderList)))
-            throw new IllegalArgumentException("Since 0.7 EncodingManager does no longer accept upper case profiles: " + encoderList);
+        encoderString = encoderString.trim();
+        if (encoderString.isEmpty())
+            throw new IllegalArgumentException("FlagEncoder cannot be empty. " + encoderString);
 
-        String[] entries = encoderList.split(",");
-        List<FlagEncoder> resultEncoders = new ArrayList<>();
-
-        for (String entry : entries) {
-            entry = toLowerCase(entry.trim());
-            if (entry.isEmpty())
-                continue;
-
-            String entryVal = "";
-            if (entry.contains("|")) {
-                entryVal = entry;
-                entry = entry.split("\\|")[0];
-            }
-            PMap configuration = new PMap(entryVal);
-            resultEncoders.add(factory.createFlagEncoder(entry, configuration));
+        String entryVal = "";
+        if (encoderString.contains("|")) {
+            entryVal = encoderString;
+            encoderString = encoderString.split("\\|")[0];
         }
-        return resultEncoders;
+        PMap configuration = new PMap(entryVal);
+        return factory.createFlagEncoder(encoderString, configuration);
     }
 
-    private void add(List<EncodedValue> returnList, EncodedValueFactory factory, String evList) {
-        if (!evList.equals(toLowerCase(evList)))
-            throw new IllegalArgumentException("Use lower case for EncodedValues: " + evList);
+    static EncodedValue parseEncodedValueString(EncodedValueFactory factory, String encodedValueString) {
+        if (!encodedValueString.equals(toLowerCase(encodedValueString)))
+            throw new IllegalArgumentException("Use lower case for EncodedValues: " + encodedValueString);
 
-        for (String entry : evList.split(",")) {
-            entry = toLowerCase(entry.trim());
-            if (entry.isEmpty())
-                continue;
+        encodedValueString = encodedValueString.trim();
+        if (encodedValueString.isEmpty())
+            throw new IllegalArgumentException("EncodedValue cannot be empty. " + encodedValueString);
 
-            EncodedValue evObject = factory.create(entry);
-            PMap map = new PMap(entry);
-            if (!map.has("version"))
-                throw new IllegalArgumentException("encoded value must have a version specified but it was " + entry);
-            returnList.add(evObject);
-        }
+        EncodedValue evObject = factory.create(encodedValueString);
+        PMap map = new PMap(encodedValueString);
+        if (!map.has("version"))
+            throw new IllegalArgumentException("encoded value must have a version specified but it was " + encodedValueString);
+        return evObject;
     }
 
-    private void add(List<TagParser> returnList, TagParserFactory factory, String tpList) {
-        if (!tpList.equals(toLowerCase(tpList)))
-            throw new IllegalArgumentException("Use lower case for TagParser: " + tpList);
+    private TagParser parseEncodedValueString(TagParserFactory factory, String tagParserString) {
+        if (!tagParserString.equals(toLowerCase(tagParserString)))
+            throw new IllegalArgumentException("Use lower case for TagParser: " + tagParserString);
 
-        for (String entry : tpList.split(",")) {
-            entry = entry.trim();
-            if (entry.isEmpty())
-                continue;
-
-            PMap map = new PMap(entry);
-            TagParser tp = factory.create(entry, map);
-            returnList.add(tp);
-        }
+        PMap map = new PMap(tagParserString);
+        return factory.create(tagParserString, map);
     }
 
     static String fixWayName(String str) {
@@ -457,7 +451,7 @@ public class EncodingManager implements EncodedValueLookup {
     private void addEncoder(AbstractFlagEncoder encoder) {
         for (FlagEncoder fe : edgeEncoders) {
             if (fe.toString().equals(encoder.toString()))
-                throw new IllegalArgumentException("Cannot register edge encoder. Name already exists: " + fe.toString());
+                throw new IllegalArgumentException("Cannot register FlagEncoder. Name already exists: " + fe.toString());
         }
 
         int encoderCount = edgeEncoders.size();

--- a/core/src/main/java/com/graphhopper/routing/util/EncodingManager.java
+++ b/core/src/main/java/com/graphhopper/routing/util/EncodingManager.java
@@ -61,12 +61,13 @@ public class EncodingManager implements EncodedValueLookup {
      * Instantiate manager with the given list of encoders. The manager knows several default
      * encoders using DefaultFlagEncoderFactory.
      */
-    public static EncodingManager create(String flagEncoders) {
-        return create(new DefaultFlagEncoderFactory(), Arrays.asList(flagEncoders.split(",")));
+    public static EncodingManager create(String flagEncoderString) {
+        return create(new DefaultFlagEncoderFactory(), flagEncoderString);
     }
 
-    public static EncodingManager create(FlagEncoderFactory factory, List<String> flagEncoderStrings) {
-        return createBuilder(flagEncoderStrings.stream().map(s -> parseEncoderString(factory, s)).collect(Collectors.toList())).build();
+    public static EncodingManager create(FlagEncoderFactory factory, String flagEncodersString) {
+        return createBuilder(Arrays.stream(flagEncodersString.split(",")).filter(s -> !s.trim().isEmpty()).
+                map(s -> parseEncoderString(factory, s)).collect(Collectors.toList())).build();
     }
 
     /**

--- a/core/src/main/java/com/graphhopper/routing/util/EncodingManager.java
+++ b/core/src/main/java/com/graphhopper/routing/util/EncodingManager.java
@@ -173,7 +173,6 @@ public class EncodingManager implements EncodedValueLookup {
             if (flagEncoderMap.containsKey(key))
                 return false;
             FlagEncoder fe = parseEncoderString(factory, flagEncoderString);
-            if (!fe.toString().equals(key)) throw new IllegalStateException("not equal " + key + ", " + fe.toString());
             flagEncoderMap.put(fe.toString(), (AbstractFlagEncoder) fe);
             return true;
         }
@@ -184,7 +183,6 @@ public class EncodingManager implements EncodedValueLookup {
             if (encodedValueMap.containsKey(key))
                 return false;
             EncodedValue ev = parseEncodedValueString(factory, encodedValueString);
-            if (!ev.getName().equals(key)) throw new IllegalStateException("not equal " + key + ", " + ev.getName());
             encodedValueMap.put(ev.getName(), ev);
             return true;
         }

--- a/core/src/main/java/com/graphhopper/routing/util/EncodingManager.java
+++ b/core/src/main/java/com/graphhopper/routing/util/EncodingManager.java
@@ -61,12 +61,12 @@ public class EncodingManager implements EncodedValueLookup {
      * Instantiate manager with the given list of encoders. The manager knows several default
      * encoders using DefaultFlagEncoderFactory.
      */
-    public static EncodingManager create(String flagEncoderString) {
-        return create(new DefaultFlagEncoderFactory(), flagEncoderString);
+    public static EncodingManager create(String flagEncodersStr) {
+        return create(new DefaultFlagEncoderFactory(), flagEncodersStr);
     }
 
-    public static EncodingManager create(FlagEncoderFactory factory, String flagEncodersString) {
-        return createBuilder(Arrays.stream(flagEncodersString.split(",")).filter(s -> !s.trim().isEmpty()).
+    public static EncodingManager create(FlagEncoderFactory factory, String flagEncodersStr) {
+        return createBuilder(Arrays.stream(flagEncodersStr.split(",")).filter(s -> !s.trim().isEmpty()).
                 map(s -> parseEncoderString(factory, s)).collect(Collectors.toList())).build();
     }
 
@@ -211,7 +211,7 @@ public class EncodingManager implements EncodedValueLookup {
         public Builder add(FlagEncoder encoder) {
             check();
             if (flagEncoderMap.containsKey(encoder.toString()))
-                throw new IllegalArgumentException("Encoder already exists: " + encoder);
+                throw new IllegalArgumentException("FlagEncoder already exists: " + encoder);
             flagEncoderMap.put(encoder.toString(), (AbstractFlagEncoder) encoder);
             return this;
         }
@@ -369,7 +369,7 @@ public class EncodingManager implements EncodedValueLookup {
 
     static FlagEncoder parseEncoderString(FlagEncoderFactory factory, String encoderString) {
         if (!encoderString.equals(toLowerCase(encoderString)))
-            throw new IllegalArgumentException("Since 0.7 EncodingManager does no longer accept upper case profiles: " + encoderString);
+            throw new IllegalArgumentException("An upper case name for the FlagEncoder is not allowed: " + encoderString);
 
         encoderString = encoderString.trim();
         if (encoderString.isEmpty())
@@ -395,7 +395,7 @@ public class EncodingManager implements EncodedValueLookup {
         EncodedValue evObject = factory.create(encodedValueString);
         PMap map = new PMap(encodedValueString);
         if (!map.has("version"))
-            throw new IllegalArgumentException("encoded value must have a version specified but it was " + encodedValueString);
+            throw new IllegalArgumentException("EncodedValue must have a version specified but it was " + encodedValueString);
         return evObject;
     }
 
@@ -485,7 +485,7 @@ public class EncodingManager implements EncodedValueLookup {
                 return encoder;
         }
         if (throwExc)
-            throw new IllegalArgumentException("Encoder for " + name + " not found. Existing: " + toFlagEncodersAsString());
+            throw new IllegalArgumentException("FlagEncoder for " + name + " not found. Existing: " + toFlagEncodersAsString());
         return null;
     }
 

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/DefaultTagParserFactory.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/DefaultTagParserFactory.java
@@ -74,6 +74,6 @@ public class DefaultTagParserFactory implements TagParserFactory {
             throw new IllegalArgumentException("The property spatial_rules.borders_directory is required in the configuration " +
                     "when using 'country' in encoded_values");
 
-        throw new IllegalArgumentException("entry in encoder list not supported " + name);
+        throw new IllegalArgumentException("encoded value not supported: " + name);
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/DefaultTagParserFactory.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/DefaultTagParserFactory.java
@@ -74,6 +74,6 @@ public class DefaultTagParserFactory implements TagParserFactory {
             throw new IllegalArgumentException("The property spatial_rules.borders_directory is required in the configuration " +
                     "when using 'country' in encoded_values");
 
-        throw new IllegalArgumentException("encoded value not supported: " + name);
+        throw new IllegalArgumentException("DefaultTagParserFactory cannot find: " + name);
     }
 }

--- a/core/src/main/java/com/graphhopper/storage/GraphBuilder.java
+++ b/core/src/main/java/com/graphhopper/storage/GraphBuilder.java
@@ -97,11 +97,6 @@ public class GraphBuilder {
         return setDir(new RAMDirectory(location, store));
     }
 
-    public GraphBuilder setBytes(long bytes) {
-        this.bytes = bytes;
-        return this;
-    }
-
     public GraphBuilder set3D(boolean withElevation) {
         this.elevation = withElevation;
         return this;

--- a/core/src/main/java/com/graphhopper/util/GHUtility.java
+++ b/core/src/main/java/com/graphhopper/util/GHUtility.java
@@ -472,7 +472,6 @@ public class GHUtility {
                 .set3D(is3D)
                 .setDir(outdir)
                 .setCHConfigs(store.getCHConfigs())
-                .setBytes(store.getNodes())
                 .create();
     }
 

--- a/core/src/test/java/com/graphhopper/GraphHopperAPITest.java
+++ b/core/src/test/java/com/graphhopper/GraphHopperAPITest.java
@@ -65,10 +65,10 @@ public class GraphHopperAPITest {
         GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 4).setDistance(40));
         GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 3).setDistance(40));
 
-        GraphHopper instance = createGraphHopper(vehicle).
+        GraphHopper instance = new GraphHopper().
                 setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting)).
                 setStoreOnFlush(false).
-                loadGraph(graph);
+                loadGraph(graph, em);
         // 3 -> 0
         GHResponse rsp = instance.route(new GHRequest(42, 10.4, 42, 10).setProfile(profile));
         assertFalse(rsp.getErrors().toString(), rsp.hasErrors());
@@ -93,10 +93,10 @@ public class GraphHopperAPITest {
         GraphHopperStorage graph = new GraphBuilder(em).create();
         initGraph(graph, em.getEncoder(vehicle));
 
-        GraphHopper instance = createGraphHopper(vehicle).
+        GraphHopper instance = new GraphHopper().
                 setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting)).
                 setStoreOnFlush(false).
-                loadGraph(graph);
+                loadGraph(graph, em);
         GHResponse rsp = instance.route(new GHRequest(42, 10, 42, 10.4).setProfile(profile));
         assertTrue(rsp.hasErrors());
 
@@ -129,10 +129,11 @@ public class GraphHopperAPITest {
         GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 3).setDistance(10));
 
         final AtomicInteger counter = new AtomicInteger(0);
-        GraphHopper instance = createGraphHopper(vehicle)
+        GraphHopper instance = new GraphHopper()
+                .setProfiles(new Profile(vehicle).setVehicle(vehicle).setWeighting("fastest"))
                 .setElevation(true)
                 .setGraphHopperLocation(loc)
-                .loadGraph(graph);
+                .loadGraph(graph, encodingManager);
         instance.flush();
         instance.close();
         assertEquals(0, counter.get());
@@ -144,7 +145,6 @@ public class GraphHopperAPITest {
                 super.interpolateBridgesTunnelsAndFerries();
             }
         }
-                .setEncodingManager(encodingManager)
                 .setProfiles(new Profile(vehicle).setVehicle(vehicle).setWeighting("fastest"))
                 .setElevation(true);
         instance.load(loc);
@@ -159,7 +159,6 @@ public class GraphHopperAPITest {
                 super.interpolateBridgesTunnelsAndFerries();
             }
         }
-                .setEncodingManager(encodingManager)
                 .setProfiles(new Profile(vehicle).setVehicle(vehicle).setWeighting("fastest"))
                 .setElevation(true);
         instance.load(loc);
@@ -175,7 +174,7 @@ public class GraphHopperAPITest {
         String profile = "profile";
         String vehicle = "car";
         String weighting = "fastest";
-        GraphHopper instance = createGraphHopper(vehicle).
+        GraphHopper instance = new GraphHopper().
                 setProfiles(new Profile(profile).setVehicle(vehicle).setVehicle(weighting)).
                 setStoreOnFlush(false);
         try {
@@ -185,18 +184,13 @@ public class GraphHopperAPITest {
             assertTrue(ex.getMessage(), ex.getMessage().startsWith("Do a successful call to load or importOrLoad before routing"));
         }
 
-        instance = createGraphHopper(vehicle);
+        instance = new GraphHopper()
+                .setProfiles(new Profile(vehicle).setVehicle(vehicle).setWeighting("fastest"));
         try {
             instance.route(new GHRequest(42, 10.4, 42, 10).setProfile(profile));
             fail();
         } catch (Exception ex) {
             assertTrue(ex.getMessage(), ex.getMessage().startsWith("Do a successful call to load or importOrLoad before routing"));
         }
-    }
-
-    private GraphHopper createGraphHopper(String vehicle) {
-        return new GraphHopper()
-                .setEncodingManager(EncodingManager.create(vehicle))
-                .setProfiles(new Profile(vehicle).setVehicle(vehicle).setWeighting("fastest"));
     }
 }

--- a/core/src/test/java/com/graphhopper/GraphHopperProfileTest.java
+++ b/core/src/test/java/com/graphhopper/GraphHopperProfileTest.java
@@ -25,7 +25,6 @@ import com.graphhopper.config.Profile;
 import com.graphhopper.jackson.Jackson;
 import com.graphhopper.jackson.ProfileMixIn;
 import com.graphhopper.routing.util.CarFlagEncoder;
-import com.graphhopper.routing.util.EncodingManager;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -95,18 +94,13 @@ public class GraphHopperProfileTest {
     }
 
     @Test
-    public void vehicleWithoutTurnCostSupport_error() {
+    public void oneVehicleWithoutTurnCostSupport_noerror() {
         final GraphHopper hopper = createHopper();
-        // either configure the EncodingManager or specify the profile with turn costs as the first to make this working:
+        // no error even if profile without turn costs is specified first
         hopper.setProfiles(
                 new Profile("profile1").setVehicle("car").setTurnCosts(false),
                 new Profile("profile2").setVehicle("car").setTurnCosts(true));
-        assertIllegalArgument(new Runnable() {
-            @Override
-            public void run() {
-                hopper.load(GH_LOCATION);
-            }
-        }, "The profile 'profile2' was configured with 'turn_costs=true', but the corresponding vehicle 'car' does not support turn costs");
+        hopper.load(GH_LOCATION);
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/routing/ch/CHProfileSelectorTest.java
+++ b/core/src/test/java/com/graphhopper/routing/ch/CHProfileSelectorTest.java
@@ -214,12 +214,11 @@ public class CHProfileSelectorTest {
     @Test
     public void multipleVehiclesMissingWeighting() {
         // this is a common use-case, there are multiple vehicles for one weighting
-        EncodingManager em = EncodingManager.create("car,bike,motorcycle,bike2,foot");
         List<Profile> profiles = new ArrayList<>();
         List<CHProfile> chProfiles = new ArrayList<>();
-        for (FlagEncoder encoder : em.fetchEdgeEncoders()) {
-            profiles.add(new Profile(encoder.toString()).setVehicle(encoder.toString()).setWeighting("short_fastest").setTurnCosts(false));
-            chProfiles.add(new CHProfile(encoder.toString()));
+        for (String vehicle : Arrays.asList("car", "bike", "motorcycle", "bike2", "foot")) {
+            profiles.add(new Profile(vehicle).setVehicle(vehicle).setWeighting("short_fastest").setTurnCosts(false));
+            chProfiles.add(new CHProfile(vehicle));
         }
         // we do not specify the weighting but this is ok, because there is only one in use
         String weighting = null;

--- a/core/src/test/java/com/graphhopper/routing/util/EncodingManagerTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/EncodingManagerTest.java
@@ -192,7 +192,7 @@ public class EncodingManagerTest {
 
     @Test
     public void testCompatibilityBug() {
-        EncodingManager manager2 = EncodingManager.create(new DefaultFlagEncoderFactory(), Arrays.asList("bike2"));
+        EncodingManager manager2 = EncodingManager.create(new DefaultFlagEncoderFactory(), "bike2");
         ReaderWay osmWay = new ReaderWay(1);
         osmWay.setTag("highway", "footway");
         osmWay.setTag("name", "test");
@@ -205,7 +205,7 @@ public class EncodingManagerTest {
         assertEquals(4, singleSpeed, 1e-3);
         assertEquals(singleSpeed, singleBikeEnc.avgSpeedEnc.getDecimal(true, flags), 1e-3);
 
-        EncodingManager manager = EncodingManager.create(new DefaultFlagEncoderFactory(), Arrays.asList("bike2", "bike", "foot"));
+        EncodingManager manager = EncodingManager.create(new DefaultFlagEncoderFactory(), "bike2,bike,foot");
         FootFlagEncoder foot = (FootFlagEncoder) manager.getEncoder("foot");
         BikeFlagEncoder bike = (BikeFlagEncoder) manager.getEncoder("bike2");
 
@@ -222,7 +222,7 @@ public class EncodingManagerTest {
     @Test
     public void testSupportFords() {
         // 1) no encoder crossing fords
-        List<String> flagEncoderStrings = Arrays.asList("car", "bike", "foot");
+        String flagEncoderStrings = "car,bike,foot";
         EncodingManager manager = EncodingManager.create(new DefaultFlagEncoderFactory(), flagEncoderStrings);
 
         assertFalse(((AbstractFlagEncoder) manager.getEncoder("car")).isBlockFords());
@@ -230,7 +230,7 @@ public class EncodingManagerTest {
         assertFalse(((AbstractFlagEncoder) manager.getEncoder("foot")).isBlockFords());
 
         // 2) two encoders crossing fords
-        flagEncoderStrings = Arrays.asList("car", "bike|block_fords=true", "foot|block_fords=false");
+        flagEncoderStrings = "car, bike|block_fords=true, foot|block_fords=false";
         manager = EncodingManager.create(new DefaultFlagEncoderFactory(), flagEncoderStrings);
 
         assertFalse(((AbstractFlagEncoder) manager.getEncoder("car")).isBlockFords());
@@ -238,7 +238,7 @@ public class EncodingManagerTest {
         assertFalse(((AbstractFlagEncoder) manager.getEncoder("foot")).isBlockFords());
 
         // 2) Try combined with another tag
-        flagEncoderStrings = Arrays.asList("car|turn_costs=true|block_fords=true", "bike", "foot|block_fords=false");
+        flagEncoderStrings = "car|turn_costs=true|block_fords=true, bike, foot|block_fords=false";
         manager = EncodingManager.create(new DefaultFlagEncoderFactory(), flagEncoderStrings);
 
         assertTrue(((AbstractFlagEncoder) manager.getEncoder("car")).isBlockFords());

--- a/core/src/test/java/com/graphhopper/routing/util/EncodingManagerTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/EncodingManagerTest.java
@@ -79,7 +79,7 @@ public class EncodingManagerTest {
             EncodingManager.create(foot, foot);
             fail("There should have been an exception");
         } catch (Exception ex) {
-            assertEquals("Encoder already exists: foot", ex.getMessage());
+            assertEquals("FlagEncoder already exists: foot", ex.getMessage());
         }
     }
 

--- a/core/src/test/java/com/graphhopper/routing/util/EncodingManagerTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/EncodingManagerTest.java
@@ -27,6 +27,7 @@ import com.graphhopper.storage.IntsRef;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.Assert.*;
 
@@ -78,7 +79,7 @@ public class EncodingManagerTest {
             EncodingManager.create(foot, foot);
             fail("There should have been an exception");
         } catch (Exception ex) {
-            assertEquals("You must not register a FlagEncoder (foot) twice or for two EncodingManagers!", ex.getMessage());
+            assertEquals("Encoder already exists: foot", ex.getMessage());
         }
     }
 
@@ -191,7 +192,7 @@ public class EncodingManagerTest {
 
     @Test
     public void testCompatibilityBug() {
-        EncodingManager manager2 = EncodingManager.create(new DefaultFlagEncoderFactory(), "bike2");
+        EncodingManager manager2 = EncodingManager.create(new DefaultFlagEncoderFactory(), Arrays.asList("bike2"));
         ReaderWay osmWay = new ReaderWay(1);
         osmWay.setTag("highway", "footway");
         osmWay.setTag("name", "test");
@@ -204,7 +205,7 @@ public class EncodingManagerTest {
         assertEquals(4, singleSpeed, 1e-3);
         assertEquals(singleSpeed, singleBikeEnc.avgSpeedEnc.getDecimal(true, flags), 1e-3);
 
-        EncodingManager manager = EncodingManager.create(new DefaultFlagEncoderFactory(), "bike2,bike,foot");
+        EncodingManager manager = EncodingManager.create(new DefaultFlagEncoderFactory(), Arrays.asList("bike2", "bike", "foot"));
         FootFlagEncoder foot = (FootFlagEncoder) manager.getEncoder("foot");
         BikeFlagEncoder bike = (BikeFlagEncoder) manager.getEncoder("bike2");
 
@@ -221,24 +222,24 @@ public class EncodingManagerTest {
     @Test
     public void testSupportFords() {
         // 1) no encoder crossing fords
-        String flagEncodersStr = "car,bike,foot";
-        EncodingManager manager = EncodingManager.create(new DefaultFlagEncoderFactory(), flagEncodersStr);
+        List<String> flagEncoderStrings = Arrays.asList("car", "bike", "foot");
+        EncodingManager manager = EncodingManager.create(new DefaultFlagEncoderFactory(), flagEncoderStrings);
 
         assertFalse(((AbstractFlagEncoder) manager.getEncoder("car")).isBlockFords());
         assertFalse(((AbstractFlagEncoder) manager.getEncoder("bike")).isBlockFords());
         assertFalse(((AbstractFlagEncoder) manager.getEncoder("foot")).isBlockFords());
 
         // 2) two encoders crossing fords
-        flagEncodersStr = "car,bike|block_fords=true,foot|block_fords=false";
-        manager = EncodingManager.create(new DefaultFlagEncoderFactory(), flagEncodersStr);
+        flagEncoderStrings = Arrays.asList("car", "bike|block_fords=true", "foot|block_fords=false");
+        manager = EncodingManager.create(new DefaultFlagEncoderFactory(), flagEncoderStrings);
 
         assertFalse(((AbstractFlagEncoder) manager.getEncoder("car")).isBlockFords());
         assertTrue(((AbstractFlagEncoder) manager.getEncoder("bike")).isBlockFords());
         assertFalse(((AbstractFlagEncoder) manager.getEncoder("foot")).isBlockFords());
 
         // 2) Try combined with another tag
-        flagEncodersStr = "car|turn_costs=true|block_fords=true,bike,foot|block_fords=false";
-        manager = EncodingManager.create(new DefaultFlagEncoderFactory(), flagEncodersStr);
+        flagEncoderStrings = Arrays.asList("car|turn_costs=true|block_fords=true", "bike", "foot|block_fords=false");
+        manager = EncodingManager.create(new DefaultFlagEncoderFactory(), flagEncoderStrings);
 
         assertTrue(((AbstractFlagEncoder) manager.getEncoder("car")).isBlockFords());
         assertFalse(((AbstractFlagEncoder) manager.getEncoder("bike")).isBlockFords());

--- a/core/src/test/java/com/graphhopper/storage/AbstractGraphStorageTester.java
+++ b/core/src/test/java/com/graphhopper/storage/AbstractGraphStorageTester.java
@@ -314,7 +314,7 @@ public abstract class AbstractGraphStorageTester {
     public void testCopyTo() {
         graph = createGHStorage();
         initExampleGraph(graph);
-        GraphHopperStorage gs = GraphBuilder.start(encodingManager).setSegmentSize(8000).setBytes(10).create();
+        GraphHopperStorage gs = GraphBuilder.start(encodingManager).setSegmentSize(8000).create();
         graph.copyTo(gs);
         checkExampleGraph(gs);
 

--- a/core/src/test/java/com/graphhopper/storage/GraphHopperStorageTest.java
+++ b/core/src/test/java/com/graphhopper/storage/GraphHopperStorageTest.java
@@ -21,6 +21,7 @@ import com.graphhopper.GraphHopper;
 import com.graphhopper.config.CHProfile;
 import com.graphhopper.config.Profile;
 import com.graphhopper.routing.util.BikeFlagEncoder;
+import com.graphhopper.routing.util.CarFlagEncoder;
 import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.util.*;
 import com.graphhopper.util.shapes.BBox;
@@ -28,6 +29,7 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
 
 import static com.graphhopper.util.EdgeIteratorState.REVERSE_STATE;
@@ -266,7 +268,8 @@ public class GraphHopperStorageTest extends AbstractGraphStorageTester {
 
         // load without configured FlagEncoders
         GraphHopper hopper = new GraphHopper();
-        hopper.setProfiles(Collections.singletonList(new Profile("p_car").setVehicle("car").setWeighting("fastest")));
+        hopper.setProfiles(Arrays.asList(new Profile("p_car").setVehicle("car").setWeighting("fastest"),
+                new Profile("p_bike").setVehicle("bike").setWeighting("fastest")));
         if (ch) {
             hopper.getCHPreparationHandler().setCHProfiles(new CHProfile("p_car"));
         }
@@ -276,10 +279,13 @@ public class GraphHopperStorageTest extends AbstractGraphStorageTester {
         assertEquals(edges, graph.getAllEdges().length());
         Helper.close(graph);
 
-        // load via explicitly configured FlagEncoders
-        hopper = new GraphHopper()
-                .setEncodingManager(encodingManager)
-                .setProfiles(Collections.singletonList(new Profile("p_car").setVehicle("car").setWeighting("fastest")));
+        // load via explicitly configured FlagEncoders then we can define only one profile
+        hopper = new GraphHopper() {
+            @Override
+            protected void customizeEncodingManager(EncodingManager.Builder emBuilder) {
+                emBuilder.add(createCarFlagEncoder()).add(new BikeFlagEncoder());
+            }
+        }.setProfiles(Collections.singletonList(new Profile("p_car").setVehicle("car").setWeighting("fastest")));
         if (ch) {
             hopper.getCHPreparationHandler().setCHProfiles(new CHProfile("p_car"));
         }

--- a/docs/core/create-new-flagencoder.md
+++ b/docs/core/create-new-flagencoder.md
@@ -34,4 +34,5 @@ and call edge.fetchWayGeometry(FetchMode.ALL) or again, see Bike2WeightFlagEncod
 ## Add to the core
 
 If you want to include your FlagEncoder in GraphHopper and e.g. still want to use the config.yml
-you can use a subclass of DefaultFlagEncoderFactory and use the configuration object to change different properties.
+you can use a subclass of DefaultFlagEncoderFactory, set it to to the GraphHopper instance
+and use the configuration object to change different properties.

--- a/docs/core/routing.md
+++ b/docs/core/routing.md
@@ -21,9 +21,6 @@ can disable speed mode using `ch.disable=true`. In this case either hybrid mode 
 chosen profile) or flexible mode will be used. To use flexible mode in the presence of an LM preparation you need to 
 also set `lm.disable=true`.
 
-If you need multiple vehicle profiles you can specify a list of vehicle profiles (see
-config.yml e.g. `graph.flag_encoders=car,bike` or use `EncodingManager.create("car,bike")`). 
-
 To calculate a route you have to pick one vehicle and optionally an algorithm like
 `bidirectional_astar`, see the test speedModeVersusHybridMode.
 

--- a/example/src/main/java/com/graphhopper/example/IsochroneExample.java
+++ b/example/src/main/java/com/graphhopper/example/IsochroneExample.java
@@ -48,7 +48,6 @@ public class IsochroneExample {
         GraphHopper hopper = new GraphHopper();
         hopper.setOSMFile(ghLoc);
         hopper.setGraphHopperLocation("target/isochrone-graph-cache");
-        hopper.setEncodingManager(EncodingManager.create("car"));
         hopper.setProfiles(new Profile("car").setVehicle("car").setWeighting("fastest").setTurnCosts(false));
         hopper.importOrLoad();
         return hopper;

--- a/example/src/main/java/com/graphhopper/example/LocationIndexExample.java
+++ b/example/src/main/java/com/graphhopper/example/LocationIndexExample.java
@@ -1,6 +1,7 @@
 package com.graphhopper.example;
 
 import com.graphhopper.GraphHopper;
+import com.graphhopper.config.Profile;
 import com.graphhopper.routing.util.CarFlagEncoder;
 import com.graphhopper.routing.util.EdgeFilter;
 import com.graphhopper.routing.util.EncodingManager;
@@ -20,7 +21,8 @@ public class LocationIndexExample {
     }
 
     public static void graphhopperLocationIndex(String relDir) {
-        GraphHopper hopper = new GraphHopper().setEncodingManager(EncodingManager.create(new CarFlagEncoder()));
+        GraphHopper hopper = new GraphHopper();
+        hopper.setProfiles(new Profile("car").setVehicle("car").setWeighting("fastest"));
         hopper.setOSMFile(relDir + "core/files/andorra.osm.pbf");
         hopper.setGraphHopperLocation("./target/locationindex-graph-cache");
         hopper.importOrLoad();

--- a/example/src/main/java/com/graphhopper/example/LowLevelAPIExample.java
+++ b/example/src/main/java/com/graphhopper/example/LowLevelAPIExample.java
@@ -16,6 +16,11 @@ import com.graphhopper.util.EdgeIteratorState;
 import com.graphhopper.util.Helper;
 import com.graphhopper.util.PMap;
 
+/**
+ * Use this example to gain access to the low level API of GraphHopper.
+ * If you want to keep using the GraphHopper class but want to customize the internal EncodingManager
+ * you can use the hook GraphHopper.customizeEncodingManager.
+ */
 public class LowLevelAPIExample {
     public static void main(String[] args) {
         createAndSaveGraph();

--- a/example/src/main/java/com/graphhopper/example/RoutingExample.java
+++ b/example/src/main/java/com/graphhopper/example/RoutingExample.java
@@ -8,6 +8,7 @@ import com.graphhopper.config.CHProfile;
 import com.graphhopper.config.LMProfile;
 import com.graphhopper.config.Profile;
 import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.routing.util.parsers.OSMSurfaceParser;
 import com.graphhopper.routing.weighting.custom.CustomProfile;
 import com.graphhopper.util.*;
 import com.graphhopper.util.shapes.GHPoint;
@@ -37,7 +38,6 @@ public class RoutingExample {
         hopper.setOSMFile(ghLoc);
         // specify where to store graphhopper files
         hopper.setGraphHopperLocation("target/routing-graph-cache");
-        hopper.setEncodingManager(EncodingManager.create("car"));
 
         // see docs/core/profiles.md to learn more about profiles
         hopper.setProfiles(new Profile("car").setVehicle("car").setWeighting("fastest").setTurnCosts(false));
@@ -121,7 +121,6 @@ public class RoutingExample {
         GraphHopper hopper = new GraphHopper();
         hopper.setOSMFile(ghLoc);
         hopper.setGraphHopperLocation("target/routing-custom-graph-cache");
-        hopper.setEncodingManager(EncodingManager.create("car"));
         hopper.setProfiles(new CustomProfile("car_custom").setCustomModel(new CustomModel()).setVehicle("car"));
 
         // The hybrid mode uses the "landmark algorithm" and is up to 15x faster than the flexible mode (Dijkstra).

--- a/example/src/main/java/com/graphhopper/example/RoutingExampleTC.java
+++ b/example/src/main/java/com/graphhopper/example/RoutingExampleTC.java
@@ -68,10 +68,6 @@ public class RoutingExampleTC {
         GraphHopper hopper = new GraphHopper();
         hopper.setOSMFile(ghLoc);
         hopper.setGraphHopperLocation("target/routing-tc-graph-cache");
-        // by enabling turn costs for the FlagEncoder, turn restriction constraints like 'no_left_turn' will be taken
-        // from OSM
-        EncodingManager encodingManager = EncodingManager.create("car|turn_costs=true");
-        hopper.setEncodingManager(encodingManager);
         Profile profile = new Profile("car").setVehicle("car").setWeighting("fastest")
                 // to actually use the turn restrictions when routing we have to enable turn costs for our routing profile
                 .setTurnCosts(true)

--- a/example/src/main/java/com/graphhopper/example/RoutingExampleTC.java
+++ b/example/src/main/java/com/graphhopper/example/RoutingExampleTC.java
@@ -68,6 +68,8 @@ public class RoutingExampleTC {
         GraphHopper hopper = new GraphHopper();
         hopper.setOSMFile(ghLoc);
         hopper.setGraphHopperLocation("target/routing-tc-graph-cache");
+        // by enabling turn costs for the FlagEncoder, turn restriction constraints like 'no_left_turn' will be taken
+        // from OSM
         Profile profile = new Profile("car").setVehicle("car").setWeighting("fastest")
                 // to actually use the turn restrictions when routing we have to enable turn costs for our routing profile
                 .setTurnCosts(true)

--- a/navigation/src/test/java/com/graphhopper/navigation/NavigateResponseConverterTest.java
+++ b/navigation/src/test/java/com/graphhopper/navigation/NavigateResponseConverterTest.java
@@ -42,7 +42,6 @@ public class NavigateResponseConverterTest {
                 setOSMFile(osmFile).
                 setStoreOnFlush(true).
                 setGraphHopperLocation(graphFolder).
-                setEncodingManager(EncodingManager.create(vehicle)).
                 setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting("fastest").setTurnCosts(false)).
                 importOrLoad();
     }

--- a/reader-gtfs/src/main/java/com/graphhopper/gtfs/GraphHopperGtfs.java
+++ b/reader-gtfs/src/main/java/com/graphhopper/gtfs/GraphHopperGtfs.java
@@ -59,7 +59,7 @@ public class GraphHopperGtfs extends GraphHopper {
     }
 
     @Override
-    protected void registerCustomEncodedValues(EncodingManager.Builder emBuilder) {
+    protected void customizeEncodingManager(EncodingManager.Builder emBuilder) {
         PtEncodedValues.createAndAddEncodedValues(emBuilder);
     }
 

--- a/reader-osm/src/test/java/com/graphhopper/GraphHopperTest.java
+++ b/reader-osm/src/test/java/com/graphhopper/GraphHopperTest.java
@@ -1643,8 +1643,8 @@ public class GraphHopperTest {
         final String profile = "profile";
         final String vehicle = "car";
         final String weighting = "fastest";
-        // note that the pure presence of the bike encoder leads to 'ghost' junctions with the bike network even for
-        // cars such that the number of visited nodes depends on the bike encoder added here or not, #1910
+        // note that the pure presence of the bike profile leads to 'ghost' junctions with the bike network even for
+        // cars such that the number of visited nodes depends on the bike profile added here or not, #1910
         GraphHopper hopper = new GraphHopper().
                 setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(MONACO).

--- a/reader-osm/src/test/java/com/graphhopper/GraphHopperTest.java
+++ b/reader-osm/src/test/java/com/graphhopper/GraphHopperTest.java
@@ -99,7 +99,8 @@ public class GraphHopperTest {
     public void testMonacoDifferentAlgorithms(String algo, boolean withCH, int expectedVisitedNodes) {
         final String vehicle = "car";
         final String weighting = "fastest";
-        GraphHopper hopper = createGraphHopper(vehicle).
+        GraphHopper hopper = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(MONACO).
                 setProfiles(new Profile("profile").setVehicle(vehicle).setWeighting(weighting)).
                 setStoreOnFlush(true);
@@ -129,7 +130,8 @@ public class GraphHopperTest {
         final String profile = "profile";
         final String vehicle = "foot";
         final String weighting = "shortest";
-        GraphHopper hopper = createGraphHopper(vehicle).
+        GraphHopper hopper = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(MONACO).
                 setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting)).
                 setStoreOnFlush(true).
@@ -181,7 +183,8 @@ public class GraphHopperTest {
         final String profile = "profile";
         final String vehicle = "foot";
         final String weighting = "shortest";
-        GraphHopper hopper = createGraphHopper(vehicle).
+        GraphHopper hopper = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(MONACO).
                 setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting)).
                 setStoreOnFlush(true).
@@ -206,7 +209,8 @@ public class GraphHopperTest {
         final String profile = "profile";
         final String vehicle = "car";
         final String weighting = "shortest";
-        GraphHopper hopper = createGraphHopper(vehicle).
+        GraphHopper hopper = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(MONACO).
                 setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting));
         hopper.importOrLoad();
@@ -235,7 +239,8 @@ public class GraphHopperTest {
     private void testImportCloseAndLoad(boolean ch, boolean lm, boolean sort, boolean custom) {
         final String vehicle = "foot";
         final String profileName = "profile";
-        GraphHopper hopper = createGraphHopper(vehicle).
+        GraphHopper hopper = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(MONACO).
                 setStoreOnFlush(true).
                 setSortGraph(sort);
@@ -253,7 +258,7 @@ public class GraphHopperTest {
             customModel.getAreas().put("area51", area51Feature);
             profile = new CustomProfile(profileName).setCustomModel(customModel).setVehicle(vehicle);
         }
-        hopper.setProfiles(Collections.singletonList(profile));
+        hopper.setProfiles(profile);
 
         if (ch) {
             hopper.getCHPreparationHandler()
@@ -264,9 +269,10 @@ public class GraphHopperTest {
                     .setLMProfiles(new LMProfile(profileName));
         }
         hopper.importAndClose();
-        hopper = createGraphHopper(vehicle).
+        hopper = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(MONACO).
-                setProfiles(Collections.singletonList(profile)).
+                setProfiles(profile).
                 setStoreOnFlush(true);
         if (ch) {
             hopper.getCHPreparationHandler()
@@ -365,7 +371,8 @@ public class GraphHopperTest {
         final String profile = "profile";
         final String vehicle = "foot";
         final String weighting = "shortest";
-        GraphHopper hopper = createGraphHopper(vehicle).
+        GraphHopper hopper = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(MONACO).
                 setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting)).
                 setStoreOnFlush(true).
@@ -398,7 +405,8 @@ public class GraphHopperTest {
         final String vehicle = "bike";
         final String weighting = "fastest";
 
-        GraphHopper hopper = createGraphHopper(vehicle).
+        GraphHopper hopper = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(BAYREUTH).
                 setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting));
         hopper.importOrLoad();
@@ -424,7 +432,8 @@ public class GraphHopperTest {
         final String vehicle = "car";
         final String weighting = "fastest";
 
-        GraphHopper hopper = createGraphHopper(vehicle).
+        GraphHopper hopper = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(BAYREUTH).
                 setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting));
         hopper.importOrLoad();
@@ -450,7 +459,8 @@ public class GraphHopperTest {
         final String vehicle = "car";
         final String weighting = "fastest";
 
-        GraphHopper hopper = createGraphHopper(vehicle).
+        GraphHopper hopper = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(LAUF).
                 setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting));
         hopper.importOrLoad();
@@ -487,7 +497,8 @@ public class GraphHopperTest {
         final String vehicle = "car";
         final String weighting = "fastest";
 
-        GraphHopper hopper = createGraphHopper(vehicle).
+        GraphHopper hopper = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(BAYREUTH).
                 setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting));
         hopper.importOrLoad();
@@ -506,7 +517,8 @@ public class GraphHopperTest {
         final String vehicle = "car";
         final String weighting = "fastest";
 
-        GraphHopper hopper = createGraphHopper(vehicle).
+        GraphHopper hopper = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(BAYREUTH).
                 setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting));
         hopper.importOrLoad();
@@ -602,13 +614,14 @@ public class GraphHopperTest {
         final String emptyCar = "empty_car";
         CustomModel customModel = new CustomModel();
         customModel.addToSpeed(Statement.If("road_class == TERTIARY", Statement.Op.MULTIPLY, 0.1));
-        GraphHopper hopper = createGraphHopper(vehicle)
-                .setOSMFile(BAYREUTH)
-                .setProfiles(
+        GraphHopper hopper = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
+                setOSMFile(BAYREUTH).
+                setProfiles(
                         new CustomProfile(emptyCar).setCustomModel(new CustomModel()).setVehicle(vehicle),
                         new CustomProfile(customCar).setCustomModel(customModel).setVehicle(vehicle)
-                )
-                .importOrLoad();
+                ).
+                importOrLoad();
 
         // standard car route
         assertDistance(hopper, emptyCar, null, 8725);
@@ -646,7 +659,8 @@ public class GraphHopperTest {
         final String profile = "profile";
         final String vehicle = "foot";
         final String weighting = "shortest";
-        GraphHopper hopper = createGraphHopper(vehicle).
+        GraphHopper hopper = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(MONACO).
                 setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting)).
                 setStoreOnFlush(true).
@@ -731,7 +745,8 @@ public class GraphHopperTest {
         final String profile = "profile";
         final String vehicle = "foot";
         final String weighting = "shortest";
-        GraphHopper hopper = createGraphHopper(vehicle).
+        GraphHopper hopper = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(MONACO).
                 setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting)).
                 setStoreOnFlush(true).
@@ -762,7 +777,8 @@ public class GraphHopperTest {
         final String profile = "profile";
         final String vehicle = "foot";
         final String weighting = "fastest";
-        GraphHopper hopper = createGraphHopper(vehicle).
+        GraphHopper hopper = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(MONACO).
                 setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting)).
                 setStoreOnFlush(true).
@@ -809,7 +825,8 @@ public class GraphHopperTest {
         final String profile = "profile";
         final String vehicle = "foot";
         final String weighting = "fastest";
-        GraphHopper hopper = createGraphHopper(vehicle).
+        GraphHopper hopper = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(MONACO).
                 setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting)).
                 setStoreOnFlush(true).
@@ -835,7 +852,8 @@ public class GraphHopperTest {
         final String profile = "profile";
         final String vehicle = "foot";
         final String weighting = "fastest";
-        GraphHopper hopper = createGraphHopper(vehicle).
+        GraphHopper hopper = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(MONACO).
                 setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting)).
                 setStoreOnFlush(true).
@@ -866,7 +884,8 @@ public class GraphHopperTest {
         final String profile = "profile";
         final String vehicle = "foot";
         final String weighting = "fastest";
-        GraphHopper hopper = createGraphHopper(vehicle).
+        GraphHopper hopper = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(MONACO).
                 setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting)).
                 setStoreOnFlush(true).
@@ -904,7 +923,8 @@ public class GraphHopperTest {
         final String profile = "profile";
         final String vehicle = "foot";
         final String weighting = "fastest";
-        GraphHopper hopper = createGraphHopper(vehicle).
+        GraphHopper hopper = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(MONACO).
                 setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting)).
                 setStoreOnFlush(true).
@@ -939,7 +959,8 @@ public class GraphHopperTest {
         final String vehicle = "foot";
         final String weighting = "shortest";
 
-        GraphHopper hopper = createGraphHopper(vehicle).
+        GraphHopper hopper = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(MONACO).
                 setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting)).
                 setStoreOnFlush(true);
@@ -992,18 +1013,21 @@ public class GraphHopperTest {
         final String vehicle = "foot";
         final String weighting = "shortest";
 
-        GraphHopper hopper = new GraphHopper()
-                .setOSMFile(MONACO)
-                .setStoreOnFlush(true)
-                .setGraphHopperLocation(GH_LOCATION)
-                .setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting))
-                .setEncodingManager(EncodingManager.start().add(new OSMRoadEnvironmentParser() {
+        GraphHopper hopper = new GraphHopper() {
+            @Override
+            protected void customizeEncodingManager(EncodingManager.Builder emBuilder) {
+                emBuilder.add(new OSMRoadEnvironmentParser() {
                     @Override
                     public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay readerWay, boolean ferry, IntsRef relationFlags) {
                         // do not change RoadEnvironment to avoid triggering tunnel interpolation
                         return edgeFlags;
                     }
-                }).addAll(new DefaultFlagEncoderFactory(), vehicle).build());
+                }).addIfAbsent(new DefaultFlagEncoderFactory(), vehicle);
+            }
+        }.setOSMFile(MONACO)
+         .setStoreOnFlush(true)
+         .setGraphHopperLocation(GH_LOCATION)
+         .setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting));
 
         hopper.setElevationProvider(new SRTMProvider(DIR));
         hopper.importOrLoad();
@@ -1031,10 +1055,12 @@ public class GraphHopperTest {
         final String vehicle = "foot";
         final String weighting = "shortest";
 
-        GraphHopper hopper = createGraphHopper("car,foot")
-                .setOSMFile(MONACO)
-                .setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting))
-                .setStoreOnFlush(true);
+        GraphHopper hopper = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
+                setOSMFile(MONACO).
+                setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting),
+                                new Profile("car").setVehicle("foot").setWeighting(weighting)).
+                setStoreOnFlush(true);
 
         hopper.setElevationProvider(new SRTMProvider(DIR));
         hopper.importOrLoad();
@@ -1063,7 +1089,8 @@ public class GraphHopperTest {
         final String vehicle = "foot";
         final String weighting = "shortest";
 
-        GraphHopper hopper = createGraphHopper(vehicle).
+        GraphHopper hopper = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(MONACO).
                 setStoreOnFlush(true).
                 setElevationWayPointMaxDistance(1).
@@ -1107,7 +1134,8 @@ public class GraphHopperTest {
         final String vehicle = "foot";
         final String weighting = "shortest";
 
-        GraphHopper hopper = createGraphHopper(vehicle).
+        GraphHopper hopper = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(MONACO).
                 setProfiles(
                         new Profile(profile).setVehicle(vehicle).setWeighting(weighting)
@@ -1137,7 +1165,8 @@ public class GraphHopperTest {
         final String vehicle2 = "bike";
         final String weighting = "fastest";
 
-        GraphHopper hopper = createGraphHopper(vehicle1 + "," + vehicle2).
+        GraphHopper hopper = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(KREMS).
                 setProfiles(
                         new Profile(profile1).setVehicle(vehicle1).setWeighting(weighting),
@@ -1187,7 +1216,8 @@ public class GraphHopperTest {
         final String vehicle2 = "bike";
         final String weighting = "fastest";
 
-        GraphHopper hopper = createGraphHopper(vehicle1 + "," + vehicle2).
+        GraphHopper hopper = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(MONACO).
                 setProfiles(Arrays.asList(
                         new Profile(profile1).setVehicle(vehicle1).setWeighting(weighting),
@@ -1232,7 +1262,8 @@ public class GraphHopperTest {
         String vehicle1 = "car";
         String vehicle2 = "bike";
         String weighting = "fastest";
-        GraphHopper hopper = createGraphHopper(vehicle1 + "," + vehicle2).
+        GraphHopper hopper = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(BERLIN).
                 setProfiles(
                         new Profile(profile1).setVehicle(vehicle1).setWeighting(weighting),
@@ -1267,7 +1298,8 @@ public class GraphHopperTest {
                 new Profile(profile1).setVehicle(vehicle1).setWeighting(weighting),
                 new Profile(profile2).setVehicle(vehicle2).setWeighting(weighting)
         );
-        GraphHopper hopper = createGraphHopper(vehicle1 + "," + vehicle2).
+        GraphHopper hopper = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(MONACO).
                 setProfiles(profiles).
                 setStoreOnFlush(true);
@@ -1318,9 +1350,10 @@ public class GraphHopperTest {
         final String profile = "profile";
         final String vehicle = "foot";
         final String weighting = "shortest";
-        GraphHopper hopper = createGraphHopper(vehicle).
+        GraphHopper hopper = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(MONACO).
-                setProfiles(Collections.singletonList(new Profile(profile).setVehicle(vehicle).setWeighting(weighting))).
+                setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting)).
                 setStoreOnFlush(true).
                 setSortGraph(sort);
         hopper.getCHPreparationHandler().setCHProfiles(new CHProfile(profile));
@@ -1355,7 +1388,8 @@ public class GraphHopperTest {
         final String profile = "profile";
         final String vehicle = "foot";
         final String weighting = "fastest";
-        GraphHopper hopper = createGraphHopper(vehicle).
+        GraphHopper hopper = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(MONACO).
                 setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting)).
                 setStoreOnFlush(true).
@@ -1384,7 +1418,8 @@ public class GraphHopperTest {
         final String vehicle = "car";
         final String weighting = "fastest";
 
-        GraphHopper hopper = createGraphHopper(vehicle).
+        GraphHopper hopper = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(BAYREUTH).
                 setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting));
         hopper.importOrLoad();
@@ -1408,7 +1443,8 @@ public class GraphHopperTest {
         final String profile = "profile";
         final String vehicle = "car";
         final String weighting = "fastest";
-        GraphHopper hopper = createGraphHopper(vehicle).
+        GraphHopper hopper = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(BAYREUTH).
                 setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting));
         hopper.importOrLoad();
@@ -1429,7 +1465,8 @@ public class GraphHopperTest {
         final String profile = "car_profile";
         final String vehicle = "car";
         final String weighting = "fastest";
-        GraphHopper hopper = createGraphHopper(vehicle).
+        GraphHopper hopper = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(MONACO).
                 setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting)).
                 setStoreOnFlush(true);
@@ -1490,7 +1527,8 @@ public class GraphHopperTest {
         final String profile2 = "p2";
         final String profile3 = "p3";
         final String vehicle = "car";
-        GraphHopper hopper = createGraphHopper(vehicle).
+        GraphHopper hopper = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(MONACO).
                 setProfiles(
                         new Profile(profile1).setVehicle("car").setWeighting("short_fastest").putHint("short_fastest.distance_factor", 0.07),
@@ -1538,7 +1576,8 @@ public class GraphHopperTest {
         final String vehicle = "mtb";
         final String weighting = "shortest";
 
-        GraphHopper hopper = createGraphHopper(vehicle + "|turn_costs=true").
+        GraphHopper hopper = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(MONACO).
                 setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting).setTurnCosts(true).putHint(U_TURN_COSTS, 123));
         hopper.importOrLoad();
@@ -1560,7 +1599,8 @@ public class GraphHopperTest {
         final String weighting1 = "fastest";
         final String weighting2 = "short_fastest";
 
-        GraphHopper hopper = createGraphHopper(vehicle).
+        GraphHopper hopper = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(MONACO).
                 setProfiles(
                         new Profile(profile1).setVehicle(vehicle).setWeighting(weighting1),
@@ -1609,9 +1649,11 @@ public class GraphHopperTest {
         final String weighting = "fastest";
         // note that the pure presence of the bike encoder leads to 'ghost' junctions with the bike network even for
         // cars such that the number of visited nodes depends on the bike encoder added here or not, #1910
-        GraphHopper hopper = createGraphHopper(vehicle + ",bike").
+        GraphHopper hopper = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(MONACO).
-                setProfiles(Collections.singletonList(new Profile(profile).setVehicle(vehicle).setWeighting(weighting))).
+                setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting),
+                        new Profile("bike").setVehicle("bike").setWeighting(weighting)).
                 setStoreOnFlush(true);
         hopper.getLMPreparationHandler().
                 setLMProfiles(new LMProfile(profile).setMaximumLMWeight(2000));
@@ -1636,11 +1678,10 @@ public class GraphHopperTest {
         final String profile = "car";
         final String vehicle = "car";
         final String weighting = "fastest";
-        GraphHopper hopper = createGraphHopper("car|turn_costs=true").
+        GraphHopper hopper = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(MOSCOW).
-                setProfiles(Collections.singletonList(
-                        new Profile(profile).setVehicle(vehicle).setWeighting(weighting).setTurnCosts(turnCosts)
-                ));
+                setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting).setTurnCosts(turnCosts));
         hopper.getCHPreparationHandler().setCHProfiles(new CHProfile(profile));
         hopper.getLMPreparationHandler().setLMProfiles(new LMProfile(profile));
         hopper.importOrLoad();
@@ -1682,11 +1723,10 @@ public class GraphHopperTest {
         final String profile = "car";
         final String vehicle = "car";
         final String weighting = "fastest";
-        GraphHopper hopper = createGraphHopper("car|turn_costs=true").
+        GraphHopper hopper = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(MOSCOW).
-                setProfiles(Collections.singletonList(
-                        new Profile(profile).setVehicle(vehicle).setWeighting(weighting).setTurnCosts(turnCosts)
-                ));
+                setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting).setTurnCosts(turnCosts));
         hopper.getCHPreparationHandler().setCHProfiles(new CHProfile(profile));
         hopper.importOrLoad();
 
@@ -1708,11 +1748,10 @@ public class GraphHopperTest {
         final String profile = "car";
         final String vehicle = "car";
         final String weighting = "fastest";
-        GraphHopper hopper = createGraphHopper("car|turn_costs=true").
+        GraphHopper hopper = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(MOSCOW).
-                setProfiles(Collections.singletonList(
-                        new Profile(profile).setVehicle(vehicle).setWeighting(weighting).setTurnCosts(true)
-                ));
+                setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting).setTurnCosts(true));
         hopper.getCHPreparationHandler().setCHProfiles(new CHProfile(profile));
         hopper.getLMPreparationHandler().setLMProfiles(new LMProfile(profile));
 
@@ -1742,11 +1781,13 @@ public class GraphHopperTest {
         final String profile2 = "profile_turn_costs";
         final String vehicle = "car";
         final String weighting = "fastest";
-        GraphHopper hopper = createGraphHopper("car|turn_costs=true").
+        GraphHopper hopper = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(MOSCOW).
+                // add profile with turn costs first when no flag encoder is explicitly added
                 setProfiles(
-                        new Profile(profile1).setVehicle(vehicle).setWeighting(weighting).setTurnCosts(false),
-                        new Profile(profile2).setVehicle(vehicle).setWeighting(weighting).setTurnCosts(true)
+                        new Profile(profile2).setVehicle(vehicle).setWeighting(weighting).setTurnCosts(true),
+                        new Profile(profile1).setVehicle(vehicle).setWeighting(weighting).setTurnCosts(false)
                 ).
                 setStoreOnFlush(true);
         hopper.importOrLoad();
@@ -1764,7 +1805,8 @@ public class GraphHopperTest {
         final String profile2 = "profile_no_turn_costs";
         final String vehicle = "car";
         final String weighting = "fastest";
-        GraphHopper hopper = createGraphHopper("car|turn_costs=true").
+        GraphHopper hopper = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(MOSCOW).
                 setProfiles(Arrays.asList(
                         new Profile(profile1).setVehicle(vehicle).setWeighting(weighting).setTurnCosts(true),
@@ -1789,11 +1831,10 @@ public class GraphHopperTest {
         final String profile = "my_car";
         final String vehicle = "car";
         final String weighting = "fastest";
-        GraphHopper hopper = createGraphHopper("car|turn_costs=true").
+        GraphHopper hopper = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(MOSCOW).
-                setProfiles(Collections.singletonList(
-                        new Profile(profile).setVehicle(vehicle).setWeighting(weighting).setTurnCosts(true))
-                ).
+                setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting).setTurnCosts(true)).
                 setStoreOnFlush(true);
         hopper.getCHPreparationHandler()
                 .setCHProfiles(new CHProfile(profile));
@@ -1819,7 +1860,8 @@ public class GraphHopperTest {
         final String profile2 = "car_profile_notc";
         final String weighting = "fastest";
         // before edge-based CH was added a common case was to use edge-based without CH and CH for node-based
-        GraphHopper hopper = createGraphHopper("car|turn_costs=true").
+        GraphHopper hopper = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(MOSCOW).
                 setProfiles(Arrays.asList(
                         new Profile(profile1).setVehicle("car").setWeighting(weighting).setTurnCosts(true),
@@ -1858,9 +1900,11 @@ public class GraphHopperTest {
         final String profile = "profile";
         final String vehicle = "foot";
         final String weighting = "fastest";
-        GraphHopper hopper = createGraphHopper("foot,car|turn_costs=true").
+        GraphHopper hopper = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(MOSCOW).
-                setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting));
+                setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting),
+                        new Profile("car").setVehicle("car").setWeighting(weighting).setTurnCosts(true));
 
         hopper.importOrLoad();
         GHPoint p = new GHPoint(55.813357, 37.5958585);
@@ -1877,7 +1921,8 @@ public class GraphHopperTest {
         // turning onto Gudulastraße. However, Gudulastraße can also not be accessed from the south/west, because
         // its a one-way. This creates a subnetwork that is not accessible at all. We can only detect this if we
         // consider the turn restrictions during the subnetwork search.
-        GraphHopper hopper = createGraphHopper("foot,car|turn_costs=true").
+        GraphHopper hopper = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(ESSEN).
                 setMinNetworkSize(50).
                 setProfiles(
@@ -1905,7 +1950,8 @@ public class GraphHopperTest {
 
     @Test
     public void testEdgeCount() {
-        GraphHopper hopper = createGraphHopper("car").
+        GraphHopper hopper = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(BAYREUTH).
                 setMinNetworkSize(50).
                 setProfiles(new Profile("car").setVehicle("car").setWeighting("fastest"));
@@ -1919,10 +1965,10 @@ public class GraphHopperTest {
 
     @Test
     public void testCurbsides() {
-        GraphHopper h = createGraphHopper("car|turn_costs=true").
+        GraphHopper h = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(BAYREUTH).
-                setProfiles(Collections.singletonList(
-                        new Profile("my_profile").setVehicle("car").setWeighting("fastest").setTurnCosts(true)));
+                setProfiles(new Profile("my_profile").setVehicle("car").setWeighting("fastest").setTurnCosts(true));
         h.getCHPreparationHandler()
                 .setCHProfiles(new CHProfile("my_profile"));
         h.importOrLoad();
@@ -1969,11 +2015,10 @@ public class GraphHopperTest {
         final String profile = "my_profile";
         final String vehicle = "car";
         final String weighting = "fastest";
-        GraphHopper h = createGraphHopper("car|turn_costs=true").
+        GraphHopper h = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(MONACO).
-                setProfiles(Collections.singletonList(
-                        new Profile(profile).setVehicle(vehicle).setWeighting(weighting).setTurnCosts(true))
-                );
+                setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting).setTurnCosts(true));
         h.getCHPreparationHandler()
                 .setCHProfiles(new CHProfile(profile));
         h.importOrLoad();
@@ -2035,13 +2080,11 @@ public class GraphHopperTest {
 
     @Test
     public void testCHWithFiniteUTurnCosts() {
-        GraphHopper h = createGraphHopper("car|turn_costs=true").
+        GraphHopper h = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(MONACO).
-                setProfiles(Collections.singletonList(
-                        new Profile("my_profile").setVehicle("car").setWeighting("fastest")
-                                .setTurnCosts(true)
-                                .putHint(U_TURN_COSTS, 40))
-                );
+                setProfiles(new Profile("my_profile").setVehicle("car").setWeighting("fastest").
+                        setTurnCosts(true).putHint(U_TURN_COSTS, 40));
         h.getCHPreparationHandler()
                 .setCHProfiles(new CHProfile("my_profile"));
         h.importOrLoad();
@@ -2063,16 +2106,16 @@ public class GraphHopperTest {
     @Test
     public void simplifyWithInstructionsAndPathDetails() {
         final String profile = "profile";
-        GraphHopper hopper = new GraphHopper().
-                setOSMFile(BAYREUTH).
-                setProfiles(new Profile(profile).setVehicle("car").setWeighting("fastest")).
-                setGraphHopperLocation(GH_LOCATION);
-        EncodingManager em = new EncodingManager.Builder()
-                .setEnableInstructions(true)
-                .add(new OSMMaxSpeedParser())
-                .add(new CarFlagEncoder())
-                .build();
-        hopper.setEncodingManager(em);
+        GraphHopper hopper = new GraphHopper() {
+            @Override
+            protected void customizeEncodingManager(EncodingManager.Builder emBuilder) {
+                    emBuilder.setEnableInstructions(true)
+                        .add(new OSMMaxSpeedParser())
+                        .add(new CarFlagEncoder());
+            }
+        }.setOSMFile(BAYREUTH).
+          setProfiles(new Profile(profile).setVehicle("car").setWeighting("fastest")).
+          setGraphHopperLocation(GH_LOCATION);
         hopper.importOrLoad();
 
         GHRequest req = new GHRequest()
@@ -2140,12 +2183,4 @@ public class GraphHopperTest {
     private void assertDetail(PathDetail detail, String expected) {
         assertEquals(expected, detail.toString());
     }
-
-    private static GraphHopper createGraphHopper(String encodingManagerString) {
-        GraphHopper hopper = new GraphHopper();
-        hopper.setEncodingManager(EncodingManager.create(encodingManagerString));
-        hopper.setGraphHopperLocation(GH_LOCATION);
-        return hopper;
-    }
-
 }

--- a/reader-osm/src/test/java/com/graphhopper/reader/osm/GraphHopperOSMTest.java
+++ b/reader-osm/src/test/java/com/graphhopper/reader/osm/GraphHopperOSMTest.java
@@ -314,7 +314,6 @@ public class GraphHopperOSMTest {
                 super.importOSM();
             }
         }.setStoreOnFlush(true).
-                setEncodingManager(EncodingManager.create("car")).
                 setGraphHopperLocation(ghLoc).
                 setProfiles(new Profile("car").setVehicle("car").setWeighting("fastest")).
                 setOSMFile(testOsm);
@@ -541,12 +540,18 @@ public class GraphHopperOSMTest {
         }
 
         // different version for car should fail
-        instance = new GraphHopper().setEncodingManager(EncodingManager.create(new FootFlagEncoder(), new CarFlagEncoder() {
+        instance = new GraphHopper() {
             @Override
-            public int getVersion() {
-                return 0;
+            protected void customizeEncodingManager(EncodingManager.Builder emBuilder) {
+                emBuilder.add(new FootFlagEncoder()).
+                        add(new CarFlagEncoder() {
+                            @Override
+                            public int getVersion() {
+                                return 0;
+                            }
+                        });
             }
-        })).init(new GraphHopperConfig().
+        }.init(new GraphHopperConfig().
                 putObject("datareader.file", testOsm3).
                 putObject("datareader.dataaccess", "RAM")).
                 setOSMFile(testOsm3).
@@ -668,7 +673,7 @@ public class GraphHopperOSMTest {
             instance.importOrLoad();
             fail();
         } catch (IllegalStateException ex) {
-            assertTrue(ex.getMessage(), ex.getMessage().startsWith("Cannot load properties to fetch EncodingManager"));
+            assertTrue(ex.getMessage(), ex.getMessage().startsWith("no profiles exist but assumed to create EncodingManager"));
         }
 
         // Import is possible even if no storeOnFlush is specified BUT here we miss the OSM file
@@ -720,9 +725,9 @@ public class GraphHopperOSMTest {
                 init(new GraphHopperConfig().
                         putObject("datareader.file", testOsm3).
                         putObject("prepare.min_network_size", 0).
-                        putObject("graph.flag_encoders", vehicle)
-                        .setProfiles(Collections.singletonList(new Profile(profile).setVehicle(vehicle).setWeighting(weighting)))
-                        .setCHProfiles(Collections.singletonList(new CHProfile(profile)))
+                        putObject("graph.flag_encoders", vehicle).
+                        setProfiles(Collections.singletonList(new Profile(profile).setVehicle(vehicle).setWeighting(weighting))).
+                        setCHProfiles(Collections.singletonList(new CHProfile(profile)))
                 ).
                 setGraphHopperLocation(ghLoc);
         instance.importOrLoad();
@@ -882,7 +887,7 @@ public class GraphHopperOSMTest {
         CarFlagEncoder carEncoder = new CarFlagEncoder();
         EncodingManager encodingManager = EncodingManager.create(carEncoder);
         Weighting weighting = new FastestWeighting(carEncoder);
-        GraphHopperStorage g = new GraphBuilder(encodingManager).setCHConfigs(CHConfig.nodeBased("p", weighting)).setBytes(20).create();
+        GraphHopperStorage g = new GraphBuilder(encodingManager).setCHConfigs(CHConfig.nodeBased("p", weighting)).create();
 
         //   2---3---4
         //  /    |    \
@@ -914,11 +919,11 @@ public class GraphHopperOSMTest {
         GHUtility.setSpeed(60, true, true, carEncoder, g.edge(5, 8).setDistance(110));
         GHUtility.setSpeed(60, true, true, carEncoder, g.edge(7, 8).setDistance(110));
 
-        GraphHopper tmp = new GraphHopper().
-                setEncodingManager(encodingManager).
-                setProfiles(new Profile("profile").setVehicle("car").setWeighting("fastest"));
-        tmp.setGraphHopperStorage(g);
-        tmp.postProcessing();
+        GraphHopper tmp = new GraphHopper() {
+            {
+                loadGraph(g, encodingManager);
+            }
+        }.setProfiles(new Profile("profile").setVehicle("car").setWeighting("fastest"));
         return tmp;
     }
 
@@ -927,16 +932,8 @@ public class GraphHopperOSMTest {
         HashMap<String, Long> shortcutCountMap = new HashMap<>();
         // try all parallelization modes        
         for (int threadCount = 1; threadCount < 6; threadCount++) {
-            EncodingManager em = EncodingManager.create(Arrays.asList(
-                    new CarFlagEncoder(),
-                    new MotorcycleFlagEncoder(),
-                    new MountainBikeFlagEncoder(),
-                    new RacingBikeFlagEncoder(),
-                    new FootFlagEncoder()));
-
             GraphHopper hopper = new GraphHopper().
                     setStoreOnFlush(false).
-                    setEncodingManager(em).
                     setProfiles(
                             new Profile("car_profile").setVehicle("car").setWeighting("fastest"),
                             new Profile("moto_profile").setVehicle("motorcycle").setWeighting("fastest"),
@@ -986,16 +983,8 @@ public class GraphHopperOSMTest {
         HashMap<String, Integer> landmarkCount = new HashMap<>();
         // try all parallelization modes
         for (int threadCount = 1; threadCount < 6; threadCount++) {
-            EncodingManager em = EncodingManager.create(Arrays.asList(
-                    new CarFlagEncoder(),
-                    new MotorcycleFlagEncoder(),
-                    new MountainBikeFlagEncoder(),
-                    new RacingBikeFlagEncoder(),
-                    new FootFlagEncoder()));
-
             GraphHopper hopper = new GraphHopper().
                     setStoreOnFlush(false).
-                    setEncodingManager(em).
                     setProfiles(Arrays.asList(
                             new Profile("car_profile").setVehicle("car").setWeighting("fastest"),
                             new Profile("moto_profile").setVehicle("motorcycle").setWeighting("fastest"),
@@ -1083,7 +1072,6 @@ public class GraphHopperOSMTest {
 
     @Test
     public void testGetMultipleWeightingsForCH() {
-        EncodingManager em = EncodingManager.create("car");
         GraphHopper hopper = new GraphHopper().
                 setProfiles(
                         new Profile("profile1").setVehicle("car").setWeighting("fastest"),
@@ -1091,8 +1079,7 @@ public class GraphHopperOSMTest {
                 ).
                 setStoreOnFlush(false).
                 setGraphHopperLocation(ghLoc).
-                setOSMFile(testOsm).
-                setEncodingManager(em);
+                setOSMFile(testOsm);
         hopper.getCHPreparationHandler().setCHProfiles(
                 new CHProfile("profile1"), new CHProfile("profile2")
         );
@@ -1110,7 +1097,6 @@ public class GraphHopperOSMTest {
             profiles.add(new Profile(enc.toString()).setVehicle(enc.toString()).setWeighting("fastest"));
         }
         return new GraphHopper().
-                setEncodingManager(em).
                 setProfiles(profiles);
     }
 
@@ -1119,7 +1105,6 @@ public class GraphHopperOSMTest {
         GraphHopper hopper = new GraphHopper()
                 .setGraphHopperLocation(ghLoc)
                 .setOSMFile(testOsm)
-                .setEncodingManager(EncodingManager.create("car"))
                 .setProfiles(new Profile("car").setVehicle("car").setWeighting("fastest"));
         hopper.getLMPreparationHandler().setLMProfiles(new LMProfile("car"));
         hopper.getCHPreparationHandler().setCHProfiles(new CHProfile("car"));
@@ -1128,7 +1113,6 @@ public class GraphHopperOSMTest {
 
         // load without problem
         hopper = new GraphHopper()
-                .setEncodingManager(EncodingManager.create("car"))
                 .setProfiles(new Profile("car").setVehicle("car").setWeighting("fastest"));
         hopper.getLMPreparationHandler().setLMProfiles(new LMProfile("car"));
         hopper.getCHPreparationHandler().setCHProfiles(new CHProfile("car"));
@@ -1137,7 +1121,6 @@ public class GraphHopperOSMTest {
 
         // problem: changed weighting in profile although LM preparation was enabled
         hopper = new GraphHopper()
-                .setEncodingManager(EncodingManager.create("car"))
                 .setProfiles(new Profile("car").setVehicle("car").setWeighting("shortest"));
         hopper.getLMPreparationHandler().setLMProfiles(new LMProfile("car"));
         // do not load CH
@@ -1152,7 +1135,6 @@ public class GraphHopperOSMTest {
 
         // problem: changed weighting in profile although CH preparation was enabled
         hopper = new GraphHopper()
-                .setEncodingManager(EncodingManager.create("car"))
                 .setProfiles(new Profile("car").setVehicle("car").setWeighting("shortest"));
         hopper.getCHPreparationHandler().setCHProfiles(new CHProfile("car"));
         // do not load LM
@@ -1172,7 +1154,6 @@ public class GraphHopperOSMTest {
         GraphHopper hopper = new GraphHopper()
                 .setGraphHopperLocation(ghLoc)
                 .setOSMFile(testOsm)
-                .setEncodingManager(EncodingManager.create("car"))
                 .setProfiles(new CustomProfile("car").setCustomModel(customModel));
         hopper.getLMPreparationHandler().setLMProfiles(new LMProfile("car"));
         hopper.importOrLoad();
@@ -1180,7 +1161,6 @@ public class GraphHopperOSMTest {
 
         // load without problem
         hopper = new GraphHopper()
-                .setEncodingManager(EncodingManager.create("car"))
                 .setProfiles(new CustomProfile("car").setCustomModel(customModel));
         hopper.getLMPreparationHandler().setLMProfiles(new LMProfile("car"));
         assertTrue(hopper.load(ghLoc));
@@ -1189,7 +1169,6 @@ public class GraphHopperOSMTest {
         // do not load changed CustomModel
         customModel.setDistanceInfluence(100);
         hopper = new GraphHopper()
-                .setEncodingManager(EncodingManager.create("car"))
                 .setProfiles(new CustomProfile("car").setCustomModel(customModel));
         hopper.getLMPreparationHandler().setLMProfiles(new LMProfile("car"));
         try {
@@ -1204,7 +1183,7 @@ public class GraphHopperOSMTest {
 
     private int[] calcNodes(GraphHopper instance, ResponsePath responsePath) {
         List<PathDetail> edgeKeys = responsePath.getPathDetails().get("edge_key");
-        int[] result = new int[edgeKeys.size()+1];
+        int[] result = new int[edgeKeys.size() + 1];
         for (int i = 0; i < edgeKeys.size(); i++) {
             int edgeKey = (int) edgeKeys.get(i).getValue();
             int edgeId = edgeKey / 2;

--- a/reader-osm/src/test/java/com/graphhopper/reader/osm/GraphHopperOSMTest.java
+++ b/reader-osm/src/test/java/com/graphhopper/reader/osm/GraphHopperOSMTest.java
@@ -81,7 +81,7 @@ public class GraphHopperOSMTest {
         String profile = "car_profile";
         String vehicle = "car";
         String weighting = "fastest";
-        GraphHopper hopper = createGraphHopper(vehicle).
+        GraphHopper hopper = new GraphHopper().
                 setStoreOnFlush(true).
                 setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting)).
                 setGraphHopperLocation(ghLoc).
@@ -128,7 +128,7 @@ public class GraphHopperOSMTest {
         final String profile = "profile";
         final String vehicle = "car";
         final String weighting = "fastest";
-        GraphHopper gh = createGraphHopper(vehicle).
+        GraphHopper gh = new GraphHopper().
                 setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting)).
                 setStoreOnFlush(true).
                 setGraphHopperLocation(ghLoc).
@@ -143,7 +143,7 @@ public class GraphHopperOSMTest {
         assertEquals(3, rsp.getBest().getPoints().getSize());
 
         gh.close();
-        gh = createGraphHopper(vehicle).
+        gh = new GraphHopper().
                 setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting)).
                 setStoreOnFlush(true);
         assertTrue(gh.load(ghLoc));
@@ -154,7 +154,7 @@ public class GraphHopperOSMTest {
 
         gh.close();
 
-        gh = createGraphHopper(vehicle).
+        gh = new GraphHopper().
                 setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting)).
                 setGraphHopperLocation(ghLoc).
                 setOSMFile(testOsm);
@@ -165,7 +165,8 @@ public class GraphHopperOSMTest {
 
     @Test
     public void testQueryLocationIndexWithBBox() {
-        final GraphHopper gh = createGraphHopper("car").
+        final GraphHopper gh = new GraphHopper().
+                setProfiles(new Profile("car").setVehicle("car").setWeighting("fastest")).
                 setStoreOnFlush(true).
                 setGraphHopperLocation(ghLoc).
                 setOSMFile("../core/files/monaco.osm.gz");
@@ -229,9 +230,9 @@ public class GraphHopperOSMTest {
         final String profile = "profile";
         final String vehicle = "car";
         final String weighting = "fastest";
-        GraphHopper gh = createGraphHopper(vehicle).
+        GraphHopper gh = new GraphHopper().
                 setStoreOnFlush(true).
-                setProfiles(Collections.singletonList(new Profile(profile).setVehicle(vehicle).setWeighting(weighting))).
+                setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting)).
                 setGraphHopperLocation(ghLoc).
                 setOSMFile(testOsm);
         gh.getCHPreparationHandler().setCHProfiles(new CHProfile(profile));
@@ -242,7 +243,8 @@ public class GraphHopperOSMTest {
         gh.close();
 
         // now load GH without CH profile
-        gh = createGraphHopper(vehicle).
+        gh = new GraphHopper().
+                setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting)).
                 setStoreOnFlush(true);
         gh.load(ghLoc);
         // no error
@@ -250,9 +252,9 @@ public class GraphHopperOSMTest {
         Helper.removeDir(new File(ghLoc));
 
         // when there is no CH preparation we get an error if we try to load GH with a CH profile
-        gh = createGraphHopper(vehicle).
+        gh = new GraphHopper().
                 setStoreOnFlush(true).
-                setProfiles(Collections.singletonList(new Profile(profile).setVehicle(vehicle).setWeighting(weighting))).
+                setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting)).
                 setGraphHopperLocation(ghLoc).
                 setOSMFile(testOsm);
         gh.importOrLoad();
@@ -261,7 +263,7 @@ public class GraphHopperOSMTest {
         assertEquals(3, rsp.getBest().getPoints().getSize());
         gh.close();
 
-        gh = createGraphHopper("car").
+        gh = new GraphHopper().
                 setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting)).
                 setStoreOnFlush(true);
         gh.getCHPreparationHandler().setCHProfiles(new CHProfile("profile"));
@@ -277,18 +279,19 @@ public class GraphHopperOSMTest {
     @Test
     public void testAllowMultipleReadingInstances() {
         String vehicle = "car";
-        GraphHopper instance1 = createGraphHopper(vehicle).
+        GraphHopper instance1 = new GraphHopper().
+                setProfiles(new Profile(vehicle).setVehicle(vehicle).setWeighting("fastest")).
                 setStoreOnFlush(true).
                 setGraphHopperLocation(ghLoc).
                 setOSMFile(testOsm);
         instance1.importOrLoad();
 
-        GraphHopper instance2 = createGraphHopper(vehicle).
+        GraphHopper instance2 = new GraphHopper().
                 setStoreOnFlush(true).
                 setOSMFile(testOsm);
         instance2.load(ghLoc);
 
-        GraphHopper instance3 = createGraphHopper(vehicle).
+        GraphHopper instance3 = new GraphHopper().
                 setStoreOnFlush(true).
                 setOSMFile(testOsm);
         instance3.load(ghLoc);
@@ -330,7 +333,8 @@ public class GraphHopperOSMTest {
         };
         thread.start();
 
-        GraphHopper instance2 = createGraphHopper("car").
+        GraphHopper instance2 = new GraphHopper().
+                setProfiles(new Profile("car").setVehicle("car").setWeighting("fastest")).
                 setStoreOnFlush(true).
                 setOSMFile(testOsm);
         try {
@@ -360,9 +364,9 @@ public class GraphHopperOSMTest {
         final String vehicle = "car";
         final String weighting = "shortest";
 
-        instance = createGraphHopper(vehicle).
+        instance = new GraphHopper().
                 setStoreOnFlush(false).
-                setProfiles(Collections.singletonList(new Profile(profile).setVehicle(vehicle).setWeighting(weighting))).
+                setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting)).
                 setGraphHopperLocation(ghLoc).
                 setOSMFile(testOsm);
         instance.getCHPreparationHandler().setCHProfiles(new CHProfile(profile));
@@ -380,7 +384,7 @@ public class GraphHopperOSMTest {
         final String profile = "profile";
         final String vehicle = "car";
         final String weighting = "fastest";
-        instance = createGraphHopper(vehicle).
+        instance = new GraphHopper().
                 setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting)).
                 setStoreOnFlush(false).
                 setSortGraph(true).
@@ -417,7 +421,7 @@ public class GraphHopperOSMTest {
         final String weighting = "fastest";
 
         // now all ways are imported
-        instance = createGraphHopper(vehicle1 + "," + vehicle2).
+        instance = new GraphHopper().
                 setProfiles(
                         new Profile(profile1).setVehicle(vehicle1).setWeighting(weighting),
                         new Profile(profile2).setVehicle(vehicle2).setWeighting(weighting)
@@ -476,12 +480,12 @@ public class GraphHopperOSMTest {
                 new GraphHopperConfig().
                         putObject("datareader.file", testOsm3).
                         putObject("datareader.dataaccess", "RAM").
-                        putObject("graph.flag_encoders", "foot,car")).
-                setGraphHopperLocation(ghLoc).
-                setProfiles(Arrays.asList(
-                        new Profile("foot").setVehicle("foot").setWeighting("fastest"),
-                        new Profile("car").setVehicle("car").setWeighting("fastest")
-                ));
+                        putObject("graph.flag_encoders", "foot,car").
+                        setProfiles(Arrays.asList(
+                                new Profile("foot").setVehicle("foot").setWeighting("fastest"),
+                                new Profile("car").setVehicle("car").setWeighting("fastest")
+                        ))).
+                setGraphHopperLocation(ghLoc);
         instance.importOrLoad();
         assertEquals(5, instance.getGraphHopperStorage().getNodes());
         instance.close();
@@ -492,11 +496,11 @@ public class GraphHopperOSMTest {
                     new GraphHopperConfig().
                             putObject("datareader.file", testOsm3).
                             putObject("datareader.dataaccess", "RAM").
-                            putObject("graph.flag_encoders", "foot")).
-                    setOSMFile(testOsm3).
-                    setProfiles(Collections.singletonList(
-                            new Profile("foot").setVehicle("foot").setWeighting("fastest")
-                    ));
+                            putObject("graph.flag_encoders", "foot").
+                            setProfiles(Collections.singletonList(
+                                    new Profile("foot").setVehicle("foot").setWeighting("fastest")
+                            ))).
+                    setOSMFile(testOsm3);
             tmpGH.load(ghLoc);
             fail();
         } catch (Exception ex) {
@@ -508,12 +512,12 @@ public class GraphHopperOSMTest {
             GraphHopper tmpGH = new GraphHopper().init(new GraphHopperConfig().
                     putObject("datareader.file", testOsm3).
                     putObject("datareader.dataaccess", "RAM").
-                    putObject("graph.flag_encoders", "car,foot")).
-                    setOSMFile(testOsm3).
+                    putObject("graph.flag_encoders", "car,foot").
                     setProfiles(Arrays.asList(
                             new Profile("car").setVehicle("car").setWeighting("fastest"),
                             new Profile("foot").setVehicle("foot").setWeighting("fastest")
-                    ));
+                    ))).
+                    setOSMFile(testOsm3);
             tmpGH.load(ghLoc);
             fail();
         } catch (Exception ex) {
@@ -526,12 +530,12 @@ public class GraphHopperOSMTest {
                         putObject("datareader.file", testOsm3).
                         putObject("datareader.dataaccess", "RAM").
                         putObject("graph.encoded_values", "road_class").
-                        putObject("graph.flag_encoders", "foot,car")).
-                setOSMFile(testOsm3).
-                setProfiles(Arrays.asList(
-                        new Profile("foot").setVehicle("foot").setWeighting("fastest"),
-                        new Profile("car").setVehicle("car").setWeighting("fastest")
-                ));
+                        putObject("graph.flag_encoders", "foot,car").
+                        setProfiles(Arrays.asList(
+                                new Profile("foot").setVehicle("foot").setWeighting("fastest"),
+                                new Profile("car").setVehicle("car").setWeighting("fastest")
+                        ))).
+                setOSMFile(testOsm3);
         try {
             instance.load(ghLoc);
             fail();
@@ -542,19 +546,17 @@ public class GraphHopperOSMTest {
         // different version for car should fail
         instance = new GraphHopper();
         instance.getEncodingManagerBuilder().add(new FootFlagEncoder()).
-                        add(new CarFlagEncoder() {
-                            @Override
-                            public int getVersion() {
-                                return 0;
-                            }
-                        });
+                add(new CarFlagEncoder() {
+                    @Override
+                    public int getVersion() {
+                        return 0;
+                    }
+                });
         instance.init(new GraphHopperConfig().
                 putObject("datareader.file", testOsm3).
-                putObject("datareader.dataaccess", "RAM")).
-                setOSMFile(testOsm3).
-                setProfiles(Collections.singletonList(
-                        new Profile("car").setVehicle("car").setWeighting("fastest")
-                ));
+                putObject("datareader.dataaccess", "RAM").
+                setProfiles(Collections.singletonList(new Profile("car").setVehicle("car").setWeighting("fastest")))).
+                setOSMFile(testOsm3);
         try {
             instance.load(ghLoc);
             fail();
@@ -569,11 +571,11 @@ public class GraphHopperOSMTest {
                 new GraphHopperConfig().
                         putObject("datareader.file", testOsm3).
                         putObject("datareader.dataaccess", "RAM").
-                        putObject("graph.flag_encoders", "foot,car")).
-                setProfiles(Arrays.asList(
-                        new Profile("foot").setVehicle("foot").setWeighting("fastest"),
-                        new Profile("car").setVehicle("car").setWeighting("fastest")
-                )).
+                        putObject("graph.flag_encoders", "foot,car").
+                        setProfiles(Arrays.asList(
+                                new Profile("foot").setVehicle("foot").setWeighting("fastest"),
+                                new Profile("car").setVehicle("car").setWeighting("fastest")
+                        ))).
                 setGraphHopperLocation(ghLoc);
         instance.importOrLoad();
         // older versions <= 0.12 did not store this property, ensure that we fail to load it
@@ -588,11 +590,11 @@ public class GraphHopperOSMTest {
                         putObject("datareader.file", testOsm3).
                         putObject("datareader.dataaccess", "RAM").
                         putObject("graph.encoded_values", "road_environment,road_class").
-                        putObject("graph.flag_encoders", "foot,car")).
-                setProfiles(Arrays.asList(
-                        new Profile("foot").setVehicle("foot").setWeighting("fastest"),
-                        new Profile("car").setVehicle("car").setWeighting("fastest")
-                )).
+                        putObject("graph.flag_encoders", "foot,car").
+                        setProfiles(Arrays.asList(
+                                new Profile("foot").setVehicle("foot").setWeighting("fastest"),
+                                new Profile("car").setVehicle("car").setWeighting("fastest")
+                        ))).
                 setOSMFile(testOsm3);
         try {
             instance.load(ghLoc);
@@ -607,7 +609,7 @@ public class GraphHopperOSMTest {
         String profile = "profile";
         String vehicle = "car";
         String weighting = "fastest";
-        instance = createGraphHopper(vehicle).
+        instance = new GraphHopper().
                 setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting)).
                 setStoreOnFlush(true);
         try {
@@ -623,7 +625,8 @@ public class GraphHopperOSMTest {
 
     @Test
     public void testDoesNotCreateEmptyFolderIfLoadingFromNonExistingPath() {
-        instance = createGraphHopper("car");
+        instance = new GraphHopper();
+        instance.setProfiles(new Profile("car").setVehicle("car").setWeighting("fastest"));
         assertFalse(instance.load(ghLoc));
         assertFalse(new File(ghLoc).exists());
     }
@@ -650,7 +653,8 @@ public class GraphHopperOSMTest {
         }
 
         // missing OSM file to import
-        instance = createGraphHopper("car").
+        instance = new GraphHopper().
+                setProfiles(new Profile("car").setVehicle("car").setWeighting("fastest")).
                 setStoreOnFlush(true).
                 setGraphHopperLocation(ghLoc);
         try {
@@ -674,7 +678,8 @@ public class GraphHopperOSMTest {
         }
 
         // Import is possible even if no storeOnFlush is specified BUT here we miss the OSM file
-        instance = createGraphHopper("car").
+        instance = new GraphHopper().
+                setProfiles(new Profile("car").setVehicle("car").setWeighting("fastest")).
                 setStoreOnFlush(false).
                 setGraphHopperLocation(ghLoc);
         try {
@@ -692,7 +697,7 @@ public class GraphHopperOSMTest {
         final String profile = "foot_profile";
         final String vehicle = "foot";
         final String weighting = "fastest";
-        instance = createGraphHopper(vehicle).
+        instance = new GraphHopper().
                 setStoreOnFlush(false).
                 setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting)).
                 setGraphHopperLocation(ghLoc).
@@ -918,9 +923,10 @@ public class GraphHopperOSMTest {
 
         GraphHopper tmp = new GraphHopper() {
             {
+                setProfiles(new Profile("profile").setVehicle("car").setWeighting("fastest"));
                 loadGraph(g, encodingManager);
             }
-        }.setProfiles(new Profile("profile").setVehicle("car").setWeighting("fastest"));
+        };
         return tmp;
     }
 
@@ -1085,16 +1091,6 @@ public class GraphHopperOSMTest {
         for (PrepareContractionHierarchies p : hopper.getCHPreparationHandler().getPreparations()) {
             assertTrue("did not get prepared", p.isPrepared());
         }
-    }
-
-    private GraphHopper createGraphHopper(String vehicles) {
-        EncodingManager em = EncodingManager.create(vehicles);
-        List<Profile> profiles = new ArrayList<>();
-        for (FlagEncoder enc : em.fetchEdgeEncoders()) {
-            profiles.add(new Profile(enc.toString()).setVehicle(enc.toString()).setWeighting("fastest"));
-        }
-        return new GraphHopper().
-                setProfiles(profiles);
     }
 
     @Test

--- a/reader-osm/src/test/java/com/graphhopper/reader/osm/OSMReaderTest.java
+++ b/reader-osm/src/test/java/com/graphhopper/reader/osm/OSMReaderTest.java
@@ -551,7 +551,6 @@ public class OSMReaderTest {
         String fileRoadAttributes = "test-road-attributes.xml";
         GraphHopper hopper = new GraphHopperFacade(fileRoadAttributes);
         hopper.getEncodingManagerBuilder().add(new OSMMaxWidthParser()).add(new OSMMaxHeightParser()).add(new OSMMaxWeightParser());
-        hopper.setProfiles(new Profile("car").setVehicle("car").setWeighting("fastest"));
         hopper.importOrLoad();
 
         DecimalEncodedValue widthEnc = hopper.getEncodingManager().getDecimalEncodedValue(MaxWidth.KEY);
@@ -833,14 +832,16 @@ public class OSMReaderTest {
 
     @Test
     public void testPreferredLanguage() {
-        GraphHopper hopper = new GraphHopperFacade(file1, false, "de").importOrLoad();
+        GraphHopper hopper = new GraphHopperFacade(file1, false, "de").
+                importOrLoad();
         GraphHopperStorage graph = hopper.getGraphHopperStorage();
         int n20 = AbstractGraphStorageTester.getIdOf(graph, 52);
         EdgeIterator iter = carOutExplorer.setBaseNode(n20);
         assertTrue(iter.next());
         assertEquals("straße 123, B 122", iter.getName());
 
-        hopper = new GraphHopperFacade(file1, false, "el").importOrLoad();
+        hopper = new GraphHopperFacade(file1, false, "el").
+                importOrLoad();
         graph = hopper.getGraphHopperStorage();
         n20 = AbstractGraphStorageTester.getIdOf(graph, 52);
         iter = carOutExplorer.setBaseNode(n20);
@@ -920,9 +921,6 @@ public class OSMReaderTest {
     }
 
     class GraphHopperFacade extends GraphHopper {
-        boolean turnCosts;
-        String prefLang;
-
         public GraphHopperFacade(String osmFile) {
             this(osmFile, false, "");
         }
@@ -931,9 +929,6 @@ public class OSMReaderTest {
             setStoreOnFlush(false);
             setOSMFile(osmFile);
             setGraphHopperLocation(dir);
-
-            this.prefLang = prefLang;
-            this.turnCosts = turnCosts;
             setProfiles(
                     new Profile("foot").setVehicle("foot").setWeighting("fastest"),
                     new Profile("car").setVehicle("car").setWeighting("fastest"),
@@ -960,11 +955,9 @@ public class OSMReaderTest {
                     getEncodingManager().needsTurnCostsSupport());
             setGraphHopperStorage(tmpGraph);
             super.importOSM();
-            if (carEncoder != null) {
-                carAccessEnc = carEncoder.getAccessEnc();
-                carOutExplorer = getGraphHopperStorage().createEdgeExplorer(DefaultEdgeFilter.outEdges(carAccessEnc));
-                carAllExplorer = getGraphHopperStorage().createEdgeExplorer(DefaultEdgeFilter.allEdges(carAccessEnc));
-            }
+            carAccessEnc = carEncoder.getAccessEnc();
+            carOutExplorer = getGraphHopperStorage().createEdgeExplorer(DefaultEdgeFilter.outEdges(carAccessEnc));
+            carAllExplorer = getGraphHopperStorage().createEdgeExplorer(DefaultEdgeFilter.allEdges(carAccessEnc));
         }
 
         @Override

--- a/reader-osm/src/test/java/com/graphhopper/routing/RoutingAlgorithmWithOSMTest.java
+++ b/reader-osm/src/test/java/com/graphhopper/routing/RoutingAlgorithmWithOSMTest.java
@@ -63,22 +63,21 @@ import static org.junit.Assert.assertTrue;
 public class RoutingAlgorithmWithOSMTest {
     TestAlgoCollector testCollector;
 
-    public static List<AlgoHelperEntry> createAlgos(final GraphHopper hopper, final String weightingStr, final String vehicleStr, TraversalMode tMode) {
+    public static List<AlgoHelperEntry> createAlgos(final GraphHopper hopper, Profile profile) {
         final GraphHopperStorage ghStorage = hopper.getGraphHopperStorage();
         LocationIndex idx = hopper.getLocationIndex();
 
+        TraversalMode tMode = profile.isTurnCosts()? TraversalMode.EDGE_BASED:TraversalMode.NODE_BASED;
         String addStr = "";
-        if (tMode.isEdgeBased())
+        if (profile.isTurnCosts())
             addStr = "turn|";
 
-        Profile profile = new Profile("profile").setVehicle(vehicleStr).setWeighting(weightingStr).setTurnCosts(tMode.isEdgeBased());
         Weighting weighting = hopper.createWeighting(profile, new PMap());
-
         PMap defaultHints = new PMap()
                 .putObject(Parameters.CH.DISABLE, true)
                 .putObject(Parameters.Landmark.DISABLE, true)
-                .putObject("vehicle", vehicleStr)
-                .putObject("weighting", weightingStr);
+                .putObject("vehicle", profile.getVehicle())
+                .putObject("weighting", profile.getWeighting());
 
         AlgorithmOptions defaultOpts = AlgorithmOptions.start(new AlgorithmOptions("", weighting, tMode)).hints(defaultHints).build();
         List<AlgoHelperEntry> algos = new ArrayList<>();
@@ -99,7 +98,7 @@ public class RoutingAlgorithmWithOSMTest {
             algos.add(new AlgoHelperEntry(ghStorage, false, opts, idx, "astarbi|landmarks|" + weighting) {
                 @Override
                 public RoutingAlgorithm createAlgo(Graph graph) {
-                    return hopper.getLMPreparationHandler().getPreparation(vehicleStr + "_profile").getRoutingAlgorithmFactory().createAlgo(graph, opts);
+                    return hopper.getLMPreparationHandler().getPreparation(profile.getName()).getRoutingAlgorithmFactory().createAlgo(graph, opts);
                 }
             });
         }
@@ -109,10 +108,10 @@ public class RoutingAlgorithmWithOSMTest {
             chHints.putObject(Parameters.CH.DISABLE, false);
             chHints.putObject(Parameters.Routing.EDGE_BASED, tMode.isEdgeBased());
             final AlgorithmOptions dijkstraOpts = AlgorithmOptions.start(dijkstrabiOpts).hints(chHints).build();
-            algos.add(new AlgoHelperEntry(ghStorage, true, dijkstraOpts, idx, "dijkstrabi|ch|prepare|" + weightingStr) {
+            algos.add(new AlgoHelperEntry(ghStorage, true, dijkstraOpts, idx, "dijkstrabi|ch|prepare|" + profile.getWeighting()) {
                 @Override
                 public RoutingAlgorithm createAlgo(Graph g) {
-                    PrepareContractionHierarchies pch = hopper.getCHPreparationHandler().getPreparation(vehicleStr + "_profile");
+                    PrepareContractionHierarchies pch = hopper.getCHPreparationHandler().getPreparation(profile.getName());
                     RoutingCHGraph routingCHGraph = ghStorage.getRoutingCHGraph(pch.getCHConfig().getName());
                     if (g instanceof QueryGraph)
                         routingCHGraph = new QueryRoutingCHGraph(routingCHGraph, (QueryGraph) g);
@@ -121,9 +120,9 @@ public class RoutingAlgorithmWithOSMTest {
             });
 
             final AlgorithmOptions astarOpts = AlgorithmOptions.start(astarbiOpts).hints(chHints).build();
-            algos.add(new AlgoHelperEntry(ghStorage, true, astarOpts, idx, "astarbi|ch|prepare|" + weightingStr) {
+            algos.add(new AlgoHelperEntry(ghStorage, true, astarOpts, idx, "astarbi|ch|prepare|" + profile.getWeighting()) {
                 public RoutingAlgorithm createAlgo(Graph g) {
-                    PrepareContractionHierarchies pch = hopper.getCHPreparationHandler().getPreparation(vehicleStr + "_profile");
+                    PrepareContractionHierarchies pch = hopper.getCHPreparationHandler().getPreparation(profile.getName());
                     RoutingCHGraph routingCHGraph = ghStorage.getRoutingCHGraph(pch.getCHConfig().getName());
                     if (g instanceof QueryGraph)
                         routingCHGraph = new QueryRoutingCHGraph(routingCHGraph, (QueryGraph) g);
@@ -162,7 +161,7 @@ public class RoutingAlgorithmWithOSMTest {
     @Test
     public void testMonaco() {
         Graph g = runAlgo(testCollector, DIR + "/monaco.osm.gz", "target/monaco-gh",
-                createMonacoCar(), "car", true, "car", "shortest", false);
+                createMonacoCar(), true, false, new Profile("car").setVehicle("car").setWeighting("shortest"));
 
         assertEquals(testCollector.toString(), 0, testCollector.errors.size());
 
@@ -185,7 +184,7 @@ public class RoutingAlgorithmWithOSMTest {
         list.add(new OneRun(43.730949, 7.412338, 43.739643, 7.424542, 2253, 120));
         list.add(new OneRun(43.727592, 7.419333, 43.727712, 7.419333, 0, 1));
         runAlgo(testCollector, DIR + "/monaco.osm.gz", "target/monaco-mc-gh",
-                list, "motorcycle", true, "motorcycle", "fastest", true);
+                list, true, true, new Profile("motorcycle").setVehicle("motorcycle").setWeighting("fastest"));
 
         assertEquals(testCollector.toString(), 0, testCollector.errors.size());
     }
@@ -200,7 +199,7 @@ public class RoutingAlgorithmWithOSMTest {
         list.add(new OneRun(43.730949, 7.412338, 43.739643, 7.424542, 2253, 120));
         list.add(new OneRun(43.727592, 7.419333, 43.727712, 7.419333, 0, 1));
         runAlgo(testCollector, DIR + "/monaco.osm.gz", "target/monaco-mc-gh",
-                list, "motorcycle", true, "motorcycle", "curvature", true);
+                list, true, true, new Profile("motorcycle").setVehicle("motorcycle").setWeighting("curvature"));
 
         assertEquals(testCollector.toString(), 0, testCollector.errors.size());
     }
@@ -212,7 +211,7 @@ public class RoutingAlgorithmWithOSMTest {
         // reverse route avoids the location
 //        list.add(new OneRun(52.349713, 8.013293, 52.349969, 8.013813, 293, 21));
         runAlgo(testCollector, DIR + "/map-bug432.osm.gz", "target/map-bug432-gh",
-                list, "bike2", true, "bike2", "fastest", true);
+                list, true, true, new Profile("bike2").setVehicle("bike2").setWeighting("fastest"));
 
         assertEquals(testCollector.toString(), 0, testCollector.errors.size());
     }
@@ -227,7 +226,7 @@ public class RoutingAlgorithmWithOSMTest {
         list.add(new OneRun(51.376509, -0.530863, 51.376197, -0.531576, 75, 15));
 
         runAlgo(testCollector, DIR + "/circle-bug.osm.gz", "target/circle-bug-gh",
-                list, "car", true, "car", "shortest", false);
+                list, true, false, new Profile("car").setVehicle("car").setWeighting("shortest"));
         assertEquals(testCollector.toString(), 0, testCollector.errors.size());
     }
 
@@ -245,7 +244,7 @@ public class RoutingAlgorithmWithOSMTest {
         // http://localhost:8989/?point=55.819066%2C37.596374&point=55.818898%2C37.59661
         list.add(new OneRun(55.819066, 37.596374, 55.818898, 37.59661, 1114, 23));
         runAlgo(testCollector, DIR + "/moscow.osm.gz", "target/moscow-gh",
-                list, "car", true, "car", "fastest", false);
+                list, true, false, new Profile("car").setVehicle("car").setWeighting("fastest"));
         assertEquals(testCollector.toString(), 0, testCollector.errors.size());
     }
 
@@ -256,7 +255,7 @@ public class RoutingAlgorithmWithOSMTest {
         list.add(new OneRun(55.813159, 37.593884, 55.811278, 37.594217, 1048, 13));
         boolean testAlsoCH = true, is3D = false;
         runAlgo(testCollector, DIR + "/moscow.osm.gz", "target/graph-moscow",
-                list, "car|turn_costs=true", testAlsoCH, "car", "fastest", is3D);
+                list, testAlsoCH, is3D, new Profile("car").setVehicle("car").setWeighting("fastest").setTurnCosts(true));
 
         assertEquals(testCollector.toString(), 0, testCollector.errors.size());
     }
@@ -267,7 +266,7 @@ public class RoutingAlgorithmWithOSMTest {
         list.add(new OneRun(-0.5, 0.0, 0.0, -0.5, 301015.98099, 6));
         boolean testAlsoCH = true, is3D = false;
         runAlgo(testCollector, DIR + "/test_simple_turncosts.osm.xml", "target/graph-simple_turncosts",
-                list, "car|turn_costs=true", testAlsoCH, "car", "fastest", is3D);
+                list, testAlsoCH, is3D, new Profile("car").setVehicle("car").setWeighting("fastest").setTurnCosts(true));
 
         assertEquals(testCollector.toString(), 0, testCollector.errors.size());
     }
@@ -278,7 +277,7 @@ public class RoutingAlgorithmWithOSMTest {
         list.add(new OneRun(0, 1, -1, 0, 667.08, 6));
         boolean testAlsoCH = true, is3D = false;
         runAlgo(testCollector, DIR + "/test_simple_pturn.osm.xml", "target/graph-simple_turncosts",
-                list, "car|turn_costs=true", testAlsoCH, "car", "fastest", is3D);
+                list, testAlsoCH, is3D, new Profile("car").setVehicle("car").setWeighting("fastest").setTurnCosts(true));
 
         assertEquals(testCollector.toString(), 0, testCollector.errors.size());
     }
@@ -293,7 +292,7 @@ public class RoutingAlgorithmWithOSMTest {
 
         boolean testAlsoCH = false, is3D = false;
         runAlgo(testCollector, DIR + "/map-sidewalk-no.osm.gz", "target/graph-sidewalkno",
-                list, "hike", testAlsoCH, "hike", "fastest", is3D);
+                list, testAlsoCH, is3D, new Profile("hike").setVehicle("hike").setWeighting("fastest"));
 
         assertEquals(testCollector.toString(), 0, testCollector.errors.size());
     }
@@ -308,7 +307,7 @@ public class RoutingAlgorithmWithOSMTest {
         list.get(4).setDistance(1, 2149);
         list.get(4).setLocs(1, 120);
         runAlgo(testCollector, DIR + "/monaco.osm.gz", "target/monaco-gh",
-                list, "car", true, "car", "fastest", false);
+                list, true, false, new Profile("car").setVehicle("car").setWeighting("fastest"));
         assertEquals(testCollector.toString(), 0, testCollector.errors.size());
     }
 
@@ -324,7 +323,9 @@ public class RoutingAlgorithmWithOSMTest {
         list.get(4).setLocs(1, 116);
 
         runAlgo(testCollector, DIR + "/monaco.osm.gz", "target/monaco-gh",
-                list, "car,foot", false, "car", "shortest", false);
+                list, false, false,
+                new Profile("car").setVehicle("car").setWeighting("shortest"),
+                new Profile("foot").setVehicle("foot").setWeighting("shortest"));
         assertEquals(testCollector.toString(), 0, testCollector.errors.size());
     }
 
@@ -340,7 +341,7 @@ public class RoutingAlgorithmWithOSMTest {
     @Test
     public void testMonacoFoot() {
         Graph g = runAlgo(testCollector, DIR + "/monaco.osm.gz", "target/monaco-gh",
-                createMonacoFoot(), "foot", true, "foot", "shortest", false);
+                createMonacoFoot(), true, false, new Profile("foot").setVehicle("foot").setWeighting("shortest"));
         assertEquals(testCollector.toString(), 0, testCollector.errors.size());
 
         // see testMonaco for a similar ID test
@@ -365,7 +366,7 @@ public class RoutingAlgorithmWithOSMTest {
         list.get(1).setLocs(1, 149);
 
         runAlgo(testCollector, DIR + "/monaco.osm.gz", "target/monaco-gh",
-                list, "foot", true, "foot", "shortest", true);
+                list, true, true, new Profile("foot").setVehicle("foot").setWeighting("shortest"));
         assertEquals(testCollector.toString(), 0, testCollector.errors.size());
     }
 
@@ -377,7 +378,7 @@ public class RoutingAlgorithmWithOSMTest {
         // prefer hiking route 'Markgrafenweg Bayreuth Kulmbach' but avoid tertiary highway from Pechgraben
         list.add(new OneRun(49.990967, 11.545258, 50.023182, 11.555386, 4746, 119));
         runAlgo(testCollector, DIR + "/north-bayreuth.osm.gz", "target/north-bayreuth-gh",
-                list, "hike", true, "hike", "fastest", true);
+                list, true, true, new Profile("hike").setVehicle("hike").setWeighting("fastest"));
         assertEquals(testCollector.toString(), 0, testCollector.errors.size());
     }
 
@@ -401,7 +402,7 @@ public class RoutingAlgorithmWithOSMTest {
         // 4. avoid tunnel(s)!
         list.add(new OneRun(43.739662, 7.424355, 43.733802, 7.413433, 2436, 112));
         runAlgo(testCollector, DIR + "/monaco.osm.gz", "target/monaco-gh",
-                list, "bike2", true, "bike2", "fastest", true);
+                list, true, true, new Profile("bike2").setVehicle("bike2").setWeighting("fastest"));
         assertEquals(testCollector.toString(), 0, testCollector.errors.size());
     }
 
@@ -415,7 +416,7 @@ public class RoutingAlgorithmWithOSMTest {
         list.add(run);
 
         runAlgo(testCollector, DIR + "/north-bayreuth.osm.gz", "target/north-bayreuth-gh",
-                list, "bike", true, "bike", "fastest", false);
+                list, true, false, new Profile("bike").setVehicle("bike").setWeighting("fastest"));
         assertEquals(testCollector.toString(), 0, testCollector.errors.size());
     }
 
@@ -429,7 +430,7 @@ public class RoutingAlgorithmWithOSMTest {
         list.add(run);
 
         runAlgo(testCollector, DIR + "/north-bayreuth.osm.gz", "target/north-bayreuth-gh",
-                list, "bike", true, "bike", "fastest", false);
+                list, true, false, new Profile("bike").setVehicle("bike").setWeighting("fastest"));
         assertEquals(testCollector.toString(), 0, testCollector.errors.size());
     }
 
@@ -441,7 +442,7 @@ public class RoutingAlgorithmWithOSMTest {
         list.add(new OneRun(43.728677, 7.41016, 43.739213, 7.427806, 2323, 121));
         list.add(new OneRun(43.733802, 7.413433, 43.739662, 7.424355, 1434, 89));
         runAlgo(testCollector, DIR + "/monaco.osm.gz", "target/monaco-gh",
-                list, "bike", true, "bike", "shortest", false);
+                list, true, false, new Profile("bike").setVehicle("bike").setWeighting("shortest"));
         assertEquals(testCollector.toString(), 0, testCollector.errors.size());
     }
 
@@ -454,11 +455,13 @@ public class RoutingAlgorithmWithOSMTest {
         // hard to select between secondary and primary (both are AVOID for mtb)
         list.add(new OneRun(43.733802, 7.413433, 43.739662, 7.424355, 1459, 88));
         runAlgo(testCollector, DIR + "/monaco.osm.gz", "target/monaco-gh",
-                list, "mtb", true, "mtb", "fastest", false);
+                list, true, false, new Profile("mtb").setVehicle("mtb").setWeighting("fastest"));
         assertEquals(testCollector.toString(), 0, testCollector.errors.size());
 
         runAlgo(testCollector, DIR + "/monaco.osm.gz", "target/monaco-gh",
-                list, "mtb,racingbike", false, "mtb", "fastest", false);
+                list, false, false,
+                new Profile("mtb").setVehicle("mtb").setWeighting("fastest"),
+                new Profile("racingbike").setVehicle("racingbike").setWeighting("fastest"));
         assertEquals(testCollector.toString(), 0, testCollector.errors.size());
     }
 
@@ -470,11 +473,13 @@ public class RoutingAlgorithmWithOSMTest {
         list.add(new OneRun(43.728677, 7.41016, 43.739213, 7.427806, 2572, 135));
         list.add(new OneRun(43.733802, 7.413433, 43.739662, 7.424355, 1490, 84));
         runAlgo(testCollector, DIR + "/monaco.osm.gz", "target/monaco-gh",
-                list, "racingbike", true, "racingbike", "fastest", false);
+                list, true, false, new Profile("racingbike").setVehicle("racingbike").setWeighting("fastest"));
         assertEquals(testCollector.toString(), 0, testCollector.errors.size());
 
         runAlgo(testCollector, DIR + "/monaco.osm.gz", "target/monaco-gh",
-                list, "bike,racingbike", false, "racingbike", "fastest", false);
+                list, false, false,
+                new Profile("racingbike").setVehicle("racingbike").setWeighting("fastest"),
+                new Profile("bike").setVehicle("bike").setWeighting("fastest"));
         assertEquals(testCollector.toString(), 0, testCollector.errors.size());
     }
 
@@ -486,11 +491,13 @@ public class RoutingAlgorithmWithOSMTest {
         list.add(new OneRun(48.412294, 15.62007, 48.398306, 15.609667, 3965, 94));
 
         runAlgo(testCollector, DIR + "/krems.osm.gz", "target/krems-gh",
-                list, "bike", true, "bike", "fastest", false);
+                list, true, false, new Profile("bike").setVehicle("bike").setWeighting("fastest"));
         assertEquals(testCollector.toString(), 0, testCollector.errors.size());
 
         runAlgo(testCollector, DIR + "/krems.osm.gz", "target/krems-gh",
-                list, "car,bike", false, "bike", "fastest", false);
+                list, false, false,
+                new Profile("bike").setVehicle("bike").setWeighting("fastest"),
+                new Profile("car").setVehicle("car").setWeighting("fastest"));
         assertEquals(testCollector.toString(), 0, testCollector.errors.size());
     }
 
@@ -502,11 +509,13 @@ public class RoutingAlgorithmWithOSMTest {
         list.add(new OneRun(48.412294, 15.62007, 48.398306, 15.609667, 3965, 95));
 
         runAlgo(testCollector, DIR + "/krems.osm.gz", "target/krems-gh",
-                list, "mtb", true, "mtb", "fastest", false);
+                list, true, false, new Profile("mtb").setVehicle("mtb").setWeighting("fastest"));
         assertEquals(testCollector.toString(), 0, testCollector.errors.size());
 
         runAlgo(testCollector, DIR + "/krems.osm.gz", "target/krems-gh",
-                list, "bike,mtb", false, "mtb", "fastest", false);
+                list, false, false,
+                new Profile("mtb").setVehicle("mtb").setWeighting("fastest"),
+                new Profile("bike").setVehicle("bike").setWeighting("fastest"));
         assertEquals(testCollector.toString(), 0, testCollector.errors.size());
     }
 
@@ -520,14 +529,14 @@ public class RoutingAlgorithmWithOSMTest {
     @Test
     public void testAndorra() {
         runAlgo(testCollector, DIR + "/andorra.osm.gz", "target/andorra-gh",
-                createAndorra(), "car", true, "car", "shortest", false);
+                createAndorra(), true, false, new Profile("car").setVehicle("car").setWeighting("shortest"));
         assertEquals(testCollector.toString(), 0, testCollector.errors.size());
     }
 
     @Test
     public void testAndorraPbf() {
         runAlgo(testCollector, DIR + "/andorra.osm.pbf", "target/andorra-gh",
-                createAndorra(), "car", true, "car", "shortest", false);
+                createAndorra(), true, false, new Profile("car").setVehicle("car").setWeighting("shortest"));
         assertEquals(testCollector.toString(), 0, testCollector.errors.size());
     }
 
@@ -540,7 +549,7 @@ public class RoutingAlgorithmWithOSMTest {
         list.get(1).setLocs(1, 431);
 
         runAlgo(testCollector, DIR + "/andorra.osm.gz", "target/andorra-gh",
-                list, "foot", true, "foot", "shortest", false);
+                list, true, false, new Profile("foot").setVehicle("foot").setWeighting("shortest"));
         assertEquals(testCollector.toString(), 0, testCollector.errors.size());
     }
 
@@ -555,7 +564,7 @@ public class RoutingAlgorithmWithOSMTest {
         list.add(new OneRun(-20.4, -54.6, -20.6, -54.54, 25516, 271));
         list.add(new OneRun(-20.43, -54.54, -20.537, -54.674, 18009, 237));
         runAlgo(testCollector, DIR + "/campo-grande.osm.gz", "target/campo-grande-gh", list,
-                "car", false, "car", "shortest", false);
+                false, false, new Profile("car").setVehicle("car").setWeighting("shortest"));
         assertEquals(testCollector.toString(), 0, testCollector.errors.size());
     }
 
@@ -570,7 +579,7 @@ public class RoutingAlgorithmWithOSMTest {
         list.add(oneRun);
 
         runAlgo(testCollector, DIR + "/monaco.osm.gz", "target/monaco-gh",
-                list, "car", true, "car", "shortest", false);
+                list, true, false, new Profile("car").setVehicle("car").setWeighting("shortest"));
         assertEquals(testCollector.toString(), 0, testCollector.errors.size());
     }
 
@@ -583,7 +592,7 @@ public class RoutingAlgorithmWithOSMTest {
         // choose Unterloher Weg and the following residential + cycleway
         // list.add(new OneRun(50.004333, 11.600254, 50.044449, 11.543434, 6931, 184));
         runAlgo(testCollector, DIR + "/north-bayreuth.osm.gz", "target/north-bayreuth-gh",
-                list, "bike", true, "bike", "fastest", false);
+                list, true, false, new Profile("bike").setVehicle("bike").setWeighting("fastest"));
         assertEquals(testCollector.toString(), 0, testCollector.errors.size());
     }
 
@@ -594,10 +603,10 @@ public class RoutingAlgorithmWithOSMTest {
         list.add(new OneRun(49.987132, 11.510496, 50.018839, 11.505024, 3985, 106));
 
         runAlgo(testCollector, DIR + "/north-bayreuth.osm.gz", "target/north-bayreuth-gh",
-                list, "bike", true, "bike", "fastest", true);
+                list, true, true, new Profile("bike").setVehicle("bike").setWeighting("fastest"));
 
         runAlgo(testCollector, DIR + "/north-bayreuth.osm.gz", "target/north-bayreuth-gh",
-                list, "bike2", true, "bike2", "fastest", true);
+                list, true, true, new Profile("bike2").setVehicle("bike2").setWeighting("fastest"));
         assertEquals(testCollector.toString(), 0, testCollector.errors.size());
     }
 
@@ -611,7 +620,7 @@ public class RoutingAlgorithmWithOSMTest {
         list.add(oneRun);
 
         runAlgo(testCollector, DIR + "/krautsand.osm.gz", "target/krautsand-gh",
-                list, "car", true, "car", "fastest", true);
+                list, true, true, new Profile("car").setVehicle("car").setWeighting("fastest"));
     }
 
     /**
@@ -619,8 +628,7 @@ public class RoutingAlgorithmWithOSMTest {
      *               preparation and takes a bit longer
      */
     Graph runAlgo(TestAlgoCollector testCollector, String osmFile,
-                  String graphFile, List<OneRun> runs, String importVehicles,
-                  boolean withCH, String vehicle, String weightStr, boolean is3D) {
+                  String graphFile, List<OneRun> runs, boolean withCH, boolean is3D, Profile... profiles) {
 
         // for different weightings we need a different storage, otherwise we would need to remove the graph folder
         // every time we come with a different weighting
@@ -629,20 +637,13 @@ public class RoutingAlgorithmWithOSMTest {
         AlgoHelperEntry algoEntry = null;
         OneRun tmpOneRun = null;
         try {
+            Profile queryProfile = profiles[0];
             Helper.removeDir(new File(graphFile));
-            EncodingManager em = EncodingManager.create(importVehicles);
-            List<Profile> profiles = new ArrayList<>();
-            for (FlagEncoder encoder : em.fetchEdgeEncoders()) {
-                String vehicleName = encoder.toString();
-                profiles.add(new Profile(vehicleName + "_profile")
-                        .setVehicle(vehicleName).setWeighting(weightStr).setTurnCosts(encoder.supportsTurnCosts()));
-            }
             GraphHopper hopper = new GraphHopper().
                     setStoreOnFlush(true).
                     setOSMFile(osmFile).
                     setProfiles(profiles).
-                    setGraphHopperLocation(graphFile).
-                    setEncodingManager(em);
+                    setGraphHopperLocation(graphFile);
             hopper.setMinNetworkSize(0);
 
             if (osmFile.contains("moscow"))
@@ -652,12 +653,12 @@ public class RoutingAlgorithmWithOSMTest {
 
             // always enable landmarks
             hopper.getLMPreparationHandler().
-                    setLMProfiles(new LMProfile(vehicle + "_profile"));
+                    setLMProfiles(new LMProfile(queryProfile.getName()));
 
             if (withCH) {
-                assert !Helper.isEmpty(weightStr);
+                assert !Helper.isEmpty(queryProfile.getWeighting());
                 hopper.getCHPreparationHandler().
-                        setCHProfiles(new CHProfile(vehicle + "_profile"));
+                        setCHProfiles(new CHProfile(queryProfile.getName()));
             }
 
             if (is3D)
@@ -665,11 +666,8 @@ public class RoutingAlgorithmWithOSMTest {
 
             hopper.importOrLoad();
 
-            TraversalMode tMode = importVehicles.contains("turn_costs=true")
-                    ? TraversalMode.EDGE_BASED : TraversalMode.NODE_BASED;
-            FlagEncoder encoder = hopper.getEncodingManager().getEncoder(vehicle);
-            Collection<AlgoHelperEntry> prepares = createAlgos(hopper, weightStr, vehicle, tMode);
-
+            Collection<AlgoHelperEntry> prepares = createAlgos(hopper, queryProfile);
+            FlagEncoder encoder = hopper.getEncodingManager().getEncoder(queryProfile.getName());
             EdgeFilter edgeFilter = DefaultEdgeFilter.allEdges(encoder.getAccessEnc());
             for (AlgoHelperEntry entry : prepares) {
                 if (entry.getExpectedAlgo().startsWith("astarbi|ch")) {
@@ -701,10 +699,8 @@ public class RoutingAlgorithmWithOSMTest {
         System.out.println("testMonacoParallel takes a bit time...");
         String graphFile = "target/monaco-gh";
         Helper.removeDir(new File(graphFile));
-        final EncodingManager encodingManager = EncodingManager.create("car");
         final GraphHopper hopper = new GraphHopper().
                 setStoreOnFlush(true).
-                setEncodingManager(encodingManager).
                 setWayPointMaxDistance(0).
                 setOSMFile(DIR + "/monaco.osm.gz").
                 setGraphHopperLocation(graphFile).
@@ -717,6 +713,7 @@ public class RoutingAlgorithmWithOSMTest {
         List<Thread> threads = new ArrayList<>();
         final AtomicInteger integ = new AtomicInteger(0);
         int MAX = 100;
+        EncodingManager encodingManager = hopper.getEncodingManager();
         final FlagEncoder carEncoder = encodingManager.getEncoder("car");
 
         // testing if algorithms are independent. should be. so test only two algorithms. 
@@ -774,8 +771,7 @@ public class RoutingAlgorithmWithOSMTest {
         new PrincetonReader(graph, eManager.getEncoder("car")).setStream(new GZIPInputStream(PrincetonReader.class.getResourceAsStream(bigFile))).read();
         GraphHopper hopper = new GraphHopper() {
             {
-                setEncodingManager(eManager);
-                loadGraph(graph);
+                loadGraph(graph, eManager);
             }
 
             @Override
@@ -784,7 +780,7 @@ public class RoutingAlgorithmWithOSMTest {
             }
         };
 
-        Collection<AlgoHelperEntry> prepares = createAlgos(hopper, "shortest", "car", TraversalMode.NODE_BASED);
+        Collection<AlgoHelperEntry> prepares = createAlgos(hopper, new Profile("car").setVehicle("car").setWeighting("shortest"));
 
         for (AlgoHelperEntry entry : prepares) {
             StopWatch sw = new StopWatch();

--- a/web/src/test/java/com/graphhopper/http/MapMatching2Test.java
+++ b/web/src/test/java/com/graphhopper/http/MapMatching2Test.java
@@ -58,11 +58,9 @@ public class MapMatching2Test {
 
     @Test
     public void testIssue13() throws IOException {
-        CarFlagEncoder encoder = new CarFlagEncoder();
         GraphHopper hopper = new GraphHopper();
         hopper.setOSMFile("../map-matching/files/map-issue13.osm.gz");
         hopper.setGraphHopperLocation(GH_LOCATION);
-        hopper.setEncodingManager(EncodingManager.create(encoder));
         hopper.setProfiles(new Profile("my_profile").setVehicle("car").setWeighting("fastest"));
         hopper.getLMPreparationHandler().setLMProfiles(new LMProfile("my_profile"));
         hopper.importOrLoad();
@@ -86,11 +84,9 @@ public class MapMatching2Test {
 
     @Test
     public void testIssue70() throws IOException {
-        CarFlagEncoder encoder = new CarFlagEncoder();
         GraphHopper hopper = new GraphHopper();
         hopper.setOSMFile("../map-matching/files/issue-70.osm.gz");
         hopper.setGraphHopperLocation(GH_LOCATION);
-        hopper.setEncodingManager(EncodingManager.create(encoder));
         hopper.setProfiles(new Profile("my_profile").setVehicle("car").setWeighting("fastest"));
         hopper.getLMPreparationHandler().setLMProfiles(new LMProfile("my_profile"));
         hopper.importOrLoad();
@@ -108,11 +104,9 @@ public class MapMatching2Test {
 
     @Test
     public void testIssue127() throws IOException {
-        CarFlagEncoder encoder = new CarFlagEncoder();
         GraphHopper hopper = new GraphHopper();
         hopper.setOSMFile("../map-matching/files/map-issue13.osm.gz");
         hopper.setGraphHopperLocation(GH_LOCATION);
-        hopper.setEncodingManager(EncodingManager.create(encoder));
         hopper.setProfiles(new Profile("my_profile").setVehicle("car").setWeighting("fastest"));
         hopper.getLMPreparationHandler().setLMProfiles(new LMProfile("my_profile"));
         hopper.importOrLoad();

--- a/web/src/test/java/com/graphhopper/http/MapMatchingTest.java
+++ b/web/src/test/java/com/graphhopper/http/MapMatchingTest.java
@@ -71,11 +71,9 @@ public class MapMatchingTest {
     @BeforeClass
     public static void setup() {
         Helper.removeDir(new File(GH_LOCATION));
-        CarFlagEncoder encoder = new CarFlagEncoder();
         graphHopper = new GraphHopper();
         graphHopper.setOSMFile("../map-matching/files/leipzig_germany.osm.pbf");
         graphHopper.setGraphHopperLocation(GH_LOCATION);
-        graphHopper.setEncodingManager(EncodingManager.create(encoder));
         graphHopper.setProfiles(new Profile("my_profile").setVehicle("car").setWeighting("fastest"));
         graphHopper.getLMPreparationHandler().setLMProfiles(new LMProfile("my_profile"));
         graphHopper.importOrLoad();

--- a/web/src/test/java/com/graphhopper/http/RoutingAdditivityTest.java
+++ b/web/src/test/java/com/graphhopper/http/RoutingAdditivityTest.java
@@ -47,11 +47,9 @@ public class RoutingAdditivityTest {
     @BeforeAll
     public static void setup() {
         Helper.removeDir(new File(GH_LOCATION));
-        CarFlagEncoder encoder = new CarFlagEncoder();
         graphHopper = new GraphHopper();
         graphHopper.setOSMFile("../map-matching/files/leipzig_germany.osm.pbf");
         graphHopper.setGraphHopperLocation(GH_LOCATION);
-        graphHopper.setEncodingManager(EncodingManager.create(encoder));
         graphHopper.setProfiles(new Profile("my_profile").setVehicle("car").setWeighting("fastest"));
         graphHopper.getLMPreparationHandler().setLMProfiles(new LMProfile("my_profile"));
         graphHopper.importOrLoad();
@@ -61,7 +59,6 @@ public class RoutingAdditivityTest {
     public static void cleanup() {
         graphHopper = null;
     }
-
 
     @Test
     public void testBoundedAdditivityOfGraphhopperTravelTimes() {

--- a/web/src/test/java/com/graphhopper/http/resources/GpxTravelTimeConsistencyTest.java
+++ b/web/src/test/java/com/graphhopper/http/resources/GpxTravelTimeConsistencyTest.java
@@ -50,7 +50,6 @@ public class GpxTravelTimeConsistencyTest {
                 setProfiles(new Profile("profile").setVehicle("foot").setWeighting("fastest")).
                 setStoreOnFlush(true).
                 setGraphHopperLocation(graphFileFoot).
-                setEncodingManager(EncodingManager.create("foot")).
                 importOrLoad();
     }
 


### PR DESCRIPTION
This is required to allow adding encoded values from profiles. 

In the most cases it makes handling of the GraphHopper class easier as only profiles (and no FlagEncoders) needs to be set.

Additionally this helps to reduce usage of the FlagEncoder class as we could add turn cost parser etc from the profile directly.

Required for #2273 