### PR TITLE
HMM-Lib: Bump Java version to 8

### DIFF
--- a/hmm-lib/pom.xml
+++ b/hmm-lib/pom.xml
@@ -57,17 +57,4 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
-
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/hmm-lib/pom.xml
+++ b/hmm-lib/pom.xml
@@ -64,8 +64,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
We switched to Junit5 some time ago. Junit5 requires Java 8. The hmm-lib is still on Java 7. 

When you try to execute the `ViterbiAlgorithmTest` in InteliJ, there is a build error, as the pom sets the language level to Java 7.

```
/graphopper/graphhopper/hmm-lib/src/test/java/com/bmw/hmm/ViterbiAlgorithmTest.java:153:9
java: cannot access java.util.function.BooleanSupplier
  class file for java.util.function.BooleanSupplier not found
```

Bumping the version to Java 8 fixes that problem. Running through the command line works fine, so I am a bit unsure about this change, but I guess bumping the version should not hurt?