### PR TITLE
Add range check for node access

### DIFF
--- a/core/src/main/java/com/graphhopper/storage/BaseGraph.java
+++ b/core/src/main/java/com/graphhopper/storage/BaseGraph.java
@@ -112,12 +112,12 @@ class BaseGraph implements Graph {
         return edgeId < edgeCount && edgeId >= 0;
     }
 
-    private void setEdgeRef(long nodeId, int edgeId) {
-        nodes.setInt(nodeId * nodeEntryBytes + N_EDGE_REF, edgeId);
+    private void setEdgeRef(int nodeId, int edgeId) {
+        nodes.setInt(toNodePointer(nodeId) + N_EDGE_REF, edgeId);
     }
 
-    int getEdgeRef(long nodeId) {
-        return nodes.getInt(nodeId * nodeEntryBytes + N_EDGE_REF);
+    int getEdgeRef(int nodeId) {
+        return nodes.getInt(toNodePointer(nodeId) + N_EDGE_REF);
     }
 
     private int getNodeA(long edgePointer) {
@@ -137,8 +137,14 @@ class BaseGraph implements Graph {
     }
 
     private long toPointer(int edgeId) {
-        assert isInBounds(edgeId) : "edgeId " + edgeId + " not in bounds [0," + edgeCount + ")";
+        if (!isInBounds(edgeId)) throw new AssertionError("edgeId " + edgeId + " not in bounds [0," + edgeCount + "[");
         return (long) edgeId * edgeEntryBytes;
+    }
+
+    long toNodePointer(int nodeId) {
+        if (nodeId < 0 || nodeId >= nodeCount)
+            throw new IllegalArgumentException("Illegal node: " + nodeId + ", must be in [0," + nodeCount + "[");
+        return (long) nodeId * nodeEntryBytes;
     }
 
     private int getOtherNode(int nodeThis, long edgePointer) {

--- a/core/src/main/java/com/graphhopper/storage/BaseGraph.java
+++ b/core/src/main/java/com/graphhopper/storage/BaseGraph.java
@@ -133,13 +133,13 @@ class BaseGraph implements Graph {
 
     long toNodePointer(int node) {
         if (node < 0 || node >= nodeCount)
-            throw new IllegalArgumentException("node: " + node + ", must be in [0," + nodeCount + "[");
+            throw new IllegalArgumentException("node: " + node + " out of bounds [0," + nodeCount + "[");
         return (long) node * nodeEntryBytes;
     }
 
     private long toEdgePointer(int edge) {
         if (edge < 0 || edge >= edgeCount)
-            throw new IllegalArgumentException("edge " + edge + " not in bounds [0," + edgeCount + "[");
+            throw new IllegalArgumentException("edge: " + edge + " out of bounds [0," + edgeCount + "[");
         return (long) edge * edgeEntryBytes;
     }
 
@@ -951,7 +951,7 @@ class BaseGraph implements Graph {
          */
         final boolean init(int edgeId, int expectedAdjNode) {
             if (edgeId < 0 || edgeId >= baseGraph.edgeCount)
-                throw new IllegalArgumentException("edge must be in bounds: [0," + baseGraph.edgeCount + "[");
+                throw new IllegalArgumentException("edge: " + edgeId + " out of bounds: [0," + baseGraph.edgeCount + "[");
             this.edgeId = edgeId;
             edgePointer = baseGraph.toEdgePointer(edgeId);
             baseNode = baseGraph.getNodeA(edgePointer);

--- a/core/src/main/java/com/graphhopper/storage/BaseGraph.java
+++ b/core/src/main/java/com/graphhopper/storage/BaseGraph.java
@@ -20,7 +20,6 @@ package com.graphhopper.storage;
 import com.graphhopper.routing.ev.*;
 import com.graphhopper.routing.util.AllEdgesIterator;
 import com.graphhopper.routing.util.EdgeFilter;
-import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.search.StringIndex;
 import com.graphhopper.util.*;
@@ -108,10 +107,6 @@ class BaseGraph implements Graph {
         }
     }
 
-    boolean isInBounds(int edgeId) {
-        return edgeId < edgeCount && edgeId >= 0;
-    }
-
     private void setEdgeRef(int nodeId, int edgeId) {
         nodes.setInt(toNodePointer(nodeId) + N_EDGE_REF, edgeId);
     }
@@ -136,15 +131,16 @@ class BaseGraph implements Graph {
         return edges.getInt(edgePointer + E_LINKB);
     }
 
-    private long toPointer(int edgeId) {
-        if (!isInBounds(edgeId)) throw new AssertionError("edgeId " + edgeId + " not in bounds [0," + edgeCount + "[");
-        return (long) edgeId * edgeEntryBytes;
+    long toNodePointer(int node) {
+        if (node < 0 || node >= nodeCount)
+            throw new IllegalArgumentException("node: " + node + ", must be in [0," + nodeCount + "[");
+        return (long) node * nodeEntryBytes;
     }
 
-    long toNodePointer(int nodeId) {
-        if (nodeId < 0 || nodeId >= nodeCount)
-            throw new IllegalArgumentException("Illegal node: " + nodeId + ", must be in [0," + nodeCount + "[");
-        return (long) nodeId * nodeEntryBytes;
+    private long toEdgePointer(int edge) {
+        if (edge < 0 || edge >= edgeCount)
+            throw new IllegalArgumentException("edge " + edge + " not in bounds [0," + edgeCount + "[");
+        return (long) edge * edgeEntryBytes;
     }
 
     private int getOtherNode(int nodeThis, long edgePointer) {
@@ -398,7 +394,7 @@ class BaseGraph implements Graph {
         System.out.format(Locale.ROOT, formatEdges, "#", "E_NODEA", "E_NODEB", "E_LINKA", "E_LINKB", "E_FLAGS", "E_DIST");
         IntsRef intsRef = new IntsRef(intsForFlags);
         for (int i = 0; i < Math.min(edgeCount, printMax); ++i) {
-            long edgePointer = toPointer(i);
+            long edgePointer = toEdgePointer(i);
             readFlags(edgePointer, intsRef);
             System.out.format(Locale.ROOT, formatEdges, i,
                     getNodeA(edgePointer),
@@ -500,7 +496,7 @@ class BaseGraph implements Graph {
      * @return the updated iterator the properties where copied to.
      */
     EdgeIteratorState copyProperties(EdgeIteratorState from, EdgeIteratorStateImpl to) {
-        long edgePointer = toPointer(to.getEdge());
+        long edgePointer = toEdgePointer(to.getEdge());
         writeFlags(edgePointer, from.getFlags());
 
         // copy the rest with higher level API
@@ -534,7 +530,7 @@ class BaseGraph implements Graph {
      */
     final int internalEdgeAdd(int newEdgeId, int nodeA, int nodeB) {
         writeEdge(newEdgeId, nodeA, nodeB);
-        long edgePointer = toPointer(newEdgeId);
+        long edgePointer = toEdgePointer(newEdgeId);
 
         int edge = getEdgeRef(nodeA);
         if (edge > EdgeIterator.NO_EDGE)
@@ -557,7 +553,7 @@ class BaseGraph implements Graph {
         if (!EdgeIterator.Edge.isValid(edgeId))
             throw new IllegalStateException("Cannot write edge with illegal ID:" + edgeId + "; nodeA:" + nodeA + ", nodeB:" + nodeB);
 
-        long edgePointer = toPointer(edgeId);
+        long edgePointer = toEdgePointer(edgeId);
         edges.setInt(edgePointer + E_NODEA, nodeA);
         edges.setInt(edgePointer + E_NODEB, nodeB);
         edges.setInt(edgePointer + E_LINKA, EdgeIterator.NO_EDGE);
@@ -587,9 +583,6 @@ class BaseGraph implements Graph {
 
     @Override
     public EdgeIteratorState getEdgeIteratorState(int edgeId, int adjNode) {
-        if (!isInBounds(edgeId))
-            throw new IllegalStateException("edgeId " + edgeId + " out of bounds, edgeCount: " + edgeCount);
-        checkAdjNodeBounds(adjNode);
         EdgeIteratorStateImpl edge = new EdgeIteratorStateImpl(this);
         if (edge.init(edgeId, adjNode))
             return edge;
@@ -636,13 +629,13 @@ class BaseGraph implements Graph {
 
     @Override
     public int getOtherNode(int edge, int node) {
-        long edgePointer = toPointer(edge);
+        long edgePointer = toEdgePointer(edge);
         return getOtherNode(node, edgePointer);
     }
 
     @Override
     public boolean isAdjacentToNode(int edge, int node) {
-        long edgePointer = toPointer(edge);
+        long edgePointer = toEdgePointer(edge);
         return isAdjacentToNode(node, edgePointer);
     }
 
@@ -868,7 +861,7 @@ class BaseGraph implements Graph {
         }
 
         void goToNext() {
-            edgePointer = baseGraph.toPointer(nextEdgeId);
+            edgePointer = baseGraph.toEdgePointer(nextEdgeId);
             edgeId = nextEdgeId;
             int nodeA = baseGraph.getNodeA(edgePointer);
             boolean baseNodeIsNodeA = baseNode == nodeA;
@@ -908,7 +901,7 @@ class BaseGraph implements Graph {
             edgeId++;
             if (edgeId >= baseGraph.edgeCount)
                 return false;
-            edgePointer = baseGraph.toPointer(edgeId);
+            edgePointer = baseGraph.toEdgePointer(edgeId);
             baseNode = baseGraph.getNodeA(edgePointer);
             adjNode = baseGraph.getNodeB(edgePointer);
             freshFlags = false;
@@ -957,10 +950,10 @@ class BaseGraph implements Graph {
          * @return false if the edge has not a node equal to expectedAdjNode
          */
         final boolean init(int edgeId, int expectedAdjNode) {
-            if (!EdgeIterator.Edge.isValid(edgeId))
-                throw new IllegalArgumentException("fetching the edge requires a valid edgeId but was " + edgeId);
+            if (edgeId < 0 || edgeId >= baseGraph.edgeCount)
+                throw new IllegalArgumentException("edge must be in bounds: [0," + baseGraph.edgeCount + "[");
             this.edgeId = edgeId;
-            edgePointer = baseGraph.toPointer(edgeId);
+            edgePointer = baseGraph.toEdgePointer(edgeId);
             baseNode = baseGraph.getNodeA(edgePointer);
             adjNode = baseGraph.getNodeB(edgePointer);
             freshFlags = false;
@@ -985,7 +978,7 @@ class BaseGraph implements Graph {
             if (edgeKey < 0)
                 throw new IllegalArgumentException("edge keys must not be negative, given: " + edgeKey);
             this.edgeId = GHUtility.getEdgeFromEdgeKey(edgeKey);
-            edgePointer = baseGraph.toPointer(edgeId);
+            edgePointer = baseGraph.toEdgePointer(edgeId);
             baseNode = baseGraph.getNodeA(edgePointer);
             adjNode = baseGraph.getNodeB(edgePointer);
             freshFlags = false;

--- a/core/src/main/java/com/graphhopper/storage/GHNodeAccess.java
+++ b/core/src/main/java/com/graphhopper/storage/GHNodeAccess.java
@@ -42,7 +42,7 @@ class GHNodeAccess implements NodeAccess {
     @Override
     public final void setNode(int nodeId, double lat, double lon, double ele) {
         baseGraph.ensureNodeIndex(nodeId);
-        long tmp = (long) nodeId * baseGraph.nodeEntryBytes;
+        long tmp = baseGraph.toNodePointer(nodeId);
         baseGraph.nodes.setInt(tmp + baseGraph.N_LAT, Helper.degreeToInt(lat));
         baseGraph.nodes.setInt(tmp + baseGraph.N_LON, Helper.degreeToInt(lon));
 
@@ -58,12 +58,12 @@ class GHNodeAccess implements NodeAccess {
 
     @Override
     public final double getLat(int nodeId) {
-        return Helper.intToDegree(baseGraph.nodes.getInt((long) nodeId * baseGraph.nodeEntryBytes + baseGraph.N_LAT));
+        return Helper.intToDegree(baseGraph.nodes.getInt(baseGraph.toNodePointer(nodeId) + baseGraph.N_LAT));
     }
 
     @Override
     public final double getLon(int nodeId) {
-        return Helper.intToDegree(baseGraph.nodes.getInt((long) nodeId * baseGraph.nodeEntryBytes + baseGraph.N_LON));
+        return Helper.intToDegree(baseGraph.nodes.getInt(baseGraph.toNodePointer(nodeId) + baseGraph.N_LON));
     }
 
     @Override
@@ -71,13 +71,13 @@ class GHNodeAccess implements NodeAccess {
         if (!elevation)
             throw new IllegalStateException("Cannot access elevation - 3D is not enabled");
 
-        return Helper.intToEle(baseGraph.nodes.getInt((long) nodeId * baseGraph.nodeEntryBytes + baseGraph.N_ELE));
+        return Helper.intToEle(baseGraph.nodes.getInt(baseGraph.toNodePointer(nodeId) + baseGraph.N_ELE));
     }
 
     public final void setTurnCostIndex(int index, int turnCostIndex) {
         if (baseGraph.supportsTurnCosts()) {
             baseGraph.ensureNodeIndex(index);
-            long tmp = (long) index * baseGraph.nodeEntryBytes;
+            long tmp = baseGraph.toNodePointer(index);
             baseGraph.nodes.setInt(tmp + baseGraph.N_TC, turnCostIndex);
         } else {
             throw new AssertionError("This graph does not support turn costs");
@@ -87,7 +87,7 @@ class GHNodeAccess implements NodeAccess {
     @Override
     public final int getTurnCostIndex(int index) {
         if (baseGraph.supportsTurnCosts())
-            return baseGraph.nodes.getInt((long) index * baseGraph.nodeEntryBytes + baseGraph.N_TC);
+            return baseGraph.nodes.getInt(baseGraph.toNodePointer(index) + baseGraph.N_TC);
         else
             throw new AssertionError("This graph does not support turn costs");
     }

--- a/core/src/main/java/com/graphhopper/storage/RoutingCHEdgeIteratorStateImpl.java
+++ b/core/src/main/java/com/graphhopper/storage/RoutingCHEdgeIteratorStateImpl.java
@@ -45,8 +45,8 @@ public class RoutingCHEdgeIteratorStateImpl implements RoutingCHEdgeIteratorStat
     }
 
     boolean init(int edge, int expectedAdjNode) {
-        if (!EdgeIterator.Edge.isValid(edge))
-            throw new IllegalArgumentException("Invalid edge: " + edge);
+        if (edge < 0 || edge >= baseGraph.edgeCount + store.getShortcuts())
+            throw new IllegalArgumentException("edge must be in bounds: [0," + (baseGraph.edgeCount + store.getShortcuts()) + "[");
         edgeId = edge;
         if (isShortcut()) {
             shortcutPointer = store.toShortcutPointer(edge - baseGraph.edgeCount);

--- a/core/src/main/java/com/graphhopper/storage/RoutingCHGraphImpl.java
+++ b/core/src/main/java/com/graphhopper/storage/RoutingCHGraphImpl.java
@@ -55,11 +55,6 @@ public class RoutingCHGraphImpl implements RoutingCHGraph {
 
     @Override
     public RoutingCHEdgeIteratorState getEdgeIteratorState(int chEdge, int adjNode) {
-        if (chEdge >= baseGraph.getEdges()) {
-            if (chEdge >= getEdges())
-                throw new IllegalStateException("chEdge " + chEdge + " out of bounds");
-        } else if (!baseGraph.isInBounds(chEdge))
-            throw new IllegalStateException("edgeId " + chEdge + " out of bounds");
         RoutingCHEdgeIteratorStateImpl edgeState =
                 new RoutingCHEdgeIteratorStateImpl(chStorage, baseGraph, new BaseGraph.EdgeIteratorStateImpl(baseGraph), weighting);
         if (edgeState.init(chEdge, adjNode))

--- a/core/src/test/java/com/graphhopper/storage/AbstractGraphStorageTester.java
+++ b/core/src/test/java/com/graphhopper/storage/AbstractGraphStorageTester.java
@@ -402,19 +402,12 @@ public abstract class AbstractGraphStorageTester {
     @Test
     public void testCheckFirstNode() {
         graph = createGHStorage();
-
+        // no nodes added yet
+        assertThrows(IllegalArgumentException.class, () -> getCountAll(1));
+        graph.getNodeAccess().setNode(1, 0, 0);
         assertEquals(0, getCountAll(1));
         GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(0, 1).setDistance(12));
         assertEquals(1, getCountAll(1));
-    }
-
-    public boolean containsLatitude(Graph g, EdgeIterator iter, double latitude) {
-        NodeAccess na = g.getNodeAccess();
-        while (iter.next()) {
-            if (Math.abs(na.getLat(iter.getAdjNode()) - latitude) < 1e-4)
-                return true;
-        }
-        return false;
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/storage/GraphHopperStorageCHTest.java
+++ b/core/src/test/java/com/graphhopper/storage/GraphHopperStorageCHTest.java
@@ -338,6 +338,14 @@ public class GraphHopperStorageCHTest extends GraphHopperStorageTest {
     }
 
     @Test
+    public void outOfBounds() {
+        graph = newGHStorage(false, true);
+        graph.freeze();
+        RoutingCHGraph lg = getRoutingCHGraph(graph);
+        assertThrows(IllegalArgumentException.class, () -> lg.getEdgeIteratorState(0, Integer.MIN_VALUE));
+    }
+
+    @Test
     public void testGetEdgeIterator() {
         graph = newGHStorage(false, true);
         GHUtility.setSpeed(60, true, false, carEncoder, graph.edge(0, 1).setDistance(1));

--- a/core/src/test/java/com/graphhopper/storage/GraphHopperStorageTest.java
+++ b/core/src/test/java/com/graphhopper/storage/GraphHopperStorageTest.java
@@ -330,4 +330,11 @@ public class GraphHopperStorageTest extends AbstractGraphStorageTester {
         assertEquals(edgeId, edge.getEdge());
         assertEquals(key, edge.getEdgeKey());
     }
+
+    @Test
+    public void outOfBounds() {
+        GraphHopperStorage graph = createGHStorage();
+        assertThrows(IllegalArgumentException.class, () -> graph.getEdgeIteratorState(0, Integer.MIN_VALUE));
+    }
+
 }

--- a/core/src/test/java/com/graphhopper/util/InstructionListTest.java
+++ b/core/src/test/java/com/graphhopper/util/InstructionListTest.java
@@ -296,6 +296,7 @@ public class InstructionListTest {
     @Test
     public void testEmptyList() {
         Graph g = new GraphBuilder(carManager).create();
+        g.getNodeAccess().setNode(1, 0, 0);
         ShortestWeighting weighting = new ShortestWeighting(carEncoder);
         Path p = new Dijkstra(g, weighting, tMode).calcPath(0, 1);
         InstructionList il = InstructionsFromEdges.calcInstructions(p, g, weighting, carManager, usTR);

--- a/web-bundle/src/main/java/com/graphhopper/resources/IsochroneResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/IsochroneResource.java
@@ -108,7 +108,7 @@ public class IsochroneResource {
             throw new IllegalArgumentException("Point not found:" + point);
         QueryGraph queryGraph = QueryGraph.create(graph, snap);
         TraversalMode traversalMode = profile.isTurnCosts() ? EDGE_BASED : NODE_BASED;
-        ShortestPathTree shortestPathTree = new ShortestPathTree(queryGraph, weighting, reverseFlow, traversalMode);
+        ShortestPathTree shortestPathTree = new ShortestPathTree(queryGraph, queryGraph.wrapWeighting(weighting), reverseFlow, traversalMode);
 
         double limit;
         if (weightLimit.get() > 0) {

--- a/web-bundle/src/main/java/com/graphhopper/resources/SPTResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/SPTResource.java
@@ -110,7 +110,7 @@ public class SPTResource {
         QueryGraph queryGraph = QueryGraph.create(graph, snap);
         NodeAccess nodeAccess = queryGraph.getNodeAccess();
         TraversalMode traversalMode = profile.isTurnCosts() ? EDGE_BASED : NODE_BASED;
-        ShortestPathTree shortestPathTree = new ShortestPathTree(queryGraph, weighting, reverseFlow, traversalMode);
+        ShortestPathTree shortestPathTree = new ShortestPathTree(queryGraph, queryGraph.wrapWeighting(weighting), reverseFlow, traversalMode);
 
         if (distanceInMeter.get() > 0) {
             shortestPathTree.setDistanceLimit(distanceInMeter.get());


### PR DESCRIPTION
So far we were able to access the node storage even outside of its bounds:

```java
GraphHopperStorage g = new GraphBuilder(encodingManager).create();
// no nodes, no edges...
graph.createEdgeExplorer().setBaseNode(5).next(); // -> no error! (also no edges)
```

This is because the created storage is initialized here: 
https://github.com/graphhopper/graphhopper/blob/a48b43ed9fbae6c06e54dc3b5afaf55971b5e475/core/src/main/java/com/graphhopper/storage/BaseGraph.java#L367

However, quite arbitrarily, this fails:

```java
GraphHopperStorage g = new GraphBuilder(encodingManager).create();
// again no nodes, no edges...
g.createEdgeExplorer().setBaseNode(87381).next(); // -> error!
```

because the node index `87381` is just out of range. This depends on the bytes parameter given to `create()` (here it is just the default of 100) and the segment size. I think it would be a lot more clear to avoid the dependency on things like the segment size here and treat the amount of allocated memory as an implementation detail. The range of valid nodes should just be given by the maximum node of the graph. We can set this maximum by simply adding nodes or edges:

```java
g.getNodeAccess().setNode(300, 0, 1); // [0, 300[ is now the valid node range
g.edge(2, 500); // [0, 500[ is now the valid edge range
```

However, it should not be allowed to rely on the range implicitly given by the size of the underlying data access.

In this PR I have implemented such a strict range check for the node access. My change also revealed a minor bug in `SPTResource` and `IsochroneResource` where we were accessing the turn cost indices with (out of range) virtual node IDs, because we did not use the QueryWeighting for QueryGraph. 

Performance does not seem to be affected by this additional check.