### PR TITLE
Avoid "bicycle=use_sidepath" ways instead of preferring it.

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
@@ -472,12 +472,13 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
             weightToPrioMap.put(100d, PREFER.getValue());
         }
 
+        if (way.hasTag("bicycle", "use_sidepath")) {
+            weightToPrioMap.put(100d, REACH_DESTINATION.getValue());
+        }
+
         if (pushingSectionsHighways.contains(highway)
                 || "parking_aisle".equals(service)) {
             int pushingSectionPrio = SLIGHT_AVOID.getValue();
-            if (way.hasTag("bicycle", "use_sidepath")) {
-                pushingSectionPrio = PREFER.getValue();
-            }
             if (way.hasTag("bicycle", "yes") || way.hasTag("bicycle", "permissive"))
                 pushingSectionPrio = PREFER.getValue();
             if (way.hasTag("bicycle", "designated") || way.hasTag("bicycle", "official"))

--- a/core/src/test/java/com/graphhopper/routing/util/BikeFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/BikeFlagEncoderTest.java
@@ -227,7 +227,7 @@ public class BikeFlagEncoderTest extends AbstractBikeFlagEncoderTester {
         way.setTag("highway", "residential");
         way.setTag("bicycle", "use_sidepath");
         assertEquals(18, encoder.getSpeed(way));
-        assertPriority(PREFER.getValue(), way);
+        assertPriority(REACH_DESTINATION.getValue(), way);
 
         way.clearTags();
         way.setTag("highway", "steps");


### PR DESCRIPTION
Fixes #1454.
Prefering ways with "bicycle=use_sidepath" is the opposite to what is correct for bicycles. Now we are avoiding these ways.
See https://wiki.openstreetmap.org/wiki/Tag:bicycle%3Duse_sidepath.