### PR TITLE
Don't ignore parsed access

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMRoadAccessParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMRoadAccessParser.java
@@ -59,7 +59,7 @@ public class OSMRoadAccessParser implements TagParser {
 
         CountryRule countryRule = readerWay.getTag("country_rule", null);
         if (countryRule != null)
-            accessValue = countryRule.getAccess(readerWay, TransportationMode.CAR, YES);
+            accessValue = countryRule.getAccess(readerWay, TransportationMode.CAR, accessValue);
 
         roadAccessEnc.setEnum(false, edgeFlags, accessValue);
         return edgeFlags;


### PR DESCRIPTION
The OSMRoadAccessParser currently ignores the parsed access and always passes RoadAccess.YES to the CountryRule