### PR TITLE
Do not ensure write access when there are no CHs/LMs to prepare

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/ch/CHPreparationHandler.java
+++ b/core/src/main/java/com/graphhopper/routing/ch/CHPreparationHandler.java
@@ -119,6 +119,10 @@ public class CHPreparationHandler {
     }
 
     public Map<String, PrepareContractionHierarchies.Result> prepare(GraphHopperStorage ghStorage, List<CHConfig> chConfigs, final boolean closeEarly) {
+        if (chConfigs.isEmpty()) {
+            LOGGER.info("There are no CHs to prepare");
+            return Collections.emptyMap();
+        }
         LOGGER.info("Creating CH preparations, {}", getMemInfo());
         List<PrepareContractionHierarchies> preparations = chConfigs.stream()
                 .map(c -> createCHPreparation(ghStorage, c))

--- a/core/src/main/java/com/graphhopper/storage/GraphHopperStorage.java
+++ b/core/src/main/java/com/graphhopper/storage/GraphHopperStorage.java
@@ -294,7 +294,7 @@ public final class GraphHopperStorage implements Graph, Closeable {
     /**
      * Flush and free base graph resources like way geometries and StringIndex
      */
-    public void flushAndCloseEarly() {
+    public void flushAndCloseGeometryAndNameStorage() {
         baseGraph.flushAndCloseGeometryAndNameStorage();
     }
 

--- a/core/src/test/java/com/graphhopper/GraphHopperTest.java
+++ b/core/src/test/java/com/graphhopper/GraphHopperTest.java
@@ -358,6 +358,11 @@ public class GraphHopperTest {
     }
 
     @Test
+    public void testImportThenLoadLMWithCustom() {
+        testImportCloseAndLoad(false, true, false, true);
+    }
+
+    @Test
     public void testImportThenLoadCHLM() {
         testImportCloseAndLoad(true, true, false, false);
     }


### PR DESCRIPTION
Fixes #2498. 

I probably introduced this bug when I was working on #2481. When we call `GraphHopper#load` and preparations are only loaded so there is nothing else to prepare we need no write access. I therefore put back the `ensureWriteAccess` calls that we just removed to partially fix the bug in 674828b1d5d987401d62fadc6cfdcca5ba0d50cd, but under the condition that there are actually things to prepare.

Closing the location index, names and way geometry storage is done unconditionally, because they aren't needed in any case (neither if there are CHs to prepare, nor if there are no CHs to prepare). We can even close the way geometry and names before the LM preparation (unless there are no custom profiles), which saves some memory if the import only includes LM.

@michaz, @oli0044 does this fix the problem you were running into? I still think we should also remove the `setAllowWrites` and lock file stuff, but I'd like to do this as a follow up and possibly at a later time if this PR fixes the actual bug for now. As a minimum requirement we should keep the lock file to prevent running two `import` commands simultaneously, see https://github.com/graphhopper/graphhopper/issues/2498#issuecomment-996012589.