### PR TITLE
Move landmark splitting and spatial rule border parsing from web-app into core

### DIFF
--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -17,6 +17,9 @@
  */
 package com.graphhopper;
 
+import com.bedatadriven.jackson.datatype.jts.JtsModule;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.graphhopper.config.CHProfile;
 import com.graphhopper.config.LMProfile;
 import com.graphhopper.config.Profile;
@@ -40,6 +43,7 @@ import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.routing.util.FlagEncoderFactory;
 import com.graphhopper.routing.util.parsers.DefaultTagParserFactory;
 import com.graphhopper.routing.util.parsers.TagParserFactory;
+import com.graphhopper.routing.util.spatialrules.SpatialRuleLookupHelper;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.routing.weighting.custom.CustomProfile;
 import com.graphhopper.routing.weighting.custom.CustomWeighting;
@@ -51,11 +55,19 @@ import com.graphhopper.util.Parameters.CH;
 import com.graphhopper.util.Parameters.Landmark;
 import com.graphhopper.util.Parameters.Routing;
 import com.graphhopper.util.details.PathDetailsBuilderFactory;
+import com.graphhopper.util.shapes.BBox;
+import org.locationtech.jts.geom.Envelope;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.text.DateFormat;
 import java.util.*;
 
@@ -436,6 +448,13 @@ public class GraphHopper implements GraphHopperAPI {
         sortGraph = ghConfig.getBool("graph.do_sort", sortGraph);
         removeZipped = ghConfig.getBool("graph.remove_zipped", removeZipped);
 
+        if (!ghConfig.getString("spatial_rules.location", "").isEmpty())
+            throw new RuntimeException("spatial_rules.location has been deprecated. Please use spatial_rules.borders_directory instead.");
+
+        String spatialRuleBordersDirLocation = ghConfig.getString("spatial_rules.borders_directory", "");
+        if (!spatialRuleBordersDirLocation.isEmpty())
+            setupCountrySpatialRules(ghConfig, spatialRuleBordersDirLocation);
+
         if (encodingManager != null)
             throw new IllegalStateException("Cannot call init twice. EncodingManager was already initialized.");
 
@@ -487,6 +506,26 @@ public class GraphHopper implements GraphHopperAPI {
         routerConfig.setActiveLandmarkCount(activeLandmarkCount);
 
         return this;
+    }
+
+    private void setupCountrySpatialRules(GraphHopperConfig ghConfig, String spatialRuleBordersDirLocation) {
+        final Envelope maxBounds = BBox.toEnvelope(BBox.parseBBoxString(ghConfig.getString("spatial_rules.max_bbox", "-180, 180, -90, 90")));
+        final Path bordersDirectory = Paths.get(spatialRuleBordersDirLocation);
+        List<JsonFeatureCollection> jsonFeatureCollections = new ArrayList<>();
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(bordersDirectory, "*.{geojson,json}")) {
+            ObjectMapper objectMapper = new ObjectMapper();
+            objectMapper.registerModule(new JtsModule());
+            objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+            for (Path borderFile : stream) {
+                try (BufferedReader reader = Files.newBufferedReader(borderFile, StandardCharsets.UTF_8)) {
+                    JsonFeatureCollection jsonFeatureCollection = objectMapper.readValue(reader, JsonFeatureCollection.class);
+                    jsonFeatureCollections.add(jsonFeatureCollection);
+                }
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        SpatialRuleLookupHelper.buildAndInjectCountrySpatialRules(this, maxBounds, jsonFeatureCollections);
     }
 
     private EncodingManager buildEncodingManager(GraphHopperConfig ghConfig) {

--- a/core/src/main/java/com/graphhopper/reader/osm/GraphHopperOSM.java
+++ b/core/src/main/java/com/graphhopper/reader/osm/GraphHopperOSM.java
@@ -26,13 +26,4 @@ import com.graphhopper.util.JsonFeatureCollection;
  */
 @Deprecated
 public class GraphHopperOSM extends GraphHopper {
-
-    public GraphHopperOSM() {
-        this(null);
-    }
-
-    public GraphHopperOSM(JsonFeatureCollection landmarkSplittingFeatureCollection) {
-        super(landmarkSplittingFeatureCollection);
-    }
-
 }

--- a/core/src/main/java/com/graphhopper/routing/util/spatialrules/SpatialRuleLookupHelper.java
+++ b/core/src/main/java/com/graphhopper/routing/util/spatialrules/SpatialRuleLookupHelper.java
@@ -80,15 +80,10 @@ public class SpatialRuleLookupHelper {
                 JSON_ID_FIELD, new CountriesSpatialRuleFactory(), maxBounds);
         logger.info("Set spatial rule lookup with {} rules", index.getRules().size());
         final TagParserFactory oldTPF = graphHopper.getTagParserFactory();
-        graphHopper.setTagParserFactory(new TagParserFactory() {
-
-            @Override
-            public TagParser create(String name, PMap configuration) {
-                if (name.equals(Country.KEY))
-                    return new SpatialRuleParser(index, Country.create());
-
-                return oldTPF.create(name, configuration);
-            }
+        graphHopper.setTagParserFactory((name, configuration) -> {
+            if (name.equals(Country.KEY))
+                return new SpatialRuleParser(index, Country.create());
+            return oldTPF.create(name, configuration);
         });
     }
 }

--- a/docs/core/spatial-rules.md
+++ b/docs/core/spatial-rules.md
@@ -8,11 +8,11 @@ different [speeds](https://wiki.openstreetmap.org/wiki/OSM_tags_for_routing/Maxs
 
 ## Enabling Rules
 
-I you have a working GraphHopper setup it is easy to enable Spatial Rules, **but they only work with the DataFlagEncoder**.
-We provide a set of approximate country borders, within the GraphHopper repository. If you need exact borders you can
-get the exact borders from [here](https://github.com/datasets/geo-countries). Go to your
-`config.yml` file and
-uncommend the line: `spatial_rules.borders_directory` and point it to the directory where your rules are. You need to re-import your graph after that.
+I you have a working GraphHopper setup it is easy to enable Spatial Rules, **but they only work with the
+DataFlagEncoder**. We provide a set of approximate country borders, within the GraphHopper repository. If you need exact
+borders you can get the exact borders from [here](https://github.com/datasets/geo-countries). Go to your
+`config.yml` file and uncomment the line: `spatial_rules.borders_directory` and point it to the directory where your
+rules are. You need to re-import your graph after that.
 
 ## Creating Rules
 

--- a/web-bundle/src/main/java/com/graphhopper/http/GraphHopperBundle.java
+++ b/web-bundle/src/main/java/com/graphhopper/http/GraphHopperBundle.java
@@ -232,7 +232,7 @@ public class GraphHopperBundle implements ConfiguredBundle<GraphHopperBundleConf
         // a single entry.
         environment.jersey().register(new IllegalArgumentExceptionMapper());
 
-        final GraphHopperManaged graphHopperManaged = new GraphHopperManaged(configuration.getGraphHopperConfiguration(), environment.getObjectMapper());
+        final GraphHopperManaged graphHopperManaged = new GraphHopperManaged(configuration.getGraphHopperConfiguration());
         environment.lifecycle().manage(graphHopperManaged);
         final GraphHopper graphHopper = graphHopperManaged.getGraphHopper();
         environment.jersey().register(new AbstractBinder() {

--- a/web/src/main/java/com/graphhopper/http/cli/ImportCommand.java
+++ b/web/src/main/java/com/graphhopper/http/cli/ImportCommand.java
@@ -32,7 +32,7 @@ public class ImportCommand extends ConfiguredCommand<GraphHopperServerConfigurat
 
     @Override
     protected void run(Bootstrap<GraphHopperServerConfiguration> bootstrap, Namespace namespace, GraphHopperServerConfiguration configuration) {
-        final GraphHopperManaged graphHopper = new GraphHopperManaged(configuration.getGraphHopperConfiguration(), bootstrap.getObjectMapper());
+        final GraphHopperManaged graphHopper = new GraphHopperManaged(configuration.getGraphHopperConfiguration());
         graphHopper.getGraphHopper().importAndClose();
     }
 


### PR DESCRIPTION
After #2354 we can now move some of the code in `GraphHopperManaged` closer to where it is actually used. Particularly we were parsing the landmark splitting borders geojson and spatial rule borders geojson files in `GraphHopperManaged` and 'injected' this code into `GraphHopper`. But the only reason we did this was that we weren't able to read geojson in core.

Also for #2353 I'd like to read the countries.geojson and other custom area geojson files directly from the GraphHopper class.

Related to #2365 