### PR TITLE
Ignore too large mtb:scale values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 5.0 [not yet released]
 
+- fixed handling of too large mtb:scale tags
 - use GraphHopper#setGraphHopperLocation before calling load() instead of GraphHopper#load(graphHopperLocation) (#2437)
 - barrier nodes at junctions are now ignored (#2433)
 - AbstractFlagEncoder#handleNodeTags was replaced by AbstractFlagEncoder#isBarrier (#2434)

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMMtbRatingParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMMtbRatingParser.java
@@ -34,7 +34,6 @@ import java.util.List;
  * @see <a href=""http://www.singletrail-skala.de/>Single Trail Scale</a>
  */
 public class OSMMtbRatingParser implements TagParser {
-
     private final IntEncodedValue mtbRatingEnc;
 
     public OSMMtbRatingParser() {
@@ -59,10 +58,8 @@ public class OSMMtbRatingParser implements TagParser {
             } catch (Exception ex) {
             }
         }
-
-        if (rating != 0)
+        if (rating > 0 && rating < 8)
             mtbRatingEnc.setInt(false, edgeFlags, rating);
-
         return edgeFlags;
     }
 }

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMMtbRatingParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMMtbRatingParserTest.java
@@ -1,0 +1,70 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.graphhopper.routing.util.parsers;
+
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.IntEncodedValue;
+import com.graphhopper.routing.ev.MtbRating;
+import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.storage.IntsRef;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class OSMMtbRatingParserTest {
+
+    @Test
+    void test() {
+        // 0 means missing (or invalid)
+        checkRating(0, null);
+        // rating=scale+1
+        checkRating(1, "0");
+        checkRating(6, "5");
+        checkRating(7, "6");
+        // we ignore + and - for now
+        checkRating(2, "1+");
+        checkRating(3, "2-");
+        // negative
+        checkRating(0, "-1");
+        // otherwise invalid
+        checkRating(0, "S1");
+        // too large value
+        checkRating(0, "8");
+        // also 'too large' even though it probably means "S1/2" etc. -> still ignored
+        checkRating(0, "12");
+        checkRating(0, "23");
+        // ... similar here
+        checkRating(0, "1-2");
+        checkRating(0, "0;1");
+        checkRating(0, "1;2");
+    }
+
+    private void checkRating(int expectedRating, String scaleString) {
+        OSMMtbRatingParser parser = new OSMMtbRatingParser();
+        EncodingManager em = new EncodingManager.Builder().add(parser).build();
+        IntEncodedValue ev = em.getIntEncodedValue(MtbRating.KEY);
+        IntsRef edgeFlags = em.createEdgeFlags();
+        ReaderWay way = new ReaderWay(0);
+        if (scaleString != null)
+            way.setTag("mtb:scale", scaleString);
+        parser.handleWayTags(edgeFlags, way, false, em.createRelationFlags());
+        assertEquals(expectedRating, ev.getInt(false, edgeFlags), "unexpected rating for mtb:scale=" + scaleString);
+    }
+
+}


### PR DESCRIPTION
Sometimes mappers seem to use `mtb:scale=12` or `mtb:scale=34`. They probably mean "S1/2", or "S3/4", but this is not recommended in the OSM wiki: https://wiki.openstreetmap.org/wiki/Key:mtb:scale?uselang=en. The wiki encourages mappers to use `1+` or `2-` instead of `S1/2` for example. There are less than 20 occurrences of `12`, `23` and `34` for the whole planet according to taginfo, so I think we can just ignore this. We already ignore the finer separation using `+/-` which is recommended in the wiki (and somewhat popular) btw.

This PR ignores values above 6. In current master we get an exception during import because the EV's maximum value is exceeded.