### PR TITLE
Convert `Directory#find` to `Directory#create`

### DIFF
--- a/core/src/main/java/com/graphhopper/coll/OSMIDMap.java
+++ b/core/src/main/java/com/graphhopper/coll/OSMIDMap.java
@@ -45,9 +45,9 @@ public class OSMIDMap implements LongIntMap {
     public OSMIDMap(Directory dir, int noNumber) {
         this.dir = dir;
         this.noEntryValue = noNumber;
-        keys = dir.find("osmid_map_keys");
+        keys = dir.create("osmid_map_keys");
         keys.create(2000);
-        values = dir.find("osmid_map_values");
+        values = dir.create("osmid_map_values");
         values.create(1000);
     }
 

--- a/core/src/main/java/com/graphhopper/reader/PillarInfo.java
+++ b/core/src/main/java/com/graphhopper/reader/PillarInfo.java
@@ -38,7 +38,7 @@ public class PillarInfo implements PointAccess {
     public PillarInfo(boolean enabled3D, Directory dir) {
         this.enabled3D = enabled3D;
         this.dir = dir;
-        this.da = dir.find("tmp_pillar_info").create(100);
+        this.da = dir.create("tmp_pillar_info").create(100);
         this.rowSizeInBytes = getDimension() * 4;
     }
 

--- a/core/src/main/java/com/graphhopper/reader/dem/AbstractSRTMElevationProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/AbstractSRTMElevationProvider.java
@@ -102,7 +102,7 @@ public abstract class AbstractSRTMElevationProvider extends TileBasedElevationPr
             if (fileName == null)
                 return 0;
 
-            DataAccess heights = getDirectory().find("dem" + intKey);
+            DataAccess heights = getDirectory().create("dem" + intKey);
             boolean loadExisting = false;
             try {
                 loadExisting = heights.loadExisting();

--- a/core/src/main/java/com/graphhopper/reader/dem/AbstractTiffElevationProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/AbstractTiffElevationProvider.java
@@ -117,7 +117,7 @@ public abstract class AbstractTiffElevationProvider extends TileBasedElevationPr
             demProvider.setInterpolate(interpolate);
 
             cacheData.put(name, demProvider);
-            DataAccess heights = getDirectory().find(name + ".gh");
+            DataAccess heights = getDirectory().create(name + ".gh");
             demProvider.setHeights(heights);
             boolean loadExisting = false;
             try {

--- a/core/src/main/java/com/graphhopper/routing/lm/LandmarkStorage.java
+++ b/core/src/main/java/com/graphhopper/routing/lm/LandmarkStorage.java
@@ -760,6 +760,13 @@ public class LandmarkStorage {
     }
 
     /**
+     * For testing only
+     */
+    DataAccess _getInternalDA() {
+        return landmarkWeightDA;
+    }
+
+    /**
      * This class is used to calculate landmark location (equally distributed).
      * It derives from DijkstraBidirectionRef, but is only used as forward or backward search.
      */

--- a/core/src/main/java/com/graphhopper/routing/lm/LandmarkStorage.java
+++ b/core/src/main/java/com/graphhopper/routing/lm/LandmarkStorage.java
@@ -132,7 +132,7 @@ public class LandmarkStorage {
         // use the node based traversal as this is a smaller weight approximation and will still produce correct results
         // In this sense its even 'better' to use node-based.
         this.traversalMode = TraversalMode.NODE_BASED;
-        this.landmarkWeightDA = dir.find("landmarks_" + lmConfig.getName());
+        this.landmarkWeightDA = dir.create("landmarks_" + lmConfig.getName());
 
         this.landmarks = landmarks;
         // one short per landmark and two directions => 2*2 byte

--- a/core/src/main/java/com/graphhopper/routing/subnetwork/SubnetworkStorage.java
+++ b/core/src/main/java/com/graphhopper/routing/subnetwork/SubnetworkStorage.java
@@ -32,7 +32,7 @@ public class SubnetworkStorage {
 
     public SubnetworkStorage(Directory dir, String postfix) {
         DAType type = dir.getDefaultType();
-        da = dir.find("subnetwork_" + postfix, type.isMMap() ? DAType.MMAP : (type.isStoring() ? DAType.RAM_STORE : DAType.RAM));
+        da = dir.create("subnetwork_" + postfix, type.isMMap() ? DAType.MMAP : (type.isStoring() ? DAType.RAM_STORE : DAType.RAM));
     }
 
     /**

--- a/core/src/main/java/com/graphhopper/search/StringIndex.java
+++ b/core/src/main/java/com/graphhopper/search/StringIndex.java
@@ -58,9 +58,9 @@ public class StringIndex {
      * Specify a larger cacheSize to reduce disk usage. Note that this increases the memory usage of this object.
      */
     public StringIndex(Directory dir, final int cacheSize) {
-        keys = dir.find("string_index_keys");
+        keys = dir.create("string_index_keys");
         keys.setSegmentSize(10 * 1024);
-        vals = dir.find("string_index_vals");
+        vals = dir.create("string_index_vals");
         smallCache = new LinkedHashMap<String, Long>(cacheSize, 0.75f, true) {
             @Override
             protected boolean removeEldestEntry(Map.Entry<String, Long> entry) {

--- a/core/src/main/java/com/graphhopper/storage/BaseGraph.java
+++ b/core/src/main/java/com/graphhopper/storage/BaseGraph.java
@@ -58,12 +58,12 @@ class BaseGraph implements Graph {
     public BaseGraph(Directory dir, int intsForFlags, boolean withElevation, boolean withTurnCosts, int segmentSize) {
         this.dir = dir;
         this.bitUtil = BitUtil.get(dir.getByteOrder());
-        this.wayGeometry = dir.find("geometry");
+        this.wayGeometry = dir.create("geometry");
         this.stringIndex = new StringIndex(dir);
         this.store = new BaseGraphNodesAndEdges(dir, intsForFlags, withElevation, withTurnCosts, segmentSize);
         this.nodeAccess = new GHNodeAccess(store);
         if (withTurnCosts) {
-            turnCostStorage = new TurnCostStorage(this, dir.find("turn_costs"));
+            turnCostStorage = new TurnCostStorage(this, dir.create("turn_costs"));
             if (segmentSize >= 0)
                 turnCostStorage.setSegmentSize(segmentSize);
         } else {

--- a/core/src/main/java/com/graphhopper/storage/BaseGraphNodesAndEdges.java
+++ b/core/src/main/java/com/graphhopper/storage/BaseGraphNodesAndEdges.java
@@ -61,8 +61,8 @@ class BaseGraphNodesAndEdges {
     private boolean frozen;
 
     public BaseGraphNodesAndEdges(Directory dir, int intsForFlags, boolean withElevation, boolean withTurnCosts, int segmentSize) {
-        nodes = dir.find("nodes", DAType.getPreferredInt(dir.getDefaultType()));
-        edges = dir.find("edges", DAType.getPreferredInt(dir.getDefaultType()));
+        nodes = dir.create("nodes", DAType.getPreferredInt(dir.getDefaultType()));
+        edges = dir.create("edges", DAType.getPreferredInt(dir.getDefaultType()));
         if (segmentSize >= 0) {
             nodes.setSegmentSize(segmentSize);
             edges.setSegmentSize(segmentSize);

--- a/core/src/main/java/com/graphhopper/storage/CHStorage.java
+++ b/core/src/main/java/com/graphhopper/storage/CHStorage.java
@@ -66,8 +66,8 @@ public class CHStorage {
 
     public CHStorage(Directory dir, String name, int segmentSize, boolean edgeBased) {
         this.edgeBased = edgeBased;
-        this.nodesCH = dir.find("nodes_ch_" + name, DAType.getPreferredInt(dir.getDefaultType()));
-        this.shortcuts = dir.find("shortcuts_" + name, DAType.getPreferredInt(dir.getDefaultType()));
+        this.nodesCH = dir.create("nodes_ch_" + name, DAType.getPreferredInt(dir.getDefaultType()));
+        this.shortcuts = dir.create("shortcuts_" + name, DAType.getPreferredInt(dir.getDefaultType()));
         if (segmentSize >= 0) {
             nodesCH.setSegmentSize(segmentSize);
             shortcuts.setSegmentSize(segmentSize);

--- a/core/src/main/java/com/graphhopper/storage/Directory.java
+++ b/core/src/main/java/com/graphhopper/storage/Directory.java
@@ -67,10 +67,5 @@ public interface Directory {
      */
     void close();
 
-    /**
-     * Returns all created directories.
-     */
-    Collection<DataAccess> getAll();
-
     Directory create();
 }

--- a/core/src/main/java/com/graphhopper/storage/Directory.java
+++ b/core/src/main/java/com/graphhopper/storage/Directory.java
@@ -43,9 +43,9 @@ public interface Directory {
      * Tries to find the object with that name if not existent it creates one and associates the
      * location with it. A name is unique in one Directory.
      */
-    DataAccess find(String name);
+    DataAccess create(String name);
 
-    DataAccess find(String name, DAType type);
+    DataAccess create(String name, DAType type);
 
     /**
      * Removes the specified object from the directory.

--- a/core/src/main/java/com/graphhopper/storage/GHDirectory.java
+++ b/core/src/main/java/com/graphhopper/storage/GHDirectory.java
@@ -19,7 +19,6 @@ package com.graphhopper.storage;
 
 import java.io.File;
 import java.nio.ByteOrder;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -56,12 +55,12 @@ public class GHDirectory implements Directory {
     }
 
     @Override
-    public DataAccess find(String name) {
-        return find(name, defaultType);
+    public DataAccess create(String name) {
+        return create(name, defaultType);
     }
 
     @Override
-    public DataAccess find(String name, DAType type) {
+    public DataAccess create(String name, DAType type) {
         if (!name.equals(toLowerCase(name)))
             throw new IllegalArgumentException("Since 0.7 DataAccess objects does no longer accept upper case names");
 

--- a/core/src/main/java/com/graphhopper/storage/GHDirectory.java
+++ b/core/src/main/java/com/graphhopper/storage/GHDirectory.java
@@ -35,7 +35,6 @@ public class GHDirectory implements Directory {
     private final DAType defaultType;
     private final ByteOrder byteOrder = ByteOrder.LITTLE_ENDIAN;
     protected Map<String, DataAccess> map = new HashMap<>();
-    protected Map<String, DAType> types = new HashMap<>();
 
     public GHDirectory(String _location, DAType defaultType) {
         this.defaultType = defaultType;
@@ -56,21 +55,9 @@ public class GHDirectory implements Directory {
         return byteOrder;
     }
 
-    public Directory put(String name, DAType type) {
-        if (!name.equals(toLowerCase(name)))
-            throw new IllegalArgumentException("Since 0.7 DataAccess objects does no longer accept upper case names");
-
-        types.put(name, type);
-        return this;
-    }
-
     @Override
     public DataAccess find(String name) {
-        DAType type = types.get(name);
-        if (type == null)
-            type = defaultType;
-
-        return find(name, type);
+        return find(name, defaultType);
     }
 
     @Override
@@ -78,14 +65,12 @@ public class GHDirectory implements Directory {
         if (!name.equals(toLowerCase(name)))
             throw new IllegalArgumentException("Since 0.7 DataAccess objects does no longer accept upper case names");
 
-        DataAccess da = map.get(name);
-        if (da != null) {
-            if (!type.equals(da.getType()))
-                throw new IllegalStateException("Found existing DataAccess object '" + name
-                        + "' but types did not match. Requested:" + type + ", was:" + da.getType());
-            return da;
-        }
+        if (map.containsKey(name))
+            // we do not allow creating two DataAccess with the same name, because on disk there can only be one DA
+            // per file name
+            throw new IllegalStateException("DataAccess " + name + " has already been created");
 
+        DataAccess da;
         if (type.isInMemory()) {
             if (type.isInteg()) {
                 if (type.isStoring())
@@ -152,11 +137,6 @@ public class GHDirectory implements Directory {
         if (isStoring())
             new File(location).mkdirs();
         return this;
-    }
-
-    @Override
-    public Collection<DataAccess> getAll() {
-        return map.values();
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/storage/StorableProperties.java
+++ b/core/src/main/java/com/graphhopper/storage/StorableProperties.java
@@ -41,7 +41,7 @@ public class StorableProperties {
     private final DataAccess da;
 
     public StorableProperties(Directory dir) {
-        this.da = dir.find("properties");
+        this.da = dir.create("properties");
         // reduce size
         da.setSegmentSize(1 << 15);
     }

--- a/core/src/main/java/com/graphhopper/storage/index/LineIntIndex.java
+++ b/core/src/main/java/com/graphhopper/storage/index/LineIntIndex.java
@@ -49,7 +49,7 @@ public class LineIntIndex {
 
     public LineIntIndex(BBox bBox, Directory dir, String name) {
         this.bounds = bBox;
-        this.dataAccess = dir.find(name, DAType.getPreferredInt(dir.getDefaultType()));
+        this.dataAccess = dir.create(name, DAType.getPreferredInt(dir.getDefaultType()));
     }
 
     public boolean loadExisting() {

--- a/core/src/main/java/com/graphhopper/storage/index/LocationIndexTree.java
+++ b/core/src/main/java/com/graphhopper/storage/index/LocationIndexTree.java
@@ -73,9 +73,25 @@ public class LocationIndexTree implements LocationIndex {
      * @param g the graph for which this index should do the lookup based on latitude,longitude.
      */
     public LocationIndexTree(Graph g, Directory dir) {
+        this(g, dir, "location_index");
+    }
+
+    public LocationIndexTree(Graph g, Directory dir, String dataAccessName) {
         this.graph = g;
         this.nodeAccess = g.getNodeAccess();
         this.directory = dir;
+
+        // Clone this defensively -- In case something funny happens and things get added to the Graph after
+        // this index is built. Reason is that the expected structure of the index is a function of the bbox, so we
+        // need it to be immutable.
+        BBox bounds = graph.getBounds().clone();
+
+        // I want to be able to create a location index for the empty graph without error, but for that
+        // I need valid bounds so that the initialization logic works.
+        if (!bounds.isValid())
+            bounds = new BBox(-10.0, 10.0, -10.0, 10.0);
+
+        lineIntIndex = new LineIntIndex(bounds, directory, dataAccessName);
     }
 
     public int getMinResolutionInMeter() {
@@ -116,18 +132,6 @@ public class LocationIndexTree implements LocationIndex {
     }
 
     public boolean loadExisting() {
-        // Clone this defensively -- In case something funny happens and things get added to the Graph after
-        // this index is built. Reason is that the expected structure of the index is a function of the bbox, so we
-        // need it to be immutable.
-        BBox bounds = graph.getBounds().clone();
-
-        // I want to be able to create a location index for the empty graph without error, but for that
-        // I need valid bounds so that the initialization logic works.
-        if (!bounds.isValid())
-            bounds = new BBox(-10.0,10.0,-10.0,10.0);
-
-        lineIntIndex = new LineIntIndex(bounds, directory, "location_index");
-
         if (!lineIntIndex.loadExisting())
             return false;
 
@@ -166,7 +170,6 @@ public class LocationIndexTree implements LocationIndex {
 
         InMemConstructionIndex inMemConstructionIndex = prepareInMemConstructionIndex(bounds, edgeFilter);
 
-        lineIntIndex = new LineIntIndex(bounds, directory, "location_index");
         lineIntIndex.setMinResolutionInMeter(minResolutionInMeter);
         lineIntIndex.store(inMemConstructionIndex);
         lineIntIndex.setChecksum(checksum());

--- a/core/src/test/java/com/graphhopper/coll/OSMIDMapTest.java
+++ b/core/src/test/java/com/graphhopper/coll/OSMIDMapTest.java
@@ -59,7 +59,7 @@ public class OSMIDMapTest {
 
     @Test
     public void testBinSearch() {
-        DataAccess da = new RAMDirectory().find("");
+        DataAccess da = new RAMDirectory().create("");
         da.create(100);
 
         da.setInt(0 * 4, 1);

--- a/core/src/test/java/com/graphhopper/reader/dem/HeightTileTest.java
+++ b/core/src/test/java/com/graphhopper/reader/dem/HeightTileTest.java
@@ -34,7 +34,7 @@ public class HeightTileTest {
         int width = 10;
         int height = 20;
         HeightTile instance = new HeightTile(0, 0, width, height, 1e-6, 10, 20);
-        DataAccess heights = new RAMDirectory().find("tmp");
+        DataAccess heights = new RAMDirectory().create("tmp");
         heights.create(2 * width * height);
         instance.setHeights(heights);
         init(heights, width, height, 1);
@@ -77,7 +77,7 @@ public class HeightTileTest {
     public void testGetHeightForNegativeTile() {
         int width = 10;
         HeightTile instance = new HeightTile(-20, -20, width, width, 1e-6, 10, 10);
-        DataAccess heights = new RAMDirectory().find("tmp");
+        DataAccess heights = new RAMDirectory().create("tmp");
         heights.create(2 * 10 * 10);
         instance.setHeights(heights);
         init(heights, width, width, 1);
@@ -98,7 +98,7 @@ public class HeightTileTest {
     @Test
     public void testInterpolate() {
         HeightTile instance = new HeightTile(0, 0, 2, 2, 1e-6, 10, 10).setInterpolate(true);
-        DataAccess heights = new RAMDirectory().find("tmp");
+        DataAccess heights = new RAMDirectory().create("tmp");
         heights.create(2 * 2 * 2);
         instance.setHeights(heights);
         double topLeft = 0;

--- a/core/src/test/java/com/graphhopper/routing/lm/LandmarkStorageTest.java
+++ b/core/src/test/java/com/graphhopper/routing/lm/LandmarkStorageTest.java
@@ -95,11 +95,9 @@ public class LandmarkStorageTest {
     public void testSetGetWeight() {
         GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(40.1));
         Directory dir = new RAMDirectory();
-        DataAccess da = dir.find("landmarks_c1");
-        da.create(2000);
-
         LandmarkStorage lms = new LandmarkStorage(graph, dir, new LMConfig("c1", new FastestWeighting(encoder)), 4).
                 setMaximumWeight(LandmarkStorage.PRECISION);
+        lms._getInternalDA().create(2000);
         // 2^16=65536, use -1 for infinity and -2 for maximum
         lms.setWeight(0, 65536);
         // reached maximum value but do not reset to 0 instead use 2^16-2
@@ -109,7 +107,7 @@ public class LandmarkStorageTest {
         lms.setWeight(0, 79999);
         assertEquals(65534, lms.getFromWeight(0, 0));
 
-        da.setInt(0, Integer.MAX_VALUE);
+        lms._getInternalDA().setInt(0, Integer.MAX_VALUE);
         assertTrue(lms.isInfinity(0));
         // for infinity return much bigger value
         // assertEquals(Integer.MAX_VALUE, lms.getFromWeight(0, 0));

--- a/core/src/test/java/com/graphhopper/storage/AbstractDirectoryTester.java
+++ b/core/src/test/java/com/graphhopper/storage/AbstractDirectoryTester.java
@@ -50,15 +50,15 @@ public abstract class AbstractDirectoryTester {
     @Test
     public void testNoDuplicates() {
         Directory dir = createDir();
-        DataAccess da1 = dir.find("testing");
-        assertThrows(IllegalStateException.class, () -> dir.find("testing"));
+        DataAccess da1 = dir.create("testing");
+        assertThrows(IllegalStateException.class, () -> dir.create("testing"));
         da1.close();
     }
 
     @Test
     public void testNoErrorForDACreate() {
         Directory dir = createDir();
-        da = dir.find("testing");
+        da = dir.create("testing");
         da.create(100);
         da.flush();
     }

--- a/core/src/test/java/com/graphhopper/storage/AbstractDirectoryTester.java
+++ b/core/src/test/java/com/graphhopper/storage/AbstractDirectoryTester.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
-import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * @author Peter Karich
@@ -51,10 +51,8 @@ public abstract class AbstractDirectoryTester {
     public void testNoDuplicates() {
         Directory dir = createDir();
         DataAccess da1 = dir.find("testing");
-        DataAccess da2 = dir.find("testing");
-        assertSame(da1, da2);
+        assertThrows(IllegalStateException.class, () -> dir.find("testing"));
         da1.close();
-        da2.close();
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/storage/AbstractGraphStorageTester.java
+++ b/core/src/test/java/com/graphhopper/storage/AbstractGraphStorageTester.java
@@ -677,6 +677,7 @@ public abstract class AbstractGraphStorageTester {
         assertEquals(Integer.MAX_VALUE / 3, edge.getFlags().ints[0]);
         graph.close();
 
+        dir = new RAMDirectory();
         graph = new GraphHopperStorage(dir, manager, false).create(defaultSize);
 
         DecimalEncodedValue avSpeed0Enc = manager.getDecimalEncodedValue(getKey("car0", "average_speed"));

--- a/reader-gtfs/src/main/java/com/graphhopper/gtfs/GraphHopperGtfs.java
+++ b/reader-gtfs/src/main/java/com/graphhopper/gtfs/GraphHopperGtfs.java
@@ -125,7 +125,8 @@ public class GraphHopperGtfs extends GraphHopper {
                 throw new RuntimeException("Error while constructing transit network. Is your GTFS file valid? Please check log for possible causes.", e);
             }
             streetNetworkIndex.close();
-            LocationIndexTree locationIndex = new LocationIndexTree(getGraphHopperStorage(), getGraphHopperStorage().getDirectory());
+            // we have to set an explicit location index name, because the default one is already taken
+            LocationIndexTree locationIndex = new LocationIndexTree(getGraphHopperStorage(), getGraphHopperStorage().getDirectory(), "location_index_pt");
             PtEncodedValues ptEncodedValues = PtEncodedValues.fromEncodingManager(getEncodingManager());
             EnumEncodedValue<GtfsStorage.EdgeType> typeEnc = ptEncodedValues.getTypeEnc();
             locationIndex.prepareIndex(edgeState -> edgeState.get(typeEnc) == GtfsStorage.EdgeType.HIGHWAY);


### PR DESCRIPTION
We currently have `Directory#find` which should rather be called `Directory#findOrCreate`. However, there are only very few cases where we actually make use of the `find` part and these look rather like `find` was used this way accidentally. The underlying problem is that generally there is a 1:1 correspondence between `DataAccess` objects and files on disk, so for every file there can only be one such object. There are some exceptions to this rule: 

* `RAM(_INT)` DataAccess aren't really related to files at all because they can never be flushed to disk
* even `RAM_STORE` DataAccess objects might live only in memory and only if they are flushed they actually correspond to a file on disk.

But anyway, making sure each name is used only once does make some sense, because this way we definitely avoid the case where multiple DataAccess could be flushed to the same file (and overwrite each other). Well, at least as long all DataAccess objects are created using the same `Directory` that is.

Our `Directory#find` method does *not* give such a guarantee though. It makes sure that no two DataAccess objects with the same name are created, but code calling `Directory#find` might still accidentally receive a reference to a DataAccess object that is already in use. In this case we might accidentally overwrite data while it is *in memory*.

There is another issue with `Directory#find`: It has a `daType` parameter, but the `daType` is only useful for the case `find()` **creates** a new object. If it just returns an existing one it is useless, and we are forced to pass 'the right' daType which is just a very annoying API. To make things worse there is also `segmentSize` which we would have to deal with the same way if we wanted to remove the (rather pointless) `setSegmentSize` setter. `setSegmentSize` is problematic, because the segment size cannot be changed after the DataAccess was created (see #1792).

In this PR I removed the `find` part of `Directory#find` and turned it into `Directory#create`. It is now illegal to use the same name multiple times. This way there cannot be multiple DataAccess objects with the same name (as long as they are created using Directory) and flushing to disk should be save in this regard.

I do not think this is the end of this story, but certainly a step into the right direction. I think after this PR we can easily fix #1792 and #2386,  and should be able to remove `DataAccess#create` and `DataAccess#loadExisting` (c.f. #2403).