### PR TITLE
Fix HashMap related flaky tests

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -79,6 +79,7 @@ Here is an overview:
  * vvikas, ideas for many to many improvements and #616
  * zstadler, multiple fixes and car4wd
  * samruston, improved point hint matching
+ * shunfan-shao, fix potential flaky tests
 
 ## Translations
 

--- a/core/src/main/java/com/graphhopper/search/StringIndex.java
+++ b/core/src/main/java/com/graphhopper/search/StringIndex.java
@@ -197,7 +197,7 @@ public class StringIndex {
         if (keyCount == 0)
             return Collections.emptyMap();
 
-        Map<String, String> map = new HashMap<>(keyCount);
+        Map<String, String> map = new LinkedHashMap<>(keyCount);
         long tmpPointer = entryPointer + 1;
         for (int i = 0; i < keyCount; i++) {
             int currentKeyIndex = vals.getShort(tmpPointer);


### PR DESCRIPTION
## Contribution Guide
Test have passed under following command
```sh
mvn clean test verify
```
## Description
Two tests
```
com.graphhopper.search.StringIndexTest.putDuplicate
com.graphhopper.search.StringIndexTest.testLoadKeys
```
failed under [NonDex](https://github.com/TestingResearchIllinois/NonDex) which detect flakiness under non-deterministic data structure usages.

The potential problem I am seeing is that `StringIndex.getAll(...)` [internally uses HashMap](https://github.com/graphhopper/graphhopper/blob/master/core/src/main/java/com/graphhopper/search/StringIndex.java#L200). As you may have known that `HashMap` does not guarantee the order consistency under different environment.

**Quoted from [Oracle Java 8 Doc](https://docs.oracle.com/javase/8/docs/api/java/util/HashMap.html)**
> This class makes no guarantees as to the order of the map; in particular, it does not guarantee that the order will remain constant over time.

## Proposal
Similar to [`StringIndexTest.createMap(...)`](https://github.com/graphhopper/graphhopper/blob/master/core/src/test/java/com/graphhopper/search/StringIndexTest.java#L24), I replaced it with `LinkedHashMap` which has a property of predictable order. Please let me know if you have better ideas or any question!
