### PR TITLE
Skip shapes which don't block any edges

### DIFF
--- a/core/src/test/java/com/graphhopper/routing/weighting/BlockAreaWeightingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/BlockAreaWeightingTest.java
@@ -48,8 +48,9 @@ public class BlockAreaWeightingTest {
         BlockAreaWeighting instance = new BlockAreaWeighting(new FastestWeighting(encoder), bArea);
         assertEquals(94.35, instance.calcEdgeWeight(edge, false), .01);
 
-        GHIntHashSet set = bArea.add(null);
+        GHIntHashSet set = new GHIntHashSet();
         set.add(0);
+        bArea.add(null, set);
         instance = new BlockAreaWeighting(new FastestWeighting(encoder), bArea);
         assertEquals(Double.POSITIVE_INFINITY, instance.calcEdgeWeight(edge, false), .01);
     }
@@ -75,8 +76,9 @@ public class BlockAreaWeightingTest {
     public void testBlockVirtualEdges_QueryGraph() {
         GraphEdgeIdFinder.BlockArea bArea = new GraphEdgeIdFinder.BlockArea(graph);
         // add base graph edge to fill caches and trigger edgeId cache search (without virtual edges)
-        GHIntHashSet set = bArea.add(new Circle(0.0025, 0.0025, 1));
+        GHIntHashSet set = new GHIntHashSet();
         set.add(0);
+        bArea.add(new Circle(0.0025, 0.0025, 1), set);
 
         LocationIndex index = new LocationIndexTree(graph, graph.getDirectory()).prepareIndex();
         Snap snap = index.findClosest(0.005, 0.005, EdgeFilter.ALL_EDGES);


### PR DESCRIPTION
BlockArea currently treats an empty GHIntHashSet the same way as a non-existing cache for blocked edges. But a small shape which doesn't cover edges in the graph would also yield an empty GHIntHashSet. For those cases BlockArea would resort to the more expensive bbox/shape intersection logic:

https://github.com/graphhopper/graphhopper/blob/0522c495ccad5f22fe19c6e858a40a7bd6f74eae/core/src/main/java/com/graphhopper/storage/GraphEdgeIdFinder.java#L198-L223

I changed the logic to explicitly store `null` as the cache for blocked edges if the shape is to large so we can properly determine if we have no cache or if it's just empty.