### PR TITLE
Remove Storable interface

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/lm/LandmarkStorage.java
+++ b/core/src/main/java/com/graphhopper/routing/lm/LandmarkStorage.java
@@ -59,7 +59,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  *
  * @author Peter Karich
  */
-public class LandmarkStorage implements Storable<LandmarkStorage> {
+public class LandmarkStorage {
 
     // Short.MAX_VALUE = 2^15-1 but we have unsigned short so we need 2^16-1
     private static final int SHORT_INFINITY = Short.MAX_VALUE * 2 + 1;
@@ -676,7 +676,6 @@ public class LandmarkStorage implements Storable<LandmarkStorage> {
         return "{ \"type\": \"FeatureCollection\", \"features\": [" + str + "]}";
     }
 
-    @Override
     public boolean loadExisting() {
         if (isInitialized())
             throw new IllegalStateException("Cannot call PrepareLandmarks.loadExisting if already initialized");
@@ -710,29 +709,20 @@ public class LandmarkStorage implements Storable<LandmarkStorage> {
         return false;
     }
 
-    @Override
-    public LandmarkStorage create(long byteCount) {
-        throw new IllegalStateException("Do not call LandmarkStore.create directly");
-    }
-
-    @Override
     public void flush() {
         landmarkWeightDA.flush();
         subnetworkStorage.flush();
     }
 
-    @Override
     public void close() {
         landmarkWeightDA.close();
         subnetworkStorage.close();
     }
 
-    @Override
     public boolean isClosed() {
         return landmarkWeightDA.isClosed();
     }
 
-    @Override
     public long getCapacity() {
         return landmarkWeightDA.getCapacity() + subnetworkStorage.getCapacity();
     }

--- a/core/src/main/java/com/graphhopper/routing/subnetwork/SubnetworkStorage.java
+++ b/core/src/main/java/com/graphhopper/routing/subnetwork/SubnetworkStorage.java
@@ -20,7 +20,6 @@ package com.graphhopper.routing.subnetwork;
 import com.graphhopper.storage.DAType;
 import com.graphhopper.storage.DataAccess;
 import com.graphhopper.storage.Directory;
-import com.graphhopper.storage.Storable;
 
 /**
  * This class handles storage of subnetwork ids for every node. Useful to pick the correct set of
@@ -28,7 +27,7 @@ import com.graphhopper.storage.Storable;
  *
  * @author Peter Karich
  */
-public class SubnetworkStorage implements Storable<SubnetworkStorage> {
+public class SubnetworkStorage {
     private final DataAccess da;
 
     public SubnetworkStorage(Directory dir, String postfix) {
@@ -55,35 +54,28 @@ public class SubnetworkStorage implements Storable<SubnetworkStorage> {
         da.setByte(nodeId, (byte) subnetwork);
     }
 
-    @Override
-
     public boolean loadExisting() {
         return da.loadExisting();
     }
 
-    @Override
     public SubnetworkStorage create(long byteCount) {
         da.create(2000);
         da.ensureCapacity(byteCount);
         return this;
     }
 
-    @Override
     public void flush() {
         da.flush();
     }
 
-    @Override
     public void close() {
         da.close();
     }
 
-    @Override
     public boolean isClosed() {
         return da.isClosed();
     }
 
-    @Override
     public long getCapacity() {
         return da.getCapacity();
     }

--- a/core/src/main/java/com/graphhopper/search/StringIndex.java
+++ b/core/src/main/java/com/graphhopper/search/StringIndex.java
@@ -19,7 +19,6 @@ package com.graphhopper.search;
 
 import com.graphhopper.storage.DataAccess;
 import com.graphhopper.storage.Directory;
-import com.graphhopper.storage.Storable;
 import com.graphhopper.util.BitUtil;
 import com.graphhopper.util.Helper;
 
@@ -28,7 +27,7 @@ import java.util.*;
 /**
  * @author Peter Karich
  */
-public class StringIndex implements Storable<StringIndex> {
+public class StringIndex {
     private static final long EMPTY_POINTER = 0, START_POINTER = 1;
     // Store the key index in 2 bytes. Use negative values for marking the value as duplicate.
     static final int MAX_UNIQUE_KEYS = (1 << 15);
@@ -70,7 +69,6 @@ public class StringIndex implements Storable<StringIndex> {
         };
     }
 
-    @Override
     public StringIndex create(long initBytes) {
         keys.create(initBytes);
         vals.create(initBytes);
@@ -80,7 +78,6 @@ public class StringIndex implements Storable<StringIndex> {
         return this;
     }
 
-    @Override
     public boolean loadExisting() {
         if (vals.loadExisting()) {
             if (!keys.loadExisting())
@@ -301,7 +298,6 @@ public class StringIndex implements Storable<StringIndex> {
         return bytes;
     }
 
-    @Override
     public void flush() {
         keys.ensureCapacity(2);
         keys.setShort(0, (short) keysInMem.size());
@@ -322,13 +318,11 @@ public class StringIndex implements Storable<StringIndex> {
         vals.flush();
     }
 
-    @Override
     public void close() {
         keys.close();
         vals.close();
     }
 
-    @Override
     public boolean isClosed() {
         return vals.isClosed() && keys.isClosed();
     }
@@ -338,7 +332,6 @@ public class StringIndex implements Storable<StringIndex> {
         vals.setSegmentSize(segments);
     }
 
-    @Override
     public long getCapacity() {
         return vals.getCapacity() + keys.getCapacity();
     }

--- a/core/src/main/java/com/graphhopper/storage/DataAccess.java
+++ b/core/src/main/java/com/graphhopper/storage/DataAccess.java
@@ -17,18 +17,15 @@
  */
 package com.graphhopper.storage;
 
+import java.io.Closeable;
+
 /**
- * Abstraction of the underlying data structure with a unique id and location. To ensure that the id
- * is unique use a Directory.attach or findAttach, if you don't need uniqueness call
- * Directory.create. Current implementations are RAM and memory mapped access.
- * <p>
  * Life cycle: (1) object creation, (2) configuration (e.g. segment size), (3) create or
  * loadExisting, (4) usage and calling ensureCapacity if necessary, (5) close
- * <p>
  *
  * @author Peter Karich
  */
-public interface DataAccess extends Storable<DataAccess> {
+public interface DataAccess extends Closeable {
     /**
      * The logical identification of this object.
      */
@@ -93,8 +90,33 @@ public interface DataAccess extends Storable<DataAccess> {
      * The first time you use a DataAccess object after configuring it you need to call this method.
      * After that first call you have to use ensureCapacity to ensure that enough space is reserved.
      */
-    @Override
     DataAccess create(long bytes);
+
+    /**
+     * This method makes sure that the underlying data is written to the storage. Keep in mind that
+     * a disc normally has an IO cache so that flush() is (less) probably not save against power
+     * loses.
+     */
+    void flush();
+
+    /**
+     * This method makes sure that the underlying used resources are released. WARNING: it does NOT
+     * flush on close!
+     */
+    @Override
+    void close();
+
+    boolean isClosed();
+
+    /**
+     * @return true if successfully loaded from persistent storage.
+     */
+    boolean loadExisting();
+
+    /**
+     * @return the allocated storage size in bytes
+     */
+    long getCapacity();
 
     /**
      * Ensures that the capacity of this object is at least the specified bytes. The first time you

--- a/core/src/main/java/com/graphhopper/storage/GraphHopperStorage.java
+++ b/core/src/main/java/com/graphhopper/storage/GraphHopperStorage.java
@@ -28,6 +28,7 @@ import com.graphhopper.util.shapes.BBox;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -43,7 +44,7 @@ import java.util.stream.Collectors;
  * @author Peter Karich
  * @see GraphBuilder to create a (CH)Graph easier
  */
-public final class GraphHopperStorage implements Storable<GraphHopperStorage>, Graph {
+public final class GraphHopperStorage implements Graph, Closeable {
     private static final Logger LOGGER = LoggerFactory.getLogger(GraphHopperStorage.class);
     private final Directory dir;
     private final EncodingManager encodingManager;
@@ -205,7 +206,6 @@ public final class GraphHopperStorage implements Storable<GraphHopperStorage>, G
     /**
      * After configuring this storage you need to create it explicitly.
      */
-    @Override
     public GraphHopperStorage create(long byteCount) {
         baseGraph.checkNotInitialized();
         if (encodingManager == null)
@@ -243,7 +243,6 @@ public final class GraphHopperStorage implements Storable<GraphHopperStorage>, G
         return properties;
     }
 
-    @Override
     public boolean loadExisting() {
         baseGraph.checkNotInitialized();
         if (properties.loadExisting()) {
@@ -301,7 +300,6 @@ public final class GraphHopperStorage implements Storable<GraphHopperStorage>, G
         }
     }
 
-    @Override
     public void flush() {
         chEntries.stream().map(ch -> ch.chStore).filter(s -> !s.isClosed()).forEach(CHStorage::flush);
         baseGraph.flush();
@@ -315,12 +313,10 @@ public final class GraphHopperStorage implements Storable<GraphHopperStorage>, G
         chEntries.stream().map(ch -> ch.chStore).filter(s -> !s.isClosed()).forEach(CHStorage::close);
     }
 
-    @Override
     public boolean isClosed() {
         return baseGraph.nodes.isClosed();
     }
 
-    @Override
     public long getCapacity() {
         long cnt = baseGraph.getCapacity() + properties.getCapacity();
         long cgs = chEntries.stream().mapToLong(ch -> ch.chStore.getCapacity()).sum();

--- a/core/src/main/java/com/graphhopper/storage/Storable.java
+++ b/core/src/main/java/com/graphhopper/storage/Storable.java
@@ -38,34 +38,9 @@ import java.io.Closeable;
  * @author Peter Karich
  */
 public interface Storable<T> extends Closeable {
-    /**
-     * @return true if successfully loaded from persistent storage.
-     */
-    boolean loadExisting();
 
-    /**
-     * Creates the underlying storage. First operation if it cannot be loaded.
-     */
-    T create(long byteCount);
-
-    /**
-     * This method makes sure that the underlying data is written to the storage. Keep in mind that
-     * a disc normally has an IO cache so that flush() is (less) probably not save against power
-     * loses.
-     */
-    void flush();
-
-    /**
-     * This method makes sure that the underlying used resources are released. WARNING: it does NOT
-     * flush on close!
-     */
-    @Override
-    void close();
 
     boolean isClosed();
 
-    /**
-     * @return the allocated storage size in bytes
-     */
-    long getCapacity();
+
 }

--- a/core/src/main/java/com/graphhopper/storage/StorableProperties.java
+++ b/core/src/main/java/com/graphhopper/storage/StorableProperties.java
@@ -33,7 +33,7 @@ import static com.graphhopper.util.Helper.*;
  *
  * @author Peter Karich
  */
-public class StorableProperties implements Storable<StorableProperties> {
+public class StorableProperties {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(StorableProperties.class);
 
@@ -46,7 +46,6 @@ public class StorableProperties implements Storable<StorableProperties> {
         da.setSegmentSize(1 << 15);
     }
 
-    @Override
     public synchronized boolean loadExisting() {
         if (!da.loadExisting())
             return false;
@@ -62,7 +61,6 @@ public class StorableProperties implements Storable<StorableProperties> {
         }
     }
 
-    @Override
     public synchronized void flush() {
         try {
             StringWriter sw = new StringWriter();
@@ -113,23 +111,19 @@ public class StorableProperties implements Storable<StorableProperties> {
         return ret;
     }
 
-    @Override
     public synchronized void close() {
         da.close();
     }
 
-    @Override
     public synchronized boolean isClosed() {
         return da.isClosed();
     }
 
-    @Override
     public synchronized StorableProperties create(long size) {
         da.create(size);
         return this;
     }
 
-    @Override
     public synchronized long getCapacity() {
         return da.getCapacity();
     }

--- a/core/src/main/java/com/graphhopper/storage/TurnCostStorage.java
+++ b/core/src/main/java/com/graphhopper/storage/TurnCostStorage.java
@@ -35,7 +35,7 @@ import com.graphhopper.util.EdgeIterator;
  * @author Peter Karich
  * @author Michael Zilske
  */
-public class TurnCostStorage implements Storable<TurnCostStorage> {
+public class TurnCostStorage {
     static final int NO_TURN_ENTRY = -1;
     private static final int EMPTY_FLAGS = 0;
     // we store each turn cost entry in the format |from_edge|to_edge|flags|next|. each entry has 4 bytes -> 16 bytes total
@@ -58,30 +58,25 @@ public class TurnCostStorage implements Storable<TurnCostStorage> {
         turnCosts.setSegmentSize(bytes);
     }
 
-    @Override
     public TurnCostStorage create(long initBytes) {
         turnCosts.create(initBytes);
         return this;
     }
 
-    @Override
     public void flush() {
         turnCosts.setHeader(0, BYTES_PER_ENTRY);
         turnCosts.setHeader(1 * 4, turnCostsCount);
         turnCosts.flush();
     }
 
-    @Override
     public void close() {
         turnCosts.close();
     }
 
-    @Override
     public long getCapacity() {
         return turnCosts.getCapacity();
     }
 
-    @Override
     public boolean loadExisting() {
         if (!turnCosts.loadExisting())
             return false;
@@ -218,7 +213,6 @@ public class TurnCostStorage implements Storable<TurnCostStorage> {
         return turnCostStorage;
     }
 
-    @Override
     public boolean isClosed() {
         return turnCosts.isClosed();
     }

--- a/core/src/main/java/com/graphhopper/storage/index/LocationIndex.java
+++ b/core/src/main/java/com/graphhopper/storage/index/LocationIndex.java
@@ -18,7 +18,6 @@
 package com.graphhopper.storage.index;
 
 import com.graphhopper.routing.util.EdgeFilter;
-import com.graphhopper.storage.Storable;
 import com.graphhopper.util.shapes.BBox;
 
 /**
@@ -30,7 +29,7 @@ import com.graphhopper.util.shapes.BBox;
  *
  * @author Peter Karich
  */
-public interface LocationIndex extends Storable<LocationIndex> {
+public interface LocationIndex {
 
     /**
      * This method returns the closest Snap for the specified location (lat, lon) and only if
@@ -54,6 +53,8 @@ public interface LocationIndex extends Storable<LocationIndex> {
      */
     void query(BBox queryBBox, Visitor function);
 
+    void close();
+
     /**
      * This interface allows to visit edges stored in the LocationIndex.
      */
@@ -61,7 +62,7 @@ public interface LocationIndex extends Storable<LocationIndex> {
     interface Visitor {
 
         void onEdge(int edgeId);
-        
+
         default boolean isTileInfo() {
             return false;
         }

--- a/core/src/main/java/com/graphhopper/storage/index/LocationIndexTree.java
+++ b/core/src/main/java/com/graphhopper/storage/index/LocationIndexTree.java
@@ -115,12 +115,6 @@ public class LocationIndexTree implements LocationIndex {
         return this;
     }
 
-    @Override
-    public LocationIndexTree create(long size) {
-        throw new UnsupportedOperationException("Not supported. Use prepareIndex instead.");
-    }
-
-    @Override
     public boolean loadExisting() {
         // Clone this defensively -- In case something funny happens and things get added to the Graph after
         // this index is built. Reason is that the expected structure of the index is a function of the bbox, so we
@@ -146,7 +140,6 @@ public class LocationIndexTree implements LocationIndex {
         return true;
     }
 
-    @Override
     public void flush() {
         lineIntIndex.flush();
     }
@@ -229,17 +222,14 @@ public class LocationIndexTree implements LocationIndex {
         return graph.getNodes() ^ graph.getAllEdges().length();
     }
 
-    @Override
     public void close() {
         lineIntIndex.close();
     }
 
-    @Override
     public boolean isClosed() {
         return lineIntIndex.isClosed();
     }
 
-    @Override
     public long getCapacity() {
         return lineIntIndex.getCapacity();
     }


### PR DESCRIPTION
We do not really use any objects through this interface. All it does is enforce a certain lifecycle for some of our persistence related classes. I think this lifecycle is a bit flawed. For example I don't think it is a good idea to create objects and `load` or `create` them afterwards. I would rather either create an object by loading it or just create it and save it later. As a first step I have removed the Storable interface here as it does more harm than good IMO.
