### PR TITLE
Update Apache Commons Compress

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-compress</artifactId>
-                <version>1.19</version>
+                <version>1.21</version>
             </dependency>
             <dependency>
                 <groupId>log4j</groupId>


### PR DESCRIPTION
This PR updates the used version of Apache Commons Compress. There are security vulnerabilities with 1.19: 
- https://nvd.nist.gov/vuln/detail/CVE-2021-35515
- https://nvd.nist.gov/vuln/detail/CVE-2021-35516
- https://nvd.nist.gov/vuln/detail/CVE-2021-35517
- https://nvd.nist.gov/vuln/detail/CVE-2021-36090

Probably not critical as we only use this for OSM files with bzip2 compression.