### PR TITLE
Refactor elevation provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - PointList#getSize() -> PointList#size()
 - migrated tests from junit 4 to 5 (#2324)
 - barriers do no longer block by default for car; remove block_barriers config option (see discussion in #2340)
+- ElevationProvider setters relative to file operations have been moved to TileBasedElevationProvider. ElevationProviders now accept an OSM node (#2381)
 
 ### 3.0 [17 May 2021]
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -30,6 +30,7 @@ Here is an overview:
  * fbonzon, several UI improvements like #615
  * florent-morel, improvements regarding fords, #320
  * fredao, translations
+ * gberaudo, improvements regarding elevation
  * GProbo, fixes like #2241
  * HarelM, improvements regarding elevation
  * HelgeKrueger, modularization of javascript, #590

--- a/core/src/main/java/com/graphhopper/reader/dem/AbstractSRTMElevationProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/AbstractSRTMElevationProvider.java
@@ -33,7 +33,7 @@ import java.net.SocketTimeoutException;
  *
  * @author Robin Boldt
  */
-public abstract class AbstractSRTMElevationProvider extends AbstractElevationProvider {
+public abstract class AbstractSRTMElevationProvider extends TileBasedElevationProvider {
 
     private static final BitUtil BIT_UTIL = BitUtil.BIG;
     private final int DEFAULT_WIDTH;

--- a/core/src/main/java/com/graphhopper/reader/dem/AbstractTiffElevationProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/AbstractTiffElevationProvider.java
@@ -32,7 +32,7 @@ import java.util.Map;
  *
  * @author Robin Boldt
  */
-public abstract class AbstractTiffElevationProvider extends AbstractElevationProvider {
+public abstract class AbstractTiffElevationProvider extends TileBasedElevationProvider {
     private final Map<String, HeightTile> cacheData = new HashMap<>();
     final double precision = 1e7;
 

--- a/core/src/main/java/com/graphhopper/reader/dem/ElevationProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/ElevationProvider.java
@@ -18,7 +18,6 @@
 package com.graphhopper.reader.dem;
 
 import com.graphhopper.reader.ReaderNode;
-import com.graphhopper.storage.DAType;
 
 /**
  * @author Peter Karich
@@ -31,25 +30,7 @@ public interface ElevationProvider {
         }
 
         @Override
-        public ElevationProvider setBaseURL(String baseURL) {
-            return this;
-        }
-
-        @Override
-        public ElevationProvider setDAType(DAType daType) {
-            return this;
-        }
-
-        @Override
         public void release() {
-        }
-
-        @Override
-        public void setAutoRemoveTemporaryFiles(boolean autoRemoveTemporary) {
-        }
-
-        @Override
-        public void setInterpolate(boolean interpolate) {
         }
 
         @Override
@@ -72,24 +53,6 @@ public interface ElevationProvider {
     }
 
     /**
-     * Specifies the service URL where to download the elevation data. An empty string should set it
-     * to the default URL. Default is a provider-dependent URL which should work out of the box.
-     */
-    ElevationProvider setBaseURL(String baseURL);
-
-    /**
-     * Set to true if you have a small area and need high speed access. Default is DAType.MMAP
-     */
-    ElevationProvider setDAType(DAType daType);
-
-    /**
-     * Configuration option to use bilinear interpolation to find the elevation at a point from the
-     * surrounding elevation points. Has only an effect if called before the first getEle call.
-     * Turned off by default.
-     */
-    void setInterpolate(boolean interpolate);
-
-    /**
      * Returns true if bilinear interpolation is enabled.
      */
     boolean getInterpolate();
@@ -98,11 +61,4 @@ public interface ElevationProvider {
      * Release resources.
      */
     void release();
-
-    /**
-     * Creating temporary files can take a long time as we need to unpack them as well as to fill
-     * our DataAccess object, so this option can be used to disable the default clear mechanism via
-     * specifying 'false'.
-     */
-    void setAutoRemoveTemporaryFiles(boolean autoRemoveTemporary);
 }

--- a/core/src/main/java/com/graphhopper/reader/dem/ElevationProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/ElevationProvider.java
@@ -17,6 +17,7 @@
  */
 package com.graphhopper.reader.dem;
 
+import com.graphhopper.reader.ReaderNode;
 import com.graphhopper.storage.DAType;
 
 /**
@@ -61,6 +62,14 @@ public interface ElevationProvider {
      * @return returns the height in meters or Double.NaN if invalid
      */
     double getEle(double lat, double lon);
+
+    /**
+     * @param node Node to read
+     * @return returns the height in meters or Double.NaN if invalid
+     */
+    default double getEle(ReaderNode node) {
+        return getEle(node.getLat(), node.getLon());
+    }
 
     /**
      * Specifies the service URL where to download the elevation data. An empty string should set it

--- a/core/src/main/java/com/graphhopper/reader/dem/GMTEDProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/GMTEDProvider.java
@@ -17,7 +17,6 @@
  */
 package com.graphhopper.reader.dem;
 
-import com.graphhopper.util.Helper;
 import org.apache.xmlgraphics.image.codec.tiff.TIFFDecodeParam;
 import org.apache.xmlgraphics.image.codec.tiff.TIFFImageDecoder;
 import org.apache.xmlgraphics.image.codec.util.SeekableStream;

--- a/core/src/main/java/com/graphhopper/reader/dem/SRTMGL1Provider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/SRTMGL1Provider.java
@@ -17,8 +17,6 @@
  */
 package com.graphhopper.reader.dem;
 
-import com.graphhopper.util.Helper;
-
 import java.io.*;
 
 import static com.graphhopper.util.Helper.*;

--- a/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
+++ b/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
@@ -527,7 +527,7 @@ public class OSMReader implements TurnCostParser.ExternalInternalMap {
 
         double lat = node.getLat();
         double lon = node.getLon();
-        double ele = eleProvider.getEle(lat, lon);
+        double ele = eleProvider.getEle(node);
         if (nodeType == TOWER_NODE) {
             addTowerNode(node.getId(), lat, lon, ele);
         } else if (nodeType == PILLAR_NODE) {

--- a/core/src/test/java/com/graphhopper/GraphHopperTest.java
+++ b/core/src/test/java/com/graphhopper/GraphHopperTest.java
@@ -22,7 +22,6 @@ import com.graphhopper.config.LMProfile;
 import com.graphhopper.config.Profile;
 import com.graphhopper.json.Statement;
 import com.graphhopper.reader.ReaderWay;
-import com.graphhopper.reader.dem.ElevationProvider;
 import com.graphhopper.reader.dem.SRTMProvider;
 import com.graphhopper.reader.dem.SkadiProvider;
 import com.graphhopper.routing.ev.Subnetwork;
@@ -1095,7 +1094,7 @@ public class GraphHopperTest {
                 setProfiles(new Profile("profile").setVehicle(vehicle).setWeighting(weighting)).
                 setLongEdgeSamplingDistance(30);
 
-        ElevationProvider elevationProvider = new SRTMProvider(DIR);
+        SRTMProvider elevationProvider = new SRTMProvider(DIR);
         elevationProvider.setInterpolate(true);
         hopper.setElevationProvider(elevationProvider);
         hopper.importOrLoad();

--- a/core/src/test/java/com/graphhopper/reader/dem/EdgeSamplingTest.java
+++ b/core/src/test/java/com/graphhopper/reader/dem/EdgeSamplingTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class EdgeSamplingTest {
-    private final ElevationProvider elevation = new AbstractElevationProvider("") {
+    private final ElevationProvider elevation = new TileBasedElevationProvider("") {
         @Override
         public double getEle(double lat, double lon) {
             return 10;


### PR DESCRIPTION
Refactor elevation provider:

- clean up interface;
- add a getEle(node) variant with a default implementation.

Fixes: #2374.
Ping @otbutz, @easbar.

I did not introduce constructor parameters as it was a bit tricky with multiple constructors like in MultiplSourceElevationProvider.
The `AbstractElevationProvider` was alreading containing filesystem related code so I moved the methods there.
I have not renamed `getInterpolate` to `canInterpolate` yet. I will work on it later.

Please let me know your feedback of this PR.