### PR TITLE
Remove FlagEncoder#getVersion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 4.0 [not yet released]
 
+- flag encoders are no longer versioned (#2355)
 - JSON route response contains now bbox if start and end are identical
 - renamed PriorityCode enums: AVOID_IF_POSSIBLE -> SLIGHT_AVOID, REACH_DEST -> AVOID, AVOID_AT_ALL_COSTS -> AVOID_MORE, WORST -> BAD
 - added smoothness encoded value, used to determine bike speed (#2303)

--- a/core/src/main/java/com/graphhopper/routing/util/Bike2WeightFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/Bike2WeightFlagEncoder.java
@@ -42,11 +42,6 @@ public class Bike2WeightFlagEncoder extends BikeFlagEncoder {
         speedTwoDirections = true;
     }
 
-    @Override
-    public int getVersion() {
-        return 3;
-    }
-
     protected void handleSpeed(IntsRef edgeFlags, ReaderWay way, double speed) {
         avgSpeedEnc.setDecimal(true, edgeFlags, speed);
         super.handleSpeed(edgeFlags, way, speed);

--- a/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
@@ -190,11 +190,6 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
     }
 
     @Override
-    public int getVersion() {
-        return 3;
-    }
-
-    @Override
     public void createEncodedValues(List<EncodedValue> registerNewEncodedValue, String prefix, int index) {
         // first two bits are reserved for route handling in superclass
         super.createEncodedValues(registerNewEncodedValue, prefix, index);

--- a/core/src/main/java/com/graphhopper/routing/util/BikeFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/BikeFlagEncoder.java
@@ -79,11 +79,6 @@ public class BikeFlagEncoder extends BikeCommonFlagEncoder {
     }
 
     @Override
-    public int getVersion() {
-        return 2;
-    }
-
-    @Override
     public String toString() {
         return "bike";
     }

--- a/core/src/main/java/com/graphhopper/routing/util/Car4WDFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/Car4WDFlagEncoder.java
@@ -33,11 +33,6 @@ public class Car4WDFlagEncoder extends CarFlagEncoder {
     }
 
     @Override
-    public int getVersion() {
-        return 2;
-    }
-
-    @Override
     public String toString() {
         return "car4wd";
     }

--- a/core/src/main/java/com/graphhopper/routing/util/CarFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/CarFlagEncoder.java
@@ -151,11 +151,6 @@ public class CarFlagEncoder extends AbstractFlagEncoder {
         return TransportationMode.CAR;
     }
 
-    @Override
-    public int getVersion() {
-        return 2;
-    }
-
     /**
      * Define the place of the speedBits in the edge flags for car.
      */

--- a/core/src/main/java/com/graphhopper/routing/util/EncodingManager.java
+++ b/core/src/main/java/com/graphhopper/routing/util/EncodingManager.java
@@ -616,9 +616,7 @@ public class EncodingManager implements EncodedValueLookup {
 
             str.append(encoder.toString())
                     .append("|")
-                    .append(encoder.getPropertiesString())
-                    .append("|version=")
-                    .append(encoder.getVersion());
+                    .append(encoder.getPropertiesString());
         }
 
         return str.toString();

--- a/core/src/main/java/com/graphhopper/routing/util/FlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/FlagEncoder.java
@@ -29,12 +29,6 @@ import com.graphhopper.routing.ev.EncodedValueLookup;
  */
 public interface FlagEncoder extends EncodedValueLookup {
 
-    /**
-     * @return the version of this FlagEncoder to enforce none-compatibility when new attributes are
-     * introduced
-     */
-    int getVersion();
-
     TransportationMode getTransportationMode();
 
     /**

--- a/core/src/main/java/com/graphhopper/routing/util/FootFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/FootFlagEncoder.java
@@ -142,11 +142,6 @@ public class FootFlagEncoder extends AbstractFlagEncoder {
     }
 
     @Override
-    public int getVersion() {
-        return 5;
-    }
-
-    @Override
     public void createEncodedValues(List<EncodedValue> registerNewEncodedValue, String prefix, int index) {
         // first two bits are reserved for route handling in superclass
         super.createEncodedValues(registerNewEncodedValue, prefix, index);

--- a/core/src/main/java/com/graphhopper/routing/util/HikeFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/HikeFlagEncoder.java
@@ -61,11 +61,6 @@ public class HikeFlagEncoder extends FootFlagEncoder {
     }
 
     @Override
-    public int getVersion() {
-        return 3;
-    }
-
-    @Override
     void collect(ReaderWay way, TreeMap<Double, Integer> weightToPrioMap) {
         String highway = way.getTag("highway");
         if (way.hasTag("foot", "designated"))

--- a/core/src/main/java/com/graphhopper/routing/util/MotorcycleFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/MotorcycleFlagEncoder.java
@@ -103,11 +103,6 @@ public class MotorcycleFlagEncoder extends CarFlagEncoder {
         defaultSpeedMap.put("track", 15);
     }
 
-    @Override
-    public int getVersion() {
-        return 3;
-    }
-
     /**
      * Define the place of the speedBits in the edge flags for car.
      */

--- a/core/src/main/java/com/graphhopper/routing/util/MountainBikeFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/MountainBikeFlagEncoder.java
@@ -145,11 +145,6 @@ public class MountainBikeFlagEncoder extends BikeCommonFlagEncoder {
     }
 
     @Override
-    public int getVersion() {
-        return 2;
-    }
-
-    @Override
     void collect(ReaderWay way, double wayTypeSpeed, TreeMap<Double, Integer> weightToPrioMap) {
         super.collect(way, wayTypeSpeed, weightToPrioMap);
 

--- a/core/src/main/java/com/graphhopper/routing/util/RacingBikeFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/RacingBikeFlagEncoder.java
@@ -157,11 +157,6 @@ public class RacingBikeFlagEncoder extends BikeCommonFlagEncoder {
     }
 
     @Override
-    public int getVersion() {
-        return 2;
-    }
-
-    @Override
     public String toString() {
         return "racingbike";
     }

--- a/core/src/main/java/com/graphhopper/routing/util/WheelchairFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/WheelchairFlagEncoder.java
@@ -106,11 +106,6 @@ public class WheelchairFlagEncoder extends FootFlagEncoder {
         speedTwoDirections = true;
     }
 
-    @Override
-    public int getVersion() {
-        return 1;
-    }
-
     /**
      * Avoid some more ways than for pedestrian like hiking trails.
      */

--- a/core/src/main/java/com/graphhopper/storage/StorableProperties.java
+++ b/core/src/main/java/com/graphhopper/storage/StorableProperties.java
@@ -169,9 +169,6 @@ public class StorableProperties implements Storable<StorableProperties> {
 
         if (!check("shortcuts", Constants.VERSION_SHORTCUT, silent))
             return false;
-
-        // The check for the encoder version is done in EncoderManager, as this class does not know about the
-        // registered encoders and their version
         return true;
     }
 

--- a/core/src/main/java/com/graphhopper/util/Constants.java
+++ b/core/src/main/java/com/graphhopper/util/Constants.java
@@ -67,7 +67,7 @@ public class Constants {
     private static final int JVM_MINOR_VERSION;
 
     public static final int VERSION_NODE = 5;
-    public static final int VERSION_EDGE = 18;
+    public static final int VERSION_EDGE = 19;
     public static final int VERSION_SHORTCUT = 7;
     public static final int VERSION_GEOMETRY = 4;
     public static final int VERSION_LOCATION_IDX = 4;

--- a/core/src/test/java/com/graphhopper/reader/osm/GraphHopperOSMTest.java
+++ b/core/src/test/java/com/graphhopper/reader/osm/GraphHopperOSMTest.java
@@ -532,27 +532,6 @@ public class GraphHopperOSMTest {
         } catch (Exception ex) {
             assertTrue(ex.getMessage().startsWith("Encoded values do not match"), ex.getMessage());
         }
-
-        // different version for car should fail
-        instance = new GraphHopper();
-        instance.getEncodingManagerBuilder().add(new FootFlagEncoder()).
-                add(new CarFlagEncoder() {
-                    @Override
-                    public int getVersion() {
-                        return 0;
-                    }
-                });
-        instance.init(new GraphHopperConfig().
-                putObject("datareader.file", testOsm3).
-                putObject("datareader.dataaccess", "RAM").
-                setProfiles(Collections.singletonList(new Profile("car").setVehicle("car").setWeighting("fastest")))).
-                setOSMFile(testOsm3);
-        try {
-            instance.load(ghLoc);
-            fail();
-        } catch (Exception ex) {
-            assertTrue(ex.getMessage().startsWith("Encoding does not match"), ex.getMessage());
-        }
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/routing/util/EncodingManagerTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/EncodingManagerTest.java
@@ -83,16 +83,11 @@ public class EncodingManagerTest {
     }
 
     @Test
-    public void testToDetailsStringIncludesEncoderVersionNumber() {
+    public void testToDetailsString() {
         FlagEncoder encoder = new AbstractFlagEncoder(1, 2.0, 0) {
             @Override
             public TransportationMode getTransportationMode() {
                 return TransportationMode.BIKE;
-            }
-
-            @Override
-            public int getVersion() {
-                return 10;
             }
 
             @Override
@@ -118,7 +113,7 @@ public class EncodingManagerTest {
 
         EncodingManager subject = EncodingManager.create(encoder);
 
-        assertEquals("new_encoder|my_properties|version=10", subject.toFlagEncodersAsString());
+        assertEquals("new_encoder|my_properties", subject.toFlagEncodersAsString());
     }
 
     @Test


### PR DESCRIPTION
We do not need to keep track of the versions in that much detail, base graph's version (nodes, edges, geometry etc.) should be enough. Also we want to get rid of `FlagEncoder` anyway. 
