### PR TITLE
Speedup handling of small areas in custom models

### DIFF
--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -943,7 +943,7 @@ public class GraphHopper implements GraphHopperAPI {
     }
 
     protected WeightingFactory createWeightingFactory() {
-        return new DefaultWeightingFactory(ghStorage, getEncodingManager());
+        return new DefaultWeightingFactory(ghStorage, locationIndex, getEncodingManager());
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/DefaultWeightingFactory.java
+++ b/core/src/main/java/com/graphhopper/routing/DefaultWeightingFactory.java
@@ -26,6 +26,7 @@ import com.graphhopper.routing.weighting.custom.CustomModelParser;
 import com.graphhopper.routing.weighting.custom.CustomProfile;
 import com.graphhopper.routing.weighting.custom.CustomWeighting;
 import com.graphhopper.storage.GraphHopperStorage;
+import com.graphhopper.storage.index.LocationIndex;
 import com.graphhopper.util.CustomModel;
 import com.graphhopper.util.PMap;
 import com.graphhopper.util.Parameters;
@@ -36,10 +37,12 @@ import static com.graphhopper.util.Helper.toLowerCase;
 
 public class DefaultWeightingFactory implements WeightingFactory {
     private final GraphHopperStorage ghStorage;
+    private final LocationIndex locationIndex;
     private final EncodingManager encodingManager;
 
-    public DefaultWeightingFactory(GraphHopperStorage ghStorage, EncodingManager encodingManager) {
+    public DefaultWeightingFactory(GraphHopperStorage ghStorage, LocationIndex locationIndex, EncodingManager encodingManager) {
         this.ghStorage = ghStorage;
+        this.locationIndex = locationIndex;
         this.encodingManager = encodingManager;
     }
 
@@ -77,7 +80,7 @@ public class DefaultWeightingFactory implements WeightingFactory {
             CustomProfile customProfile = (CustomProfile) profile;
             queryCustomModel = queryCustomModel == null ?
                     customProfile.getCustomModel() : CustomModel.merge(customProfile.getCustomModel(), queryCustomModel);
-            weighting = CustomModelParser.createWeighting(encoder, encodingManager, turnCostProvider, queryCustomModel);
+            weighting = CustomModelParser.createWeighting(encoder, ghStorage, locationIndex, encodingManager, turnCostProvider, queryCustomModel);
         } else if ("shortest".equalsIgnoreCase(weightingStr)) {
             weighting = new ShortestWeighting(encoder, turnCostProvider);
         } else if ("fastest".equalsIgnoreCase(weightingStr)) {

--- a/core/src/main/java/com/graphhopper/routing/Router.java
+++ b/core/src/main/java/com/graphhopper/routing/Router.java
@@ -484,7 +484,7 @@ public class Router {
             requestHints.putObject(CustomModel.KEY, request.getCustomModel());
             Weighting weighting = weightingFactory.createWeighting(profile, requestHints, false);
             if (requestHints.has(Parameters.Routing.BLOCK_AREA)) {
-                GraphEdgeIdFinder.BlockArea blockArea = GraphEdgeIdFinder.createBlockArea(ghStorage, locationIndex,
+                GraphEdgeIdFinder.ShapeFilter blockArea = GraphEdgeIdFinder.createBlockArea(ghStorage, locationIndex,
                         request.getPoints(), requestHints, new FiniteWeightFilter(weighting));
                 weighting = new BlockAreaWeighting(weighting, blockArea);
             }

--- a/core/src/main/java/com/graphhopper/routing/weighting/BlockAreaWeighting.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/BlockAreaWeighting.java
@@ -9,9 +9,9 @@ import com.graphhopper.util.EdgeIteratorState;
  */
 public class BlockAreaWeighting extends AbstractAdjustedWeighting {
 
-    private GraphEdgeIdFinder.BlockArea blockArea;
+    private GraphEdgeIdFinder.ShapeFilter blockArea;
 
-    public BlockAreaWeighting(Weighting superWeighting, GraphEdgeIdFinder.BlockArea blockArea) {
+    public BlockAreaWeighting(Weighting superWeighting, GraphEdgeIdFinder.ShapeFilter blockArea) {
         super(superWeighting);
         this.blockArea = blockArea;
     }

--- a/core/src/main/java/com/graphhopper/routing/weighting/custom/CustomModelParser.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/custom/CustomModelParser.java
@@ -22,6 +22,8 @@ import com.graphhopper.routing.ev.*;
 import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.routing.weighting.TurnCostProvider;
+import com.graphhopper.storage.Graph;
+import com.graphhopper.storage.index.LocationIndex;
 import com.graphhopper.util.CustomModel;
 import com.graphhopper.util.EdgeIteratorState;
 import com.graphhopper.util.GHUtility;
@@ -74,11 +76,12 @@ public class CustomModelParser {
         // utility class
     }
 
-    public static CustomWeighting createWeighting(FlagEncoder baseFlagEncoder, EncodedValueLookup lookup, TurnCostProvider turnCostProvider,
-                                                  CustomModel customModel) {
+    public static CustomWeighting createWeighting(FlagEncoder baseFlagEncoder, Graph graph, LocationIndex locationIndex, EncodedValueLookup lookup,
+                                                  TurnCostProvider turnCostProvider, CustomModel customModel) {
         if (customModel == null)
             throw new IllegalStateException("CustomModel cannot be null");
-        CustomWeighting.Parameters parameters = createWeightingParameters(customModel, lookup, baseFlagEncoder.getMaxSpeed(), baseFlagEncoder.getAverageSpeedEnc());
+        CustomWeighting.Parameters parameters = createWeightingParameters(customModel, graph, locationIndex, lookup, baseFlagEncoder.getMaxSpeed(),
+                        baseFlagEncoder.getAverageSpeedEnc());
         return new CustomWeighting(baseFlagEncoder, turnCostProvider, parameters);
     }
 
@@ -86,8 +89,8 @@ public class CustomModelParser {
      * This method compiles a new subclass of CustomWeightingHelper composed from the provided CustomModel caches this
      * and returns an instance.
      */
-    static CustomWeighting.Parameters createWeightingParameters(CustomModel customModel, EncodedValueLookup lookup, double globalMaxSpeed,
-                                                                DecimalEncodedValue avgSpeedEnc) {
+    static CustomWeighting.Parameters createWeightingParameters(CustomModel customModel, Graph graph, LocationIndex locationIndex,
+                                     EncodedValueLookup lookup, double globalMaxSpeed, DecimalEncodedValue avgSpeedEnc) {
         String key = customModel.toString() + ",global:" + globalMaxSpeed;
         if (key.length() > 100_000) throw new IllegalArgumentException("Custom Model too big: " + key.length());
 

--- a/core/src/main/java/com/graphhopper/routing/weighting/custom/CustomWeightingHelper.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/custom/CustomWeightingHelper.java
@@ -19,12 +19,8 @@ package com.graphhopper.routing.weighting.custom;
 
 import com.graphhopper.routing.ev.DecimalEncodedValue;
 import com.graphhopper.routing.ev.EncodedValueLookup;
+import com.graphhopper.storage.GraphEdgeIdFinder.ShapeFilter;
 import com.graphhopper.util.EdgeIteratorState;
-import com.graphhopper.util.FetchMode;
-import com.graphhopper.util.GHUtility;
-import com.graphhopper.util.JsonFeature;
-import com.graphhopper.util.shapes.BBox;
-import com.graphhopper.util.shapes.Polygon;
 
 import java.util.Map;
 
@@ -38,7 +34,7 @@ public class CustomWeightingHelper {
     protected CustomWeightingHelper() {
     }
 
-    public void init(EncodedValueLookup lookup, DecimalEncodedValue avgSpeedEnc, Map<String, JsonFeature> areas) {
+    public void init(EncodedValueLookup lookup, DecimalEncodedValue avgSpeedEnc, Map<String, ShapeFilter> areas) {
         this.avg_speed_enc = avgSpeedEnc;
     }
 
@@ -55,12 +51,5 @@ public class CustomWeightingHelper {
         if (Double.isInfinite(speed) || Double.isNaN(speed) || speed < 0)
             throw new IllegalStateException("Invalid estimated speed " + speed);
         return speed;
-    }
-
-    public static boolean in(Polygon p, EdgeIteratorState edge) {
-        BBox bbox = GHUtility.createBBox(edge);
-        if (p.getBounds().intersects(bbox))
-            return p.intersects(edge.fetchWayGeometry(FetchMode.ALL).makeImmutable()); // TODO PERF: cache bbox and edge wayGeometry for multiple area
-        return false;
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/weighting/custom/ExpressionVisitor.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/custom/ExpressionVisitor.java
@@ -65,8 +65,7 @@ class ExpressionVisitor implements Visitor.AtomVisitor<Boolean, Exception> {
                 String arg = n.identifiers[0];
                 if (arg.startsWith(IN_AREA_PREFIX)) {
                     int start = rv.getLocation().getColumnNumber() - 1;
-                    replacements.put(start, new Replacement(start, arg.length(),
-                            CustomWeightingHelper.class.getSimpleName() + ".in(this." + arg + ", edge)"));
+                    replacements.put(start, new Replacement(start, arg.length(), "this." + arg + ".intersects(edge)"));
                     result.guessedVariables.add(arg);
                     return true;
                 } else {

--- a/core/src/main/java/com/graphhopper/storage/GraphEdgeIdFinder.java
+++ b/core/src/main/java/com/graphhopper/storage/GraphEdgeIdFinder.java
@@ -169,7 +169,7 @@ public class GraphEdgeIdFinder {
     public ShapeFilter createFilter(List<Shape> shapes) {
         ShapeFilter shapeFilter = new ShapeFilter(graph);
         for (Shape shape : shapes) {
-            if (calculateArea(shape) <= useEdgeIdsUntilAreaSize) {
+            if (locationIndex != null && calculateArea(shape) <= useEdgeIdsUntilAreaSize) {
                 GHIntHashSet blockedEdges = findEdgesInShape(shape, edgeFilter);
                 if (!blockedEdges.isEmpty()) {
                     shapeFilter.add(shape, blockedEdges);

--- a/core/src/test/java/com/graphhopper/routing/HeadingRoutingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/HeadingRoutingTest.java
@@ -191,7 +191,7 @@ class HeadingRoutingTest {
         Map<String, Profile> profilesByName = new HashMap<>();
         profilesByName.put("profile", new Profile("profile").setVehicle("car").setWeighting("fastest"));
         return new Router(graph, locationIndex, profilesByName, new PathDetailsBuilderFactory(), new TranslationMap().doImport(), new RouterConfig(),
-                new DefaultWeightingFactory(graph, graph.getEncodingManager()), Collections.emptyMap(), Collections.emptyMap());
+                new DefaultWeightingFactory(graph, locationIndex, graph.getEncodingManager()), Collections.emptyMap(), Collections.emptyMap());
     }
 
     private GraphHopperStorage createSquareGraph() {

--- a/core/src/test/java/com/graphhopper/routing/weighting/BlockAreaWeightingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/BlockAreaWeightingTest.java
@@ -43,7 +43,7 @@ public class BlockAreaWeightingTest {
 
     @Test
     public void testBlockedById() {
-        GraphEdgeIdFinder.BlockArea bArea = new GraphEdgeIdFinder.BlockArea(graph);
+        GraphEdgeIdFinder.ShapeFilter bArea = new GraphEdgeIdFinder.ShapeFilter(graph);
         EdgeIteratorState edge = graph.getEdgeIteratorState(0, 1);
         BlockAreaWeighting instance = new BlockAreaWeighting(new FastestWeighting(encoder), bArea);
         assertEquals(94.35, instance.calcEdgeWeight(edge, false), .01);
@@ -58,14 +58,14 @@ public class BlockAreaWeightingTest {
     @Test
     public void testBlockedByShape() {
         EdgeIteratorState edge = graph.getEdgeIteratorState(0, 1);
-        GraphEdgeIdFinder.BlockArea bArea = new GraphEdgeIdFinder.BlockArea(graph);
+        GraphEdgeIdFinder.ShapeFilter bArea = new GraphEdgeIdFinder.ShapeFilter(graph);
         BlockAreaWeighting instance = new BlockAreaWeighting(new FastestWeighting(encoder), bArea);
         assertEquals(94.35, instance.calcEdgeWeight(edge, false), 0.01);
 
         bArea.add(new Circle(0.01, 0.01, 100));
         assertEquals(Double.POSITIVE_INFINITY, instance.calcEdgeWeight(edge, false), .01);
 
-        bArea = new GraphEdgeIdFinder.BlockArea(graph);
+        bArea = new GraphEdgeIdFinder.ShapeFilter(graph);
         instance = new BlockAreaWeighting(new FastestWeighting(encoder), bArea);
         // Do not match 1,1 of edge
         bArea.add(new Circle(0.1, 0.1, 100));
@@ -74,7 +74,7 @@ public class BlockAreaWeightingTest {
 
     @Test
     public void testBlockVirtualEdges_QueryGraph() {
-        GraphEdgeIdFinder.BlockArea bArea = new GraphEdgeIdFinder.BlockArea(graph);
+        GraphEdgeIdFinder.ShapeFilter bArea = new GraphEdgeIdFinder.ShapeFilter(graph);
         // add base graph edge to fill caches and trigger edgeId cache search (without virtual edges)
         GHIntHashSet set = new GHIntHashSet();
         set.add(0);

--- a/core/src/test/java/com/graphhopper/routing/weighting/custom/CustomWeightingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/custom/CustomWeightingTest.java
@@ -14,6 +14,8 @@ import com.graphhopper.routing.weighting.FastestWeighting;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.GraphBuilder;
 import com.graphhopper.storage.GraphHopperStorage;
+import com.graphhopper.storage.RAMDirectory;
+import com.graphhopper.storage.index.LocationIndexTree;
 import com.graphhopper.util.CustomModel;
 import com.graphhopper.util.EdgeIteratorState;
 import com.graphhopper.util.GHUtility;
@@ -30,6 +32,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class CustomWeightingTest {
 
     GraphHopperStorage graph;
+    LocationIndexTree locationIndex;
     DecimalEncodedValue avSpeedEnc;
     BooleanEncodedValue accessEnc;
     DecimalEncodedValue maxSpeedEnc;
@@ -46,6 +49,8 @@ class CustomWeightingTest {
         maxSpeedEnc = encodingManager.getDecimalEncodedValue(MaxSpeed.KEY);
         roadClassEnc = encodingManager.getEnumEncodedValue(KEY, RoadClass.class);
         graph = new GraphBuilder(encodingManager).create();
+        locationIndex = new LocationIndexTree(graph, new RAMDirectory());
+        locationIndex.prepareIndex();
     }
 
     @Test
@@ -265,6 +270,6 @@ class CustomWeightingTest {
     }
 
     private Weighting createWeighting(CustomModel vehicleModel) {
-        return CustomModelParser.createWeighting(carFE, encodingManager, NO_TURN_COST_PROVIDER, vehicleModel);
+        return CustomModelParser.createWeighting(carFE, graph, locationIndex, encodingManager, NO_TURN_COST_PROVIDER, vehicleModel);
     }
 }

--- a/core/src/test/java/com/graphhopper/routing/weighting/custom/ExpressionVisitorTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/custom/ExpressionVisitorTest.java
@@ -72,7 +72,7 @@ public class ExpressionVisitorTest {
         assertEquals("toll == Toll.NO || road_class == RoadClass.NO", parseExpression("toll == NO || road_class == NO", validVariable, lookup).converted.toString());
 
         // convert in_area variable to function call:
-        assertEquals(CustomWeightingHelper.class.getSimpleName() + ".in(this.in_custom_1, edge)",
+        assertEquals("this.in_custom_1.intersects(edge)",
                 parseExpression("in_custom_1", validVariable, lookup).converted.toString());
 
         // no need to inject:

--- a/core/src/test/java/com/graphhopper/storage/GraphEdgeIdFinderTest.java
+++ b/core/src/test/java/com/graphhopper/storage/GraphEdgeIdFinderTest.java
@@ -58,7 +58,7 @@ public class GraphEdgeIdFinderTest {
                 .prepareIndex();
 
         GraphEdgeIdFinder graphFinder = new GraphEdgeIdFinder(graph, locationIndex);
-        GraphEdgeIdFinder.BlockArea blockArea = graphFinder.parseBlockArea("0.01,0.005,1", AccessFilter.allEdges(encoder.getAccessEnc()), 1000 * 1000);
+        GraphEdgeIdFinder.ShapeFilter blockArea = graphFinder.parseBlockArea("0.01,0.005,1", AccessFilter.allEdges(encoder.getAccessEnc()), 1000 * 1000);
         assertEquals("[0]", blockArea.toString(0));
 
         // big area => no edgeIds are collected up-front
@@ -111,7 +111,7 @@ public class GraphEdgeIdFinderTest {
         GraphEdgeIdFinder graphFinder = new GraphEdgeIdFinder(graph, locationIndex);
         // big value => the polygon is small => force edgeId optimization
         double area = 500_000L * 500_000L;
-        GraphEdgeIdFinder.BlockArea blockArea = graphFinder.parseBlockArea("2.1,1, -1.1,2, 2,3", AccessFilter.allEdges(encoder.getAccessEnc()), area);
+        GraphEdgeIdFinder.ShapeFilter blockArea = graphFinder.parseBlockArea("2.1,1, -1.1,2, 2,3", AccessFilter.allEdges(encoder.getAccessEnc()), area);
         assertEquals("[1, 2, 6, 7, 11, 12]", blockArea.toString(0));
         assertEdges(graph, "[1, 2, 6, 7, 11, 12]", blockArea);
 
@@ -125,7 +125,7 @@ public class GraphEdgeIdFinderTest {
         assertEdges(graph, "[2, 7]", blockArea);
     }
 
-    private void assertEdges(Graph g, String assertSetContent, GraphEdgeIdFinder.BlockArea blockArea) {
+    private void assertEdges(Graph g, String assertSetContent, GraphEdgeIdFinder.ShapeFilter blockArea) {
         Set<Integer> blockedEdges = new TreeSet<>();
         AllEdgesIterator edgeIterator = g.getAllEdges();
         while (edgeIterator.next()) {

--- a/web-bundle/src/main/java/com/graphhopper/resources/IsochroneResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/IsochroneResource.java
@@ -99,7 +99,7 @@ public class IsochroneResource {
         Weighting weighting = graphHopper.createWeighting(profile, hintsMap);
         BooleanEncodedValue inSubnetworkEnc = graphHopper.getEncodingManager().getBooleanEncodedValue(Subnetwork.key(profileName));
         if (hintsMap.has(Parameters.Routing.BLOCK_AREA)) {
-            GraphEdgeIdFinder.BlockArea blockArea = GraphEdgeIdFinder.createBlockArea(graph, locationIndex,
+            GraphEdgeIdFinder.ShapeFilter blockArea = GraphEdgeIdFinder.createBlockArea(graph, locationIndex,
                     Collections.singletonList(point.get()), hintsMap, new FiniteWeightFilter(weighting));
             weighting = new BlockAreaWeighting(weighting, blockArea);
         }

--- a/web-bundle/src/main/java/com/graphhopper/resources/SPTResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/SPTResource.java
@@ -100,7 +100,7 @@ public class SPTResource {
         Weighting weighting = graphHopper.createWeighting(profile, hintsMap);
         BooleanEncodedValue inSubnetworkEnc = graphHopper.getEncodingManager().getBooleanEncodedValue(Subnetwork.key(profileName));
         if (hintsMap.has(Parameters.Routing.BLOCK_AREA)) {
-            GraphEdgeIdFinder.BlockArea blockArea = GraphEdgeIdFinder.createBlockArea(graph, locationIndex,
+            GraphEdgeIdFinder.ShapeFilter blockArea = GraphEdgeIdFinder.createBlockArea(graph, locationIndex,
                     Collections.singletonList(point.get()), hintsMap, new FiniteWeightFilter(weighting));
             weighting = new BlockAreaWeighting(weighting, blockArea);
         }


### PR DESCRIPTION
Fixes #2313 

This PR refactors our older BlockArea logic and reuses it to enable faster intersection checks for small polygons.

* renamed BlockArea to ShapeFilter as it's not only used for blocking anymore
* create a ShapeFilter per JsonFeature and pass the filters via `CustomWeightingHelper.init()`
* adapt CustomModelParser and ExpressionVisitor to use the ShapeFilter
* pass `Graph` and `LocationIndex` into DefaultWeightingFactory and CustomModelParser in order to lookup edge ids

TODO
- [ ] allow to configure max area size