### PR TITLE
Remove ferry argument from TagParser#handleWayTags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 5.0 [not yet released]
 
+- removed the ferry argument of TagParser#handleWayTags. ferry ways can be recognized using the reader way (#2467)
 - removed RoadEnvironment.SHUTTLE_TRAIN. this is covered by `FERRY` (#2466)
 - create edge flags per edge, not per way. increases custom_area precision -> (#2457)
 - fixed handling of too large mtb:scale tags (#2458)

--- a/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
@@ -207,7 +207,7 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
             EncodingManager.Access accept = EncodingManager.Access.CAN_SKIP;
 
             if (way.hasTag("route", ferries)) {
-                // if bike is NOT explicitly tagged allow bike but only if foot is not specified
+                // if bike is NOT explicitly tagged allow bike but only if foot is not specified either
                 String bikeTag = way.getTag("bicycle");
                 if (bikeTag == null && !way.hasTag("foot") || intendedValues.contains(bikeTag))
                     accept = EncodingManager.Access.FERRY;

--- a/core/src/main/java/com/graphhopper/routing/util/EncodingManager.java
+++ b/core/src/main/java/com/graphhopper/routing/util/EncodingManager.java
@@ -568,7 +568,7 @@ public class EncodingManager implements EncodedValueLookup {
     public IntsRef handleWayTags(ReaderWay way, AcceptWay acceptWay, IntsRef relationFlags) {
         IntsRef edgeFlags = createEdgeFlags();
         for (TagParser parser : edgeTagParsers) {
-            parser.handleWayTags(edgeFlags, way, acceptWay.isFerry(), relationFlags);
+            parser.handleWayTags(edgeFlags, way, relationFlags);
         }
         for (AbstractFlagEncoder encoder : edgeEncoders) {
             encoder.handleWayTags(edgeFlags, way, acceptWay.get(encoder.toString()));

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/CountryParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/CountryParser.java
@@ -18,10 +18,10 @@
 package com.graphhopper.routing.util.parsers;
 
 import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.Country;
 import com.graphhopper.routing.ev.EncodedValue;
 import com.graphhopper.routing.ev.EncodedValueLookup;
 import com.graphhopper.routing.ev.EnumEncodedValue;
-import com.graphhopper.routing.ev.Country;
 import com.graphhopper.storage.IntsRef;
 
 import java.util.List;
@@ -39,7 +39,7 @@ public class CountryParser implements TagParser {
     }
 
     @Override
-    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay way, boolean ferry, IntsRef relationFlags) {
+    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay way, IntsRef relationFlags) {
         Country country = way.getTag("country", Country.MISSING);
         countryEnc.setEnum(false, edgeFlags, country);
         return edgeFlags;

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMBikeNetworkTagParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMBikeNetworkTagParser.java
@@ -65,7 +65,7 @@ public class OSMBikeNetworkTagParser implements RelationTagParser {
     }
 
     @Override
-    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay way, boolean ferry, IntsRef relationFlags) {
+    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay way, IntsRef relationFlags) {
         // just copy value into different bit range
         RouteNetwork routeNetwork = transformerRouteRelEnc.getEnum(false, relationFlags);
         bikeRouteEnc.setEnum(false, edgeFlags, routeNetwork);

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMFootNetworkTagParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMFootNetworkTagParser.java
@@ -65,7 +65,7 @@ public class OSMFootNetworkTagParser implements RelationTagParser {
     }
 
     @Override
-    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay way, boolean ferry, IntsRef relationFlags) {
+    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay way, IntsRef relationFlags) {
         // just copy value into different bit range
         RouteNetwork footNetwork = transformerRouteRelEnc.getEnum(false, relationFlags);
         footRouteEnc.setEnum(false, edgeFlags, footNetwork);

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMGetOffBikeParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMGetOffBikeParser.java
@@ -36,7 +36,7 @@ public class OSMGetOffBikeParser implements TagParser {
     }
 
     @Override
-    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay way, boolean ferry, IntsRef relationFlags) {
+    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay way, IntsRef relationFlags) {
         String highway = way.getTag("highway");
         if (!way.hasTag("bicycle", accepted) && (pushBikeHighwayTags.contains(highway) || way.hasTag("railway", "platform"))
                 || "steps".equals(highway) || way.hasTag("bicycle", "dismount")) {

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMHazmatParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMHazmatParser.java
@@ -23,7 +23,7 @@ public class OSMHazmatParser implements TagParser {
     }
 
     @Override
-    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay readerWay, boolean ferry, IntsRef relationFlags) {
+    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay readerWay, IntsRef relationFlags) {
         if (readerWay.hasTag("hazmat", "no")) {
             hazEnc.setEnum(false, edgeFlags, Hazmat.NO);
         }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMHazmatTunnelParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMHazmatTunnelParser.java
@@ -33,7 +33,7 @@ public class OSMHazmatTunnelParser implements TagParser {
     }
 
     @Override
-    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay readerWay, boolean ferry, IntsRef relationFlags) {
+    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay readerWay, IntsRef relationFlags) {
         if (readerWay.hasTag("hazmat:adr_tunnel_cat", TUNNEL_CATEGORY_NAMES)) {
             HazmatTunnel code = HazmatTunnel.valueOf(readerWay.getTag("hazmat:adr_tunnel_cat"));
             hazTunnelEnc.setEnum(false, edgeFlags, code);

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMHazmatWaterParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMHazmatWaterParser.java
@@ -24,7 +24,7 @@ public class OSMHazmatWaterParser implements TagParser {
     }
 
     @Override
-    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay readerWay, boolean ferry, IntsRef relationFlags) {
+    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay readerWay, IntsRef relationFlags) {
         if (readerWay.hasTag("hazmat:water", "no")) {
             hazWaterEnc.setEnum(false, edgeFlags, HazmatWater.NO);
         } else if (readerWay.hasTag("hazmat:water", "permissive")) {

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMHikeRatingParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMHikeRatingParser.java
@@ -45,7 +45,7 @@ public class OSMHikeRatingParser implements TagParser {
     }
 
     @Override
-    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay readerWay, boolean ferry, IntsRef relationFlags) {
+    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay readerWay, IntsRef relationFlags) {
         String scale = readerWay.getTag("sac_scale");
         int rating = 0;
         if (scale != null) {

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMHorseRatingParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMHorseRatingParser.java
@@ -45,7 +45,7 @@ public class OSMHorseRatingParser implements TagParser {
     }
 
     @Override
-    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay readerWay, boolean ferry, IntsRef relationFlags) {
+    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay readerWay, IntsRef relationFlags) {
         String scale = readerWay.getTag("horse_scale");
         int rating = 0;
         if (scale != null) {

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMLanesParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMLanesParser.java
@@ -43,7 +43,7 @@ public class OSMLanesParser implements TagParser {
     }
 
     @Override
-    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay way, boolean ferry, IntsRef relationFlags) {
+    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay way, IntsRef relationFlags) {
         int laneCount = 1;
         if (way.hasTag("lanes")) {
             String noLanes = way.getTag("lanes");

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMMaxAxleLoadParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMMaxAxleLoadParser.java
@@ -46,7 +46,7 @@ public class OSMMaxAxleLoadParser implements TagParser {
     }
 
     @Override
-    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay way, boolean ferry, IntsRef relationFlags) {
+    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay way, IntsRef relationFlags) {
         OSMValueExtractor.extractTons(edgeFlags, way, maxAxleLoadEncoder, Collections.singletonList("maxaxleload"));
         return edgeFlags;
     }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMMaxHeightParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMMaxHeightParser.java
@@ -46,7 +46,7 @@ public class OSMMaxHeightParser implements TagParser {
     }
 
     @Override
-    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay way, boolean ferry, IntsRef relationFlags) {
+    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay way, IntsRef relationFlags) {
         List<String> heightTags = Arrays.asList("maxheight", "maxheight:physical"/*, the OSM tag "height" is not used for the height of a road, so omit it here! */);
         OSMValueExtractor.extractMeter(edgeFlags, way, heightEncoder, heightTags);
         return edgeFlags;

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMMaxLengthParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMMaxLengthParser.java
@@ -46,7 +46,7 @@ public class OSMMaxLengthParser implements TagParser {
     }
 
     @Override
-    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay way, boolean ferry, IntsRef relationFlags) {
+    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay way, IntsRef relationFlags) {
         OSMValueExtractor.extractMeter(edgeFlags, way, lengthEncoder, Collections.singletonList("maxlength"));
         return edgeFlags;
     }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMMaxSpeedParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMMaxSpeedParser.java
@@ -18,10 +18,13 @@
 package com.graphhopper.routing.util.parsers;
 
 import com.graphhopper.reader.ReaderWay;
-import com.graphhopper.routing.ev.*;
+import com.graphhopper.routing.ev.DecimalEncodedValue;
+import com.graphhopper.routing.ev.EncodedValue;
+import com.graphhopper.routing.ev.EncodedValueLookup;
+import com.graphhopper.routing.ev.MaxSpeed;
+import com.graphhopper.routing.util.TransportationMode;
 import com.graphhopper.routing.util.countryrules.CountryRule;
 import com.graphhopper.routing.util.parsers.helpers.OSMValueExtractor;
-import com.graphhopper.routing.util.TransportationMode;
 import com.graphhopper.storage.IntsRef;
 
 import java.util.List;
@@ -49,7 +52,7 @@ public class OSMMaxSpeedParser implements TagParser {
     }
 
     @Override
-    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay way, boolean ferry, IntsRef relationFlags) {
+    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay way, IntsRef relationFlags) {
         double maxSpeed = OSMValueExtractor.stringToKmh(way.getTag("maxspeed"));
 
         CountryRule countryRule = way.getTag("country_rule", null);

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMMaxWeightParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMMaxWeightParser.java
@@ -46,7 +46,7 @@ public class OSMMaxWeightParser implements TagParser {
     }
 
     @Override
-    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay way, boolean ferry, IntsRef relationFlags) {
+    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay way, IntsRef relationFlags) {
         // do not include OSM tag "height" here as it has completely different meaning (height of peak)
         List<String> weightTags = Arrays.asList("maxweight", "maxgcweight");
         OSMValueExtractor.extractTons(edgeFlags, way, weightEncoder, weightTags);

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMMaxWidthParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMMaxWidthParser.java
@@ -46,7 +46,7 @@ public class OSMMaxWidthParser implements TagParser {
     }
 
     @Override
-    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay way, boolean ferry, IntsRef relationFlags) {
+    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay way, IntsRef relationFlags) {
         List<String> widthTags = Arrays.asList("maxwidth", "maxwidth:physical", "width");
         OSMValueExtractor.extractMeter(edgeFlags, way, widthEncoder, widthTags);
         return edgeFlags;

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMMtbRatingParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMMtbRatingParser.java
@@ -46,7 +46,7 @@ public class OSMMtbRatingParser implements TagParser {
     }
 
     @Override
-    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay readerWay, boolean ferry, IntsRef relationFlags) {
+    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay readerWay, IntsRef relationFlags) {
         String scale = readerWay.getTag("mtb:scale");
         int rating = 0;
         if (scale != null) {

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMRoadAccessParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMRoadAccessParser.java
@@ -18,7 +18,10 @@
 package com.graphhopper.routing.util.parsers;
 
 import com.graphhopper.reader.ReaderWay;
-import com.graphhopper.routing.ev.*;
+import com.graphhopper.routing.ev.EncodedValue;
+import com.graphhopper.routing.ev.EncodedValueLookup;
+import com.graphhopper.routing.ev.EnumEncodedValue;
+import com.graphhopper.routing.ev.RoadAccess;
 import com.graphhopper.routing.util.TransportationMode;
 import com.graphhopper.routing.util.countryrules.CountryRule;
 import com.graphhopper.storage.IntsRef;
@@ -47,7 +50,7 @@ public class OSMRoadAccessParser implements TagParser {
     }
 
     @Override
-    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay readerWay, boolean ferry, IntsRef relationFlags) {
+    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay readerWay, IntsRef relationFlags) {
         RoadAccess accessValue = YES;
         RoadAccess tmpAccessValue;
         for (String restriction : restrictions) {

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMRoadClassLinkParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMRoadClassLinkParser.java
@@ -37,7 +37,7 @@ public class OSMRoadClassLinkParser implements TagParser {
     }
 
     @Override
-    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay readerWay, boolean ferry, IntsRef relationFlags) {
+    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay readerWay, IntsRef relationFlags) {
         String highwayTag = readerWay.getTag("highway");
         if (!Helper.isEmpty(highwayTag) && highwayTag.endsWith("_link"))
             linkEnc.setBool(false, edgeFlags, true);

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMRoadClassParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMRoadClassParser.java
@@ -42,10 +42,7 @@ public class OSMRoadClassParser implements TagParser {
     }
 
     @Override
-    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay readerWay, boolean ferry, IntsRef relationFlags) {
-        if (ferry)
-            return edgeFlags;
-
+    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay readerWay, IntsRef relationFlags) {
         String roadClassTag = readerWay.getTag("highway");
         if (roadClassTag == null)
             return edgeFlags;

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMRoadEnvironmentParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMRoadEnvironmentParser.java
@@ -42,7 +42,7 @@ public class OSMRoadEnvironmentParser implements TagParser {
     }
 
     @Override
-    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay readerWay, boolean ferry, IntsRef relationFlags) {
+    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay readerWay, IntsRef relationFlags) {
         RoadEnvironment roadEnvironment = OTHER;
         if ((readerWay.hasTag("route", "ferry") && !readerWay.hasTag("ferry", "no")) ||
                 // TODO shuttle_train is sometimes also used in relations, e.g. https://www.openstreetmap.org/relation/1932780

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMRoundaboutParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMRoundaboutParser.java
@@ -44,9 +44,7 @@ public class OSMRoundaboutParser implements TagParser {
     }
 
     @Override
-    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay way, boolean ferry, IntsRef relationFlags) {
-        if (ferry)
-            return edgeFlags;
+    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay way, IntsRef relationFlags) {
         boolean isRoundabout = way.hasTag("junction", "roundabout") || way.hasTag("junction", "circular");
         if (isRoundabout)
             roundaboutEnc.setBool(false, edgeFlags, true);

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMSmoothnessParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMSmoothnessParser.java
@@ -26,7 +26,8 @@ import com.graphhopper.storage.IntsRef;
 
 import java.util.List;
 
-import static com.graphhopper.routing.ev.Smoothness.*;
+import static com.graphhopper.routing.ev.Smoothness.KEY;
+import static com.graphhopper.routing.ev.Smoothness.MISSING;
 
 public class OSMSmoothnessParser implements TagParser {
 
@@ -46,7 +47,7 @@ public class OSMSmoothnessParser implements TagParser {
     }
 
     @Override
-    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay readerWay, boolean ferry, IntsRef relationFlags) {
+    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay readerWay, IntsRef relationFlags) {
         String smoothnessTag = readerWay.getTag("smoothness");
         Smoothness smoothness = Smoothness.find(smoothnessTag);
         if (smoothness == MISSING)

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMSurfaceParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMSurfaceParser.java
@@ -46,7 +46,7 @@ public class OSMSurfaceParser implements TagParser {
     }
 
     @Override
-    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay readerWay, boolean ferry, IntsRef relationFlags) {
+    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay readerWay, IntsRef relationFlags) {
         String surfaceTag = readerWay.getTag("surface");
         Surface surface = Surface.find(surfaceTag);
         if (surface == MISSING)

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMTollParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMTollParser.java
@@ -49,7 +49,7 @@ public class OSMTollParser implements TagParser {
     }
 
     @Override
-    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay readerWay, boolean ferry, IntsRef relationFlags) {
+    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay readerWay, IntsRef relationFlags) {
         Toll toll;
         if (readerWay.hasTag("toll", "yes")) {
             toll = Toll.ALL;

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMTrackTypeParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMTrackTypeParser.java
@@ -42,10 +42,7 @@ public class OSMTrackTypeParser implements TagParser {
     }
 
     @Override
-    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay readerWay, boolean ferry, IntsRef relationFlags) {
-        if (ferry)
-            return edgeFlags;
-
+    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay readerWay, IntsRef relationFlags) {
         String trackTypeTag = readerWay.getTag("tracktype");
         TrackType trackType = TrackType.find(trackTypeTag);
         if (trackType != MISSING)

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/TagParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/TagParser.java
@@ -32,5 +32,5 @@ public interface TagParser {
 
     void createEncodedValues(EncodedValueLookup lookup, List<EncodedValue> registerNewEncodedValue);
 
-    IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay way, boolean ferry, IntsRef relationFlags);
+    IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay way, IntsRef relationFlags);
 }

--- a/core/src/test/java/com/graphhopper/GraphHopperTest.java
+++ b/core/src/test/java/com/graphhopper/GraphHopperTest.java
@@ -1040,7 +1040,7 @@ public class GraphHopperTest {
         if (!withTunnelInterpolation) {
             hopper.getEncodingManagerBuilder().add(new OSMRoadEnvironmentParser() {
                 @Override
-                public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay readerWay, boolean ferry, IntsRef relationFlags) {
+                public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay readerWay, IntsRef relationFlags) {
                     // do not change RoadEnvironment to avoid triggering tunnel interpolation
                     return edgeFlags;
                 }

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMHazmatParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMHazmatParserTest.java
@@ -30,22 +30,22 @@ public class OSMHazmatParserTest {
         ReaderWay readerWay = new ReaderWay(1);
         IntsRef intsRef = em.createEdgeFlags();
         readerWay.setTag("hazmat", "no");
-        parser.handleWayTags(intsRef, readerWay, false, relFlags);
+        parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(Hazmat.NO, hazEnc.getEnum(false, intsRef));
 
         intsRef = em.createEdgeFlags();
         readerWay.setTag("hazmat", "yes");
-        parser.handleWayTags(intsRef, readerWay, false, relFlags);
+        parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(Hazmat.YES, hazEnc.getEnum(false, intsRef));
 
         intsRef = em.createEdgeFlags();
         readerWay.setTag("hazmat", "designated");
-        parser.handleWayTags(intsRef, readerWay, false, relFlags);
+        parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(Hazmat.YES, hazEnc.getEnum(false, intsRef));
 
         intsRef = em.createEdgeFlags();
         readerWay.setTag("hazmat", "designated");
-        parser.handleWayTags(intsRef, readerWay, false, relFlags);
+        parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(Hazmat.YES, hazEnc.getEnum(false, intsRef));
     }
 
@@ -53,7 +53,7 @@ public class OSMHazmatParserTest {
     public void testNoNPE() {
         ReaderWay readerWay = new ReaderWay(1);
         IntsRef intsRef = em.createEdgeFlags();
-        parser.handleWayTags(intsRef, readerWay, false, relFlags);
+        parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(Hazmat.YES, hazEnc.getEnum(false, intsRef));
     }
 }

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMHazmatTunnelParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMHazmatTunnelParserTest.java
@@ -30,31 +30,31 @@ public class OSMHazmatTunnelParserTest {
         IntsRef intsRef = em.createEdgeFlags();
         ReaderWay readerWay = new ReaderWay(1);
         readerWay.setTag("hazmat:adr_tunnel_cat", "A");
-        parser.handleWayTags(intsRef, readerWay, false, relFlags);
+        parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(HazmatTunnel.A, hazTunnelEnc.getEnum(false, intsRef));
 
         intsRef = em.createEdgeFlags();
         readerWay = new ReaderWay(1);
         readerWay.setTag("hazmat:adr_tunnel_cat", "B");
-        parser.handleWayTags(intsRef, readerWay, false, relFlags);
+        parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(HazmatTunnel.B, hazTunnelEnc.getEnum(false, intsRef));
 
         intsRef = em.createEdgeFlags();
         readerWay = new ReaderWay(1);
         readerWay.setTag("hazmat:adr_tunnel_cat", "C");
-        parser.handleWayTags(intsRef, readerWay, false, relFlags);
+        parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(HazmatTunnel.C, hazTunnelEnc.getEnum(false, intsRef));
 
         intsRef = em.createEdgeFlags();
         readerWay = new ReaderWay(1);
         readerWay.setTag("hazmat:adr_tunnel_cat", "D");
-        parser.handleWayTags(intsRef, readerWay, false, relFlags);
+        parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(HazmatTunnel.D, hazTunnelEnc.getEnum(false, intsRef));
 
         intsRef = em.createEdgeFlags();
         readerWay = new ReaderWay(1);
         readerWay.setTag("hazmat:adr_tunnel_cat", "E");
-        parser.handleWayTags(intsRef, readerWay, false, relFlags);
+        parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(HazmatTunnel.E, hazTunnelEnc.getEnum(false, intsRef));
     }
 
@@ -63,31 +63,31 @@ public class OSMHazmatTunnelParserTest {
         IntsRef intsRef = em.createEdgeFlags();
         ReaderWay readerWay = new ReaderWay(1);
         readerWay.setTag("hazmat:tunnel_cat", "A");
-        parser.handleWayTags(intsRef, readerWay, false, relFlags);
+        parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(HazmatTunnel.A, hazTunnelEnc.getEnum(false, intsRef));
 
         intsRef = em.createEdgeFlags();
         readerWay = new ReaderWay(1);
         readerWay.setTag("hazmat:tunnel_cat", "B");
-        parser.handleWayTags(intsRef, readerWay, false, relFlags);
+        parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(HazmatTunnel.B, hazTunnelEnc.getEnum(false, intsRef));
 
         intsRef = em.createEdgeFlags();
         readerWay = new ReaderWay(1);
         readerWay.setTag("hazmat:tunnel_cat", "C");
-        parser.handleWayTags(intsRef, readerWay, false, relFlags);
+        parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(HazmatTunnel.C, hazTunnelEnc.getEnum(false, intsRef));
 
         intsRef = em.createEdgeFlags();
         readerWay = new ReaderWay(1);
         readerWay.setTag("hazmat:tunnel_cat", "D");
-        parser.handleWayTags(intsRef, readerWay, false, relFlags);
+        parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(HazmatTunnel.D, hazTunnelEnc.getEnum(false, intsRef));
 
         intsRef = em.createEdgeFlags();
         readerWay = new ReaderWay(1);
         readerWay.setTag("hazmat:tunnel_cat", "E");
-        parser.handleWayTags(intsRef, readerWay, false, relFlags);
+        parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(HazmatTunnel.E, hazTunnelEnc.getEnum(false, intsRef));
     }
 
@@ -97,35 +97,35 @@ public class OSMHazmatTunnelParserTest {
         ReaderWay readerWay = new ReaderWay(1);
         readerWay.setTag("tunnel", "yes");
         readerWay.setTag("hazmat:A", "no");
-        parser.handleWayTags(intsRef, readerWay, false, relFlags);
+        parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(HazmatTunnel.A, hazTunnelEnc.getEnum(false, intsRef));
 
         intsRef = em.createEdgeFlags();
         readerWay = new ReaderWay(1);
         readerWay.setTag("tunnel", "yes");
         readerWay.setTag("hazmat:B", "no");
-        parser.handleWayTags(intsRef, readerWay, false, relFlags);
+        parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(HazmatTunnel.B, hazTunnelEnc.getEnum(false, intsRef));
 
         intsRef = em.createEdgeFlags();
         readerWay = new ReaderWay(1);
         readerWay.setTag("tunnel", "yes");
         readerWay.setTag("hazmat:C", "no");
-        parser.handleWayTags(intsRef, readerWay, false, relFlags);
+        parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(HazmatTunnel.C, hazTunnelEnc.getEnum(false, intsRef));
 
         intsRef = em.createEdgeFlags();
         readerWay = new ReaderWay(1);
         readerWay.setTag("tunnel", "yes");
         readerWay.setTag("hazmat:D", "no");
-        parser.handleWayTags(intsRef, readerWay, false, relFlags);
+        parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(HazmatTunnel.D, hazTunnelEnc.getEnum(false, intsRef));
 
         intsRef = em.createEdgeFlags();
         readerWay = new ReaderWay(1);
         readerWay.setTag("tunnel", "yes");
         readerWay.setTag("hazmat:E", "no");
-        parser.handleWayTags(intsRef, readerWay, false, relFlags);
+        parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(HazmatTunnel.E, hazTunnelEnc.getEnum(false, intsRef));
     }
 
@@ -139,7 +139,7 @@ public class OSMHazmatTunnelParserTest {
         readerWay.setTag("hazmat:C", "no");
         readerWay.setTag("hazmat:D", "no");
         readerWay.setTag("hazmat:E", "no");
-        parser.handleWayTags(intsRef, readerWay, false, relFlags);
+        parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(HazmatTunnel.E, hazTunnelEnc.getEnum(false, intsRef));
 
         intsRef = em.createEdgeFlags();
@@ -148,7 +148,7 @@ public class OSMHazmatTunnelParserTest {
         readerWay.setTag("hazmat:A", "no");
         readerWay.setTag("hazmat:B", "no");
         readerWay.setTag("hazmat:C", "no");
-        parser.handleWayTags(intsRef, readerWay, false, relFlags);
+        parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(HazmatTunnel.C, hazTunnelEnc.getEnum(false, intsRef));
 
         intsRef = em.createEdgeFlags();
@@ -156,7 +156,7 @@ public class OSMHazmatTunnelParserTest {
         readerWay.setTag("tunnel", "yes");
         readerWay.setTag("hazmat:B", "no");
         readerWay.setTag("hazmat:E", "no");
-        parser.handleWayTags(intsRef, readerWay, false, relFlags);
+        parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(HazmatTunnel.E, hazTunnelEnc.getEnum(false, intsRef));
     }
 
@@ -165,7 +165,7 @@ public class OSMHazmatTunnelParserTest {
         IntsRef intsRef = em.createEdgeFlags();
         ReaderWay readerWay = new ReaderWay(1);
         readerWay.setTag("hazmat:B", "no");
-        parser.handleWayTags(intsRef, readerWay, false, relFlags);
+        parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(HazmatTunnel.A, hazTunnelEnc.getEnum(false, intsRef));
     }
 
@@ -173,7 +173,7 @@ public class OSMHazmatTunnelParserTest {
     public void testNoNPE() {
         ReaderWay readerWay = new ReaderWay(1);
         IntsRef intsRef = em.createEdgeFlags();
-        parser.handleWayTags(intsRef, readerWay, false, relFlags);
+        parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(HazmatTunnel.A, hazTunnelEnc.getEnum(false, intsRef));
     }
 }

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMHazmatWaterParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMHazmatWaterParserTest.java
@@ -30,17 +30,17 @@ public class OSMHazmatWaterParserTest {
         ReaderWay readerWay = new ReaderWay(1);
         IntsRef intsRef = em.createEdgeFlags();
         readerWay.setTag("hazmat:water", "no");
-        parser.handleWayTags(intsRef, readerWay, false, relFlags);
+        parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(HazmatWater.NO, hazWaterEnc.getEnum(false, intsRef));
 
         intsRef = em.createEdgeFlags();
         readerWay.setTag("hazmat:water", "yes");
-        parser.handleWayTags(intsRef, readerWay, false, relFlags);
+        parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(HazmatWater.YES, hazWaterEnc.getEnum(false, intsRef));
 
         intsRef = em.createEdgeFlags();
         readerWay.setTag("hazmat:water", "permissive");
-        parser.handleWayTags(intsRef, readerWay, false, relFlags);
+        parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(HazmatWater.PERMISSIVE, hazWaterEnc.getEnum(false, intsRef));
     }
 
@@ -48,7 +48,7 @@ public class OSMHazmatWaterParserTest {
     public void testNoNPE() {
         ReaderWay readerWay = new ReaderWay(1);
         IntsRef intsRef = em.createEdgeFlags();
-        parser.handleWayTags(intsRef, readerWay, false, relFlags);
+        parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(HazmatWater.YES, hazWaterEnc.getEnum(false, intsRef));
     }
 }

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMLanesParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMLanesParserTest.java
@@ -42,7 +42,7 @@ class OSMLanesParserTest {
         ReaderWay readerWay = new ReaderWay(1);
         IntsRef intsRef = em.createEdgeFlags();
         readerWay.setTag("lanes", "4");
-        parser.handleWayTags(intsRef, readerWay, false, em.createRelationFlags());
+        parser.handleWayTags(intsRef, readerWay, em.createRelationFlags());
         Assertions.assertEquals(4, em.getIntEncodedValue(Lanes.KEY).getInt(false, intsRef));
     }
 
@@ -50,7 +50,7 @@ class OSMLanesParserTest {
     void notTagged() {
         ReaderWay readerWay = new ReaderWay(1);
         IntsRef intsRef = em.createEdgeFlags();
-        parser.handleWayTags(intsRef, readerWay, false, em.createRelationFlags());
+        parser.handleWayTags(intsRef, readerWay, em.createRelationFlags());
         Assertions.assertEquals(1, em.getIntEncodedValue(Lanes.KEY).getInt(false, intsRef));
     }
 

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMMaxAxleLoadParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMMaxAxleLoadParserTest.java
@@ -30,13 +30,13 @@ public class OSMMaxAxleLoadParserTest {
         ReaderWay readerWay = new ReaderWay(1);
         IntsRef intsRef = em.createEdgeFlags();
         readerWay.setTag("maxaxleload", "11.5");
-        parser.handleWayTags(intsRef, readerWay, false, relFlags);
+        parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(11.5, malEnc.getDecimal(false, intsRef), .01);
 
         // if value is beyond the maximum then do not use infinity instead fallback to more restrictive maximum
         intsRef = em.createEdgeFlags();
         readerWay.setTag("maxaxleload", "80");
-        parser.handleWayTags(intsRef, readerWay, false, relFlags);
+        parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(malEnc.getMaxDecimal(), malEnc.getDecimal(false, intsRef), .01);
     }
 
@@ -45,17 +45,17 @@ public class OSMMaxAxleLoadParserTest {
         ReaderWay readerWay = new ReaderWay(1);
         IntsRef intsRef = em.createEdgeFlags();
         readerWay.setTag("maxaxleload", "4.8");
-        parser.handleWayTags(intsRef, readerWay, false, relFlags);
+        parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(5.0, malEnc.getDecimal(false, intsRef), .01);
 
         intsRef = em.createEdgeFlags();
         readerWay.setTag("maxaxleload", "3.6");
-        parser.handleWayTags(intsRef, readerWay, false, relFlags);
+        parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(3.5, malEnc.getDecimal(false, intsRef), .01);
 
         intsRef = em.createEdgeFlags();
         readerWay.setTag("maxaxleload", "2.4");
-        parser.handleWayTags(intsRef, readerWay, false, relFlags);
+        parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(2.5, malEnc.getDecimal(false, intsRef), .01);
     }
 
@@ -63,7 +63,7 @@ public class OSMMaxAxleLoadParserTest {
     public void testNoLimit() {
         ReaderWay readerWay = new ReaderWay(1);
         IntsRef intsRef = em.createEdgeFlags();
-        parser.handleWayTags(intsRef, readerWay, false, relFlags);
+        parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(Double.POSITIVE_INFINITY, malEnc.getDecimal(false, intsRef), .01);
     }
 }

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMMaxSpeedParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMMaxSpeedParserTest.java
@@ -20,7 +20,6 @@ package com.graphhopper.routing.util.parsers;
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.DecimalEncodedValue;
 import com.graphhopper.routing.ev.MaxSpeed;
-import com.graphhopper.routing.ev.RoadClass;
 import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.routing.util.TransportationMode;
@@ -54,12 +53,12 @@ class OSMMaxSpeedParserTest {
                 return 5;
             }
         });
-        parser.handleWayTags(e1.getFlags(), way, false, relFlags);
+        parser.handleWayTags(e1.getFlags(), way, relFlags);
         assertEquals(5, e1.get(maxSpeedEnc), .1);
 
         // without a country_rule we get the default value
         way.removeTag("country_rule");
-        parser.handleWayTags(e2.getFlags(), way, false, relFlags);
+        parser.handleWayTags(e2.getFlags(), way, relFlags);
         assertEquals(MaxSpeed.UNSET_SPEED, e2.get(maxSpeedEnc), .1);
     }
 

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMMaxWeightParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMMaxWeightParserTest.java
@@ -29,13 +29,13 @@ public class OSMMaxWeightParserTest {
         IntsRef intsRef = em.createEdgeFlags();
         readerWay.setTag("highway", "primary");
         readerWay.setTag("maxweight", "5");
-        parser.handleWayTags(intsRef, readerWay, false, em.createRelationFlags());
+        parser.handleWayTags(intsRef, readerWay, em.createRelationFlags());
         assertEquals(5.0, mwEnc.getDecimal(false, intsRef), .01);
 
         // if value is beyond the maximum then do not use infinity instead fallback to more restrictive maximum
         intsRef = em.createEdgeFlags();
         readerWay.setTag("maxweight", "50");
-        parser.handleWayTags(intsRef, readerWay, false, em.createRelationFlags());
+        parser.handleWayTags(intsRef, readerWay, em.createRelationFlags());
         assertEquals(mwEnc.getMaxDecimal(), mwEnc.getDecimal(false, intsRef), .01);
     }
 }

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMMtbRatingParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMMtbRatingParserTest.java
@@ -63,7 +63,7 @@ class OSMMtbRatingParserTest {
         ReaderWay way = new ReaderWay(0);
         if (scaleString != null)
             way.setTag("mtb:scale", scaleString);
-        parser.handleWayTags(edgeFlags, way, false, em.createRelationFlags());
+        parser.handleWayTags(edgeFlags, way, em.createRelationFlags());
         assertEquals(expectedRating, ev.getInt(false, edgeFlags), "unexpected rating for mtb:scale=" + scaleString);
     }
 

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMRoadAccessParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMRoadAccessParserTest.java
@@ -21,7 +21,6 @@ package com.graphhopper.routing.util.parsers;
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.EnumEncodedValue;
 import com.graphhopper.routing.ev.RoadAccess;
-import com.graphhopper.routing.ev.RoadClass;
 import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.routing.util.TransportationMode;
@@ -56,12 +55,12 @@ class OSMRoadAccessParserTest {
                 return RoadAccess.DESTINATION;
             }
         });
-        parser.handleWayTags(e1.getFlags(), way, false, relFlags);
+        parser.handleWayTags(e1.getFlags(), way, relFlags);
         assertEquals(RoadAccess.DESTINATION, e1.get(roadAccessEnc));
 
         // if there is no country rule we get the default value
         way.removeTag("country_rule");
-        parser.handleWayTags(e2.getFlags(), way, false, relFlags);
+        parser.handleWayTags(e2.getFlags(), way, relFlags);
         assertEquals(RoadAccess.YES, e2.get(roadAccessEnc));
     }
 

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMRoadClassParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMRoadClassParserTest.java
@@ -30,17 +30,17 @@ public class OSMRoadClassParserTest {
         ReaderWay readerWay = new ReaderWay(1);
         IntsRef edgeFlags = em.createEdgeFlags();
         readerWay.setTag("highway", "primary");
-        parser.handleWayTags(edgeFlags, readerWay, false, relFlags);
+        parser.handleWayTags(edgeFlags, readerWay, relFlags);
         assertEquals(RoadClass.PRIMARY, rcEnc.getEnum(false, edgeFlags));
 
         edgeFlags = em.createEdgeFlags();
         readerWay.setTag("highway", "unknownstuff");
-        parser.handleWayTags(edgeFlags, readerWay, false, relFlags);
+        parser.handleWayTags(edgeFlags, readerWay, relFlags);
         assertEquals(RoadClass.OTHER, rcEnc.getEnum(false, edgeFlags));
 
         edgeFlags = em.createEdgeFlags();
         readerWay.setTag("highway", "motorway_link");
-        parser.handleWayTags(edgeFlags, readerWay, false, relFlags);
+        parser.handleWayTags(edgeFlags, readerWay, relFlags);
         assertEquals(RoadClass.MOTORWAY, rcEnc.getEnum(false, edgeFlags));
     }
 
@@ -49,7 +49,7 @@ public class OSMRoadClassParserTest {
         ReaderWay readerWay = new ReaderWay(1);
         IntsRef edgeFlags = em.createEdgeFlags();
         readerWay.setTag("route", "ferry");
-        parser.handleWayTags(edgeFlags, readerWay, true, relFlags);
+        parser.handleWayTags(edgeFlags, readerWay, relFlags);
         assertEquals(RoadClass.OTHER, rcEnc.getEnum(false, edgeFlags));
     }
 
@@ -57,7 +57,7 @@ public class OSMRoadClassParserTest {
     public void testNoNPE() {
         ReaderWay readerWay = new ReaderWay(1);
         IntsRef edgeFlags = em.createEdgeFlags();
-        parser.handleWayTags(edgeFlags, readerWay, false, relFlags);
+        parser.handleWayTags(edgeFlags, readerWay, relFlags);
         assertEquals(RoadClass.OTHER, rcEnc.getEnum(false, edgeFlags));
     }
 }

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMRoadEnvironmentParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMRoadEnvironmentParserTest.java
@@ -41,9 +41,7 @@ class OSMRoadEnvironmentParserTest {
         IntsRef edgeFlags = em.createEdgeFlags();
         ReaderWay way = new ReaderWay(0);
         way.setTag("route", "shuttle_train");
-        EncodingManager.AcceptWay acceptWay = new EncodingManager.AcceptWay();
-        em.acceptWay(way, acceptWay);
-        parser.handleWayTags(edgeFlags, way, acceptWay.isFerry(), em.createRelationFlags());
+        parser.handleWayTags(edgeFlags, way, em.createRelationFlags());
         RoadEnvironment roadEnvironment = roadEnvironmentEnc.getEnum(false, edgeFlags);
         assertEquals(RoadEnvironment.FERRY, roadEnvironment);
     }

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMSmoothnessParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMSmoothnessParserTest.java
@@ -30,11 +30,11 @@ public class OSMSmoothnessParserTest {
         ReaderWay readerWay = new ReaderWay(1);
         IntsRef intsRef = em.createEdgeFlags();
         readerWay.setTag("highway", "primary");
-        parser.handleWayTags(intsRef, readerWay, false, relFlags);
+        parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(Smoothness.MISSING, smoothnessEnc.getEnum(false, intsRef));
 
         readerWay.setTag("smoothness", "bad");
-        parser.handleWayTags(intsRef, readerWay, false, relFlags);
+        parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(Smoothness.BAD, smoothnessEnc.getEnum(false, intsRef));
         assertTrue(Smoothness.BAD.ordinal() < Smoothness.VERY_BAD.ordinal());
     }

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMSurfaceParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMSurfaceParserTest.java
@@ -30,16 +30,16 @@ public class OSMSurfaceParserTest {
         ReaderWay readerWay = new ReaderWay(1);
         IntsRef intsRef = em.createEdgeFlags();
         readerWay.setTag("highway", "primary");
-        parser.handleWayTags(intsRef, readerWay, false, relFlags);
+        parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(Surface.MISSING, surfaceEnc.getEnum(false, intsRef));
 
         readerWay.setTag("surface", "cobblestone");
-        parser.handleWayTags(intsRef, readerWay, false, relFlags);
+        parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(Surface.COBBLESTONE, surfaceEnc.getEnum(false, intsRef));
         assertTrue(Surface.COBBLESTONE.ordinal() > Surface.ASPHALT.ordinal());
 
         readerWay.setTag("surface", "earth");
-        parser.handleWayTags(intsRef, readerWay, false, relFlags);
+        parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(Surface.DIRT, surfaceEnc.getEnum(false, intsRef));
     }
 }

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMTollParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMTollParserTest.java
@@ -28,31 +28,31 @@ public class OSMTollParserTest {
         IntsRef relFlags = em.createRelationFlags();
         IntsRef intsRef = em.createEdgeFlags();
         readerWay.setTag("highway", "primary");
-        parser.handleWayTags(intsRef, readerWay, false, relFlags);
+        parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(Toll.MISSING, tollEnc.getEnum(false, intsRef));
 
         intsRef = em.createEdgeFlags();
         readerWay.setTag("highway", "primary");
         readerWay.setTag("toll:hgv", "yes");
-        parser.handleWayTags(intsRef, readerWay, false, relFlags);
+        parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(Toll.HGV, tollEnc.getEnum(false, intsRef));
 
         intsRef = em.createEdgeFlags();
         readerWay.setTag("highway", "primary");
         readerWay.setTag("toll:N2", "yes");
-        parser.handleWayTags(intsRef, readerWay, false, relFlags);
+        parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(Toll.HGV, tollEnc.getEnum(false, intsRef));
 
         intsRef = em.createEdgeFlags();
         readerWay.setTag("highway", "primary");
         readerWay.setTag("toll:N3", "yes");
-        parser.handleWayTags(intsRef, readerWay, false, relFlags);
+        parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(Toll.HGV, tollEnc.getEnum(false, intsRef));
 
         intsRef = em.createEdgeFlags();
         readerWay.setTag("highway", "primary");
         readerWay.setTag("toll", "yes");
-        parser.handleWayTags(intsRef, readerWay, false, relFlags);
+        parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(Toll.ALL, tollEnc.getEnum(false, intsRef));
 
         intsRef = em.createEdgeFlags();
@@ -61,7 +61,7 @@ public class OSMTollParserTest {
         readerWay.setTag("toll:hgv", "yes");
         readerWay.setTag("toll:N2", "yes");
         readerWay.setTag("toll:N3", "yes");
-        parser.handleWayTags(intsRef, readerWay, false, relFlags);
+        parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(Toll.ALL, tollEnc.getEnum(false, intsRef));
     }
 }

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMTrackTypeParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMTrackTypeParserTest.java
@@ -30,27 +30,27 @@ public class OSMTrackTypeParserTest {
         ReaderWay readerWay = new ReaderWay(1);
         IntsRef intsRef = em.createEdgeFlags();
         readerWay.setTag("tracktype", "grade1");
-        parser.handleWayTags(intsRef, readerWay, false, relFlags);
+        parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(TrackType.GRADE1, ttEnc.getEnum(false, intsRef));
 
         intsRef = em.createEdgeFlags();
         readerWay.setTag("tracktype", "grade2");
-        parser.handleWayTags(intsRef, readerWay, false, relFlags);
+        parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(TrackType.GRADE2, ttEnc.getEnum(false, intsRef));
 
         intsRef = em.createEdgeFlags();
         readerWay.setTag("tracktype", "grade3");
-        parser.handleWayTags(intsRef, readerWay, false, relFlags);
+        parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(TrackType.GRADE3, ttEnc.getEnum(false, intsRef));
 
         intsRef = em.createEdgeFlags();
         readerWay.setTag("tracktype", "grade4");
-        parser.handleWayTags(intsRef, readerWay, false, relFlags);
+        parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(TrackType.GRADE4, ttEnc.getEnum(false, intsRef));
 
         intsRef = em.createEdgeFlags();
         readerWay.setTag("tracktype", "grade5");
-        parser.handleWayTags(intsRef, readerWay, false, relFlags);
+        parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(TrackType.GRADE5, ttEnc.getEnum(false, intsRef));
     }
 
@@ -59,7 +59,7 @@ public class OSMTrackTypeParserTest {
         ReaderWay readerWay = new ReaderWay(1);
         IntsRef intsRef = em.createEdgeFlags();
         readerWay.setTag("tracktype", "unknownstuff");
-        parser.handleWayTags(intsRef, readerWay, false, relFlags);
+        parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(TrackType.MISSING, ttEnc.getEnum(false, intsRef));
     }
 
@@ -67,7 +67,7 @@ public class OSMTrackTypeParserTest {
     public void testNoNPE() {
         ReaderWay readerWay = new ReaderWay(1);
         IntsRef intsRef = em.createEdgeFlags();
-        parser.handleWayTags(intsRef, readerWay, false, relFlags);
+        parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(TrackType.MISSING, ttEnc.getEnum(false, intsRef));
     }
 }


### PR DESCRIPTION
Fixes #2465. After #2466 this is a no-brainer, because the ferry argument is no longer used. This will be useful also for #2462.