### PR TITLE
Remove EncodingManager from BaseGraph, cleanup nodes and edges header

### DIFF
--- a/core/src/main/java/com/graphhopper/storage/GraphHopperStorage.java
+++ b/core/src/main/java/com/graphhopper/storage/GraphHopperStorage.java
@@ -69,7 +69,7 @@ public final class GraphHopperStorage implements GraphStorage, Graph {
         this.dir = dir;
         this.properties = new StorableProperties(dir);
         this.segmentSize = segmentSize;
-        baseGraph = new BaseGraph(dir, encodingManager, withElevation, withTurnCosts, segmentSize);
+        baseGraph = new BaseGraph(dir, encodingManager.getIntsForFlags(), withElevation, withTurnCosts, segmentSize);
         chEntries = new ArrayList<>();
     }
 

--- a/core/src/main/java/com/graphhopper/util/Constants.java
+++ b/core/src/main/java/com/graphhopper/util/Constants.java
@@ -66,8 +66,8 @@ public class Constants {
     private static final int JVM_MAJOR_VERSION;
     private static final int JVM_MINOR_VERSION;
 
-    public static final int VERSION_NODE = 5;
-    public static final int VERSION_EDGE = 19;
+    public static final int VERSION_NODE = 6;
+    public static final int VERSION_EDGE = 20;
     public static final int VERSION_SHORTCUT = 7;
     public static final int VERSION_GEOMETRY = 4;
     public static final int VERSION_LOCATION_IDX = 4;


### PR DESCRIPTION
Looks like we do not need the EncodingManager in BaseGraph, see comments inline