### PR TITLE
Remove small segment size optimization for sea level elevation tiles

### DIFF
--- a/core/src/main/java/com/graphhopper/reader/dem/AbstractSRTMElevationProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/AbstractSRTMElevationProvider.java
@@ -119,8 +119,8 @@ public abstract class AbstractSRTMElevationProvider extends TileBasedElevationPr
                     demProvider.setHeights(heights);
                     demProvider.setSeaLevel(true);
                     // use small size on disc and in-memory
-                    heights.setSegmentSize(100).create(10).
-                            flush();
+                    heights.create(10)
+                            .flush();
                     return 0;
                 }
             }

--- a/core/src/main/java/com/graphhopper/reader/dem/AbstractTiffElevationProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/AbstractTiffElevationProvider.java
@@ -135,8 +135,7 @@ public abstract class AbstractTiffElevationProvider extends TileBasedElevationPr
                 } catch (IOException e) {
                     demProvider.setSeaLevel(true);
                     // use small size on disc and in-memory
-                    heights.setSegmentSize(100).create(10).
-                            flush();
+                    heights.create(10).flush();
                     return 0;
                 }
 

--- a/core/src/test/java/com/graphhopper/reader/dem/CGIARProviderTest.java
+++ b/core/src/test/java/com/graphhopper/reader/dem/CGIARProviderTest.java
@@ -89,9 +89,9 @@ public class CGIARProviderTest {
         });
         assertEquals(0, instance.getEle(46, -20), 1);
 
-        // file not found => small!
+        // file not found
         assertTrue(file.exists());
-        assertEquals(228, file.length());
+        assertEquals(1048767, file.length());
 
         instance.setDownloader(new Downloader("test GH") {
             @Override

--- a/core/src/test/java/com/graphhopper/reader/dem/CGIARProviderTest.java
+++ b/core/src/test/java/com/graphhopper/reader/dem/CGIARProviderTest.java
@@ -91,7 +91,7 @@ public class CGIARProviderTest {
 
         // file not found
         assertTrue(file.exists());
-        assertEquals(1048767, file.length());
+        assertEquals(1048676, file.length());
 
         instance.setDownloader(new Downloader("test GH") {
             @Override

--- a/core/src/test/java/com/graphhopper/reader/dem/GMTEDProviderTest.java
+++ b/core/src/test/java/com/graphhopper/reader/dem/GMTEDProviderTest.java
@@ -96,9 +96,9 @@ public class GMTEDProviderTest {
         });
         assertEquals(0, instance.getEle(46, -20), 1);
 
-        // file not found => small!
+        // file not found
         assertTrue(file.exists());
-        assertEquals(228, file.length());
+        assertEquals(1048676, file.length());
 
         instance.setDownloader(new Downloader("test GH") {
             @Override


### PR DESCRIPTION
We reduce the segment size (1MB) by default for elevation tiles where the elevation is equal to the sealevel everywhere anyway. However, this only affects a minor fraction of these tiles so no real need for this optimization.

Getting rid of this will help with #1794, but once we got rid of the `loadExisting` lifecycle of `DataAccess` we can probably easily put it back if we really want to. Another option could be to just always use the smaller segment size (also for the normal elevation tiles), but not sure how this will affect performance.