### PR TITLE
Fix wrong maxSpeed for custom models using limit_to and else statements

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/weighting/custom/CustomModelParser.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/custom/CustomModelParser.java
@@ -406,10 +406,8 @@ public class CustomModelParser {
     }
 
     static double findMaxSpeed(CustomModel customModel, final double maxSpeed) {
-        double globalMin_maxSpeed = maxSpeed;
-        double blockMax_maxSpeed = 0;
+        double globalMin_maxSpeed = maxSpeed, blockMax_maxSpeed = maxSpeed;
         for (Statement statement : customModel.getSpeed()) {
-            // Lowering the max_speed estimate for 'limit_to' only (TODO later also for MULTIPLY)
             if (statement.getOperation() == Statement.Op.LIMIT) {
                 if (statement.getValue() > maxSpeed)
                     throw new IllegalArgumentException("Can never apply 'limit_to': " + statement.getValue()
@@ -436,6 +434,11 @@ public class CustomModelParser {
 
                 if (globalMin_maxSpeed <= 0)
                     throw new IllegalArgumentException("speed is always limited to 0. This must not be but results from " + statement);
+            } else {
+                // reset blockMax for every new block that starts with IF but has no limit_to Op
+                // TODO further reduce max speed via value in Statement.Op.MULTIPLY
+                if (statement.getKeyword() == Statement.Keyword.IF)
+                    blockMax_maxSpeed = maxSpeed;
             }
         }
 

--- a/core/src/main/java/com/graphhopper/routing/weighting/custom/CustomWeighting.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/custom/CustomWeighting.java
@@ -126,7 +126,8 @@ public final class CustomWeighting extends AbstractWeighting {
             return Double.POSITIVE_INFINITY;
 
         double speed = edgeToSpeedMapping.get(edgeState, reverse);
-        assert speed <= maxSpeed * SPEED_CONV : "for " + getName() + " speed <= maxSpeed is violated, " + speed + " <= " + maxSpeed * SPEED_CONV;
+        if (speed > maxSpeed * SPEED_CONV)
+            throw new IllegalStateException("for " + getName() + " speed <= maxSpeed is violated, " + speed + " <= " + maxSpeed * SPEED_CONV);
         if (speed == 0)
             return Double.POSITIVE_INFINITY;
         if (speed < 0)

--- a/core/src/test/java/com/graphhopper/routing/weighting/custom/CustomModelParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/custom/CustomModelParserTest.java
@@ -195,6 +195,16 @@ class CustomModelParserTest {
     }
 
     @Test
+    public void findMaxSpeed_limitAndMultiply() {
+        CustomModel customModel = new CustomModel();
+        customModel.addToSpeed(If("road_class == TERTIARY", LIMIT, 90));
+        customModel.addToSpeed(ElseIf("road_class == SECONDARY", MULTIPLY, 1.0));
+        customModel.addToSpeed(ElseIf("road_class == PRIMARY", LIMIT, 30));
+        customModel.addToSpeed(Else(LIMIT, 3));
+        assertEquals(140, CustomModelParser.findMaxSpeed(customModel, 140));
+    }
+
+    @Test
     public void multipleAreas() {
         CustomModel customModel = new CustomModel();
         Map<String, JsonFeature> areas = new HashMap<>();

--- a/core/src/test/java/com/graphhopper/routing/weighting/custom/CustomWeightingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/custom/CustomWeightingTest.java
@@ -260,8 +260,8 @@ class CustomWeightingTest {
                 .addToSpeed(Statement.If("road_class == MOTORWAY", Statement.Op.MULTIPLY, 0.7))
                 .addToSpeed(Statement.Else(Statement.Op.LIMIT, 30));
         Weighting weighting = createWeighting(customModel);
-        // todonow: assert weight/time
-        weighting.calcEdgeWeight(motorway, false);
+        double weight = weighting.calcEdgeWeight(motorway, false);
+        assertEquals(1.3429, weight, 1e-4);
     }
 
     private Weighting createWeighting(CustomModel vehicleModel) {

--- a/core/src/test/java/com/graphhopper/routing/weighting/custom/CustomWeightingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/custom/CustomWeightingTest.java
@@ -253,15 +253,15 @@ class CustomWeightingTest {
     }
 
     @Test
-    public void maxSpeedViolated_bug() {
+    public void maxSpeedViolated_bug_2307() {
         EdgeIteratorState motorway = graph.edge(0, 1).setDistance(10).
                 set(roadClassEnc, MOTORWAY).set(avSpeedEnc, 80).set(accessEnc, true, true);
         CustomModel customModel = new CustomModel()
                 .addToSpeed(Statement.If("road_class == MOTORWAY", Statement.Op.MULTIPLY, 0.7))
                 .addToSpeed(Statement.Else(Statement.Op.LIMIT, 30));
         Weighting weighting = createWeighting(customModel);
-        double weight = weighting.calcEdgeWeight(motorway, false);
-        assertEquals(1.3429, weight, 1e-4);
+        assertEquals(1.3429, weighting.calcEdgeWeight(motorway, false), 1e-4);
+        assertEquals(10 / (80 * 0.7 / 3.6) * 1000, weighting.calcEdgeMillis(motorway, false), 1);
     }
 
     private Weighting createWeighting(CustomModel vehicleModel) {


### PR DESCRIPTION
Using this custom profile

```yaml
  profiles:
    - name: small_truck
      vehicle: small_truck
      weighting: custom
      custom_model:
         speed:
           - if: road_class == MOTORWAY
             multiply_by: 0.7
           - else: ""
             limit_to: 30
```

the import fails with `java.lang.Exception: java.lang.AssertionError: for custom speed <= maxSpeed is violated, 42.0 <= 30.000000000000004`

The error is thrown from an `assert` in `CustomWeighting`, so it only comes up when the -ea flag is enabled. If this is an actual error we should probably rather throw an exception? But also it is not clear to me how we exceed the max speed here, because both the `multiply_by` and the `limit_to` operators are supposed to reduce the speed.

It seems like the `MULTIPLY` statement reduces the speed from 80 to 56 as expected, but then the `LIMIT` statement somehow reduces maxSpeed from 38 to 3.8... (m/s). Update: Yes, the maxSpeed is reduced in CustomModelParser#findMaxSpeed.