### PR TITLE
Do not include empty vehicle in client hc for POST matrix requests

### DIFF
--- a/client-hc/src/main/java/com/graphhopper/api/GHMatrixAbstractRequester.java
+++ b/client-hc/src/main/java/com/graphhopper/api/GHMatrixAbstractRequester.java
@@ -102,7 +102,6 @@ public abstract class GHMatrixAbstractRequester {
 
         putStrings(requestJson, "snap_preventions", ghRequest.getSnapPreventions());
         putStrings(requestJson, "out_arrays", outArraysList);
-        requestJson.put("vehicle", ghRequest.getHints().getString("vehicle", ""));
         // requestJson.put("elevation", ghRequest.getHints().getBool("elevation", false));
         requestJson.put("fail_fast", ghRequest.getFailFast());
 

--- a/client-hc/src/main/java/com/graphhopper/api/GraphHopperWeb.java
+++ b/client-hc/src/main/java/com/graphhopper/api/GraphHopperWeb.java
@@ -106,7 +106,6 @@ public class GraphHopperWeb implements GraphHopperAPI {
         ignoreSet.add("algorithm");
         ignoreSet.add("locale");
         ignoreSet.add("point");
-        ignoreSet.add("vehicle");
 
         // some are special and need to be avoided
         ignoreSet.add("points_encoded");
@@ -286,7 +285,7 @@ public class GraphHopperWeb implements GraphHopperAPI {
         return builder.build();
     }
 
-    private Request createGetRequest(GHRequest ghRequest) {
+    Request createGetRequest(GHRequest ghRequest) {
         boolean tmpInstructions = ghRequest.getHints().getBool(INSTRUCTIONS, instructions);
         boolean tmpCalcPoints = ghRequest.getHints().getBool(CALC_POINTS, calcPoints);
         String tmpOptimize = ghRequest.getHints().getString("optimize", optimize);
@@ -317,10 +316,6 @@ public class GraphHopperWeb implements GraphHopperAPI {
                 + "&locale=" + ghRequest.getLocale().toString()
                 + "&elevation=" + tmpElevation
                 + "&optimize=" + tmpOptimize;
-
-        if (ghRequest.getHints().has("vehicle")) {
-            url += "&vehicle=" + ghRequest.getHints().getString("vehicle", "");
-        }
 
         for (String details : ghRequest.getPathDetails()) {
             url += "&" + Parameters.Details.PATH_DETAILS + "=" + details;

--- a/client-hc/src/test/java/com/graphhopper/api/GHMatrixBatchTest.java
+++ b/client-hc/src/test/java/com/graphhopper/api/GHMatrixBatchTest.java
@@ -26,4 +26,9 @@ public class GHMatrixBatchTest extends AbstractGHMatrixWebTester {
             }
         }.setSleepAfterGET(0));
     }
+
+    @Override
+    GHMatrixAbstractRequester createRequester(String url) {
+        return new GHMatrixBatchRequester(url);
+    }
 }

--- a/client-hc/src/test/java/com/graphhopper/api/GHMatrixSyncTest.java
+++ b/client-hc/src/test/java/com/graphhopper/api/GHMatrixSyncTest.java
@@ -27,4 +27,9 @@ public class GHMatrixSyncTest extends AbstractGHMatrixWebTester {
             }
         });
     }
+
+    @Override
+    GHMatrixAbstractRequester createRequester(String url) {
+        return new GHMatrixSyncRequester(url);
+    }
 }

--- a/client-hc/src/test/java/com/graphhopper/api/GraphHopperWebTest.java
+++ b/client-hc/src/test/java/com/graphhopper/api/GraphHopperWebTest.java
@@ -2,6 +2,7 @@ package com.graphhopper.api;
 
 import com.graphhopper.GHRequest;
 import com.graphhopper.util.shapes.GHPoint;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -23,6 +24,20 @@ public class GraphHopperWebTest {
         req.putHint(GraphHopperWeb.TIMEOUT, 5);
 
         assertEquals(5, gh.getClientForRequest(req).connectTimeoutMillis());
+    }
+
+    @Test
+    public void vehicleIncludedAsGiven() {
+        GraphHopperWeb hopper = new GraphHopperWeb("https://localhost:8000/route");
+        // no vehicle -> no vehicle
+        assertEquals("https://localhost:8000/route?&profile=&type=json&instructions=true&points_encoded=true" +
+                        "&calc_points=true&algorithm=&locale=en_US&elevation=false&optimize=false",
+                hopper.createGetRequest(new GHRequest()).url().toString());
+
+        // vehicle given -> vehicle used in url
+        assertEquals("https://localhost:8000/route?&profile=my_profile&type=json&instructions=true&points_encoded=true" +
+                        "&calc_points=true&algorithm=&locale=en_US&elevation=false&optimize=false&vehicle=my_car",
+                hopper.createGetRequest(new GHRequest().putHint("vehicle", "my_car").setProfile("my_profile")).url().toString());
     }
 
 }


### PR DESCRIPTION
Client HC included an empty string for the `"vehicle"` parameter for matrix requests even when no vehicle was given. `GraphHopperWeb` already handled this correctly but there is no need to add `vehicle` to the `ignoreSet`.