### PR TITLE
map matching: properly access turn costs for virtual nodes

### DIFF
--- a/map-matching/src/main/java/com/graphhopper/matching/MapMatching.java
+++ b/map-matching/src/main/java/com/graphhopper/matching/MapMatching.java
@@ -83,7 +83,8 @@ public class MapMatching {
     private double transitionProbabilityBeta = 2.0;
     private final int maxVisitedNodes;
     private final DistanceCalc distanceCalc = new DistancePlaneProjection();
-    private final Weighting weighting;
+    private final Weighting unwrappedWeighting;
+    private Weighting weighting;
     private final BooleanEncodedValue inSubnetworkEnc;
     private QueryGraph queryGraph;
 
@@ -141,7 +142,7 @@ public class MapMatching {
             landmarks = null;
         }
         graph = graphHopper.getGraphHopperStorage();
-        weighting = graphHopper.createWeighting(profile, hints);
+        unwrappedWeighting = graphHopper.createWeighting(profile, hints);
         inSubnetworkEnc = graphHopper.getEncodingManager().getBooleanEncodedValue(Subnetwork.key(profileStr));
         this.maxVisitedNodes = hints.getInt(Parameters.Routing.MAX_VISITED_NODES, Integer.MAX_VALUE);
     }
@@ -173,6 +174,7 @@ public class MapMatching {
         // Create the query graph, containing split edges so that all the places where an observation might have happened
         // are a node. This modifies the Snap objects and puts the new node numbers into them.
         queryGraph = QueryGraph.create(graph, snapsPerObservation.stream().flatMap(Collection::stream).collect(Collectors.toList()));
+        weighting = queryGraph.wrapWeighting(unwrappedWeighting);
 
         // Creates candidates from the Snaps of all observations (a candidate is basically a
         // Snap + direction).
@@ -219,7 +221,7 @@ public class MapMatching {
         double rLon = (measurementErrorSigma * 360.0 / DistanceCalcEarth.DIST_EARTH.calcCircumference(queryLat));
         double rLat = measurementErrorSigma / DistanceCalcEarth.METERS_PER_DEGREE;
         Envelope envelope = new Envelope(queryLon, queryLon, queryLat, queryLat);
-        for (int i=0; i<50; i++) {
+        for (int i = 0; i < 50; i++) {
             envelope.expandBy(rLon, rLat);
             List<Snap> snaps = findCandidateSnapsInBBox(queryLat, queryLon, BBox.fromEnvelope(envelope));
             if (!snaps.isEmpty()) {
@@ -230,7 +232,7 @@ public class MapMatching {
     }
 
     private List<Snap> findCandidateSnapsInBBox(double queryLat, double queryLon, BBox queryShape) {
-        EdgeFilter edgeFilter = new DefaultSnapFilter(weighting, inSubnetworkEnc);
+        EdgeFilter edgeFilter = new DefaultSnapFilter(unwrappedWeighting, inSubnetworkEnc);
         List<Snap> snaps = new ArrayList<>();
         IntHashSet seenEdges = new IntHashSet();
         IntHashSet seenNodes = new IntHashSet();


### PR DESCRIPTION
MapMatching uses the weighting and access the turn costs data of the baseGraph even for virtual nodes that can lead to rare exceptions ala:

```
java.lang.ArrayIndexOutOfBoundsException: Index 4476 out of bounds for length 4476
	at com.graphhopper.storage.RAMIntDataAccess.getInt(RAMIntDataAccess.java:208)
	at com.graphhopper.storage.GHNodeAccess.getTurnCostIndex(GHNodeAccess.java:90)
	at com.graphhopper.storage.TurnCostStorage.readFlags(TurnCostStorage.java:186)
	at com.graphhopper.storage.TurnCostStorage.readFlags(TurnCostStorage.java:181)
	at com.graphhopper.storage.TurnCostStorage.get(TurnCostStorage.java:167)
	at com.graphhopper.routing.weighting.DefaultTurnCostProvider.calcTurnWeight(DefaultTurnCostProvider.java:69)
	at com.graphhopper.routing.weighting.AbstractWeighting.calcTurnWeight(AbstractWeighting.java:84)
	at com.graphhopper.util.GHUtility.calcWeightWithTurnWeight(GHUtility.java:725)
	at com.graphhopper.util.GHUtility.calcWeightWithTurnWeightWithAccess(GHUtility.java:708)
	at com.graphhopper.routing.AbstractNonCHBidirAlgo.calcWeight(AbstractNonCHBidirAlgo.java:188)
	at com.graphhopper.routing.AStarBidirection.calcWeight(AStarBidirection.java:108)
	at com.graphhopper.routing.AbstractNonCHBidirAlgo.fillEdges(AbstractNonCHBidirAlgo.java:152)
	at com.graphhopper.routing.AbstractNonCHBidirAlgo.fillEdgesTo(AbstractNonCHBidirAlgo.java:142)
	at com.graphhopper.routing.AbstractBidirAlgo.runAlgo(AbstractBidirAlgo.java:154)
	at com.graphhopper.routing.AbstractBidirAlgo.calcPath(AbstractBidirAlgo.java:93)
	at com.graphhopper.matching.MapMatching.computeViterbiSequence(MapMatching.java:344)
	at com.graphhopper.matching.MapMatching.match(MapMatching.java:182)
	at com.graphhopper.resources.MapMatchingResource.match(MapMatchingResource.java:118)
```