### PR TITLE
Register country rules in a map

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/countryrules/AustriaCountryRule.java
+++ b/core/src/main/java/com/graphhopper/routing/util/countryrules/AustriaCountryRule.java
@@ -24,7 +24,6 @@ import com.graphhopper.routing.ev.RoadClass;
 import com.graphhopper.routing.util.TransportationMode;
 
 public class AustriaCountryRule implements CountryRule {
-    public final static AustriaCountryRule RULE = new AustriaCountryRule();
 
     @Override
     public double getMaxSpeed(ReaderWay readerWay, TransportationMode transportationMode, double currentMaxSpeed) {

--- a/core/src/main/java/com/graphhopper/routing/util/countryrules/CountryRuleFactory.java
+++ b/core/src/main/java/com/graphhopper/routing/util/countryrules/CountryRuleFactory.java
@@ -18,18 +18,28 @@
 
 package com.graphhopper.routing.util.countryrules;
 
+
+import static com.graphhopper.routing.ev.Country.*;
+
+import java.util.EnumMap;
+import java.util.Map;
+
 import com.graphhopper.routing.ev.Country;
 
 public class CountryRuleFactory {
+    
+    private final Map<Country, CountryRule> rules = new EnumMap<>(Country.class);
+    
+    public CountryRuleFactory() {
+        rules.put(AUT, new AustriaCountryRule());
+        rules.put(DEU, new GermanyCountryRule());
+    }
 
     public CountryRule getCountryRule(Country country) {
-        switch (country) {
-            case DEU:
-                return GermanyCountryRule.RULE;
-            case AUT:
-                return AustriaCountryRule.RULE;
-            default:
-                return null;
-        }
+        return rules.get(country);
+    }
+    
+    public Map<Country, CountryRule> getCountryToRuleMap() {
+        return rules;
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/util/countryrules/GermanyCountryRule.java
+++ b/core/src/main/java/com/graphhopper/routing/util/countryrules/GermanyCountryRule.java
@@ -28,7 +28,6 @@ import com.graphhopper.routing.util.TransportationMode;
  * @author Robin Boldt
  */
 public class GermanyCountryRule implements CountryRule {
-    public final static GermanyCountryRule RULE = new GermanyCountryRule();
 
     /**
      * In Germany there are roads without a speed limit. For these roads, this method


### PR DESCRIPTION
* avoids the need for static `RULE` instances
* allows lib users to easily manipulate registered rules without having to implement their own factory

See discussion in https://github.com/graphhopper/graphhopper/issues/2404