### PR TITLE
Remove GraphHopperAPI#load

### DIFF
--- a/api/src/main/java/com/graphhopper/GraphHopperAPI.java
+++ b/api/src/main/java/com/graphhopper/GraphHopperAPI.java
@@ -24,14 +24,6 @@ package com.graphhopper;
  * @author Peter Karich
  */
 public interface GraphHopperAPI {
-    /**
-     * Connects to the specified service (graphhopper URL) or loads a graph from the graphhopper
-     * folder.
-     * <p>
-     *
-     * @return true if successfully connected or loaded
-     */
-    boolean load(String urlOrFile);
 
     /**
      * Calculates the path from specified request visiting the specified locations.

--- a/client-hc/src/main/java/com/graphhopper/api/GraphHopperWeb.java
+++ b/client-hc/src/main/java/com/graphhopper/api/GraphHopperWeb.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.graphhopper.GHRequest;
 import com.graphhopper.GHResponse;
-import com.graphhopper.GraphHopperAPI;
 import com.graphhopper.ResponsePath;
 import com.graphhopper.jackson.Jackson;
 import com.graphhopper.jackson.ResponsePathDeserializer;
@@ -52,11 +51,11 @@ import static com.graphhopper.util.Parameters.Routing.INSTRUCTIONS;
  *
  * @author Peter Karich
  */
-public class GraphHopperWeb implements GraphHopperAPI {
+public class GraphHopperWeb {
 
     private final ObjectMapper objectMapper;
+    private final String routeServiceUrl;
     private OkHttpClient downloader;
-    private String routeServiceUrl;
     private String key = "";
     private boolean instructions = true;
     private boolean calcPoints = true;
@@ -125,12 +124,6 @@ public class GraphHopperWeb implements GraphHopperAPI {
         return downloader;
     }
 
-    @Override
-    public boolean load(String serviceUrl) {
-        this.routeServiceUrl = serviceUrl;
-        return true;
-    }
-
     public GraphHopperWeb setKey(String key) {
         Objects.requireNonNull(key,"Key must not be null");
         if (key.isEmpty()) {
@@ -189,7 +182,6 @@ public class GraphHopperWeb implements GraphHopperAPI {
         return this;
     }
 
-    @Override
     public GHResponse route(GHRequest ghRequest) {
         ResponseBody rspBody = null;
         try {

--- a/core/files/changelog.txt
+++ b/core/files/changelog.txt
@@ -1,4 +1,5 @@
 3.0
+    the load method in GraphHopperWeb (client-hc) was removed
     routing.ch.disabling_allowed and routing.lm.disabling_allowed configuration options are no longer supported
     moved the graphhopper-reader-osm module into core, use the graphhopper-core module directly instead. GraphHopperOSM is deprecated, use GraphHopper instead.
     subnetwork removal has changed and for every LocationIndex lookup one needs to explicitly include the new 'subnetwork' EncodedValue, see #2290

--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -674,7 +674,6 @@ public class GraphHopper implements GraphHopperAPI {
      * @param graphHopperFolder is the folder containing graphhopper files. Can be a compressed file
      *                          too ala folder-content.ghz.
      */
-    @Override
     public boolean load(String graphHopperFolder) {
         if (isEmpty(graphHopperFolder))
             throw new IllegalStateException("GraphHopperLocation is not specified. Call setGraphHopperLocation or init before");

--- a/web/src/test/java/com/graphhopper/http/resources/RouteResourceTest.java
+++ b/web/src/test/java/com/graphhopper/http/resources/RouteResourceTest.java
@@ -20,7 +20,6 @@ package com.graphhopper.http.resources;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.graphhopper.GHRequest;
 import com.graphhopper.GHResponse;
-import com.graphhopper.GraphHopperAPI;
 import com.graphhopper.ResponsePath;
 import com.graphhopper.api.GraphHopperWeb;
 import com.graphhopper.config.CHProfile;
@@ -220,8 +219,7 @@ public class RouteResourceTest {
 
     @Test
     public void testGraphHopperWeb() {
-        GraphHopperWeb hopper = new GraphHopperWeb();
-        assertTrue(hopper.load(clientUrl(app, "/route")));
+        GraphHopperWeb hopper = new GraphHopperWeb(clientUrl(app, "/route"));
         GHResponse rsp = hopper.route(new GHRequest(42.554851, 1.536198, 42.510071, 1.548128).setProfile("my_car"));
         assertFalse(rsp.hasErrors(), rsp.getErrors().toString());
         assertTrue(rsp.getErrors().isEmpty(), rsp.getErrors().toString());
@@ -250,11 +248,10 @@ public class RouteResourceTest {
 
     @Test
     public void testPathDetailsRoadClass() {
-        GraphHopperAPI hopper = new com.graphhopper.api.GraphHopperWeb();
-        assertTrue(hopper.load(clientUrl(app, "/route")));
+        GraphHopperWeb client = new GraphHopperWeb(clientUrl(app, "/route"));
         GHRequest request = new GHRequest(42.546757, 1.528645, 42.520573, 1.557999).setProfile("my_car");
         request.setPathDetails(Arrays.asList(RoadClass.KEY, Surface.KEY, RoadEnvironment.KEY, "average_speed", RoadClassLink.KEY));
-        GHResponse rsp = hopper.route(request);
+        GHResponse rsp = client.route(request);
         assertFalse(rsp.hasErrors(), rsp.getErrors().toString());
         assertEquals(4, rsp.getBest().getPathDetails().get(RoadClass.KEY).size());
         assertEquals(RoadClass.PRIMARY.toString(), rsp.getBest().getPathDetails().get(RoadClass.KEY).get(3).getValue());
@@ -268,11 +265,10 @@ public class RouteResourceTest {
 
     @Test
     public void testPathDetails() {
-        GraphHopperAPI hopper = new com.graphhopper.api.GraphHopperWeb();
-        assertTrue(hopper.load(clientUrl(app, "/route")));
+        GraphHopperWeb client = new GraphHopperWeb(clientUrl(app, "/route"));
         GHRequest request = new GHRequest(42.554851, 1.536198, 42.510071, 1.548128).setProfile("my_car");
         request.setPathDetails(Arrays.asList("average_speed", "edge_id", "time"));
-        GHResponse rsp = hopper.route(request);
+        GHResponse rsp = client.route(request);
         assertFalse(rsp.hasErrors(), rsp.getErrors().toString());
         assertTrue(rsp.getErrors().isEmpty(), rsp.getErrors().toString());
         Map<String, List<PathDetail>> pathDetails = rsp.getBest().getPathDetails();
@@ -306,8 +302,7 @@ public class RouteResourceTest {
 
     @Test
     public void testPathDetailsSamePoint() {
-        GraphHopperAPI hopper = new com.graphhopper.api.GraphHopperWeb();
-        assertTrue(hopper.load(clientUrl(app, "/route")));
+        GraphHopperWeb hopper = new GraphHopperWeb(clientUrl(app, "/route"));
         GHRequest request = new GHRequest(42.554851, 1.536198, 42.554851, 1.536198)
                 .setPathDetails(Arrays.asList("average_speed", "edge_id", "time"))
                 .setProfile("my_car");
@@ -318,8 +313,7 @@ public class RouteResourceTest {
 
     @Test
     public void testPathDetailsNoConnection() {
-        GraphHopperAPI hopper = new com.graphhopper.api.GraphHopperWeb();
-        assertTrue(hopper.load(clientUrl(app, "/route")));
+        GraphHopperWeb hopper = new GraphHopperWeb(clientUrl(app, "/route"));
         GHRequest request = new GHRequest(42.542078, 1.45586, 42.537841, 1.439981);
         request.setPathDetails(Collections.singletonList("average_speed"));
         request.setProfile("my_car");
@@ -358,8 +352,7 @@ public class RouteResourceTest {
 
     @Test
     public void testInitInstructionsWithTurnDescription() {
-        GraphHopperAPI hopper = new com.graphhopper.api.GraphHopperWeb();
-        assertTrue(hopper.load(clientUrl(app, "/route")));
+        GraphHopperWeb hopper = new GraphHopperWeb(clientUrl(app, "/route"));
         GHRequest request = new GHRequest(42.554851, 1.536198, 42.510071, 1.548128);
         request.setProfile("my_car");
         GHResponse rsp = hopper.route(request);
@@ -374,8 +367,7 @@ public class RouteResourceTest {
 
     @Test
     public void testSnapPreventions() {
-        GraphHopperAPI hopper = new com.graphhopper.api.GraphHopperWeb();
-        assertTrue(hopper.load(clientUrl(app, "route")));
+        GraphHopperWeb hopper = new GraphHopperWeb(clientUrl(app, "route"));
         GHRequest request = new GHRequest(42.511139, 1.53285, 42.508165, 1.532271);
         request.setProfile("my_car");
         GHResponse rsp = hopper.route(request);
@@ -389,8 +381,7 @@ public class RouteResourceTest {
 
     @Test
     public void testSnapPreventionsAndPointHints() {
-        GraphHopperAPI hopper = new com.graphhopper.api.GraphHopperWeb();
-        assertTrue(hopper.load(clientUrl(app, "/route")));
+        GraphHopperWeb hopper = new GraphHopperWeb(clientUrl(app, "/route"));
         GHRequest request = new GHRequest(42.511139, 1.53285, 42.508165, 1.532271);
         request.setProfile("my_car");
         request.setSnapPreventions(Collections.singletonList("tunnel"));
@@ -429,8 +420,7 @@ public class RouteResourceTest {
     @ParameterizedTest(name = "POST = {0}")
     @ValueSource(booleans = {false, true})
     public void testGraphHopperWebRealExceptions(boolean usePost) {
-        GraphHopperAPI hopper = new GraphHopperWeb().setPostRequest(usePost);
-        assertTrue(hopper.load(clientUrl(app, "/route")));
+        GraphHopperWeb hopper = new GraphHopperWeb(clientUrl(app, "/route")).setPostRequest(usePost);
 
         // this one actually works
         List<GHPoint> points = Arrays.asList(new GHPoint(42.554851, 1.536198), new GHPoint(42.510071, 1.548128));


### PR DESCRIPTION
This method is not really used in a meaningful way. The main users of `GraphHopperAPI`:  `RouteResource` and `NavigateResource` do not use it either.