### PR TITLE
explicitly treat unhewn_cobblestone as a bad surface

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -48,7 +48,7 @@ Here is an overview:
  * kodonnell, adding support for CH and other algorithms (#60) and penalizing inner-link U-turns (#88)
  * legraina, improved docker for dockerhub
  * lmar, improved instructions
- * matkoniecz, tweaking documentation
+ * Mateusz Konieczny (matkoniecz), tweaking documentation and minor fixes
  * manueltimita, fixes like #1651
  * mathstpierre, fixes like #1753
  * michalmac, fixes like #1467

--- a/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
@@ -112,7 +112,8 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
 
         setSurfaceSpeed("paved", 18);
         setSurfaceSpeed("asphalt", 18);
-        setSurfaceSpeed("cobblestone", 8);
+        setSurfaceSpeed("unhewn_cobblestone", 4);
+        setSurfaceSpeed("cobblestone", 10);
         setSurfaceSpeed("cobblestone:flattened", 10);
         setSurfaceSpeed("sett", 10);
         setSurfaceSpeed("concrete", 18);

--- a/core/src/main/java/com/graphhopper/routing/util/CarFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/CarFlagEncoder.java
@@ -96,6 +96,7 @@ public class CarFlagEncoder extends AbstractFlagEncoder {
         blockByDefaultBarriers.add("sump_buster");
 
         badSurfaceSpeedMap.add("cobblestone");
+        badSurfaceSpeedMap.add("unhewn_cobblestone");
         badSurfaceSpeedMap.add("grass_paver");
         badSurfaceSpeedMap.add("gravel");
         badSurfaceSpeedMap.add("sand");

--- a/core/src/main/java/com/graphhopper/routing/util/MountainBikeFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/MountainBikeFlagEncoder.java
@@ -56,6 +56,7 @@ public class MountainBikeFlagEncoder extends BikeCommonFlagEncoder {
 
         setSurfaceSpeed("paved", 18);
         setSurfaceSpeed("asphalt", 18);
+        setSurfaceSpeed("unhewn_cobblestone", 6);
         setSurfaceSpeed("cobblestone", 10);
         setSurfaceSpeed("cobblestone:flattened", 10);
         setSurfaceSpeed("sett", 10);

--- a/core/src/main/java/com/graphhopper/routing/util/RacingBikeFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/RacingBikeFlagEncoder.java
@@ -62,6 +62,7 @@ public class RacingBikeFlagEncoder extends BikeCommonFlagEncoder {
 
         setSurfaceSpeed("paved", 20);
         setSurfaceSpeed("asphalt", 20);
+        setSurfaceSpeed("unhewn_cobblestone", PUSHING_SECTION_SPEED);
         setSurfaceSpeed("cobblestone", 10);
         setSurfaceSpeed("cobblestone:flattened", 10);
         setSurfaceSpeed("sett", 10);

--- a/core/src/main/java/com/graphhopper/routing/util/WheelchairFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/WheelchairFlagEncoder.java
@@ -87,6 +87,7 @@ public class WheelchairFlagEncoder extends FootFlagEncoder {
         excludeHighwayTags.add("steps");
         excludeHighwayTags.add("track");
 
+        excludeSurfaces.add("unhewn_cobblestone");
         excludeSurfaces.add("cobblestone");
         excludeSurfaces.add("gravel");
         excludeSurfaces.add("sand");

--- a/core/src/test/java/com/graphhopper/routing/util/CarFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/CarFlagEncoderTest.java
@@ -340,6 +340,13 @@ public class CarFlagEncoderTest {
         assertEquals(30, avSpeedEnc.getDecimal(false, edgeFlags), 1e-1);
 
         way.clearTags();
+        way.setTag("highway", "residential");
+        way.setTag("surface", "unhewn_cobblestone");
+        allowed = encoder.getAccess(way);
+        edgeFlags = encoder.handleWayTags(em.createEdgeFlags(), way, allowed);
+        assertEquals(30, avSpeedEnc.getDecimal(false, edgeFlags), 1e-1);
+
+        way.clearTags();
         way.setTag("highway", "track");
         allowed = encoder.getAccess(way);
         edgeFlags = encoder.handleWayTags(em.createEdgeFlags(), way, allowed);


### PR DESCRIPTION
https://wiki.openstreetmap.org/wiki/Tag:surface%3Dunhewn_cobblestone
https://taginfo.openstreetmap.org/tags/surface=unhewn_cobblestone#chronology

My contribution falls under the Apache License 2.0

Untested.

I still need to follow https://github.com/graphhopper/graphhopper/blob/master/CONTRIBUTING.md fully - I just noticed that this surface is still missing while updating my presentation slides

Disclaimer: I am author of this OSM wiki page and contributor to StreetComplete, one of main promoters of that tag