### PR TITLE
upgrade some dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-dependencies</artifactId>
-                <version>2.0.16</version>
+                <version>2.0.21</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -150,7 +150,7 @@
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.4</version>
+                <version>2.7</version>
             </dependency>
             <dependency>
                 <groupId>org.mapdb</groupId>


### PR DESCRIPTION
version upgrade of commons-io (to 2.7) and dropwizard (to 2.0.21)