### PR TITLE
Dummy implementation of new DataAccess

### DIFF
--- a/core/src/main/java/com/graphhopper/storage/NewDataAccess.java
+++ b/core/src/main/java/com/graphhopper/storage/NewDataAccess.java
@@ -1,0 +1,29 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.graphhopper.storage;
+
+public interface NewDataAccess {
+
+    boolean ensureCapacity(long bytes);
+
+    void setInt(long bytePos, int value);
+
+    int getInt(long bytePos);
+
+}

--- a/core/src/main/java/com/graphhopper/storage/NewMMapDataAccess.java
+++ b/core/src/main/java/com/graphhopper/storage/NewMMapDataAccess.java
@@ -1,0 +1,241 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.graphhopper.storage;
+
+import com.graphhopper.util.BitUtil;
+import com.graphhopper.util.Helper;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.io.UncheckedIOException;
+import java.nio.ByteOrder;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+import java.util.ArrayList;
+import java.util.List;
+
+public class NewMMapDataAccess implements NewDataAccess {
+    private static final String GH_FILE_MARKER = "GH";
+    private final String path;
+    private final boolean readOnly;
+    private final RandomAccessFile raFile;
+    private final ByteOrder byteOrder;
+    private final List<MappedByteBuffer> segments;
+    private final BitUtil bitUtil;
+    private final int bytesPerSegment;
+    // these two will be derived from bytesPerSegment and are only stored for faster index calculations
+    private final int log2bytesPerSegment;
+    private final int offsetDivisor;
+
+    public NewMMapDataAccess(String path, int bytesPerSegment, boolean readOnly) {
+        if (bytesPerSegment < 2)
+            throw new IllegalArgumentException("bytesPerSegment must be >= 2");
+        if (!isPowerOfTwo(bytesPerSegment))
+            throw new IllegalArgumentException("bytesPerSegment must be a power of two, but got: " + bytesPerSegment);
+        this.path = path;
+        this.readOnly = readOnly;
+        try {
+            raFile = new RandomAccessFile(path, readOnly ? "r" : "rw");
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        byteOrder = ByteOrder.BIG_ENDIAN;
+        segments = new ArrayList<>();
+        bitUtil = BitUtil.get(byteOrder);
+        this.bytesPerSegment = bytesPerSegment;
+        this.log2bytesPerSegment = log2(bytesPerSegment);
+        this.offsetDivisor = bytesPerSegment - 1;
+    }
+
+    public static NewMMapDataAccess load(String path, boolean readOnly) {
+        File file = new File(path);
+        if (!file.exists() || file.length() == 0)
+            return null;
+        int numSegments;
+        int bytesPerSegment;
+        try (RandomAccessFile raf = new RandomAccessFile(path, "r")) {
+            String fileMarker = raf.readUTF();
+            if (!GH_FILE_MARKER.equals(fileMarker))
+                throw new IllegalArgumentException("Not a GraphHopper file, expected 'GH' file marker, but was " + fileMarker);
+            numSegments = raf.readInt();
+            bytesPerSegment = raf.readInt();
+        } catch (IOException e) {
+            throw new UncheckedIOException("Problem while loading " + path, e);
+        }
+        NewMMapDataAccess da = new NewMMapDataAccess(path, bytesPerSegment, readOnly);
+        da.mapSegments((long) numSegments * bytesPerSegment);
+        return da;
+    }
+
+    public static void flush(NewMMapDataAccess da) {
+        try {
+            for (MappedByteBuffer bb : da.segments)
+                bb.force();
+            da.raFile.seek(0);
+            da.raFile.writeUTF(GH_FILE_MARKER);
+            da.raFile.writeInt(da.segments.size());
+            da.raFile.writeInt(da.bytesPerSegment);
+
+            // this could be necessary too
+            // http://stackoverflow.com/q/14011398/194609
+            da.raFile.getFD().sync();
+            // equivalent to raFile.getChannel().force(true);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public boolean ensureCapacity(long bytes) {
+        return mapSegments(bytes);
+    }
+
+    private boolean mapSegments(long byteCount) {
+        long capacity = (long) segments.size() * bytesPerSegment;
+        long newBytes = byteCount - capacity;
+        if (newBytes <= 0)
+            return false;
+        long longBytesPerSegment = bytesPerSegment;
+        int segmentsToMap = (int) (byteCount / longBytesPerSegment);
+        if (segmentsToMap < 0)
+            throw new IllegalStateException("Too many segments needs to be allocated. Increase segmentSize.");
+
+        if (byteCount % longBytesPerSegment != 0)
+            segmentsToMap++;
+
+        if (segmentsToMap == 0)
+            throw new IllegalStateException("0 segments are not allowed.");
+
+        // todonow
+        int offset = 20;
+        long bufferStart = offset;
+        int i = 0;
+        long newFileLength = offset + segmentsToMap * longBytesPerSegment;
+        try {
+            // ugly remapping
+            // http://stackoverflow.com/q/14011919/194609
+            // This approach is probably problematic but a bit faster if done often.
+            // Here we rely on the OS+file system that increasing the file
+            // size has no effect on the old mappings!
+            bufferStart += segments.size() * longBytesPerSegment;
+            int newSegments = segmentsToMap - segments.size();
+            // rely on automatically increasing when mapping
+            // raFile.setLength(newFileLength);
+            for (; i < newSegments; i++) {
+                segments.add(newByteBuffer(bufferStart, longBytesPerSegment));
+                bufferStart += longBytesPerSegment;
+            }
+            return true;
+        } catch (IOException ex) {
+            // we could get an exception here if buffer is too small and area too large
+            // e.g. I got an exception for the 65421th buffer (probably around 2**16 == 65536)
+            throw new RuntimeException("Couldn't map buffer " + i + " of " + segmentsToMap + " with " + longBytesPerSegment
+                    + " for " + path + " at position " + bufferStart + " for " + byteCount + " bytes with offset " + offset
+                    + ", new fileLength:" + newFileLength + ", " + Helper.getMemInfo(), ex);
+        }
+    }
+
+    private MappedByteBuffer newByteBuffer(long offset, long byteCount) throws IOException {
+        // If we request a buffer larger than the file length, it will automatically increase the file length!
+        // Will this cause problems? http://stackoverflow.com/q/14011919/194609
+        // For trimTo we need to reset the file length later to reduce that size
+        MappedByteBuffer buf = null;
+        IOException ioex = null;
+        // One retry if it fails. It could fail e.g. if previously buffer wasn't yet unmapped from the jvm
+        for (int trial = 0; trial < 1; ) {
+            try {
+                buf = raFile.getChannel().map(
+                        readOnly ? FileChannel.MapMode.READ_ONLY : FileChannel.MapMode.READ_WRITE, offset, byteCount);
+                break;
+            } catch (IOException tmpex) {
+                ioex = tmpex;
+                trial++;
+                try {
+                    // mini sleep to let JVM do unmapping
+                    Thread.sleep(5);
+                } catch (InterruptedException iex) {
+                    throw new IOException(iex);
+                }
+            }
+        }
+        if (buf == null) {
+            if (ioex == null) {
+                throw new AssertionError("internal problem as the exception 'ioex' shouldn't be null");
+            }
+            throw ioex;
+        }
+
+        buf.order(byteOrder);
+        return buf;
+    }
+
+    @Override
+    public void setInt(long bytePos, int value) {
+// begin c&p (except segments[][] vs. list)
+        int segment = getSegment(bytePos);
+        int offset = getOffset(bytePos);
+        // todonow: synchronized?
+        if (offset + 4 > bytesPerSegment)
+            for (int i = 0; i < 4; i++)
+                if (offset + i < bytesPerSegment)
+                    segments.get(segment).put(offset + i, bitUtil.getByte(value, i));
+                else
+                    segments.get(segment + 1).put(offset + i - bytesPerSegment, bitUtil.getByte(value, i));
+        else
+            segments.get(segment).putInt(offset, value);
+        // end c&p
+    }
+
+    @Override
+    public int getInt(long bytePos) {
+        int segment = getSegment(bytePos);
+        int offset = getOffset(bytePos);
+        // todonow: synchronized
+        if (offset + 4 > bytesPerSegment)
+            return bitUtil.getInt(
+                    offset < bytesPerSegment ? segments.get(segment).get(offset) : segments.get(segment + 1).get(offset - bytesPerSegment),
+                    offset + 1 < bytesPerSegment ? segments.get(segment).get(offset + 1) : segments.get(segment + 1).get(offset + 1 - bytesPerSegment),
+                    offset + 2 < bytesPerSegment ? segments.get(segment).get(offset + 2) : segments.get(segment + 1).get(offset + 2 - bytesPerSegment),
+                    offset + 3 < bytesPerSegment ? segments.get(segment).get(offset + 3) : segments.get(segment + 1).get(offset + 3 - bytesPerSegment)
+            );
+        else
+            return segments.get(segment).getInt(offset);
+    }
+
+    // begin c&p
+    private int getSegment(long bytePos) {
+        return (int) bytePos >>> log2bytesPerSegment;
+    }
+
+    private int getOffset(long bytePos) {
+        return (int) bytePos & offsetDivisor;
+    }
+
+    private static boolean isPowerOfTwo(int x) {
+        return x != 0 && (x & (x - 1)) == 0;
+    }
+
+    private static int log2(int x) {
+        if (x <= 0)
+            throw new IllegalArgumentException("x must be < 0, got: " + x);
+        return 31 - Integer.numberOfLeadingZeros(x);
+    }
+    // end c&p
+}

--- a/core/src/main/java/com/graphhopper/storage/NewRAMDataAccess.java
+++ b/core/src/main/java/com/graphhopper/storage/NewRAMDataAccess.java
@@ -1,0 +1,172 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.graphhopper.storage;
+
+import com.graphhopper.util.BitUtil;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.io.UncheckedIOException;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+import java.util.Optional;
+
+public class NewRAMDataAccess implements NewDataAccess {
+    private static final String GH_FILE_MARKER = "GH";
+    private final BitUtil bitUtil;
+    private byte[][] segments;
+    private final int bytesPerSegment;
+    // these two will be derived from bytesPerSegment and are only stored for faster index calculations
+    private final int log2bytesPerSegment;
+    private final int offsetDivisor;
+
+    public NewRAMDataAccess() {
+        // ~1MB per segment is the default
+        this(1 << 20);
+    }
+
+    public NewRAMDataAccess(int bytesPerSegment) {
+        this(new byte[0][], bytesPerSegment);
+    }
+
+    private NewRAMDataAccess(byte[][] segments, int bytesPerSegment) {
+        if (bytesPerSegment < 2)
+            throw new IllegalArgumentException("bytesPerSegment must be >= 2");
+        if (!isPowerOfTwo(bytesPerSegment))
+            throw new IllegalArgumentException("bytesPerSegment must be a power of two, but got: " + bytesPerSegment);
+        for (byte[] segment : segments)
+            if (segment.length != bytesPerSegment)
+                throw new IllegalArgumentException("found segment with invalid length: " + segment.length + ", expected: " + bytesPerSegment);
+        bitUtil = BitUtil.get(ByteOrder.BIG_ENDIAN);
+        this.segments = segments;
+        this.bytesPerSegment = bytesPerSegment;
+        this.log2bytesPerSegment = log2(bytesPerSegment);
+        this.offsetDivisor = bytesPerSegment - 1;
+    }
+
+    public static NewRAMDataAccess load(String path) {
+        File file = new File(path);
+        if (!file.exists() || file.length() == 0)
+            return null;
+        try (RandomAccessFile raf = new RandomAccessFile(path, "r")) {
+            String fileMarker = raf.readUTF();
+            if (!GH_FILE_MARKER.equals(fileMarker))
+                throw new IllegalArgumentException("Not a GraphHopper file, expected 'GH' file marker, but was " + fileMarker);
+            int numSegments = raf.readInt();
+            int bytesPerSegment = raf.readInt();
+
+            byte[][] segments = new byte[numSegments][];
+            for (int s = 0; s < numSegments; s++) {
+                byte[] bytes = new byte[bytesPerSegment];
+                if (raf.read(bytes) <= 0)
+                    throw new IllegalStateException("segment " + s + " is empty, path: " + path);
+                segments[s] = bytes;
+            }
+            return new NewRAMDataAccess(segments, bytesPerSegment);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Problem while loading " + path, e);
+        }
+    }
+
+    public static void flush(NewRAMDataAccess da, String path) {
+        try (RandomAccessFile raf = new RandomAccessFile(path, "rw")) {
+            raf.writeUTF(GH_FILE_MARKER);
+            raf.writeInt(da.segments.length);
+            raf.writeInt(da.bytesPerSegment);
+            for (byte[] segment : da.segments)
+                raf.write(segment);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Couldn't store bytes to " + path, e);
+        }
+    }
+
+    @Override
+    public boolean ensureCapacity(long bytes) {
+        long capacity = (long) segments.length * bytesPerSegment;
+        long newBytes = bytes - capacity;
+        if (newBytes <= 0)
+            return false;
+        int segmentsToCreate = (int) (newBytes / bytesPerSegment);
+        if (newBytes % bytesPerSegment != 0)
+            segmentsToCreate++;
+        try {
+            byte[][] newSegments = Arrays.copyOf(segments, segments.length + segmentsToCreate);
+            for (int i = segments.length; i < newSegments.length; ++i)
+                newSegments[i] = new byte[bytesPerSegment];
+            segments = newSegments;
+        } catch (OutOfMemoryError err) {
+            throw new OutOfMemoryError(err.getMessage() + " - problem when allocating new memory. Old capacity: "
+                    + capacity + ", new bytes: " + newBytes + ", bytesPerSegment: " + bytesPerSegment
+                    + ", new segments: " + segmentsToCreate + ", existing: " + segments.length);
+        }
+        return true;
+    }
+
+    @Override
+    public void setInt(long bytePos, int value) {
+        int segment = getSegment(bytePos);
+        int offset = getOffset(bytePos);
+        if (offset + 4 > bytesPerSegment)
+            for (int i = 0; i < 4; i++)
+                if (offset + i < bytesPerSegment)
+                    segments[segment][offset + i] = bitUtil.getByte(value, i);
+                else
+                    segments[segment + 1][offset + i - bytesPerSegment] = bitUtil.getByte(value, i);
+        else
+            bitUtil.fromInt(segments[segment], value, offset);
+    }
+
+    @Override
+    public int getInt(long bytePos) {
+        int segment = getSegment(bytePos);
+        int offset = getOffset(bytePos);
+        if (offset + 4 > bytesPerSegment)
+            return bitUtil.getInt(
+                    offset < bytesPerSegment ? segments[segment][offset] : segments[segment + 1][offset - bytesPerSegment],
+                    offset + 1 < bytesPerSegment ? segments[segment][offset + 1] : segments[segment + 1][offset + 1 - bytesPerSegment],
+                    offset + 2 < bytesPerSegment ? segments[segment][offset + 2] : segments[segment + 1][offset + 2 - bytesPerSegment],
+                    offset + 3 < bytesPerSegment ? segments[segment][offset + 3] : segments[segment + 1][offset + 3 - bytesPerSegment]
+            );
+        else
+            return bitUtil.toInt(segments[segment], offset);
+    }
+
+    public void flush(String path) {
+        NewRAMDataAccess.flush(this, path);
+    }
+
+    private int getSegment(long bytePos) {
+        return (int) bytePos >>> log2bytesPerSegment;
+    }
+
+    private int getOffset(long bytePos) {
+        return (int) bytePos & offsetDivisor;
+    }
+
+    private static boolean isPowerOfTwo(int x) {
+        return x != 0 && (x & (x - 1)) == 0;
+    }
+
+    private static int log2(int x) {
+        if (x <= 0)
+            throw new IllegalArgumentException("x must be < 0, got: " + x);
+        return 31 - Integer.numberOfLeadingZeros(x);
+    }
+}

--- a/core/src/main/java/com/graphhopper/util/BitUtil.java
+++ b/core/src/main/java/com/graphhopper/util/BitUtil.java
@@ -48,6 +48,18 @@ public abstract class BitUtil {
             return BitUtil.LITTLE;
     }
 
+    public abstract byte getByte(short value, int pos);
+
+    public abstract byte getByte(int value, int pos);
+
+    public abstract byte getByte(long value, int pos);
+
+    public abstract short getShort(byte b0, byte b1);
+
+    public abstract int getInt(byte b0, byte b1, byte b2, byte b3);
+
+    public abstract long getLong(byte b0, byte b1, byte b2, byte b3, byte b4, byte b5, byte b6, byte b7);
+
     public final double toDouble(byte[] bytes) {
         return toDouble(bytes, 0);
     }

--- a/core/src/main/java/com/graphhopper/util/BitUtilBig.java
+++ b/core/src/main/java/com/graphhopper/util/BitUtilBig.java
@@ -27,6 +27,30 @@ public class BitUtilBig extends BitUtil {
     BitUtilBig() {
     }
 
+    public byte getByte(short value, int pos) {
+        return (byte) (value >>> (8 - 8 * pos));
+    }
+
+    public byte getByte(int value, int pos) {
+        return (byte) (value >>> (24 - 8 * pos));
+    }
+
+    public byte getByte(long value, int pos) {
+        return (byte) (value >>> (56 - 8 * pos));
+    }
+
+    public short getShort(byte b0, byte b1) {
+        return (short) ((b0 & 0xFF) << 8 | (b1 & 0xFF));
+    }
+
+    public int getInt(byte b0, byte b1, byte b2, byte b3) {
+        return (b0 & 0xFF) << 24 | (b1 & 0xFF) << 16 | (b2 & 0xFF) << 8 | (b3 & 0xFF);
+    }
+
+    public long getLong(byte b0, byte b1, byte b2, byte b3, byte b4, byte b5, byte b6, byte b7) {
+        return (long) getInt(b0, b1, b2, b3) << 32 | (getInt(b4, b5, b6, b7) & 0xFFFFFFFFL);
+    }
+
     @Override
     public final short toShort(byte[] b, int offset) {
         return (short) ((b[offset] & 0xFF) << 8 | (b[offset + 1] & 0xFF));

--- a/core/src/main/java/com/graphhopper/util/BitUtilLittle.java
+++ b/core/src/main/java/com/graphhopper/util/BitUtilLittle.java
@@ -27,6 +27,30 @@ public class BitUtilLittle extends BitUtil {
     BitUtilLittle() {
     }
 
+    public byte getByte(short value, int pos) {
+        return (byte) (value >>> (8 * pos));
+    }
+
+    public byte getByte(int value, int pos) {
+        return (byte) (value >>> (8 * pos));
+    }
+
+    public byte getByte(long value, int pos) {
+        return (byte) (value >>> (8 * pos));
+    }
+
+    public short getShort(byte b0, byte b1) {
+        return (short) ((b1 & 0xFF) << 8 | (b0 & 0xFF));
+    }
+
+    public int getInt(byte b0, byte b1, byte b2, byte b3) {
+        return (b3 & 0xFF) << 24 | (b2 & 0xFF) << 16 | (b1 & 0xFF) << 8 | (b0 & 0xFF);
+    }
+
+    public long getLong(byte b0, byte b1, byte b2, byte b3, byte b4, byte b5, byte b6, byte b7) {
+        return (long) getInt(b7, b6, b5, b4) << 32 | (getInt(b3, b2, b1, b0) & 0xFFFFFFFFL);
+    }
+
     @Override
     public final short toShort(byte[] b, int offset) {
         return (short) ((b[offset + 1] & 0xFF) << 8 | (b[offset] & 0xFF));

--- a/core/src/test/java/com/graphhopper/storage/NewDataAccessTest.java
+++ b/core/src/test/java/com/graphhopper/storage/NewDataAccessTest.java
@@ -1,0 +1,104 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.graphhopper.storage;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+// todonow: parameterize for little/big endian, but do we ever need this?
+
+/**
+ * Test interface for {@link NewDataAccess}
+ */
+interface NewDataAccessTest {
+
+    NewDataAccess create(int bytesPerSegment);
+
+    void flush(NewDataAccess da);
+
+    NewDataAccess load();
+
+    @Test
+    default void illegalBytesPerSegment() {
+        assertIllegalArgument(() -> create(-1), "bytesPerSegment must be >= 2");
+        assertIllegalArgument(() -> create(0), "bytesPerSegment must be >= 2");
+        assertIllegalArgument(() -> create(1), "bytesPerSegment must be >= 2");
+        assertDoesNotThrow(() -> create(2));
+        assertIllegalArgument(() -> create(3), "bytesPerSegment must be a power of two, but got: 3");
+        assertDoesNotThrow(() -> create(4));
+        assertIllegalArgument(() -> create(15), "bytesPerSegment must be a power of two, but got: 15");
+        assertDoesNotThrow(() -> create(16));
+        assertDoesNotThrow(() -> create(1 << 6));
+        assertIllegalArgument(() -> create(Integer.MAX_VALUE), "bytesPerSegment must be a power of two, but got: 2147483647");
+    }
+
+    @Test
+    default void outOfRange() {
+        NewDataAccess da = create(8);
+        assertThrows(IndexOutOfBoundsException.class, () -> da.setInt(0, 19));
+        da.ensureCapacity(3);
+        da.setInt(0, 19);
+        assertThrows(IndexOutOfBoundsException.class, () -> da.setInt(6, 21));
+    }
+
+    @Test
+    default void readWriteInts() {
+        NewDataAccess da = create(4);
+        da.ensureCapacity(4);
+        da.setInt(0, 19);
+        assertEquals(19, da.getInt(0));
+        da.ensureCapacity(8);
+        da.setInt(4, 12);
+        assertEquals(12, da.getInt(4));
+    }
+
+    @Test
+    default void readWriteInts_acrossSegments() {
+        NewDataAccess da = create(2);
+        da.ensureCapacity(4);
+        da.setInt(0, 1 << 25);
+        assertEquals(33554432, da.getInt(0));
+
+        da = create(4);
+        da.ensureCapacity(5);
+        da.setInt(1, 658948);
+        assertEquals(658948, da.getInt(1));
+    }
+
+    @Test
+    default void flushAndLoad() {
+        NewDataAccess da = create(16);
+        da.ensureCapacity(40);
+        for (int i = 0; i < 10; i++)
+            da.setInt(4 * i, i * 10_000_000);
+        flush(da);
+
+        da = load();
+        assertNotNull(da);
+        for (int i = 0; i < 10; i++)
+            assertEquals(i * 10_000_000, da.getInt(4 * i));
+    }
+
+    default void assertIllegalArgument(Executable executable, String message) {
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, executable);
+        assertEquals(message, e.getMessage());
+    }
+}

--- a/core/src/test/java/com/graphhopper/storage/NewMMapDataAccessTest.java
+++ b/core/src/test/java/com/graphhopper/storage/NewMMapDataAccessTest.java
@@ -1,0 +1,49 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.graphhopper.storage;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+public class NewMMapDataAccessTest implements NewDataAccessTest {
+
+    private String path;
+
+    @BeforeEach
+    void setup(@TempDir Path path) {
+        this.path = path.resolve("test_mmap_file").toAbsolutePath().toString();
+    }
+
+    @Override
+    public NewDataAccess create(int bytesPerSegment) {
+        return new NewMMapDataAccess(path, bytesPerSegment, false);
+    }
+
+    @Override
+    public void flush(NewDataAccess da) {
+        NewMMapDataAccess.flush((NewMMapDataAccess) da);
+    }
+
+    @Override
+    public NewDataAccess load() {
+        return NewMMapDataAccess.load(path, false);
+    }
+}

--- a/core/src/test/java/com/graphhopper/storage/NewRAMDataAccessTest.java
+++ b/core/src/test/java/com/graphhopper/storage/NewRAMDataAccessTest.java
@@ -1,0 +1,49 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.graphhopper.storage;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+class NewRAMDataAccessTest implements NewDataAccessTest {
+
+    private String path;
+
+    @BeforeEach
+    void setup(@TempDir Path path) {
+        this.path = path.resolve("test_ram_file").toAbsolutePath().toString();
+    }
+
+    @Override
+    public NewDataAccess create(int bytesPerSegment) {
+        return new NewRAMDataAccess(bytesPerSegment);
+    }
+
+    @Override
+    public void flush(NewDataAccess da) {
+        NewRAMDataAccess.flush((NewRAMDataAccess) da, path);
+    }
+
+    @Override
+    public NewDataAccess load() {
+        return NewRAMDataAccess.load(path);
+    }
+}


### PR DESCRIPTION
Here I tried to get rid of the lifecycle methods we currently enforce for `DataAccess`. There are two implementations: RAM and MMAP.

For `NewRAMDataAccess` it is pretty clear I think:

```java
// A new data access (yay!). No need to attach a 'name', or specify whether or not it will be 'stored' in the future. 
// The segment size is final because changing it later would not work anyway.
NewDataAccess da = new NewRAMDataAccess();
// Allocate some memory before we can store data
da.ensureCapacity(300);
// set/get an int, just like before
da.setInt(20, 123);
assertEquals(123, da.getInt(20));
// Let's store this thing to disk. This is just a static function. All we need is specify where it should go
NewRamDataAccess.flush(da, "my_path");
// Let's load from disk again. The segment size is just stored in the file already, so everything is included already.
da = NewRAMDataAccess.load("my_path");
```

For `NewMMapDataAccess` it is a bit less clear, because unlike for RAM we have to specify the disk location already at the beginning:

```java
boolean readOnly =  false;
int bytesPerSegment = 64;
// create the mmap DataAccess, no memory is allocated yet
NewDataAccess da = new NewMMapDataAccess("my_path", bytesPerSegment, readOnly);
// now we allocate/map the memory
da.ensureCapacity(300);
// ... and use it
da.setInt(20, 123);
assertEquals(123, da.getInt(20));
// flush to disk. Here we do not need to specify a path, because the location is already set in the constructor.
NewMMapDataAccess.flush(da);
// we have to explicitly release the resources
da.close();
// Loading from disk involves, memory mapping. This is just done using another static function:
da = NewMMapDataAccess.load("my_path", readOnly);
// it is ready to use:
assertEquals(123, da.getInt(20));
```

