### PR TITLE
country_rules: fix documentation in example config

### DIFF
--- a/config-example.yml
+++ b/config-example.yml
@@ -165,7 +165,7 @@ graphhopper:
 
   ##### Country Rules #####
   # GraphHopper applies country-specific routing rules during import (not enabled by default).
-  # You need to redo the import for change to take effect.
+  # You need to redo the import for changes to take effect.
   # country_rules.enabled: true
 
 # Dropwizard server configuration

--- a/config-example.yml
+++ b/config-example.yml
@@ -164,9 +164,9 @@ graphhopper:
   # custom_areas.directory: path/to/custom_areas
 
   ##### Country Rules #####
-  # GraphHopper applies country-specific routing rules (enabled by default) during import.
-  # Use this flag to disable these rules (you need to repeat the import for changes to take effect)
-  # country_rules.enable: false
+  # GraphHopper applies country-specific routing rules during import (not enabled by default).
+  # You need to redo the import for change to take effect.
+  # country_rules.enabled: true
 
 # Dropwizard server configuration
 server:

--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -460,10 +460,7 @@ public class GraphHopper {
             graphHopperFolder = pruneFileEnd(osmFile) + "-gh";
         }
 
-        if (ghConfig.has("country_rules.enabled")) {
-            boolean countryRulesEnabled = ghConfig.getBool("country_rules.enabled", false);
-            countryRuleFactory = countryRulesEnabled ? new CountryRuleFactory() : null;
-        }
+        countryRuleFactory = ghConfig.getBool("country_rules.enabled", false) ? new CountryRuleFactory() : null;
         customAreasDirectory = ghConfig.getString("custom_areas.directory", customAreasDirectory);
 
         // graph


### PR DESCRIPTION
I think that the documentation does not match the code. At the moment the default is "disabled country rules".