### PR TITLE
Load CountryRules via ServiceLoader

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/countryrules/AustriaCountryRule.java
+++ b/core/src/main/java/com/graphhopper/routing/util/countryrules/AustriaCountryRule.java
@@ -25,7 +25,6 @@ import com.graphhopper.routing.ev.RoadClass;
 import com.graphhopper.routing.util.TransportationMode;
 
 public class AustriaCountryRule implements CountryRule {
-    public final static AustriaCountryRule RULE = new AustriaCountryRule();
     
     @Override
     public Country getCountry() {

--- a/core/src/main/java/com/graphhopper/routing/util/countryrules/AustriaCountryRule.java
+++ b/core/src/main/java/com/graphhopper/routing/util/countryrules/AustriaCountryRule.java
@@ -19,12 +19,18 @@
 package com.graphhopper.routing.util.countryrules;
 
 import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.Country;
 import com.graphhopper.routing.ev.RoadAccess;
 import com.graphhopper.routing.ev.RoadClass;
 import com.graphhopper.routing.util.TransportationMode;
 
 public class AustriaCountryRule implements CountryRule {
     public final static AustriaCountryRule RULE = new AustriaCountryRule();
+    
+    @Override
+    public Country getCountry() {
+        return Country.AUT;
+    }
 
     @Override
     public double getMaxSpeed(ReaderWay readerWay, TransportationMode transportationMode, double currentMaxSpeed) {

--- a/core/src/main/java/com/graphhopper/routing/util/countryrules/CountryRule.java
+++ b/core/src/main/java/com/graphhopper/routing/util/countryrules/CountryRule.java
@@ -21,13 +21,15 @@ package com.graphhopper.routing.util.countryrules;
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.Country;
 import com.graphhopper.routing.ev.RoadAccess;
-import com.graphhopper.routing.ev.RoadClass;
 import com.graphhopper.routing.util.TransportationMode;
 
 /**
  * GraphHopper uses country rules to adjust the routing behavior based on the country an edge is located in
  */
 public interface CountryRule {
+    
+    Country getCountry();
+    
     default double getMaxSpeed(ReaderWay readerWay, TransportationMode transportationMode, double currentMaxSpeed) {
         return currentMaxSpeed;
     }

--- a/core/src/main/java/com/graphhopper/routing/util/countryrules/CountryRuleFactory.java
+++ b/core/src/main/java/com/graphhopper/routing/util/countryrules/CountryRuleFactory.java
@@ -18,18 +18,30 @@
 
 package com.graphhopper.routing.util.countryrules;
 
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.ServiceLoader;
+
 import com.graphhopper.routing.ev.Country;
 
 public class CountryRuleFactory {
+    
+    private final Map<Country, CountryRule> rules;
+    
+    public CountryRuleFactory() {
+        Map<Country, CountryRule> rulesMap = new EnumMap<>(Country.class);
+        ServiceLoader<CountryRule> loader = ServiceLoader.load(CountryRule.class);
+        for (CountryRule rule : loader) {
+            if (rule.getCountry() == null) {
+                throw new IllegalStateException("CountryRule needs to define a countrycode.");
+            }
+            rulesMap.put(rule.getCountry(), rule);
+        }
+        this.rules = Collections.unmodifiableMap(rulesMap);
+    }
 
     public CountryRule getCountryRule(Country country) {
-        switch (country) {
-            case DEU:
-                return GermanyCountryRule.RULE;
-            case AUT:
-                return AustriaCountryRule.RULE;
-            default:
-                return null;
-        }
+        return rules.get(country);
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/util/countryrules/GermanyCountryRule.java
+++ b/core/src/main/java/com/graphhopper/routing/util/countryrules/GermanyCountryRule.java
@@ -29,7 +29,6 @@ import com.graphhopper.routing.util.TransportationMode;
  * @author Robin Boldt
  */
 public class GermanyCountryRule implements CountryRule {
-    public final static GermanyCountryRule RULE = new GermanyCountryRule();
     
     @Override
     public Country getCountry() {

--- a/core/src/main/java/com/graphhopper/routing/util/countryrules/GermanyCountryRule.java
+++ b/core/src/main/java/com/graphhopper/routing/util/countryrules/GermanyCountryRule.java
@@ -19,6 +19,7 @@
 package com.graphhopper.routing.util.countryrules;
 
 import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.Country;
 import com.graphhopper.routing.ev.MaxSpeed;
 import com.graphhopper.routing.ev.RoadAccess;
 import com.graphhopper.routing.ev.RoadClass;
@@ -29,6 +30,11 @@ import com.graphhopper.routing.util.TransportationMode;
  */
 public class GermanyCountryRule implements CountryRule {
     public final static GermanyCountryRule RULE = new GermanyCountryRule();
+    
+    @Override
+    public Country getCountry() {
+        return Country.DEU;
+    }
 
     /**
      * In Germany there are roads without a speed limit. For these roads, this method

--- a/core/src/main/resources/META-INF/services/com.graphhopper.routing.util.countryrules.CountryRule
+++ b/core/src/main/resources/META-INF/services/com.graphhopper.routing.util.countryrules.CountryRule
@@ -1,0 +1,2 @@
+com.graphhopper.routing.util.countryrules.AustriaCountryRule
+com.graphhopper.routing.util.countryrules.GermanyCountryRule

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMMaxSpeedParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMMaxSpeedParserTest.java
@@ -18,6 +18,7 @@
 package com.graphhopper.routing.util.parsers;
 
 import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.Country;
 import com.graphhopper.routing.ev.DecimalEncodedValue;
 import com.graphhopper.routing.ev.MaxSpeed;
 import com.graphhopper.routing.ev.RoadClass;
@@ -49,6 +50,11 @@ class OSMMaxSpeedParserTest {
         ReaderWay way = new ReaderWay(29L);
         way.setTag("highway", "living_street");
         way.setTag("country_rule", new CountryRule() {
+            @Override
+            public Country getCountry() {
+                return Country.MISSING;
+            }
+            
             @Override
             public double getMaxSpeed(ReaderWay readerWay, TransportationMode transportationMode, double currentMaxSpeed) {
                 return 5;

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMRoadAccessParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMRoadAccessParserTest.java
@@ -19,6 +19,7 @@
 package com.graphhopper.routing.util.parsers;
 
 import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.Country;
 import com.graphhopper.routing.ev.EnumEncodedValue;
 import com.graphhopper.routing.ev.RoadAccess;
 import com.graphhopper.routing.ev.RoadClass;
@@ -51,6 +52,11 @@ class OSMRoadAccessParserTest {
         ReaderWay way = new ReaderWay(27L);
         way.setTag("highway", "track");
         way.setTag("country_rule", new CountryRule() {
+            @Override
+            public Country getCountry() {
+                return Country.MISSING;
+            }
+            
             @Override
             public RoadAccess getAccess(ReaderWay readerWay, TransportationMode transportationMode, RoadAccess currentRoadAccess) {
                 return RoadAccess.DESTINATION;


### PR DESCRIPTION
Fixes #2404

I've only added  a check for the CountryCode not being null as ServiceLoader.iterator() throws an exception for malformed entries and missing or uninstantiable classes: https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html#iterator--

We can also add a unittest to check if all rules are added to the service definition file.