### PR TITLE
Use bbox intersection logic for rectangles

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/weighting/custom/CustomWeightingHelper.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/custom/CustomWeightingHelper.java
@@ -59,8 +59,10 @@ public class CustomWeightingHelper {
 
     public static boolean in(Polygon p, EdgeIteratorState edge) {
         BBox bbox = GHUtility.createBBox(edge);
-        if (p.getBounds().intersects(bbox))
-            return p.intersects(edge.fetchWayGeometry(FetchMode.ALL).makeImmutable()); // TODO PERF: cache bbox and edge wayGeometry for multiple area
-        return false;
+        if (!p.getBounds().intersects(bbox))
+            return false;
+        if (p.isRectangle())
+            return true;
+        return p.intersects(edge.fetchWayGeometry(FetchMode.ALL).makeImmutable()); // TODO PERF: cache bbox and edge wayGeometry for multiple area
     }
 }

--- a/core/src/main/java/com/graphhopper/storage/GraphEdgeIdFinder.java
+++ b/core/src/main/java/com/graphhopper/storage/GraphEdgeIdFinder.java
@@ -226,6 +226,8 @@ public class GraphEdgeIdFinder {
 
                 Shape shape = blockedShapes.get(shapeIdx);
                 if (shape.getBounds().intersects(bbox)) {
+                    if (shape instanceof Polygon && ((Polygon) shape).isRectangle())
+                        return true;
                     if (pointList == null)
                         pointList = edgeState.fetchWayGeometry(FetchMode.ALL).makeImmutable();
                     if (shape.intersects(pointList))

--- a/core/src/main/java/com/graphhopper/util/shapes/Polygon.java
+++ b/core/src/main/java/com/graphhopper/util/shapes/Polygon.java
@@ -37,10 +37,12 @@ public class Polygon implements Shape {
 
     private final GeometryFactory factory = new GeometryFactory();
     public final PreparedGeometry prepPolygon;
+    public final boolean rectangle;
     public final Envelope envelope;
 
     public Polygon(PreparedPolygon prepPolygon) {
         this.prepPolygon = prepPolygon;
+        this.rectangle = prepPolygon.getGeometry().isRectangle();
         this.envelope = prepPolygon.getGeometry().getEnvelopeInternal();
     }
 
@@ -57,6 +59,7 @@ public class Polygon implements Shape {
         }
         coordinates[lats.length] = coordinates[0];
         this.prepPolygon = new PreparedPolygon(factory.createPolygon(new PackedCoordinateSequence.Double(coordinates, 2)));
+        this.rectangle = prepPolygon.getGeometry().isRectangle();
         this.envelope = prepPolygon.getGeometry().getEnvelopeInternal();
     }
 
@@ -98,6 +101,10 @@ public class Polygon implements Shape {
 
     public double getMaxLon() {
         return envelope.getMaxX();
+    }
+    
+    public boolean isRectangle() {
+        return rectangle;
     }
 
     @Override


### PR DESCRIPTION
If a polygon describes a rectangle, we don't need to load the way geometry to check for an intersection.
This should be especially beneficial for large areas, for which we previously had to load all intersecting edge geometries.