### PR TITLE
Add Austria specific rule for dismounting bike at paths

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/countryrules/AustriaCountryRule.java
+++ b/core/src/main/java/com/graphhopper/routing/util/countryrules/AustriaCountryRule.java
@@ -72,4 +72,12 @@ public class AustriaCountryRule implements CountryRule {
                 return RoadAccess.YES;
         }
     }
+
+    @Override
+    public boolean getOffBike(ReaderWay readerWay, boolean currentOffBike) {
+        if (currentOffBike == true)
+            return currentOffBike;
+        RoadClass roadClass = RoadClass.find(readerWay.getTag("highway", "path"));
+        return (roadClass == RoadClass.PATH);
+    }
 }

--- a/core/src/main/java/com/graphhopper/routing/util/countryrules/CountryRule.java
+++ b/core/src/main/java/com/graphhopper/routing/util/countryrules/CountryRule.java
@@ -35,4 +35,8 @@ public interface CountryRule {
     default RoadAccess getAccess(ReaderWay readerWay, TransportationMode transportationMode, RoadAccess currentRoadAccess) {
         return currentRoadAccess;
     }
+
+    default boolean getOffBike( ReaderWay readerWay, boolean currentGetOffBike) {
+        return currentGetOffBike;
+    }
 }

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMGetOffBikeParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMGetOffBikeParserTest.java
@@ -7,6 +7,7 @@ import com.graphhopper.routing.ev.GetOffBike;
 import com.graphhopper.routing.ev.RoadClass;
 import com.graphhopper.routing.util.BikeFlagEncoder;
 import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.routing.util.countryrules.CountryRule;
 import com.graphhopper.storage.IntsRef;
 import org.junit.jupiter.api.Test;
 
@@ -81,7 +82,7 @@ public class OSMGetOffBikeParserTest {
         way = new ReaderWay(1);
         way.setTag("highway", "path");
         way.setTag("surface", "concrete");
-        assertTrue(isGetOffBike(way));
+        assertFalse(isGetOffBike(way));
         way.setTag("bicycle", "yes");
         assertFalse(isGetOffBike(way));
         way.setTag("bicycle", "designated");
@@ -97,8 +98,23 @@ public class OSMGetOffBikeParserTest {
 
         way = new ReaderWay(1);
         way.setTag("highway", "path");
+        assertFalse(isGetOffBike(way));
+        way.setTag("country_rule", new CountryRule() {
+            @Override
+            public boolean getOffBike(ReaderWay readerWay, boolean currentGetOffBike) {
+                return true;
+            }
+        });
+        assertTrue(isGetOffBike(way));
+        way.setTag("bicycle", "yes");
+        assertFalse(isGetOffBike(way));
+
+        way = new ReaderWay(1);
+        way.setTag("highway", "path");
         way.setTag("foot", "designated");
         assertTrue(isGetOffBike(way));
+        way.setTag("bicycle", "designated");
+        assertFalse(isGetOffBike(way));
     }
 
     private RoadClass getRoadClass(ReaderWay way) {


### PR DESCRIPTION
Working on #2389 there was the insight we should add a contry specific rule for Austria:
* Bicycle riders have to push their bike on "highway=path" , unless it is explicitly allowed in Austria.
* Changing the rules in a way to push bikes on "highway=path" when it is a "foot=designated" path, unless biking is explicitly allowed.