### PR TITLE
Transfer legs

### DIFF
--- a/reader-gtfs/src/main/java/com/graphhopper/gtfs/GraphExplorer.java
+++ b/reader-gtfs/src/main/java/com/graphhopper/gtfs/GraphExplorer.java
@@ -251,9 +251,9 @@ public final class GraphExplorer {
         }
     }
 
-    public List<Label.Transition> walkPath(int[] skippedEdgesForTransfer) {
+    public List<Label.Transition> walkPath(int[] skippedEdgesForTransfer, long currentTime) {
         EdgeIteratorState firstEdge = graph.getEdgeIteratorStateForKey(skippedEdgesForTransfer[0]);
-        Label label = new Label(0, null, new Label.NodeId(firstEdge.getBaseNode(), -1), 0, null, 0, 0, 0, false, null);
+        Label label = new Label(currentTime, null, new Label.NodeId(firstEdge.getBaseNode(), -1), 0, null, 0, 0, 0, false, null);
         for (int i : skippedEdgesForTransfer) {
             EdgeIteratorState e = graph.getEdgeIteratorStateForKey(i);
             MultiModalEdge multiModalEdge = new MultiModalEdge(e.getEdge(), e.getBaseNode(), e.getAdjNode(), (long) (accessEgressWeighting.calcEdgeMillis(e, reverse) * (5.0 / walkSpeedKmH)), e.getDistance());

--- a/reader-gtfs/src/main/java/com/graphhopper/gtfs/GraphExplorer.java
+++ b/reader-gtfs/src/main/java/com/graphhopper/gtfs/GraphExplorer.java
@@ -26,12 +26,14 @@ import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.Graph;
 import com.graphhopper.util.EdgeExplorer;
 import com.graphhopper.util.EdgeIterator;
+import com.graphhopper.util.EdgeIteratorState;
 
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Spliterators;
 import java.util.function.Consumer;
 
@@ -49,8 +51,10 @@ public final class GraphExplorer {
     private final boolean ignoreValidities;
     private final int blockedRouteTypes;
     private final PtGraph ptGraph;
+    private final Graph graph;
 
     public GraphExplorer(Graph graph, PtGraph ptGraph, Weighting accessEgressWeighting, GtfsStorage gtfsStorage, RealtimeFeed realtimeFeed, boolean reverse, boolean walkOnly, boolean ptOnly, double walkSpeedKmh, boolean ignoreValidities, int blockedRouteTypes) {
+        this.graph = graph;
         this.ptGraph = ptGraph;
         this.accessEgressWeighting = accessEgressWeighting;
         this.accessEnc = accessEgressWeighting.getFlagEncoder().getAccessEnc();
@@ -245,6 +249,17 @@ public final class GraphExplorer {
         } else {
             return true;
         }
+    }
+
+    public List<Label.Transition> walkPath(int[] skippedEdgesForTransfer) {
+        EdgeIteratorState firstEdge = graph.getEdgeIteratorStateForKey(skippedEdgesForTransfer[0]);
+        Label label = new Label(0, null, new Label.NodeId(firstEdge.getBaseNode(), -1), 0, null, 0, 0, 0, false, null);
+        for (int i : skippedEdgesForTransfer) {
+            EdgeIteratorState e = graph.getEdgeIteratorStateForKey(i);
+            MultiModalEdge multiModalEdge = new MultiModalEdge(e.getEdge(), e.getBaseNode(), e.getAdjNode(), (long) (accessEgressWeighting.calcEdgeMillis(e, reverse) * (5.0 / walkSpeedKmH)), e.getDistance());
+            label = new Label(label.currentTime + multiModalEdge.time, multiModalEdge, new Label.NodeId(firstEdge.getBaseNode(), -1), 0, null, 0, 0, 0, false, label);
+        }
+        return Label.getTransitions(label, false);
     }
 
     public class MultiModalEdge {

--- a/reader-gtfs/src/main/java/com/graphhopper/gtfs/GraphHopperGtfs.java
+++ b/reader-gtfs/src/main/java/com/graphhopper/gtfs/GraphHopperGtfs.java
@@ -136,8 +136,10 @@ public class GraphHopperGtfs extends GraphHopper {
                                         EdgeIteratorState edgeIteratorState = graphHopperStorage.getEdgeIteratorState(t.edge.getId(), adjNode.streetNode);
                                         return edgeIteratorState.getEdgeKey();
                                     }).toArray();
-                                    for (Integer transferEdgeId : transferEdgeIds) {
-                                        gtfsStorage.getSkippedEdgesForTransfer().put(transferEdgeId, edgeIds);
+                                    if (edgeIds.length > 0) { // TODO: Elsewhere, we distinguish empty path ("at" a node) from no path
+                                        for (Integer transferEdgeId : transferEdgeIds) {
+                                            gtfsStorage.getSkippedEdgesForTransfer().put(transferEdgeId, edgeIds);
+                                        }
                                     }
                                 } else {
                                     List<Transfer> transfersToStop = transfers.getTransfersToStop(toPlatformDescriptor.stop_id, routeIdOrNull(toPlatformDescriptor));

--- a/reader-gtfs/src/main/java/com/graphhopper/gtfs/GtfsReader.java
+++ b/reader-gtfs/src/main/java/com/graphhopper/gtfs/GtfsReader.java
@@ -210,20 +210,23 @@ class GtfsReader {
         });
     }
 
-    public void insertTransferEdges(int arrivalPlatformNode, int minTransferTime, GtfsStorage.PlatformDescriptor departurePlatform) {
-        insertTransferEdges(arrivalPlatformNode, minTransferTime, departureTimelinesByStop.get(departurePlatform.stop_id).get(departurePlatform), departurePlatform);
+    public ArrayList<Integer> insertTransferEdges(int arrivalPlatformNode, int minTransferTime, GtfsStorage.PlatformDescriptor departurePlatform) {
+        return insertTransferEdges(arrivalPlatformNode, minTransferTime, departureTimelinesByStop.get(departurePlatform.stop_id).get(departurePlatform), departurePlatform);
     }
 
-    private void insertTransferEdges(int arrivalPlatformNode, int minTransferTime, NavigableMap<Integer, Integer> departureTimeline, GtfsStorage.PlatformDescriptor departurePlatform) {
+    private ArrayList<Integer> insertTransferEdges(int arrivalPlatformNode, int minTransferTime, NavigableMap<Integer, Integer> departureTimeline, GtfsStorage.PlatformDescriptor departurePlatform) {
+        ArrayList<Integer> result = new ArrayList<>();
         for (PtGraph.PtEdge e : ptGraph.backEdgesAround(arrivalPlatformNode)) {
             if (e.getType() == GtfsStorage.EdgeType.LEAVE_TIME_EXPANDED_NETWORK) {
                 int arrivalTime = e.getTime();
                 SortedMap<Integer, Integer> tailSet = departureTimeline.tailMap(arrivalTime + minTransferTime);
                 if (!tailSet.isEmpty()) {
-                    out.createEdge(e.getAdjNode(), tailSet.get(tailSet.firstKey()), new PtEdgeAttributes(GtfsStorage.EdgeType.TRANSFER, tailSet.firstKey() - arrivalTime, null, routeType(departurePlatform), null, 0, -1, null, departurePlatform));
+                    int id = out.createEdge(e.getAdjNode(), tailSet.get(tailSet.firstKey()), new PtEdgeAttributes(GtfsStorage.EdgeType.TRANSFER, tailSet.firstKey() - arrivalTime, null, routeType(departurePlatform), null, 0, -1, null, departurePlatform));
+                    result.add(id);
                 }
             }
         }
+        return result;
     }
 
     void wireUpAdditionalDeparturesAndArrivals(ZoneId zoneId) {

--- a/reader-gtfs/src/main/java/com/graphhopper/gtfs/GtfsStorage.java
+++ b/reader-gtfs/src/main/java/com/graphhopper/gtfs/GtfsStorage.java
@@ -57,7 +57,11 @@ public class GtfsStorage {
         this.ptGraph = ptGraph;
     }
 
-    public static class Validity implements Serializable {
+	public Map<Integer, int[]> getSkippedEdgesForTransfer() {
+		return skippedEdgesForTransfer;
+	}
+
+	public static class Validity implements Serializable {
 		final BitSet validity;
 		final ZoneId zoneId;
 		final LocalDate start;
@@ -134,6 +138,7 @@ public class GtfsStorage {
 	private Map<String, GTFSFeed> gtfsFeeds = new HashMap<>();
 	private Map<String, Map<String, Fare>> faresByFeed;
 	private Map<FeedIdWithStopId, Integer> stationNodes;
+	private Map<Integer, int[]> skippedEdgesForTransfer;
 
 	private Map<Integer, Integer> ptToStreet;
 	private Map<Integer, Integer> streetToPt;
@@ -188,6 +193,7 @@ public class GtfsStorage {
 		this.stationNodes = data.getHashMap("stationNodes");
 		this.ptToStreet = data.getHashMap("ptToStreet");
 		this.streetToPt = data.getHashMap("streetToPt");
+		this.skippedEdgesForTransfer = data.getHashMap("skippedEdgesForTransfer");
 	}
 
 	void loadGtfsFromZipFileOrDirectory(String id, File zipFileOrDirectory) {
@@ -247,7 +253,7 @@ public class GtfsStorage {
 		public String stop_id;
 
 		public static PlatformDescriptor route(String feed_id, String stop_id, String route_id) {
-			GtfsStorage.RoutePlatform routePlatform = new GtfsStorage.RoutePlatform();
+			RoutePlatform routePlatform = new RoutePlatform();
 			routePlatform.feed_id = feed_id;
 			routePlatform.stop_id = stop_id;
 			routePlatform.route_id = route_id;
@@ -268,8 +274,8 @@ public class GtfsStorage {
 			return Objects.hash(feed_id, stop_id);
 		}
 
-		public static GtfsStorage.RouteTypePlatform routeType(String feed_id, String stop_id, int route_type) {
-			GtfsStorage.RouteTypePlatform routeTypePlatform = new GtfsStorage.RouteTypePlatform();
+		public static RouteTypePlatform routeType(String feed_id, String stop_id, int route_type) {
+			RouteTypePlatform routeTypePlatform = new RouteTypePlatform();
 			routeTypePlatform.feed_id = feed_id;
 			routeTypePlatform.stop_id = stop_id;
 			routeTypePlatform.route_type = route_type;

--- a/reader-gtfs/src/main/java/com/graphhopper/gtfs/Label.java
+++ b/reader-gtfs/src/main/java/com/graphhopper/gtfs/Label.java
@@ -57,9 +57,9 @@ public class Label {
 
     public final Label parent;
 
-    Label(long currentTime, GraphExplorer.MultiModalEdge edgeId, NodeId node, int nTransfers, Long departureTime, long streetTime, long extraWeight, long residualDelay, boolean impossible, Label parent) {
+    Label(long currentTime, GraphExplorer.MultiModalEdge edge, NodeId node, int nTransfers, Long departureTime, long streetTime, long extraWeight, long residualDelay, boolean impossible, Label parent) {
         this.currentTime = currentTime;
-        this.edge = edgeId;
+        this.edge = edge;
         this.node = node;
         this.nTransfers = nTransfers;
         this.departureTime = departureTime;

--- a/reader-gtfs/src/main/java/com/graphhopper/gtfs/PtRouterFreeWalkImpl.java
+++ b/reader-gtfs/src/main/java/com/graphhopper/gtfs/PtRouterFreeWalkImpl.java
@@ -190,7 +190,7 @@ public final class PtRouterFreeWalkImpl implements PtRouter {
         }
 
         private void parseSolutionsAndAddToResponse(List<List<Label.Transition>> solutions, PointList waypoints) {
-            TripFromLabel tripFromLabel = new TripFromLabel(queryGraph, gtfsStorage, realtimeFeed, pathDetailsBuilderFactory);
+            TripFromLabel tripFromLabel = new TripFromLabel(queryGraph, gtfsStorage, realtimeFeed, pathDetailsBuilderFactory, walkSpeedKmH);
             for (List<Label.Transition> solution : solutions) {
                 final ResponsePath responsePath = tripFromLabel.createResponsePath(translation, waypoints, queryGraph, accessWeighting, egressWeighting, solution, requestedPathDetails);
                 responsePath.setImpossible(solution.stream().anyMatch(t -> t.label.impossible));

--- a/reader-gtfs/src/main/java/com/graphhopper/gtfs/PtRouterImpl.java
+++ b/reader-gtfs/src/main/java/com/graphhopper/gtfs/PtRouterImpl.java
@@ -188,7 +188,7 @@ public final class PtRouterImpl implements PtRouter {
         }
 
         private void parseSolutionsAndAddToResponse(List<List<Label.Transition>> solutions, PointList waypoints) {
-            TripFromLabel tripFromLabel = new TripFromLabel(queryGraph, gtfsStorage, realtimeFeed, pathDetailsBuilderFactory);
+            TripFromLabel tripFromLabel = new TripFromLabel(queryGraph, gtfsStorage, realtimeFeed, pathDetailsBuilderFactory, walkSpeedKmH);
             for (List<Label.Transition> solution : solutions) {
                 final ResponsePath responsePath = tripFromLabel.createResponsePath(translation, waypoints, queryGraph, accessWeighting, egressWeighting, solution, requestedPathDetails);
                 responsePath.setImpossible(solution.stream().anyMatch(t -> t.label.impossible));

--- a/reader-gtfs/src/main/java/com/graphhopper/gtfs/TripFromLabel.java
+++ b/reader-gtfs/src/main/java/com/graphhopper/gtfs/TripFromLabel.java
@@ -404,7 +404,7 @@ class TripFromLabel {
             return Collections.singletonList(new Trip.WalkLeg(
                     "Walk",
                     Date.from(departureTime),
-                    lineStringFromEdges(path),
+                    lineStringFromInstructions(instructions),
                     edges(path).mapToDouble(edgeLabel -> edgeLabel.getDistance()).sum(),
                     instructions,
                     pathDetails,
@@ -421,13 +421,12 @@ class TripFromLabel {
         return path.stream().filter(t -> t.edge != null).map(t -> t.edge);
     }
 
-    private Geometry lineStringFromEdges(List<Label.Transition> transitions) {
-        final Iterator<Label.Transition> iterator = transitions.iterator();
-        iterator.next();
-        Label.Transition first = iterator.next();
-        List<Coordinate> coordinates = new ArrayList<>(toCoordinateArray(graph.getEdgeIteratorState(first.edge.getId(), first.edge.getAdjNode().streetNode).fetchWayGeometry(FetchMode.ALL)));
-        iterator.forEachRemaining(transition -> coordinates.addAll(toCoordinateArray(graph.getEdgeIteratorState(transition.edge.getId(), transition.edge.getAdjNode().streetNode).fetchWayGeometry(FetchMode.PILLAR_AND_ADJ))));
-        return geometryFactory.createLineString(coordinates.toArray(new Coordinate[coordinates.size()]));
+    private Geometry lineStringFromInstructions(InstructionList instructions) {
+        final PointList pointsList = new PointList();
+        for (Instruction instruction : instructions) {
+            pointsList.add(instruction.getPoints());
+        }
+        return pointsList.toLineString(false);
     }
 
     private static List<Coordinate> toCoordinateArray(PointList pointList) {

--- a/reader-gtfs/src/test/java/com/graphhopper/AnotherAgencyIT.java
+++ b/reader-gtfs/src/test/java/com/graphhopper/AnotherAgencyIT.java
@@ -25,6 +25,9 @@ import com.graphhopper.util.TranslationMap;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKTReader;
 
 import java.io.File;
 import java.time.Duration;
@@ -36,8 +39,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static com.graphhopper.gtfs.GtfsHelper.time;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static com.graphhopper.util.Parameters.Details.EDGE_KEY;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class AnotherAgencyIT {
 
@@ -151,6 +154,7 @@ public class AnotherAgencyIT {
         );
         ghRequest.setIgnoreTransfers(true);
         ghRequest.setWalkSpeedKmH(0.5); // Prevent walk solution
+        ghRequest.setPathDetails(Arrays.asList(EDGE_KEY));
         GHResponse route = ptRouter.route(ghRequest);
 
         assertFalse(route.hasErrors());
@@ -163,7 +167,13 @@ public class AnotherAgencyIT {
         assertEquals(4500000L, transitSolution.getTime());
         assertEquals(4500000.0, transitSolution.getRouteWeight());
 
-        // TODO: We probably want something like a transfer leg here
+        assertTrue(transitSolution.getLegs().get(0) instanceof Trip.PtLeg);
+        assertTrue(transitSolution.getLegs().get(1) instanceof Trip.WalkLeg);
+        assertTrue(transitSolution.getLegs().get(2) instanceof Trip.PtLeg);
+
+        Trip.WalkLeg walkLeg = (Trip.WalkLeg) transitSolution.getLegs().get(1);
+        assertEquals(readWktLineString("LINESTRING (-116.7616398 36.9060932, -116.761812 36.905928, -116.76217 36.905659)"), walkLeg.geometry);
+
         assertEquals(time(1, 15), transitSolution.getTime(), "Expected total travel time == scheduled travel time + wait time");
     }
 
@@ -183,6 +193,17 @@ public class AnotherAgencyIT {
         assertEquals(1, walkRoute.getLegs().size());
         assertEquals(486660, walkRoute.getTime()); // < 10 min, so the transfer in test above works ^^
         assertFalse(route.hasErrors());
+    }
+
+    private LineString readWktLineString(String wkt) {
+        WKTReader wktReader = new WKTReader();
+        LineString expectedGeometry = null;
+        try {
+            expectedGeometry = (LineString) wktReader.read(wkt);
+        } catch (ParseException e) {
+            e.printStackTrace();
+        }
+        return expectedGeometry;
     }
 
 }

--- a/reader-gtfs/src/test/java/com/graphhopper/GraphHopperMultimodalIT.java
+++ b/reader-gtfs/src/test/java/com/graphhopper/GraphHopperMultimodalIT.java
@@ -31,6 +31,10 @@ import com.graphhopper.util.shapes.GHPoint;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKTReader;
 
 import java.io.File;
 import java.time.*;
@@ -295,6 +299,21 @@ public class GraphHopperMultimodalIT {
         assertThat(responses).allMatch(r -> !r.getAll().isEmpty());
     }
 
+    @Test
+    public void testLineStringWhenWalking() {
+        Request ghRequest = new Request(
+                36.90662748004327, -116.76506702494832,
+                36.90814220713894, -116.76219285567532
+        );
+        ghRequest.setEarliestDepartureTime(LocalDateTime.of(2007, 1, 1, 6, 40, 0).atZone(zoneId).toInstant());
+
+        GHResponse response = graphHopper.route(ghRequest);
+        Geometry routeGeometry = response.getAll().get(0).getPoints().toLineString(false);
+        Geometry legGeometry = response.getAll().get(0).getLegs().get(0).geometry;
+        assertThat(routeGeometry).isEqualTo(readWktLineString("LINESTRING (-116.765169 36.906693, -116.764614 36.907243, -116.763438 36.908382, -116.762615 36.907825, -116.762241 36.908175)"));
+        assertThat(legGeometry).isEqualTo(readWktLineString("LINESTRING (-116.765169 36.906693, -116.764614 36.907243, -116.763438 36.908382, -116.762615 36.907825, -116.762241 36.908175)"));
+    }
+
     private Duration legDuration(Trip.Leg leg) {
         return Duration.between(departureTime(leg), arrivalTime(leg));
     }
@@ -313,5 +332,15 @@ public class GraphHopperMultimodalIT {
         return Instant.ofEpochMilli(leg.getArrivalTime().getTime());
     }
 
+    private LineString readWktLineString(String wkt) {
+        WKTReader wktReader = new WKTReader();
+        LineString expectedGeometry = null;
+        try {
+            expectedGeometry = (LineString) wktReader.read(wkt);
+        } catch (ParseException e) {
+            e.printStackTrace();
+        }
+        return expectedGeometry;
+    }
 
 }


### PR DESCRIPTION
Insert WalkLegs into the response itinerary for all transfers that are not specified in the GTFS, but that were "interpolated" by walking the road network.