### PR TITLE
Fix loading localizations from ios bundle

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -72,6 +72,7 @@ Here is an overview:
  * vvikas, ideas for many to many improvements and #616
  * zstadler, multiple fixes and car4wd
  * samruston, improved point hint matching
+ * OlKir, improvements regarding iOS
 
 ## Translations
 

--- a/core/src/main/java/com/graphhopper/util/TranslationMap.java
+++ b/core/src/main/java/com/graphhopper/util/TranslationMap.java
@@ -69,7 +69,11 @@ public class TranslationMap {
         try {
             for (String locale : LOCALES) {
                 TranslationHashMap trMap = new TranslationHashMap(getLocale(locale));
-                trMap.doImport(TranslationMap.class.getResourceAsStream(locale + ".txt"));
+                InputStream stream = TranslationMap.class.getResourceAsStream(locale + ".txt");
+                if (stream == null) {
+                    stream = TranslationMap.class.getResourceAsStream("/" + locale + ".txt");
+                }
+                trMap.doImport(stream);
                 add(trMap);
             }
             postImportHook();


### PR DESCRIPTION
Because in iOS app bundle resources (including localization files) placed differently as in web version `TranslationMap.class.getResourceAsStream` returns `null` instead of stream. To fix this add "/" if the first attempt failed.