### PR TITLE
Cancel node-based witness searches early -> ~20% faster CH preparation

### DIFF
--- a/core/src/main/java/com/graphhopper/apache/commons/collections/IntFloatBinaryHeap.java
+++ b/core/src/main/java/com/graphhopper/apache/commons/collections/IntFloatBinaryHeap.java
@@ -182,4 +182,8 @@ public class IntFloatBinaryHeap {
     public long getCapacity() {
         return elements.length;
     }
+
+    public long getMemoryUsage() {
+        return elements.length * 4L + keys.length * 4L;
+    }
 }

--- a/core/src/main/java/com/graphhopper/routing/ch/NodeBasedNodeContractor.java
+++ b/core/src/main/java/com/graphhopper/routing/ch/NodeBasedNodeContractor.java
@@ -87,7 +87,7 @@ class NodeBasedNodeContractor implements NodeContractor {
         inEdgeExplorer = null;
         outEdgeExplorer = null;
         existingShortcutExplorer = null;
-        witnessPathSearcher.close();
+        witnessPathSearcher = null;
     }
 
     /**
@@ -232,8 +232,7 @@ class NodeBasedNodeContractor implements NodeContractor {
             }
             // collect outgoing nodes (goal-nodes) only once
             PrepareGraphEdgeIterator outgoingEdges = outEdgeExplorer.setBaseNode(node);
-            // force fresh maps etc as this cannot be determined by from node alone (e.g. same from node but different avoidNode)
-            witnessPathSearcher.clear();
+            witnessPathSearcher.init(fromNode, node);
             degree++;
             while (outgoingEdges.next()) {
                 int toNode = outgoingEdges.getAdjNode();
@@ -248,17 +247,12 @@ class NodeBasedNodeContractor implements NodeContractor {
                 if (Double.isInfinite(existingDirectWeight))
                     continue;
 
-                witnessPathSearcher.setWeightLimit(existingDirectWeight);
-                witnessPathSearcher.setMaxVisitedNodes(maxVisitedNodes);
-                witnessPathSearcher.ignoreNode(node);
-
                 dijkstraSW.start();
                 dijkstraCount++;
-                int endNode = witnessPathSearcher.findEndNode(fromNode, toNode);
+                double maxWeight = witnessPathSearcher.findUpperBoundShortestPathWeight(toNode, existingDirectWeight, maxVisitedNodes);
                 dijkstraSW.stop();
 
-                // compare end node as the limit could force dijkstra to finish earlier
-                if (endNode == toNode && witnessPathSearcher.getWeight(endNode) <= existingDirectWeight)
+                if (maxWeight <= existingDirectWeight)
                     // FOUND witness path, so do not add shortcut
                     continue;
 

--- a/core/src/main/java/com/graphhopper/routing/ch/NodeBasedNodeContractor.java
+++ b/core/src/main/java/com/graphhopper/routing/ch/NodeBasedNodeContractor.java
@@ -249,7 +249,7 @@ class NodeBasedNodeContractor implements NodeContractor {
 
                 dijkstraSW.start();
                 dijkstraCount++;
-                double maxWeight = witnessPathSearcher.findUpperBoundShortestPathWeight(toNode, existingDirectWeight, maxVisitedNodes);
+                double maxWeight = witnessPathSearcher.findUpperBound(toNode, existingDirectWeight, maxVisitedNodes);
                 dijkstraSW.stop();
 
                 if (maxWeight <= existingDirectWeight)

--- a/core/src/test/java/com/graphhopper/routing/ch/NodeBasedWitnessPathSearcherTest.java
+++ b/core/src/test/java/com/graphhopper/routing/ch/NodeBasedWitnessPathSearcherTest.java
@@ -18,95 +18,90 @@
 
 package com.graphhopper.routing.ch;
 
-import com.graphhopper.routing.Dijkstra;
-import com.graphhopper.routing.util.CarFlagEncoder;
-import com.graphhopper.routing.util.EncodingManager;
-import com.graphhopper.routing.util.TraversalMode;
-import com.graphhopper.routing.weighting.ShortestWeighting;
-import com.graphhopper.routing.weighting.Weighting;
-import com.graphhopper.storage.*;
-import com.graphhopper.util.GHUtility;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class NodeBasedWitnessPathSearcherTest {
 
-    private final CarFlagEncoder encoder = new CarFlagEncoder();
-    private final EncodingManager encodingManager = EncodingManager.create(encoder);
-    private final Weighting weighting = new ShortestWeighting(encoder);
-    private final GraphHopperStorage graph = new GraphBuilder(encodingManager).setCHConfigs(CHConfig.nodeBased("profile", weighting)).create();
-    private final CHStorage store = graph.getCHStore();
-    private final CHStorageBuilder chBuilder = new CHStorageBuilder(store);
-
     @Test
-    public void testShortestPathSkipNode() {
-        createExampleGraph();
-        CHPreparationGraph prepareGraph = CHPreparationGraph.nodeBased(graph.getNodes(), graph.getEdges());
-        CHPreparationGraph.buildFromGraph(prepareGraph, graph, weighting);
-        final double normalDist = new Dijkstra(graph, weighting, TraversalMode.NODE_BASED).calcPath(4, 2).getDistance();
-        NodeBasedWitnessPathSearcher algo = new NodeBasedWitnessPathSearcher(prepareGraph);
-
-        setMaxLevelOnAllNodes();
-
-        algo.init(4, 3);
-        double w = algo.findUpperBoundShortestPathWeight(2, 100, Integer.MAX_VALUE);
-        assertTrue(w > normalDist);
-        algo.init(4, 3);
-        assertEquals(Double.MAX_VALUE, algo.findUpperBoundShortestPathWeight(2, 100, 1));
+    void ignoreNode() {
+        //  /- 3 -\
+        // 0 - 1 - 2
+        CHPreparationGraph p = CHPreparationGraph.nodeBased(5, 10);
+        p.addEdge(0, 1, 0, 10, 10);
+        p.addEdge(1, 2, 1, 10, 10);
+        p.addEdge(0, 3, 2, 9, 9);
+        p.addEdge(3, 2, 3, 9, 9);
+        p.prepareForContraction();
+        NodeBasedWitnessPathSearcher algo = new NodeBasedWitnessPathSearcher(p);
+        // just use 1 as ignore node and make sure the witness 0-3-2 is found.
+        algo.init(0, 1);
+        assertEquals(18, algo.findUpperBound(2, 100, Integer.MAX_VALUE));
+        // if we ignore 3 instead we get the longer path
+        algo.init(0, 3);
+        assertEquals(20, algo.findUpperBound(2, 100, Integer.MAX_VALUE));
+        assertEquals(2, algo.getSettledNodes());
     }
 
     @Test
-    public void testShortestPathSkipNode2() {
-        createExampleGraph();
-        CHPreparationGraph prepareGraph = CHPreparationGraph.nodeBased(graph.getNodes(), graph.getEdges());
-        CHPreparationGraph.buildFromGraph(prepareGraph, graph, weighting);
-        final double normalDist = new Dijkstra(graph, weighting, TraversalMode.NODE_BASED).calcPath(4, 2).getDistance();
-        assertEquals(3, normalDist, 1e-5);
-        NodeBasedWitnessPathSearcher algo = new NodeBasedWitnessPathSearcher(prepareGraph);
+    void acceptedWeight() {
+        //  /-----------\
+        // 0 - 1 - ... - 5
+        CHPreparationGraph p = CHPreparationGraph.nodeBased(10, 10);
+        p.addEdge(0, 5, 0, 10, 10);
+        for (int i = 0; i < 5; i++)
+            p.addEdge(i, i + 1, i + 1, 1, 1);
+        p.prepareForContraction();
+        NodeBasedWitnessPathSearcher algo = new NodeBasedWitnessPathSearcher(p);
+        algo.init(0, -1);
+        // here we set acceptable weight to 100, so even the suboptimal path 0-5 is 'good enough' for us and the search
+        // stops as soon as 0-5 has been discovered
+        assertEquals(10, algo.findUpperBound(5, 100, Integer.MAX_VALUE));
+        assertEquals(1, algo.getSettledNodes());
+        // .. repeating this over and over does not change continue the search
+        assertEquals(10, algo.findUpperBound(5, 100, Integer.MAX_VALUE));
+        assertEquals(10, algo.findUpperBound(5, 100, Integer.MAX_VALUE));
+        assertEquals(10, algo.findUpperBound(5, 100, Integer.MAX_VALUE));
+        assertEquals(1, algo.getSettledNodes());
 
-        setMaxLevelOnAllNodes();
-
-        algo.init(4, 3);
-        assertEquals(4, algo.findUpperBoundShortestPathWeight(2, 10, Integer.MAX_VALUE));
-        assertEquals(4, algo.findUpperBoundShortestPathWeight(1, 10, Integer.MAX_VALUE));
+        // if we lower our requirement we enforce a longer search and find the actual shortest path
+        algo.init(0, -1);
+        assertEquals(5, algo.findUpperBound(5, 8, Integer.MAX_VALUE));
+        // if we lower it further (below the shortest path weight) we might not find the shortest path and get the
+        // sup optimal weight again. however, we know for sure that there is no path with weight <= 1.
+        algo.init(0, -1);
+        assertEquals(10, algo.findUpperBound(5, 1, Integer.MAX_VALUE));
+        assertEquals(2, algo.getSettledNodes());
     }
 
     @Test
-    public void testShortestPathLimit() {
-        createExampleGraph();
-        CHPreparationGraph prepareGraph = CHPreparationGraph.nodeBased(graph.getNodes(), graph.getEdges());
-        CHPreparationGraph.buildFromGraph(prepareGraph, graph, weighting);
-        NodeBasedWitnessPathSearcher algo = new NodeBasedWitnessPathSearcher(prepareGraph);
-
-        setMaxLevelOnAllNodes();
-        algo.init(4, 0);
-        assertEquals(Double.MAX_VALUE, algo.findUpperBoundShortestPathWeight(1, 2, Integer.MAX_VALUE));
-//        algo.ignoreNode(0);
-//        algo.setWeightLimit(2);
-//        int endNode = algo.findEndNode(4, 1);
-//         did not reach endNode
-//        assertNotEquals(1, endNode);
+    void settledNodes() {
+        //  /-----------\
+        // 0 - 1 - ... - 5
+        CHPreparationGraph p = CHPreparationGraph.nodeBased(10, 10);
+        p.addEdge(0, 5, 0, 10, 10);
+        for (int i = 0; i < 5; i++)
+            p.addEdge(i, i + 1, i + 1, 1, 1);
+        p.prepareForContraction();
+        NodeBasedWitnessPathSearcher algo = new NodeBasedWitnessPathSearcher(p);
+        algo.init(0, -1);
+        assertEquals(5, algo.findUpperBound(5, 5, Integer.MAX_VALUE));
+        assertEquals(5, algo.getSettledNodes());
+        algo.init(0, -1);
+        assertEquals(10, algo.findUpperBound(5, 5, 2));
+        assertEquals(2, algo.getSettledNodes());
+        algo.init(0, -1);
+        assertEquals(Double.POSITIVE_INFINITY, algo.findUpperBound(5, 5, 0));
+        assertEquals(0, algo.getSettledNodes());
+        // repeating the search does not change the number of settled nodes
+        algo.init(0, -1);
+        assertEquals(10, algo.findUpperBound(5, 5, 2));
+        assertEquals(2, algo.getSettledNodes());
+        assertEquals(10, algo.findUpperBound(5, 5, 2));
+        assertEquals(10, algo.findUpperBound(5, 5, 2));
+        assertEquals(10, algo.findUpperBound(5, 5, 2));
+        assertEquals(2, algo.getSettledNodes());
     }
 
-    private void createExampleGraph() {
-        //5-1-----2
-        //   \ __/|
-        //    0   |
-        //   /    |
-        //  4-----3
-        //
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(1));
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 2).setDistance(1));
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 4).setDistance(3));
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(3));
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 3).setDistance(1));
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 3).setDistance(2));
-        GHUtility.setSpeed(60, true, true, encoder, graph.edge(5, 1).setDistance(2));
-        graph.freeze();
-    }
-
-    private void setMaxLevelOnAllNodes() {
-        chBuilder.setLevelForAllNodes(store.getNodes());
-    }
 }

--- a/core/src/test/java/com/graphhopper/routing/ch/NodeBasedWitnessPathSearcherTest.java
+++ b/core/src/test/java/com/graphhopper/routing/ch/NodeBasedWitnessPathSearcherTest.java
@@ -49,15 +49,11 @@ class NodeBasedWitnessPathSearcherTest {
 
         setMaxLevelOnAllNodes();
 
-        algo.ignoreNode(3);
-        algo.setWeightLimit(100);
-        int nodeEntry = algo.findEndNode(4, 2);
-        assertTrue(algo.getWeight(nodeEntry) > normalDist);
-
-        algo.clear();
-        algo.setMaxVisitedNodes(1);
-        nodeEntry = algo.findEndNode(4, 2);
-        assertEquals(-1, nodeEntry);
+        algo.init(4, 3);
+        double w = algo.findUpperBoundShortestPathWeight(2, 100, Integer.MAX_VALUE);
+        assertTrue(w > normalDist);
+        algo.init(4, 3);
+        assertEquals(Double.MAX_VALUE, algo.findUpperBoundShortestPathWeight(2, 100, 1));
     }
 
     @Test
@@ -71,13 +67,9 @@ class NodeBasedWitnessPathSearcherTest {
 
         setMaxLevelOnAllNodes();
 
-        algo.ignoreNode(3);
-        algo.setWeightLimit(10);
-        int nodeEntry = algo.findEndNode(4, 2);
-        assertEquals(4, algo.getWeight(nodeEntry), 1e-5);
-
-        nodeEntry = algo.findEndNode(4, 1);
-        assertEquals(4, algo.getWeight(nodeEntry), 1e-5);
+        algo.init(4, 3);
+        assertEquals(4, algo.findUpperBoundShortestPathWeight(2, 10, Integer.MAX_VALUE));
+        assertEquals(4, algo.findUpperBoundShortestPathWeight(1, 10, Integer.MAX_VALUE));
     }
 
     @Test
@@ -88,12 +80,13 @@ class NodeBasedWitnessPathSearcherTest {
         NodeBasedWitnessPathSearcher algo = new NodeBasedWitnessPathSearcher(prepareGraph);
 
         setMaxLevelOnAllNodes();
-
-        algo.ignoreNode(0);
-        algo.setWeightLimit(2);
-        int endNode = algo.findEndNode(4, 1);
-        // did not reach endNode
-        assertNotEquals(1, endNode);
+        algo.init(4, 0);
+        assertEquals(Double.MAX_VALUE, algo.findUpperBoundShortestPathWeight(1, 2, Integer.MAX_VALUE));
+//        algo.ignoreNode(0);
+//        algo.setWeightLimit(2);
+//        int endNode = algo.findEndNode(4, 1);
+//         did not reach endNode
+//        assertNotEquals(1, endNode);
     }
 
     private void createExampleGraph() {


### PR DESCRIPTION
Any path with equal or smaller weight than the path via the contracted node serves as witness. Therefore we can cancel the witness search as soon as we found such a path and do not have to continue the search until we found the actual shortest path.