### PR TITLE
use custom_model parameter directly in GH Maps URL

### DIFF
--- a/web-bundle/src/main/resources/com/graphhopper/maps/js/main-template.js
+++ b/web-bundle/src/main/resources/com/graphhopper/maps/js/main-template.js
@@ -164,13 +164,17 @@ $(document).ready(function (e) {
 
     var urlParams = urlTools.parseUrlWithHisto();
 
-    var customURL = urlParams.load_custom;
-    if(urlParams.load_custom)
+    var customModelJSON = urlParams.custom_model;
+    if(customModelJSON) {
         toggleCustomModelBox(false);
-    if(customURL && ghenv.environment === 'development')
-        $.ajax(customURL).
-            done(function(data) { cmEditor.value = data; sendCustomData(); }).
-            fail(function(err)  { console.log("Cannot load custom URL " + customURL); });
+        cmEditor.value = customModelJSON;
+        try {
+            var tmpObj = JSON.parse(customModelJSON);
+            cmEditor.value = JSON.stringify(tmpObj, null, 2);
+        } catch(e) {
+            console.warn('cannot pretty print custom model');
+        }
+    }
 
     $.when(ghRequest.fetchTranslationMap(urlParams.locale), ghRequest.getInfo())
             .then(function (arg1, arg2) {


### PR DESCRIPTION
Loading an external JSON is ugly as we hit an external URL (potential security problem, slower and no way to quickly edit)

This PR uses the custom_model JSON directly from the URL.

For a short URL and to properly URL encode the `&&` I suggest e.g. https://www.minifyjson.org/ (tick at 'Convert all &') before copying into the URL.