### PR TITLE
Update config-example.yml

### DIFF
--- a/config-example.yml
+++ b/config-example.yml
@@ -187,11 +187,11 @@ logging:
   - type: file
     time_zone: UTC
     current_log_filename: logs/graphhopper.log
-    log_format: "%d{YYYY-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"
+    log_format: "%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"
     archive: true
     archived_log_filename_pattern: ./logs/graphhopper-%d.log.gz
     archived_file_count: 30
     never_block: true
   - type: console
     time_zone: UTC
-    log_format: "%d{YYYY-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"
+    log_format: "%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"


### PR DESCRIPTION
Do not use week year.

The `Y` refers to the 'Week year': https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html

> A week year is in sync with a WEEK_OF_YEAR cycle. All weeks between the first and last weeks (inclusive) have the same week year value. Therefore, the first and last days of a week year may have different calendar year values.

> For example, January 1, 1998 is a Thursday. If getFirstDayOfWeek() is MONDAY and getMinimalDaysInFirstWeek() is 4 (ISO 8601 standard compatible setting), then week 1 of 1998 starts on December 29, 1997, and ends on January 4, 1998. The week year is 1998 for the last three days of calendar year 1997. If, however, getFirstDayOfWeek() is SUNDAY, then week 1 of 1998 starts on January 4, 1998, and ends on January 10, 1998; the first three days of 1998 then are part of week 53 of 1997 and their week year is 1997. 

https://docs.oracle.com/javase/8/docs/api/java/util/GregorianCalendar.html#week_year

So since we were using `Y` for 'Week year' the last few days of 2021 were logged as 2022, and Jan 1st 2022 was even logged as 2023.

Thanks for @easbar for helping me to find this "feature" and fix an ugly problem in production :D 