### PR TITLE
make absolute barriers passable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - moved custom model editor to github.com/graphhopper/custom-model-editor
 - PointList#getSize() -> PointList#size()
 - migrated tests from junit 4 to 5 (#2324)
+- removal of block_barriers config option (result of discussion in #2340)
 
 ### 3.0 [17 May 2021]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - moved custom model editor to github.com/graphhopper/custom-model-editor
 - PointList#getSize() -> PointList#size()
 - migrated tests from junit 4 to 5 (#2324)
-- removal of block_barriers config option (result of discussion in #2340)
+- barriers do no longer block by default for car; remove block_barriers config option (see discussion in #2340)
 
 ### 3.0 [17 May 2021]
 

--- a/core/src/main/java/com/graphhopper/routing/util/AbstractFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/AbstractFlagEncoder.java
@@ -163,8 +163,8 @@ public abstract class AbstractFlagEncoder implements FlagEncoder {
      * @return encoded values or 0 if not blocking or no value stored
      */
     public long handleNodeTags(ReaderNode node) {
-        if ((node.hasTag("barrier", blockByDefaultBarriers)) || 
-           (node.hasTag("barrier", passByDefaultBarriers)) ) {
+        boolean blockByDefault = node.hasTag("barrier", blockByDefaultBarriers);
+        if (blockByDefault || node.hasTag("barrier", passByDefaultBarriers)) {
             boolean locked = false;
             if (node.hasTag("locked", "yes"))
                 locked = true;
@@ -176,12 +176,10 @@ public abstract class AbstractFlagEncoder implements FlagEncoder {
                 if (node.hasTag(res, restrictedValues))
                     return encoderBit;
             }
-            // blockByDefaultBarriers are blocked except they are explicitly allowed
-            if (node.hasTag("barrier", blockByDefaultBarriers))
-               return encoderBit;
-            else
-               // passByDefaultBarriers only blocks if explicitly blocked in the above checks
-               return 0;
+
+            if (blockByDefault)
+                return encoderBit;
+            return 0;
         }
 
         if ((node.hasTag("highway", "ford") || node.hasTag("ford", "yes"))

--- a/core/src/main/java/com/graphhopper/routing/util/AbstractFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/AbstractFlagEncoder.java
@@ -47,8 +47,8 @@ public abstract class AbstractFlagEncoder implements FlagEncoder {
     protected final Set<String> ferries = new HashSet<>(5);
     protected final Set<String> oneways = new HashSet<>(5);
     // http://wiki.openstreetmap.org/wiki/Mapfeatures#Barrier
-    protected final Set<String> absoluteBarriers = new HashSet<>(5);
-    protected final Set<String> potentialBarriers = new HashSet<>(5);
+    protected final Set<String> blockByDefaultBarriers = new HashSet<>(5); // barrier which needs to be explicitly allowed, otherwise it blocks
+    protected final Set<String> passByDefaultBarriers = new HashSet<>(5);  // barrier which may be explicitly forbidden, otherwise it is allowed
     protected final int speedBits;
     protected final double speedFactor;
     private final int maxTurnCosts;
@@ -59,7 +59,6 @@ public abstract class AbstractFlagEncoder implements FlagEncoder {
     // This value determines the maximal possible speed of any road regardless of the maxspeed value
     // lower values allow more compact representation of the routing graph
     protected int maxPossibleSpeed;
-    private boolean blockByDefault = true;
     private boolean blockFords = true;
     private boolean registered;
     protected EncodedValueLookup encodedValueLookup;
@@ -106,17 +105,6 @@ public abstract class AbstractFlagEncoder implements FlagEncoder {
     @Override
     public boolean isRegistered() {
         return registered;
-    }
-
-    /**
-     * Should potential barriers block when no access limits are given?
-     */
-    protected void blockBarriersByDefault(boolean blockByDefault) {
-        this.blockByDefault = blockByDefault;
-    }
-
-    public boolean isBlockBarriers() {
-        return blockByDefault;
     }
 
     public boolean isBlockFords() {
@@ -175,12 +163,8 @@ public abstract class AbstractFlagEncoder implements FlagEncoder {
      * @return encoded values or 0 if not blocking or no value stored
      */
     public long handleNodeTags(ReaderNode node) {
-        // absolute barriers always block
-        if (node.hasTag("barrier", absoluteBarriers))
-            return encoderBit;
-
-        // movable barriers block if they are not marked as passable
-        if (node.hasTag("barrier", potentialBarriers)) {
+        if ((node.hasTag("barrier", blockByDefaultBarriers)) || 
+           (node.hasTag("barrier", passByDefaultBarriers)) ) {
             boolean locked = false;
             if (node.hasTag("locked", "yes"))
                 locked = true;
@@ -192,9 +176,12 @@ public abstract class AbstractFlagEncoder implements FlagEncoder {
                 if (node.hasTag(res, restrictedValues))
                     return encoderBit;
             }
-
-            if (blockByDefault)
-                return encoderBit;
+            // blockByDefaultBarriers are blocked except they are explicitly allowed
+            if (node.hasTag("barrier", blockByDefaultBarriers))
+               return encoderBit;
+            else
+               // passByDefaultBarriers only blocks if explicitly blocked in the above checks
+               return 0;
         }
 
         if ((node.hasTag("highway", "ford") || node.hasTag("ford", "yes"))

--- a/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
@@ -79,16 +79,15 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
         oppositeLanes.add("opposite_lane");
         oppositeLanes.add("opposite_track");
 
-        blockBarriersByDefault(false);
-        potentialBarriers.add("gate");
+        passByDefaultBarriers.add("gate");
         // potentialBarriers.add("lift_gate");
-        potentialBarriers.add("swing_gate");
-        potentialBarriers.add("cattle_grid");
-        potentialBarriers.add("chain");
+        passByDefaultBarriers.add("swing_gate");
+        passByDefaultBarriers.add("cattle_grid");
+        passByDefaultBarriers.add("chain");
 
-        absoluteBarriers.add("fence");
-        absoluteBarriers.add("stile");
-        absoluteBarriers.add("turnstile");
+        blockByDefaultBarriers.add("fence");
+        blockByDefaultBarriers.add("stile");
+        blockByDefaultBarriers.add("turnstile");
 
         unpavedSurfaceTags.add("unpaved");
         unpavedSurfaceTags.add("gravel");

--- a/core/src/main/java/com/graphhopper/routing/util/BikeFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/BikeFlagEncoder.java
@@ -35,7 +35,6 @@ public class BikeFlagEncoder extends BikeCommonFlagEncoder {
                 properties.getInt("speed_factor", 2),
                 properties.getBool("turn_costs", false) ? 1 : 0);
 
-        blockBarriersByDefault(properties.getBool("block_barriers", false));
         blockPrivate(properties.getBool("block_private", true));
         blockFords(properties.getBool("block_fords", false));
     }
@@ -72,7 +71,7 @@ public class BikeFlagEncoder extends BikeCommonFlagEncoder {
         // SmoothnessSpeed <= smoothnessFactorPushingSectionThreshold gets mapped to speed PUSHING_SECTION_SPEED
         setSmoothnessSpeedFactor(com.graphhopper.routing.ev.Smoothness.IMPASSABLE, smoothnessFactorPushingSectionThreshold);
 
-        absoluteBarriers.add("kissing_gate");
+        blockByDefaultBarriers.add("kissing_gate");
         setSpecificClassBicycle("touring");
     }
 

--- a/core/src/main/java/com/graphhopper/routing/util/CarFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/CarFlagEncoder.java
@@ -71,29 +71,28 @@ public class CarFlagEncoder extends AbstractFlagEncoder {
 
         blockPrivate(properties.getBool("block_private", true));
         blockFords(properties.getBool("block_fords", false));
-        blockBarriersByDefault(properties.getBool("block_barriers", true));
         setSpeedTwoDirections(properties.getBool("speed_two_directions", false));
 
         intendedValues.add("yes");
         intendedValues.add("designated");
         intendedValues.add("permissive");
 
-        potentialBarriers.add("gate");
-        potentialBarriers.add("lift_gate");
-        potentialBarriers.add("kissing_gate");
-        potentialBarriers.add("swing_gate");
-        potentialBarriers.add("cattle_grid");
-        potentialBarriers.add("chain");
+        passByDefaultBarriers.add("gate");
+        passByDefaultBarriers.add("lift_gate");
+        passByDefaultBarriers.add("kissing_gate");
+        passByDefaultBarriers.add("swing_gate");
+        passByDefaultBarriers.add("cattle_grid");
+        passByDefaultBarriers.add("chain");
 
-        absoluteBarriers.add("fence");
-        absoluteBarriers.add("bollard");
-        absoluteBarriers.add("stile");
-        absoluteBarriers.add("turnstile");
-        absoluteBarriers.add("cycle_barrier");
-        absoluteBarriers.add("motorcycle_barrier");
-        absoluteBarriers.add("block");
-        absoluteBarriers.add("bus_trap");
-        absoluteBarriers.add("sump_buster");
+        blockByDefaultBarriers.add("fence");
+        blockByDefaultBarriers.add("bollard");
+        blockByDefaultBarriers.add("stile");
+        blockByDefaultBarriers.add("turnstile");
+        blockByDefaultBarriers.add("cycle_barrier");
+        blockByDefaultBarriers.add("motorcycle_barrier");
+        blockByDefaultBarriers.add("block");
+        blockByDefaultBarriers.add("bus_trap");
+        blockByDefaultBarriers.add("sump_buster");
 
         badSurfaceSpeedMap.add("cobblestone");
         badSurfaceSpeedMap.add("grass_paver");

--- a/core/src/main/java/com/graphhopper/routing/util/FootFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/FootFlagEncoder.java
@@ -63,7 +63,6 @@ public class FootFlagEncoder extends AbstractFlagEncoder {
 
         blockPrivate(properties.getBool("block_private", true));
         blockFords(properties.getBool("block_fords", false));
-        blockBarriersByDefault(properties.getBool("block_barriers", false));
         speedTwoDirections = properties.getBool("speed_two_directions", false);
     }
 
@@ -91,11 +90,10 @@ public class FootFlagEncoder extends AbstractFlagEncoder {
         sidewalkValues.add("left");
         sidewalkValues.add("right");
 
-        blockBarriersByDefault(false);
-        absoluteBarriers.add("fence");
-        potentialBarriers.add("gate");
-        potentialBarriers.add("cattle_grid");
-        potentialBarriers.add("chain");
+        blockByDefaultBarriers.add("fence");
+        passByDefaultBarriers.add("gate");
+        passByDefaultBarriers.add("cattle_grid");
+        passByDefaultBarriers.add("chain");
 
         safeHighwayTags.add("footway");
         safeHighwayTags.add("path");

--- a/core/src/main/java/com/graphhopper/routing/util/HikeFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/HikeFlagEncoder.java
@@ -43,7 +43,6 @@ public class HikeFlagEncoder extends FootFlagEncoder {
 
         blockPrivate(properties.getBool("block_private", true));
         blockFords(properties.getBool("block_fords", false));
-        blockBarriersByDefault(properties.getBool("block_barriers", false));
         speedTwoDirections = properties.getBool("speed_two_directions", false);
     }
 

--- a/core/src/main/java/com/graphhopper/routing/util/MotorcycleFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/MotorcycleFlagEncoder.java
@@ -53,8 +53,8 @@ public class MotorcycleFlagEncoder extends CarFlagEncoder {
     public MotorcycleFlagEncoder(PMap properties) {
         super(properties.putObject("speed_two_directions", true));
 
-        absoluteBarriers.remove("bus_trap");
-        absoluteBarriers.remove("sump_buster");
+        blockByDefaultBarriers.remove("bus_trap");
+        blockByDefaultBarriers.remove("sump_buster");
 
         trackTypeSpeedMap.clear();
         defaultSpeedMap.clear();

--- a/core/src/main/java/com/graphhopper/routing/util/MountainBikeFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/MountainBikeFlagEncoder.java
@@ -42,7 +42,6 @@ public class MountainBikeFlagEncoder extends BikeCommonFlagEncoder {
                 properties.getDouble("speed_factor", 2),
                 properties.getBool("turn_costs", false) ? 1 : 0);
 
-        blockBarriersByDefault(properties.getBool("block_barriers", false));
         blockPrivate(properties.getBool("block_private", true));
         blockFords(properties.getBool("block_fords", false));
     }
@@ -138,7 +137,7 @@ public class MountainBikeFlagEncoder extends BikeCommonFlagEncoder {
         // SmoothnessSpeed <= smoothnessFactorPushingSectionThreshold gets mapped to speed PUSHING_SECTION_SPEED
         setSmoothnessSpeedFactor(com.graphhopper.routing.ev.Smoothness.IMPASSABLE, smoothnessFactorPushingSectionThreshold);
 
-        potentialBarriers.add("kissing_gate");
+        passByDefaultBarriers.add("kissing_gate");
         setSpecificClassBicycle("mtb");
     }
 

--- a/core/src/main/java/com/graphhopper/routing/util/RacingBikeFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/RacingBikeFlagEncoder.java
@@ -41,7 +41,6 @@ public class RacingBikeFlagEncoder extends BikeCommonFlagEncoder {
                 properties.getDouble("speed_factor", 2),
                 properties.getBool("turn_costs", false) ? 1 : 0);
 
-        blockBarriersByDefault(properties.getBool("block_barriers", false));
         blockPrivate(properties.getBool("block_private", true));
         blockFords(properties.getBool("block_fords", false));
     }
@@ -127,7 +126,7 @@ public class RacingBikeFlagEncoder extends BikeCommonFlagEncoder {
         routeMap.put(REGIONAL, VERY_NICE.getValue());
         routeMap.put(LOCAL, UNCHANGED.getValue());
 
-        absoluteBarriers.add("kissing_gate");
+        blockByDefaultBarriers.add("kissing_gate");
 
         setAvoidSpeedLimit(81);
         setSpecificClassBicycle("roadcycling");

--- a/core/src/main/java/com/graphhopper/routing/util/WheelchairFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/WheelchairFlagEncoder.java
@@ -54,19 +54,18 @@ public class WheelchairFlagEncoder extends FootFlagEncoder {
 
         blockPrivate(properties.getBool("block_private", true));
         blockFords(properties.getBool("block_fords", false));
-        blockBarriersByDefault(properties.getBool("block_barriers", false));
     }
 
     protected WheelchairFlagEncoder(int speedBits, double speedFactor) {
         super(speedBits, speedFactor);
 
         restrictions.add("wheelchair");
-        absoluteBarriers.add("handrail");
-        absoluteBarriers.add("wall");
-        absoluteBarriers.add("turnstile");
-        potentialBarriers.add("kerb");
-        potentialBarriers.add("cattle_grid");
-        potentialBarriers.add("motorcycle_barrier");
+        blockByDefaultBarriers.add("handrail");
+        blockByDefaultBarriers.add("wall");
+        blockByDefaultBarriers.add("turnstile");
+        passByDefaultBarriers.add("kerb");
+        passByDefaultBarriers.add("cattle_grid");
+        passByDefaultBarriers.add("motorcycle_barrier");
 
         safeHighwayTags.add("footway");
         safeHighwayTags.add("pedestrian");

--- a/core/src/test/java/com/graphhopper/GraphHopperTest.java
+++ b/core/src/test/java/com/graphhopper/GraphHopperTest.java
@@ -90,12 +90,12 @@ public class GraphHopperTest {
 
     @ParameterizedTest
     @CsvSource({
-            DIJKSTRA + ",false,501",
-            ASTAR + ",false,439",
-            DIJKSTRA_BI + ",false,208",
-            ASTAR_BI + ",false,172",
-            ASTAR_BI + ",true,35",
-            DIJKSTRA_BI + ",true,34"
+            DIJKSTRA + ",false,505",
+            ASTAR + ",false,438",
+            DIJKSTRA_BI + ",false,224",
+            ASTAR_BI + ",false,180",
+            ASTAR_BI + ",true,41",
+            DIJKSTRA_BI + ",true,41"
     })
     public void testMonacoDifferentAlgorithms(String algo, boolean withCH, int expectedVisitedNodes) {
         final String vehicle = "car";
@@ -627,9 +627,9 @@ public class GraphHopperTest {
         // standard car route
         assertDistance(hopper, emptyCar, null, 8725);
         // the custom car takes a detour in the north to avoid tertiary roads
-        assertDistance(hopper, customCar, null, 13223);
+        assertDistance(hopper, customCar, null, 11553);
         // we can achieve the same by using the empty profile and using a client-side model, we just need to copy the model because of the internal flag
-        assertDistance(hopper, emptyCar, new CustomModel(customModel), 13223);
+        assertDistance(hopper, emptyCar, new CustomModel(customModel), 11553);
         // now we prevent using unclassified roads as well and the route goes even further north
         CustomModel strictCustomModel = new CustomModel().addToSpeed(
                 Statement.If("road_class == TERTIARY || road_class == UNCLASSIFIED", Statement.Op.MULTIPLY, 0.1));
@@ -640,9 +640,9 @@ public class GraphHopperTest {
         );
         assertDistance(hopper, customCar, customModelWithUnclassifiedRule, 18114);
         // now we use distance influence to avoid the detour
-        assertDistance(hopper, customCar, new CustomModel(customModelWithUnclassifiedRule).setDistanceInfluence(400), 8725);
-        // a slightly smaller value yields a completely different route going south
-        assertDistance(hopper, customCar, new CustomModel(customModelWithUnclassifiedRule).setDistanceInfluence(380), 12246);
+        assertDistance(hopper, customCar, new CustomModel(customModelWithUnclassifiedRule).setDistanceInfluence(400), 10601);
+        // FIXME to be checked!!! Why do we get the same result compared to above
+        assertDistance(hopper, customCar, new CustomModel(customModelWithUnclassifiedRule).setDistanceInfluence(380), 10601);
     }
 
     private void assertDistance(GraphHopper hopper, String profile, CustomModel customModel, double expectedDistance) {
@@ -1547,9 +1547,9 @@ public class GraphHopperTest {
         hopper.importOrLoad();
 
         // flex
-        testCrossQueryAssert(profile1, hopper, 528.3, 152, true);
-        testCrossQueryAssert(profile2, hopper, 635.8, 150, true);
-        testCrossQueryAssert(profile3, hopper, 815.2, 146, true);
+        testCrossQueryAssert(profile1, hopper, 528.3, 160, true);
+        testCrossQueryAssert(profile2, hopper, 635.8, 158, true);
+        testCrossQueryAssert(profile3, hopper, 815.2, 154, true);
 
         // LM (should be the same as flex, but with less visited nodes!)
         testCrossQueryAssert(profile1, hopper, 528.3, 74, false);
@@ -1557,7 +1557,7 @@ public class GraphHopperTest {
         // this is actually interesting: the number of visited nodes *increases* once again (while it strictly decreases
         // with rising distance factor for flex): cross-querying 'works', but performs *worse*, because the landmarks
         // were not customized for the weighting in use. Creating a separate LM preparation for profile3 yields 74
-        testCrossQueryAssert(profile3, hopper, 815.2, 138, false);
+        testCrossQueryAssert(profile3, hopper, 815.2, 148, false);
     }
 
     private void testCrossQueryAssert(String profile, GraphHopper hopper, double expectedWeight, int expectedVisitedNodes, boolean disableLM) {

--- a/core/src/test/java/com/graphhopper/GraphHopperTest.java
+++ b/core/src/test/java/com/graphhopper/GraphHopperTest.java
@@ -614,7 +614,7 @@ public class GraphHopperTest {
         final String customCar = "custom_car";
         final String emptyCar = "empty_car";
         CustomModel customModel = new CustomModel();
-        customModel.addToSpeed(Statement.If("road_class == TERTIARY", Statement.Op.MULTIPLY, 0.1));
+        customModel.addToSpeed(Statement.If("road_class == TERTIARY || road_class == TRACK", Statement.Op.MULTIPLY, 0.1));
         GraphHopper hopper = new GraphHopper().
                 setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(BAYREUTH).
@@ -627,22 +627,21 @@ public class GraphHopperTest {
         // standard car route
         assertDistance(hopper, emptyCar, null, 8725);
         // the custom car takes a detour in the north to avoid tertiary roads
-        assertDistance(hopper, customCar, null, 11553);
+        assertDistance(hopper, customCar, null, 13223);
         // we can achieve the same by using the empty profile and using a client-side model, we just need to copy the model because of the internal flag
-        assertDistance(hopper, emptyCar, new CustomModel(customModel), 11553);
+        assertDistance(hopper, emptyCar, new CustomModel(customModel), 13223);
         // now we prevent using unclassified roads as well and the route goes even further north
         CustomModel strictCustomModel = new CustomModel().addToSpeed(
-                Statement.If("road_class == TERTIARY || road_class == UNCLASSIFIED", Statement.Op.MULTIPLY, 0.1));
-        assertDistance(hopper, emptyCar, strictCustomModel, 18114);
+                Statement.If("road_class == TERTIARY || road_class == TRACK || road_class == UNCLASSIFIED", Statement.Op.MULTIPLY, 0.1));
+        assertDistance(hopper, emptyCar, strictCustomModel, 19289);
         // we can achieve the same by 'adding' a rule to the server-side custom model
         CustomModel customModelWithUnclassifiedRule = new CustomModel().addToSpeed(
                 Statement.If("road_class == UNCLASSIFIED", Statement.Op.MULTIPLY, 0.1)
         );
-        assertDistance(hopper, customCar, customModelWithUnclassifiedRule, 18114);
+        assertDistance(hopper, customCar, customModelWithUnclassifiedRule, 19289);
         // now we use distance influence to avoid the detour
-        assertDistance(hopper, customCar, new CustomModel(customModelWithUnclassifiedRule).setDistanceInfluence(400), 10601);
-        // FIXME to be checked!!! Why do we get the same result compared to above
-        assertDistance(hopper, customCar, new CustomModel(customModelWithUnclassifiedRule).setDistanceInfluence(380), 10601);
+        assertDistance(hopper, customCar, new CustomModel(customModelWithUnclassifiedRule).setDistanceInfluence(200), 8725);
+        assertDistance(hopper, customCar, new CustomModel(customModelWithUnclassifiedRule).setDistanceInfluence(100), 14475);
     }
 
     private void assertDistance(GraphHopper hopper, String profile, CustomModel customModel, double expectedDistance) {

--- a/core/src/test/java/com/graphhopper/reader/osm/GraphHopperOSMTest.java
+++ b/core/src/test/java/com/graphhopper/reader/osm/GraphHopperOSMTest.java
@@ -614,22 +614,6 @@ public class GraphHopperOSMTest {
     }
 
     @Test
-    public void profileWithExistingEncoderConfig() {
-        final GraphHopper hopper = new GraphHopper();
-        GraphHopperConfig config = new GraphHopperConfig();
-        config.putObject("graph.flag_encoders", "car|block_barriers=false|turn_costs=true");
-        config.putObject("graph.dataaccess", "RAM");
-        config.putObject("graph.location", ghLoc);
-        config.putObject("datareader.file", testOsm);
-        config.setProfiles(Arrays.asList(new Profile("profile2").setVehicle("car").setTurnCosts(true)));
-        hopper.init(config);
-
-        hopper.importOrLoad();
-
-        assertFalse(((CarFlagEncoder) hopper.getEncodingManager().getEncoder("car")).isBlockBarriers());
-    }
-
-    @Test
     public void testDoesNotCreateEmptyFolderIfLoadingFromNonExistingPath() {
         instance = new GraphHopper();
         instance.setProfiles(new Profile("car").setVehicle("car").setWeighting("fastest"));

--- a/core/src/test/java/com/graphhopper/reader/osm/OSMReaderTest.java
+++ b/core/src/test/java/com/graphhopper/reader/osm/OSMReaderTest.java
@@ -335,7 +335,7 @@ public class OSMReaderTest {
         assertEquals(n10, iter.getAdjNode());
         assertEquals(88643, iter.getDistance(), 1);
     }
-
+/*  FIXME to be checked!!!
     @Test
     public void testBarriers() {
         GraphHopper hopper = new GraphHopperFacade(fileBarriers).
@@ -343,7 +343,7 @@ public class OSMReaderTest {
                 importOrLoad();
 
         Graph graph = hopper.getGraphHopperStorage();
-        assertEquals(8, graph.getNodes());
+        assertEquals(5, graph.getNodes());
 
         int n10 = AbstractGraphStorageTester.getIdOf(graph, 51);
         int n20 = AbstractGraphStorageTester.getIdOf(graph, 52);
@@ -372,7 +372,7 @@ public class OSMReaderTest {
         assertEquals(n30, iter.getAdjNode());
         assertFalse(iter.next());
     }
-
+*/
     @Test
     public void avoidsLoopEdges_1525() {
         // loops in OSM should be avoided by adding additional tower node (see #1525, #1531)
@@ -421,14 +421,14 @@ public class OSMReaderTest {
         assertTrue(nodeB > -1, "could not find OSM node B");
         assertEquals(2, GHUtility.count(graph.createEdgeExplorer().setBaseNode(nodeB)));
     }
-
+/* FIXME to be checked!!!
     @Test
     public void testBarriersOnTowerNodes() {
         GraphHopper hopper = new GraphHopperFacade(fileBarriers).
                 setMinNetworkSize(0).
                 importOrLoad();
         Graph graph = hopper.getGraphHopperStorage();
-        assertEquals(8, graph.getNodes());
+        assertEquals(5, graph.getNodes());
 
         int n60 = AbstractGraphStorageTester.getIdOf(graph, 56);
         int newId = 5;
@@ -444,7 +444,7 @@ public class OSMReaderTest {
         assertEquals(n60, iter.getAdjNode());
         assertFalse(iter.next());
     }
-
+*/
     @Test
     public void testRelation() {
         EncodingManager manager = EncodingManager.create("bike");

--- a/core/src/test/java/com/graphhopper/reader/osm/OSMReaderTest.java
+++ b/core/src/test/java/com/graphhopper/reader/osm/OSMReaderTest.java
@@ -335,7 +335,7 @@ public class OSMReaderTest {
         assertEquals(n10, iter.getAdjNode());
         assertEquals(88643, iter.getDistance(), 1);
     }
-/*  FIXME to be checked!!!
+
     @Test
     public void testBarriers() {
         GraphHopper hopper = new GraphHopperFacade(fileBarriers).
@@ -343,7 +343,7 @@ public class OSMReaderTest {
                 importOrLoad();
 
         Graph graph = hopper.getGraphHopperStorage();
-        assertEquals(5, graph.getNodes());
+        assertEquals(8, graph.getNodes());
 
         int n10 = AbstractGraphStorageTester.getIdOf(graph, 51);
         int n20 = AbstractGraphStorageTester.getIdOf(graph, 52);
@@ -372,7 +372,7 @@ public class OSMReaderTest {
         assertEquals(n30, iter.getAdjNode());
         assertFalse(iter.next());
     }
-*/
+
     @Test
     public void avoidsLoopEdges_1525() {
         // loops in OSM should be avoided by adding additional tower node (see #1525, #1531)
@@ -421,14 +421,14 @@ public class OSMReaderTest {
         assertTrue(nodeB > -1, "could not find OSM node B");
         assertEquals(2, GHUtility.count(graph.createEdgeExplorer().setBaseNode(nodeB)));
     }
-/* FIXME to be checked!!!
+
     @Test
     public void testBarriersOnTowerNodes() {
         GraphHopper hopper = new GraphHopperFacade(fileBarriers).
                 setMinNetworkSize(0).
                 importOrLoad();
         Graph graph = hopper.getGraphHopperStorage();
-        assertEquals(5, graph.getNodes());
+        assertEquals(8, graph.getNodes());
 
         int n60 = AbstractGraphStorageTester.getIdOf(graph, 56);
         int newId = 5;
@@ -444,7 +444,7 @@ public class OSMReaderTest {
         assertEquals(n60, iter.getAdjNode());
         assertFalse(iter.next());
     }
-*/
+
     @Test
     public void testRelation() {
         EncodingManager manager = EncodingManager.create("bike");

--- a/core/src/test/java/com/graphhopper/routing/RoutingAlgorithmWithOSMTest.java
+++ b/core/src/test/java/com/graphhopper/routing/RoutingAlgorithmWithOSMTest.java
@@ -170,13 +170,13 @@ public class RoutingAlgorithmWithOSMTest {
         List<Query> queries = new ArrayList<>();
         // choose perpendicular
         // http://localhost:8989/?point=55.818994%2C37.595354&point=55.819175%2C37.596931
-        queries.add(new Query(55.818994, 37.595354, 55.819175, 37.596931, 1052, 14));
+        queries.add(new Query(55.818994, 37.595354, 55.819175, 37.596931, 70, 2));
         // should choose the closest road not the other one (opposite direction)
         // http://localhost:8989/?point=55.818898%2C37.59661&point=55.819066%2C37.596374
-        queries.add(new Query(55.818898, 37.59661, 55.819066, 37.596374, 24, 2));
+        queries.add(new Query(55.818898, 37.59661, 55.819066, 37.596374, 1, 1));
         // respect one way!
         // http://localhost:8989/?point=55.819066%2C37.596374&point=55.818898%2C37.59661
-        queries.add(new Query(55.819066, 37.596374, 55.818898, 37.59661, 1114, 23));
+        queries.add(new Query(55.819066, 37.596374, 55.818898, 37.59661, 1, 1));
         GraphHopper hopper = createHopper(MOSCOW,
                 new Profile("car").setVehicle("car").setWeighting("fastest"));
         hopper.setMinNetworkSize(200);

--- a/core/src/test/java/com/graphhopper/routing/RoutingAlgorithmWithOSMTest.java
+++ b/core/src/test/java/com/graphhopper/routing/RoutingAlgorithmWithOSMTest.java
@@ -170,13 +170,13 @@ public class RoutingAlgorithmWithOSMTest {
         List<Query> queries = new ArrayList<>();
         // choose perpendicular
         // http://localhost:8989/?point=55.818994%2C37.595354&point=55.819175%2C37.596931
-        queries.add(new Query(55.818994, 37.595354, 55.819175, 37.596931, 70, 2));
+        queries.add(new Query(55.818891, 37.59515, 55.81997, 37.59854, 1052, 14));
         // should choose the closest road not the other one (opposite direction)
         // http://localhost:8989/?point=55.818898%2C37.59661&point=55.819066%2C37.596374
-        queries.add(new Query(55.818898, 37.59661, 55.819066, 37.596374, 1, 1));
+        queries.add(new Query(55.818536, 37.595848, 55.818702, 37.595564, 24, 2));
         // respect one way!
         // http://localhost:8989/?point=55.819066%2C37.596374&point=55.818898%2C37.59661
-        queries.add(new Query(55.819066, 37.596374, 55.818898, 37.59661, 1, 1));
+        queries.add(new Query(55.818702, 37.595564, 55.818536, 37.595848, 1114, 23));
         GraphHopper hopper = createHopper(MOSCOW,
                 new Profile("car").setVehicle("car").setWeighting("fastest"));
         hopper.setMinNetworkSize(200);

--- a/core/src/test/java/com/graphhopper/routing/util/BikeFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/BikeFlagEncoderTest.java
@@ -632,8 +632,8 @@ public class BikeFlagEncoderTest extends AbstractBikeFlagEncoderTester {
         node = new ReaderNode(1, -1, -1);
         node.setTag("barrier", "kissing_gate");
         node.setTag("bicycle", "yes");
-        // barrier!
-        assertFalse(encoder.handleNodeTags(node) == 0);
+        // no barrier!
+        assertTrue(encoder.handleNodeTags(node) == 0);
 
         // Test if cattle_grid is non blocking
         node = new ReaderNode(1, -1, -1);

--- a/core/src/test/java/com/graphhopper/routing/util/CarFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/CarFlagEncoderTest.java
@@ -544,8 +544,8 @@ public class CarFlagEncoderTest {
         node = new ReaderNode(1, -1, -1);
         node.setTag("barrier", "lift_gate");
         node.setTag("bicycle", "yes");
-        // barrier!
-        assertTrue(encoder.handleNodeTags(node) > 0);
+        // no barrier!
+        assertTrue(encoder.handleNodeTags(node) == 0);
 
         node = new ReaderNode(1, -1, -1);
         node.setTag("barrier", "lift_gate");
@@ -566,11 +566,6 @@ public class CarFlagEncoderTest {
         // barrier!
         assertTrue(encoder.handleNodeTags(node) > 0);
 
-        // ignore other access tags for absolute barriers!
-        node.setTag("motorcar", "yes");
-        // still barrier!
-        assertTrue(encoder.handleNodeTags(node) > 0);
-
         CarFlagEncoder tmpEncoder = new CarFlagEncoder(new PMap("block_barriers=false"));
         EncodingManager.create(tmpEncoder);
 
@@ -585,7 +580,7 @@ public class CarFlagEncoderTest {
         // by default allow access through the gate for bike & foot!
         ReaderNode node = new ReaderNode(1, -1, -1);
         node.setTag("barrier", "chain");
-        assertTrue(encoder.handleNodeTags(node) > 0);
+        assertTrue(encoder.handleNodeTags(node) == 0);
         node.setTag("motor_vehicle", "no");
         assertTrue(encoder.handleNodeTags(node) > 0);
         node.setTag("motor_vehicle", "yes");

--- a/core/src/test/java/com/graphhopper/routing/util/FootFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/FootFlagEncoderTest.java
@@ -428,14 +428,14 @@ public class FootFlagEncoderTest {
         assertTrue(tmpFootEncoder.handleNodeTags(node) > 0);
         node.setTag("barrier", "fence");
         node.setTag("access", "yes");
-        assertTrue(tmpFootEncoder.handleNodeTags(node) > 0);
+        assertFalse(tmpFootEncoder.handleNodeTags(node) > 0);
 
-        // block potential barriers per default (if no other access tag exists)
-        tmpFootEncoder = new FootFlagEncoder(new PMap("block_barriers=true"));
+        // pass potential barriers per default (if no other access tag exists)
+        tmpFootEncoder = new FootFlagEncoder();
         EncodingManager.create(tmpFootEncoder);
         node = new ReaderNode(1, -1, -1);
         node.setTag("barrier", "gate");
-        assertTrue(tmpFootEncoder.handleNodeTags(node) > 0);
+        assertFalse(tmpFootEncoder.handleNodeTags(node) > 0);
         node.setTag("access", "yes");
         assertEquals(0, tmpFootEncoder.handleNodeTags(node));
 

--- a/core/src/test/java/com/graphhopper/routing/util/WheelchairFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/WheelchairFlagEncoderTest.java
@@ -398,12 +398,12 @@ public class WheelchairFlagEncoderTest {
 
         ReaderNode node = new ReaderNode(1, -1, -1);
         node.setTag("barrier", "gate");
-        // potential barriers are no barrier by default
+        // passByDefaultBarriers are no barrier by default
         assertEquals(0, tmpWheelchairEncoder.handleNodeTags(node));
         node.setTag("access", "no");
         assertTrue(tmpWheelchairEncoder.handleNodeTags(node) > 0);
 
-        // absolute barriers always block
+        // these barriers block
         node = new ReaderNode(1, -1, -1);
         node.setTag("barrier", "fence");
         assertTrue(tmpWheelchairEncoder.handleNodeTags(node) > 0);
@@ -413,22 +413,19 @@ public class WheelchairFlagEncoderTest {
         assertTrue(tmpWheelchairEncoder.handleNodeTags(node) > 0);
         node.setTag("barrier", "turnstile");
         assertTrue(tmpWheelchairEncoder.handleNodeTags(node) > 0);
+        // Explictly allowed access is allowed
         node.setTag("barrier", "fence");
         node.setTag("access", "yes");
-        assertTrue(tmpWheelchairEncoder.handleNodeTags(node) > 0);
+        assertTrue(tmpWheelchairEncoder.handleNodeTags(node) == 0);
 
-        // Now let's block potential barriers per default (if no other access tag exists)
-        tmpWheelchairEncoder = new WheelchairFlagEncoder(new PMap("block_barriers=true"));
-        EncodingManager.create(tmpWheelchairEncoder);
         node = new ReaderNode(1, -1, -1);
         node.setTag("barrier", "gate");
-        assertTrue(tmpWheelchairEncoder.handleNodeTags(node) > 0);
         node.setTag("access", "yes");
         assertEquals(0, tmpWheelchairEncoder.handleNodeTags(node));
 
         node = new ReaderNode(1, -1, -1);
         node.setTag("barrier", "kerb");
-        assertTrue(tmpWheelchairEncoder.handleNodeTags(node) > 0);
+        assertTrue(tmpWheelchairEncoder.handleNodeTags(node) == 0);
         node.setTag("wheelchair", "yes");
         assertEquals(0, tmpWheelchairEncoder.handleNodeTags(node));
 

--- a/core/src/test/resources/com/graphhopper/reader/osm/test-barriers.xml
+++ b/core/src/test/resources/com/graphhopper/reader/osm/test-barriers.xml
@@ -4,16 +4,16 @@
         <tag k="name" v="Wiesbaden-Naurod"/>
     </node>
     <node id="20" lat="52" lon="9.4" version="1">
-        <tag k="barrier" v="gate"/>
+        <tag k="barrier" v="fence"/>
     </node>
     <node id="30" lat="53" lon="9.4" version="1">
     </node>
     <node id="40" lat="54" lon="9.4" version="1">
     </node>
 
-    <!--     barrier on tower node -->
+    <!-- barrier on tower node -->
     <node id="50" lat="55" lon="9.4" version="1">
-        <tag k="barrier" v="gate"/>
+        <tag k="barrier" v="fence"/>
     </node>
     <node id="60" lat="56" lon="9.4" version="1">
     </node>

--- a/web/src/test/java/com/graphhopper/http/resources/RouteResourceTest.java
+++ b/web/src/test/java/com/graphhopper/http/resources/RouteResourceTest.java
@@ -343,7 +343,7 @@ public class RouteResourceTest {
         int firstLink = edgeIds.get(0).get(2).asInt();
         int lastLink = edgeIds.get(edgeIds.size() - 1).get(2).asInt();
         assertEquals(880, firstLink);
-        assertEquals(1421, lastLink);
+        assertEquals(1420, lastLink);
 
         JsonNode maxSpeed = details.get("max_speed");
         assertEquals(-1, maxSpeed.get(0).get(2).asDouble(-1), .01);

--- a/web/src/test/java/com/graphhopper/http/resources/SPTResourceTest.java
+++ b/web/src/test/java/com/graphhopper/http/resources/SPTResourceTest.java
@@ -96,9 +96,9 @@ public class SPTResourceTest {
         String[] lines = rspCsvString.split("\n");
         assertTrue(lines.length > 500);
         assertEquals("prev_node_id,edge_id,node_id,time,distance", lines[0]);
-        assertEquals("-1,-1,1944,0,0", lines[1]);
-        assertEquals("1944,2273,1324,3817,74", lines[2]);
-        assertEquals("1944,2272,263,13496,262", lines[3]);
+        assertEquals("-1,-1,1941,0,0", lines[1]);
+        assertEquals("1941,2270,1324,3817,74", lines[2]);
+        assertEquals("1941,2269,263,13496,262", lines[3]);
     }
 
     @Test


### PR DESCRIPTION
Replaces #2344

 - make absolute barriers passable (now called `blockByDefaultBarriers`)
 - car now also allows passing "potential barriers" by default (those barriers are now called `passByDefaultBarriers`)
 - removal of configuration option "blockByDefault".