### PR TITLE
Node out of bounds error when using average_speed path detail

### DIFF
--- a/core/src/test/java/com/graphhopper/GraphHopperTest.java
+++ b/core/src/test/java/com/graphhopper/GraphHopperTest.java
@@ -2452,4 +2452,26 @@ public class GraphHopperTest {
         }
     }
 
+    @Test
+    void averageSpeedPathDetailBug() {
+        final String profile = "profile";
+        GraphHopper hopper = new GraphHopper()
+                .setProfiles(new Profile(profile).setVehicle("car").setWeighting("fastest").setTurnCosts(true).putHint(U_TURN_COSTS, 80))
+                .setGraphHopperLocation(GH_LOCATION)
+                .setMinNetworkSize(200)
+                .setOSMFile(BAYREUTH);
+        hopper.importOrLoad();
+        GHPoint pointA = new GHPoint(50.020562, 11.500196);
+        GHPoint pointB = new GHPoint(50.019935, 11.500567);
+        GHPoint pointC = new GHPoint(50.022027, 11.498255);
+        GHRequest request = new GHRequest(Arrays.asList(pointA, pointB, pointC));
+        request.setProfile(profile);
+        request.setPathDetails(Collections.singletonList("average_speed"));
+        // this used to fail, because we did not wrap the weighting for query graph and so we tried calculating turn costs for virtual nodes
+        GHResponse response = hopper.route(request);
+        assertFalse(response.hasErrors(), response.getErrors().toString());
+        double distance = response.getBest().getDistance();
+        assertEquals(467, distance, 1);
+    }
+
 }


### PR DESCRIPTION
For a `car` profile with turn costs, e.g. this route http://localhost:8989/maps/?point=50.018339%2C11.502782&point=50.017515%2C11.501698&point=50.017129%2C11.504467&locale=en-US&elevation=false&profile=car&use_miles=false&layer=Omniscale&details=average_speed fails with an error like

```
node: 1942 out of bounds [0,1942[
```

(depending on the size of the map). The reason is that the turn cost storage is queried with a virtual node ID (node 1942 is a virtual node and thus beyond the range of valid node IDs). The error only occurs when the `average_speed` path detail is enabled and a virtual node is part of the route between two via points. So in the simplest case a route with one via-point A-B-C is such that we visit A again when we go from B to C. Otherwise the error does not occur, because we do not consider the turn costs at via points when calculating `average_speed` (and the same for instructions). I already fixed this here: 0c23614503fdc940a09192ac43bc5f0d48fb32c2.