### PR TITLE
add applyWayTags to TagParser

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/EncodingManager.java
+++ b/core/src/main/java/com/graphhopper/routing/util/EncodingManager.java
@@ -633,6 +633,9 @@ public class EncodingManager implements EncodedValueLookup {
 
         if (Double.isInfinite(edge.getDistance()))
             throw new IllegalStateException("Infinite distance should not happen due to #435. way ID=" + way.getId());
+        for (TagParser parser : edgeTagParsers) {
+            parser.applyWayTags(way, edge);
+        }
         for (AbstractFlagEncoder encoder : edgeEncoders) {
             encoder.applyWayTags(way, edge);
         }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/TagParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/TagParser.java
@@ -21,6 +21,7 @@ import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.EncodedValue;
 import com.graphhopper.routing.ev.EncodedValueLookup;
 import com.graphhopper.storage.IntsRef;
+import com.graphhopper.util.EdgeIteratorState;
 
 import java.util.List;
 
@@ -33,4 +34,7 @@ public interface TagParser {
     void createEncodedValues(EncodedValueLookup lookup, List<EncodedValue> registerNewEncodedValue);
 
     IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay way, IntsRef relationFlags);
+
+    default void applyWayTags(ReaderWay way, EdgeIteratorState edge) {
+    }
 }


### PR DESCRIPTION
When we add the applyWayTags method to the TagParser interface we could move a few EncodedValues like curvature (or even elevation based encoded values) outside of the FlagEncoder. The question is only if we should use the same TagParser interface.