### PR TITLE
Remove RoadEnvironment.SHUTTLE_TRAIN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### 5.0 [not yet released]
 
-- removed RoadEnvironment.SHUTTLE_TRAIN. this is covered by `FERRY` (# ???)
+- removed RoadEnvironment.SHUTTLE_TRAIN. this is covered by `FERRY` (#2466)
 - fixed handling of too large mtb:scale tags
 - use GraphHopper#setGraphHopperLocation before calling load() instead of GraphHopper#load(graphHopperLocation) (#2437)
 - barrier nodes at junctions are now ignored (#2433)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 5.0 [not yet released]
 
+- removed RoadEnvironment.SHUTTLE_TRAIN. this is covered by `FERRY` (# ???)
 - fixed handling of too large mtb:scale tags
 - use GraphHopper#setGraphHopperLocation before calling load() instead of GraphHopper#load(graphHopperLocation) (#2437)
 - barrier nodes at junctions are now ignored (#2433)

--- a/core/src/main/java/com/graphhopper/routing/ev/RoadEnvironment.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/RoadEnvironment.java
@@ -20,12 +20,12 @@ package com.graphhopper.routing.ev;
 import com.graphhopper.util.Helper;
 
 /**
- * This enum the road environment of an edge. Currently road, ferry, tunnel, ford, bridge and shuttle_train. All edges
+ * This enum the road environment of an edge. Currently road, ferry, tunnel, ford, bridge. All edges
  * that do not fit get "other" as value.
  */
 public enum RoadEnvironment {
     OTHER("other"), ROAD("road"), FERRY("ferry"),
-    TUNNEL("tunnel"), BRIDGE("bridge"), FORD("ford"), SHUTTLE_TRAIN("shuttle_train");
+    TUNNEL("tunnel"), BRIDGE("bridge"), FORD("ford");
 
     public static final String KEY = "road_environment";
 

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMRoadEnvironmentParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMRoadEnvironmentParser.java
@@ -45,6 +45,7 @@ public class OSMRoadEnvironmentParser implements TagParser {
     public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay readerWay, boolean ferry, IntsRef relationFlags) {
         RoadEnvironment roadEnvironment = OTHER;
         if ((readerWay.hasTag("route", "ferry") && !readerWay.hasTag("ferry", "no")) ||
+                // TODO shuttle_train is sometimes also used in relations, e.g. https://www.openstreetmap.org/relation/1932780
                 readerWay.hasTag("route", "shuttle_train") && !readerWay.hasTag("shuttle_train", "no"))
             roadEnvironment = FERRY;
         else if (readerWay.hasTag("bridge") && !readerWay.hasTag("bridge", "no"))

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMRoadEnvironmentParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMRoadEnvironmentParser.java
@@ -44,7 +44,8 @@ public class OSMRoadEnvironmentParser implements TagParser {
     @Override
     public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay readerWay, boolean ferry, IntsRef relationFlags) {
         RoadEnvironment roadEnvironment = OTHER;
-        if (ferry)
+        if ((readerWay.hasTag("route", "ferry") && !readerWay.hasTag("ferry", "no")) ||
+                readerWay.hasTag("route", "shuttle_train") && !readerWay.hasTag("shuttle_train", "no"))
             roadEnvironment = FERRY;
         else if (readerWay.hasTag("bridge") && !readerWay.hasTag("bridge", "no"))
             roadEnvironment = BRIDGE;
@@ -52,9 +53,6 @@ public class OSMRoadEnvironmentParser implements TagParser {
             roadEnvironment = TUNNEL;
         else if (readerWay.hasTag("ford") || readerWay.hasTag("highway", "ford"))
             roadEnvironment = FORD;
-        else if (readerWay.hasTag("route", "shuttle_train"))
-            // TODO how to feed this information from a relation like https://www.openstreetmap.org/relation/1932780
-            roadEnvironment = SHUTTLE_TRAIN;
         else if (readerWay.hasTag("highway"))
             roadEnvironment = ROAD;
 

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMRoadEnvironmentParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMRoadEnvironmentParserTest.java
@@ -1,0 +1,51 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.graphhopper.routing.util.parsers;
+
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.EnumEncodedValue;
+import com.graphhopper.routing.ev.RoadEnvironment;
+import com.graphhopper.routing.util.CarFlagEncoder;
+import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.storage.IntsRef;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class OSMRoadEnvironmentParserTest {
+
+    @Test
+    void ferry() {
+        OSMRoadEnvironmentParser parser = new OSMRoadEnvironmentParser();
+        CarFlagEncoder carEncoder = new CarFlagEncoder();
+        EncodingManager em = new EncodingManager.Builder()
+                .add(carEncoder)
+                .add(parser).build();
+        EnumEncodedValue<RoadEnvironment> roadEnvironmentEnc = em.getEnumEncodedValue(RoadEnvironment.KEY, RoadEnvironment.class);
+        IntsRef edgeFlags = em.createEdgeFlags();
+        ReaderWay way = new ReaderWay(0);
+        way.setTag("route", "shuttle_train");
+        EncodingManager.AcceptWay acceptWay = new EncodingManager.AcceptWay();
+        em.acceptWay(way, acceptWay);
+        parser.handleWayTags(edgeFlags, way, acceptWay.isFerry(), em.createRelationFlags());
+        RoadEnvironment roadEnvironment = roadEnvironmentEnc.getEnum(false, edgeFlags);
+        assertEquals(RoadEnvironment.FERRY, roadEnvironment);
+    }
+
+}


### PR DESCRIPTION
See #2465. The alternative to removing it would be making sure it is actually used and handled properly also for snap_prevention and elevation interpolation.