### PR TITLE
Clean up FerrySpeedCalculator, use exact edge distance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - OSMReader no longer sets the artificial estimated_distance tag, but sets the edge_distance and point_list tags for all
   edges, the way_distance for selected ways and additionally the duration:seconds and speed_from_duration tags when the
   duration tag is present (#2528)
+- fixed speed calculation for ferry routes with duration tags (#2528)
 - request gzipping for matrix and route clients (#2511)
 - bugfix: client-hc now considers headings and custom models (#2009, #2535)
 - the artificial tag duration:seconds is now a long, no longer a string, commit 6d81d8ae8de52987522991edd835e42c8d2046cf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ### 5.0 [not yet released]
 
-- OSMReader no longer sets the artificial estimated_distance tag, but sets the edge_distance and point_list tags instead.
+- OSMReader no longer sets the artificial estimated_distance tag, but sets the edge_distance and point_list tags for all
+  edges, the way_distance for selected ways and additionally the duration:seconds and speed_from_duration tags when the
+  duration tag is present (#2528)
 - request gzipping for matrix and route clients (#2511)
 - bugfix: client-hc now considers headings (#2009)
 - the artificial tag duration:seconds is now a long, no longer a string, commit 6d81d8ae8de52987522991edd835e42c8d2046cf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### 5.0 [not yet released]
 
-- OSMReader no longer sets the artificial estimated_distance tag, but sets beeline_distance, edge_distance and
-  point_list instead.
+- OSMReader no longer sets the artificial estimated_distance tag, but sets the edge_distance and point_list tags
+  instead.
 - the artificial tag duration:seconds is now a long, not a string, commit 6d81d8ae8de52987522991edd835e42c8d2046cf
 - added FlagEncoder#getName (use just like toString() before), commit 86f6a8b5209ad8ef47c24d935f5746e7694eb11c
 - faster edge-based CH preparation, especially with large u-turn costs and GermanyCountryRule (many large weight edges

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ### 5.0 [not yet released]
 
-- the artificial tag duration:seconds is now a long, not a string
+- OSMReader no longer sets the artificial estimated_distance tag, but sets beeline_distance, road_distance and
+  point_list instead.
+- the artificial tag duration:seconds is now a long, not a string, commit 6d81d8ae8de52987522991edd835e42c8d2046cf
 - added FlagEncoder#getName (use just like toString() before), commit 86f6a8b5209ad8ef47c24d935f5746e7694eb11c
 - faster edge-based CH preparation, especially with large u-turn costs and GermanyCountryRule (many large weight edges
   due to access=destination on tracks) (#2522)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### 5.0 [not yet released]
 
-- OSMReader no longer sets the artificial estimated_distance tag, but sets beeline_distance, road_distance and
+- OSMReader no longer sets the artificial estimated_distance tag, but sets beeline_distance, edge_distance and
   point_list instead.
 - the artificial tag duration:seconds is now a long, not a string, commit 6d81d8ae8de52987522991edd835e42c8d2046cf
 - added FlagEncoder#getName (use just like toString() before), commit 86f6a8b5209ad8ef47c24d935f5746e7694eb11c

--- a/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
+++ b/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
@@ -394,8 +394,9 @@ public class OSMReader {
         }
 
         double speedInKmPerHour = distance / 1000 / (durationInSeconds / 60.0 / 60.0);
-        if (speedInKmPerHour < 0.01d) {
-            LOGGER.warn("Unrealistic low speed calculated from duration. Maybe duration is too long for OSM way: "
+        if (speedInKmPerHour < 0.1d) {
+            // often there are mapping errors like duration=30:00 (30h) instead of duration=00:30 (30min)
+            LOGGER.warn("Unrealistic low speed calculated from duration. Maybe the duration is too long, or it is applied to a way that only represents a part of the connection? OSM way: "
                     + way.getId() + ". duration=" + durationTag + " (= " + Math.round(durationInSeconds / 60.0) +
                     " + minutes), distance=" + Math.round(distance / 1000.0) + "km");
             return;

--- a/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
+++ b/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
@@ -199,7 +199,7 @@ public class OSMReader {
         double firstLat = pointList.getLat(0), firstLon = pointList.getLon(0);
         double lastLat = pointList.getLat(pointList.size() - 1), lastLon = pointList.getLon(pointList.size() - 1);
         way.setTag("beeline_distance", distCalc.calcDist(firstLat, firstLon, lastLat, lastLon));
-        way.setTag("total_distance", distance);
+        way.setTag("road_distance", distance);
         way.setTag("point_list", pointList);
 
         // we have to remove existing artificial tags, because we modify the way even though there can be multiple edges

--- a/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
+++ b/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
@@ -352,6 +352,12 @@ public class OSMReader {
                     + ", difference: " + (edgeDistance - geometryDistance));
     }
 
+    /**
+     * This method is called for each way during the second pass and before the way is split into edges.
+     * We currently use it to calculate the distance of a way and determine the speed based on the duration tag when
+     * it is present. This cannot be done on a per-edge basis, because the duration tag refers to the duration of the
+     * entire way.
+     */
     protected void preprocessWay(ReaderWay way, WaySegmentParser.CoordinateSupplier coordinateSupplier) {
         if (!isCalculateWayDistance(way))
             return;

--- a/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
+++ b/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
@@ -395,7 +395,7 @@ public class OSMReader {
 
         double speedInKmPerHour = distance / 1000 / (durationInSeconds / 60.0 / 60.0);
         if (speedInKmPerHour < 0.1d) {
-            // often there are mapping errors like duration=30:00 (30h) instead of duration=00:30 (30min). If there are none anymore, maybe make this check more strict.
+            // often there are mapping errors like duration=30:00 (30h) instead of duration=00:30 (30min). If there are none anymore, maybe raise the limit to find more cases.
             LOGGER.warn("Unrealistic low speed calculated from duration. Maybe the duration is too long, or it is applied to a way that only represents a part of the connection? OSM way: "
                     + way.getId() + ". duration=" + durationTag + " (= " + Math.round(durationInSeconds / 60.0) +
                     " + minutes), distance=" + Math.round(distance / 1000.0) + "km");

--- a/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
+++ b/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
@@ -394,11 +394,12 @@ public class OSMReader {
         }
 
         double speedInKmPerHour = distance / 1000 / (durationInSeconds / 60.0 / 60.0);
-        if (speedInKmPerHour < 0.01d)
+        if (speedInKmPerHour < 0.01d) {
             LOGGER.warn("Unrealistic low speed calculated from duration. Maybe duration is too long for OSM way: "
                     + way.getId() + ". duration=" + durationTag + " (= " + Math.round(durationInSeconds / 60.0) +
-                    " + minutes), distance=" + (distance / 1000.0) + "km");
-
+                    " + minutes), distance=" + Math.round(distance / 1000.0) + "km");
+            return;
+        }
         // These tags will be present if 1) isCalculateWayDistance was true for this way, 2) no OSM nodes were missing
         // such that the distance could actually be calculated, 3) there was a duration tag we could parse, and 4) the
         // derived speed was not unrealistically slow.

--- a/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
+++ b/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
@@ -195,17 +195,16 @@ public class OSMReader {
      * This method is called during the second pass of {@link WaySegmentParser} and provides an entry point to enrich
      * the given OSM way with additional tags before it is passed on to the tag parsers.
      */
-    protected void setArtificialWayTags(PointList pointList, ReaderWay way) {
-        // Estimate length of ways containing a route tag e.g. for ferry speed calculation
+    protected void setArtificialWayTags(PointList pointList, ReaderWay way, double distance) {
         double firstLat = pointList.getLat(0), firstLon = pointList.getLon(0);
         double lastLat = pointList.getLat(pointList.size() - 1), lastLon = pointList.getLon(pointList.size() - 1);
+        way.setTag("beeline_distance", distCalc.calcDist(firstLat, firstLon, lastLat, lastLon));
+        way.setTag("total_distance", distance);
+        way.setTag("point_list", pointList);
+
         // we have to remove existing artificial tags, because we modify the way even though there can be multiple edges
         // per way. sooner or later we should separate the artificial ('edge') tags from the way, see discussion here:
         // https://github.com/graphhopper/graphhopper/pull/2457#discussion_r751155404
-        way.removeTag("estimated_distance");
-        double estimatedDist = distCalc.calcDist(firstLat, firstLon, lastLat, lastLon);
-        way.setTag("estimated_distance", estimatedDist);
-
         way.removeTag("duration:seconds");
         if (way.getTag("duration") != null) {
             try {
@@ -290,29 +289,29 @@ public class OSMReader {
         if (config.getMaxWayPointDistance() > 0 && pointList.size() > 2)
             simplifyAlgo.simplify(pointList);
 
-        double towerNodeDistance = distCalc.calcDistance(pointList);
+        double distance = distCalc.calcDistance(pointList);
 
-        if (towerNodeDistance < 0.001) {
+        if (distance < 0.001) {
             // As investigation shows often two paths should have crossed via one identical point
             // but end up in two very close points.
             zeroCounter++;
-            towerNodeDistance = 0.001;
+            distance = 0.001;
         }
 
         double maxDistance = (Integer.MAX_VALUE - 1) / 1000d;
-        if (Double.isNaN(towerNodeDistance)) {
-            LOGGER.warn("Bug in OSM or GraphHopper. Illegal tower node distance " + towerNodeDistance + " reset to 1m, osm way " + way.getId());
-            towerNodeDistance = 1;
+        if (Double.isNaN(distance)) {
+            LOGGER.warn("Bug in OSM or GraphHopper. Illegal tower node distance " + distance + " reset to 1m, osm way " + way.getId());
+            distance = 1;
         }
 
-        if (Double.isInfinite(towerNodeDistance) || towerNodeDistance > maxDistance) {
+        if (Double.isInfinite(distance) || distance > maxDistance) {
             // Too large is very rare and often the wrong tagging. See #435
             // so we can avoid the complexity of splitting the way for now (new towernodes would be required, splitting up geometry etc)
-            LOGGER.warn("Bug in OSM or GraphHopper. Too big tower node distance " + towerNodeDistance + " reset to large value, osm way " + way.getId());
-            towerNodeDistance = maxDistance;
+            LOGGER.warn("Bug in OSM or GraphHopper. Too big tower node distance " + distance + " reset to large value, osm way " + way.getId());
+            distance = maxDistance;
         }
 
-        setArtificialWayTags(pointList, way);
+        setArtificialWayTags(pointList, way, distance);
         IntsRef relationFlags = getRelFlagsMap(way.getId());
         IntsRef edgeFlags = encodingManager.handleWayTags(way, relationFlags);
         if (edgeFlags.isEmpty())
@@ -322,7 +321,7 @@ public class OSMReader {
         if (!nodeTags.isEmpty())
             edgeFlags = encodingManager.handleNodeTags(nodeTags, edgeFlags);
 
-        EdgeIteratorState iter = ghStorage.edge(fromIndex, toIndex).setDistance(towerNodeDistance).setFlags(edgeFlags);
+        EdgeIteratorState iter = ghStorage.edge(fromIndex, toIndex).setDistance(distance).setFlags(edgeFlags);
 
         // If the entire way is just the first and last point, do not waste space storing an empty way geometry
         if (pointList.size() > 2) {

--- a/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
+++ b/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
@@ -380,8 +380,8 @@ public class OSMReader {
         // into edges.
         String durationTag = way.getTag("duration");
         if (durationTag == null) {
-            // no duration tag -> we cannot derive speed
-            if (isFerry(way) && distance > 20_000)
+            // no duration tag -> we cannot derive speed.
+            if (isFerry(way) && distance > 500_000)
                 LOGGER.warn("Long ferry OSM way without duration tag: " + way.getId() + ", distance: " + Math.round(distance / 1000.0) + " km");
             return;
         }
@@ -395,7 +395,7 @@ public class OSMReader {
 
         double speedInKmPerHour = distance / 1000 / (durationInSeconds / 60.0 / 60.0);
         if (speedInKmPerHour < 0.1d) {
-            // often there are mapping errors like duration=30:00 (30h) instead of duration=00:30 (30min)
+            // often there are mapping errors like duration=30:00 (30h) instead of duration=00:30 (30min). If there are none anymore, maybe make this check more strict.
             LOGGER.warn("Unrealistic low speed calculated from duration. Maybe the duration is too long, or it is applied to a way that only represents a part of the connection? OSM way: "
                     + way.getId() + ". duration=" + durationTag + " (= " + Math.round(durationInSeconds / 60.0) +
                     " + minutes), distance=" + Math.round(distance / 1000.0) + "km");

--- a/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
+++ b/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
@@ -196,9 +196,6 @@ public class OSMReader {
      * the given OSM way with additional tags before it is passed on to the tag parsers.
      */
     protected void setArtificialWayTags(PointList pointList, ReaderWay way, double distance) {
-        double firstLat = pointList.getLat(0), firstLon = pointList.getLon(0);
-        double lastLat = pointList.getLat(pointList.size() - 1), lastLon = pointList.getLon(pointList.size() - 1);
-        way.setTag("beeline_distance", distCalc.calcDist(firstLat, firstLon, lastLat, lastLon));
         way.setTag("edge_distance", distance);
         way.setTag("point_list", pointList);
 
@@ -227,6 +224,8 @@ public class OSMReader {
                 middleLat = pointList.getLat(pointList.size() / 2);
                 middleLon = pointList.getLon(pointList.size() / 2);
             } else {
+                double firstLat = pointList.getLat(0), firstLon = pointList.getLon(0);
+                double lastLat = pointList.getLat(pointList.size() - 1), lastLon = pointList.getLon(pointList.size() - 1);
                 middleLat = (firstLat + lastLat) / 2;
                 middleLon = (firstLon + lastLon) / 2;
             }

--- a/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
+++ b/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
@@ -382,7 +382,7 @@ public class OSMReader {
         if (durationTag == null) {
             // no duration tag -> we cannot derive speed
             if (isFerry(way) && distance > 20_000)
-                LOGGER.warn("Long ferry OSM way without duration tag: " + way.getId() + ", distance: " + Math.round(distance / 1000.0) + "m");
+                LOGGER.warn("Long ferry OSM way without duration tag: " + way.getId() + ", distance: " + Math.round(distance / 1000.0) + " km");
             return;
         }
         long durationInSeconds;

--- a/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
+++ b/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
@@ -199,7 +199,7 @@ public class OSMReader {
         double firstLat = pointList.getLat(0), firstLon = pointList.getLon(0);
         double lastLat = pointList.getLat(pointList.size() - 1), lastLon = pointList.getLon(pointList.size() - 1);
         way.setTag("beeline_distance", distCalc.calcDist(firstLat, firstLon, lastLat, lastLon));
-        way.setTag("road_distance", distance);
+        way.setTag("edge_distance", distance);
         way.setTag("point_list", pointList);
 
         // we have to remove existing artificial tags, because we modify the way even though there can be multiple edges

--- a/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
+++ b/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
@@ -381,8 +381,8 @@ public class OSMReader {
         String durationTag = way.getTag("duration");
         if (durationTag == null) {
             // no duration tag -> we cannot derive speed
-            if (isFerry(way))
-                LOGGER.warn("Long ferry OSM way without duration tag: " + way.getId() + ", distance: " + distance / 1000.0 + "m");
+            if (isFerry(way) && distance > 20_000)
+                LOGGER.warn("Long ferry OSM way without duration tag: " + way.getId() + ", distance: " + Math.round(distance / 1000.0) + "m");
             return;
         }
         long durationInSeconds;

--- a/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
+++ b/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
@@ -18,6 +18,7 @@
 package com.graphhopper.reader.osm;
 
 import com.carrotsearch.hppc.IntLongMap;
+import com.carrotsearch.hppc.LongArrayList;
 import com.graphhopper.coll.GHIntLongHashMap;
 import com.graphhopper.coll.GHLongHashSet;
 import com.graphhopper.coll.GHLongLongHashMap;
@@ -39,6 +40,7 @@ import com.graphhopper.storage.NodeAccess;
 import com.graphhopper.storage.TurnCostStorage;
 import com.graphhopper.util.*;
 import com.graphhopper.util.shapes.GHPoint;
+import com.graphhopper.util.shapes.GHPoint3D;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -145,6 +147,7 @@ public class OSMReader {
                 .setElevationProvider(eleProvider)
                 .setWayFilter(this::acceptWay)
                 .setSplitNodeFilter(this::isBarrierNode)
+                .setWayPreprocessor(this::preprocessWay)
                 .setRelationPreprocessor(this::preprocessRelations)
                 .setRelationProcessor(this::processRelation)
                 .setEdgeHandler(this::addEdge)
@@ -192,6 +195,13 @@ public class OSMReader {
     }
 
     /**
+     * @return true if the length of the way shall be calculated and added as an artificial way tag
+     */
+    protected boolean isCalculateWayDistance(ReaderWay way) {
+        return way.hasTag("route", "ferry", "shuttle_train");
+    }
+
+    /**
      * This method is called during the second pass of {@link WaySegmentParser} and provides an entry point to enrich
      * the given OSM way with additional tags before it is passed on to the tag parsers.
      */
@@ -203,21 +213,10 @@ public class OSMReader {
         // we have to remove existing artificial tags, because we modify the way even though there can be multiple edges
         // per way. sooner or later we should separate the artificial ('edge') tags from the way, see discussion here:
         // https://github.com/graphhopper/graphhopper/pull/2457#discussion_r751155404
-        way.removeTag("estimated_distance");
-        way.removeTag("duration:seconds");
-        if (way.getTag("duration") != null) {
-            try {
-                long durationInSeconds = OSMReaderUtility.parseDuration(way.getTag("duration"));
-                way.setTag("duration:seconds", durationInSeconds);
-            } catch (Exception ex) {
-                LOGGER.warn("Parsing error in way with OSMID=" + way.getId() + " : " + ex.getMessage());
-            }
-        }
-
         way.removeTag("country");
         way.removeTag("country_rule");
         way.removeTag("custom_areas");
-        
+
         List<CustomArea> customAreas;
         if (areaIndex != null) {
             double middleLat;
@@ -318,7 +317,7 @@ public class OSMReader {
         if (edgeFlags.isEmpty())
             return;
 
-        EdgeIteratorState iter = ghStorage.edge(fromIndex, toIndex).setDistance(distance).setFlags(edgeFlags);
+        EdgeIteratorState edge = ghStorage.edge(fromIndex, toIndex).setDistance(distance).setFlags(edgeFlags);
 
         // If the entire way is just the first and last point, do not waste space storing an empty way geometry
         if (pointList.size() > 2) {
@@ -326,13 +325,13 @@ public class OSMReader {
             // are equal to the tower node coordinates
             checkCoordinates(fromIndex, pointList.get(0));
             checkCoordinates(toIndex, pointList.get(pointList.size() - 1));
-            iter.setWayGeometry(pointList.shallowCopy(1, pointList.size() - 1, false));
+            edge.setWayGeometry(pointList.shallowCopy(1, pointList.size() - 1, false));
         }
-        encodingManager.applyWayTags(way, iter);
+        encodingManager.applyWayTags(way, edge);
 
-        checkDistance(iter);
+        checkDistance(edge);
         if (osmWayIdSet.contains(way.getId())) {
-            getEdgeIdToOsmWayIdMap().put(iter.getEdge(), way.getId());
+            getEdgeIdToOsmWayIdMap().put(edge.getEdge(), way.getId());
         }
     }
 
@@ -351,6 +350,73 @@ public class OSMReader {
         else if (Math.abs(edgeDistance - geometryDistance) > tolerance)
             throw new IllegalStateException("Suspicious distance for edge: " + edge + " " + edgeDistance + " vs. " + geometryDistance
                     + ", difference: " + (edgeDistance - geometryDistance));
+    }
+
+    protected void preprocessWay(ReaderWay way, WaySegmentParser.CoordinateSupplier coordinateSupplier) {
+        if (!isCalculateWayDistance(way))
+            return;
+
+        double distance = calcDistance(way, coordinateSupplier);
+        if (Double.isNaN(distance)) {
+            // Some nodes were missing, and we cannot determine the distance. This can happen e.g. when ferry routes
+            // are only included partially in an OSM extract. In this case the duration tag is useless and we simply
+            // ignore it.
+            LOGGER.warn("Could not determine distance for OSM way: " + way.getId());
+            return;
+        }
+        way.setTag("way_distance", distance);
+
+        // For ways with a duration tag we determine the average speed. This is needed for e.g. ferry routes, because
+        // the duration tag is only valid for the entire way, and it would be wrong to use it after splitting the way
+        // into edges.
+        String durationTag = way.getTag("duration");
+        if (durationTag == null)
+            // no duration tag -> we cannot derive speed
+            return;
+        long durationInSeconds;
+        try {
+            durationInSeconds = OSMReaderUtility.parseDuration(durationTag);
+        } catch (Exception e) {
+            LOGGER.warn("Could not parse duration tag '" + durationTag + "' in OSM way: " + way.getId());
+            return;
+        }
+
+        double speedInKmPerHour = distance / 1000 / (durationInSeconds / 60.0 / 60.0);
+        if (speedInKmPerHour < 0.01d)
+            LOGGER.warn("Unrealistic low speed calculated from duration. Maybe duration is too long for OSM way: "
+                    + way.getId() + ". duration=" + durationTag + " (= " + Math.round(durationInSeconds / 60.0) +
+                    " + minutes), distance=" + (distance / 1000.0) + "km");
+
+        // These tags will be present if 1) isCalculateWayDistance was true for this way, 2) no OSM nodes were missing
+        // such that the distance could actually be calculated, 3) there was a duration tag we could parse, and 4) the
+        // derived speed was not unrealistically slow.
+        way.setTag("speed_from_duration", speedInKmPerHour);
+        way.setTag("duration:seconds", durationInSeconds);
+    }
+
+    /**
+     * @return the distance of the given way or NaN if some nodes were missing
+     */
+    private double calcDistance(ReaderWay way, WaySegmentParser.CoordinateSupplier coordinateSupplier) {
+        LongArrayList nodes = way.getNodes();
+        // every way has at least two nodes according to our acceptWay function
+        GHPoint3D prevPoint = coordinateSupplier.getCoordinate(nodes.get(0));
+        if (prevPoint == null)
+            return Double.NaN;
+        boolean is3D = !Double.isNaN(prevPoint.ele);
+        double distance = 0;
+        for (int i = 1; i < nodes.size(); i++) {
+            GHPoint3D point = coordinateSupplier.getCoordinate(nodes.get(i));
+            if (point == null)
+                return Double.NaN;
+            if (Double.isNaN(point.ele) == is3D)
+                throw new IllegalStateException("There should be elevation data for either all points or no points at all. OSM way: " + way.getId());
+            distance += is3D
+                    ? distCalc.calcDist3D(prevPoint.lat, prevPoint.lon, prevPoint.ele, point.lat, point.lon, point.ele)
+                    : distCalc.calcDist(prevPoint.lat, prevPoint.lon, point.lat, point.lon);
+            prevPoint = point;
+        }
+        return distance;
     }
 
     /**

--- a/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
+++ b/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
@@ -380,7 +380,7 @@ public class OSMReader {
         // into edges.
         String durationTag = way.getTag("duration");
         if (durationTag == null) {
-            // no duration tag -> we cannot derive speed.
+            // no duration tag -> we cannot derive speed. happens very frequently for short ferries, but also for some long ones, see: #2532
             if (isFerry(way) && distance > 500_000)
                 LOGGER.warn("Long ferry OSM way without duration tag: " + way.getId() + ", distance: " + Math.round(distance / 1000.0) + " km");
             return;
@@ -395,7 +395,8 @@ public class OSMReader {
 
         double speedInKmPerHour = distance / 1000 / (durationInSeconds / 60.0 / 60.0);
         if (speedInKmPerHour < 0.1d) {
-            // often there are mapping errors like duration=30:00 (30h) instead of duration=00:30 (30min). If there are none anymore, maybe raise the limit to find more cases.
+            // Often there are mapping errors like duration=30:00 (30h) instead of duration=00:30 (30min). In this case we
+            // ignore the duration tag. If no such cases show up anymore, because they were fixed, maybe raise the limit to find some more.
             LOGGER.warn("Unrealistic low speed calculated from duration. Maybe the duration is too long, or it is applied to a way that only represents a part of the connection? OSM way: "
                     + way.getId() + ". duration=" + durationTag + " (= " + Math.round(durationInSeconds / 60.0) +
                     " + minutes), distance=" + Math.round(distance / 1000.0) + "km");

--- a/core/src/main/java/com/graphhopper/reader/osm/WaySegmentParser.java
+++ b/core/src/main/java/com/graphhopper/reader/osm/WaySegmentParser.java
@@ -256,7 +256,6 @@ public class WaySegmentParser {
             splitWayAtJunctionsAndEmptySections(segment, way);
         }
 
-
         private void splitWayAtJunctionsAndEmptySections(List<SegmentNode> fullSegment, ReaderWay way) {
             List<SegmentNode> segment = new ArrayList<>();
             for (SegmentNode node : fullSegment) {

--- a/core/src/main/java/com/graphhopper/reader/osm/WaySegmentParser.java
+++ b/core/src/main/java/com/graphhopper/reader/osm/WaySegmentParser.java
@@ -30,6 +30,7 @@ import com.graphhopper.util.Helper;
 import com.graphhopper.util.PointAccess;
 import com.graphhopper.util.PointList;
 import com.graphhopper.util.StopWatch;
+import com.graphhopper.util.shapes.GHPoint3D;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -251,9 +252,10 @@ public class WaySegmentParser {
             List<SegmentNode> segment = new ArrayList<>(way.getNodes().size());
             for (LongCursor node : way.getNodes())
                 segment.add(new SegmentNode(node.value, nodeData.getId(node.value)));
-            wayPreprocessor.preprocessWay(way);
+            wayPreprocessor.preprocessWay(way, osmNodeId -> nodeData.getCoordinates(nodeData.getId(osmNodeId)));
             splitWayAtJunctionsAndEmptySections(segment, way);
         }
+
 
         private void splitWayAtJunctionsAndEmptySections(List<SegmentNode> fullSegment, ReaderWay way) {
             List<SegmentNode> segment = new ArrayList<>();
@@ -411,7 +413,7 @@ public class WaySegmentParser {
         private ElevationProvider elevationProvider = ElevationProvider.NOOP;
         private Predicate<ReaderWay> wayFilter = way -> true;
         private Predicate<ReaderNode> splitNodeFilter = node -> false;
-        private WayPreprocessor wayPreprocessor = way -> {
+        private WayPreprocessor wayPreprocessor = (way, supplier) -> {
         };
         private Consumer<ReaderRelation> relationPreprocessor = relation -> {
         };
@@ -462,7 +464,7 @@ public class WaySegmentParser {
         }
 
         /**
-         * @param wayPreprocessor callback function that is called for each accepted OSM way during the first pass
+         * @param wayPreprocessor callback function that is called for each accepted OSM way during the second pass
          */
         public Builder setWayPreprocessor(WayPreprocessor wayPreprocessor) {
             this.wayPreprocessor = wayPreprocessor;
@@ -554,6 +556,15 @@ public class WaySegmentParser {
     }
 
     public interface WayPreprocessor {
-        void preprocessWay(ReaderWay way);
+        /**
+         * @param coordinateSupplier maps an OSM node ID (as it can be obtained by way.getNodes()) to the coordinates
+         *                           of this node. If elevation is disabled it will be NaN. Returns null if no such OSM
+         *                           node exists.
+         */
+        void preprocessWay(ReaderWay way, CoordinateSupplier coordinateSupplier);
+    }
+
+    public interface CoordinateSupplier {
+        GHPoint3D getCoordinate(long osmNodeId);
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/util/AbstractFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/AbstractFlagEncoder.java
@@ -87,7 +87,7 @@ public abstract class AbstractFlagEncoder implements FlagEncoder {
     }
 
     protected void init(DateRangeParser dateRangeParser) {
-        ferrySpeedCalc = new FerrySpeedCalculator(speedFactor, maxPossibleSpeed, 30, 20, 5);
+        ferrySpeedCalc = new FerrySpeedCalculator(speedFactor, maxPossibleSpeed, 5);
 
         setConditionalTagInspector(new ConditionalOSMTagInspector(Collections.singletonList(dateRangeParser),
                 restrictions, restrictedValues, intendedValues, false));

--- a/core/src/main/java/com/graphhopper/routing/util/AbstractFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/AbstractFlagEncoder.java
@@ -87,7 +87,7 @@ public abstract class AbstractFlagEncoder implements FlagEncoder {
     }
 
     protected void init(DateRangeParser dateRangeParser) {
-        ferrySpeedCalc = new FerrySpeedCalculator(speedFactor, maxPossibleSpeed, 5);
+        ferrySpeedCalc = new FerrySpeedCalculator(speedFactor / 2, maxPossibleSpeed, 5);
 
         setConditionalTagInspector(new ConditionalOSMTagInspector(Collections.singletonList(dateRangeParser),
                 restrictions, restrictedValues, intendedValues, false));

--- a/core/src/main/java/com/graphhopper/routing/util/FerrySpeedCalculator.java
+++ b/core/src/main/java/com/graphhopper/routing/util/FerrySpeedCalculator.java
@@ -1,11 +1,8 @@
 package com.graphhopper.routing.util;
 
 import com.graphhopper.reader.ReaderWay;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class FerrySpeedCalculator {
-    private static final Logger LOGGER = LoggerFactory.getLogger(FerrySpeedCalculator.class);
     private final double unknownSpeed, minSpeed, maxSpeed;
 
     public FerrySpeedCalculator(double minSpeed, double maxSpeed, double unknownSpeed) {

--- a/core/src/main/java/com/graphhopper/routing/util/FerrySpeedCalculator.java
+++ b/core/src/main/java/com/graphhopper/routing/util/FerrySpeedCalculator.java
@@ -7,13 +7,12 @@ import org.slf4j.LoggerFactory;
 public class FerrySpeedCalculator {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(FerrySpeedCalculator.class);
-    private final double speedFactor;
-    private final double unknownSpeed, maxSpeed;
+    private final double unknownSpeed, minSpeed, maxSpeed;
 
-    public FerrySpeedCalculator(double speedFactor, double maxSpeed, double unknownSpeed) {
-        this.speedFactor = speedFactor;
-        this.unknownSpeed = unknownSpeed;
+    public FerrySpeedCalculator(double minSpeed, double maxSpeed, double unknownSpeed) {
+        this.minSpeed = minSpeed;
         this.maxSpeed = maxSpeed;
+        this.unknownSpeed = unknownSpeed;
     }
 
     /**
@@ -40,14 +39,11 @@ public class FerrySpeedCalculator {
             // Plausibility check especially for the case of wrongly used PxM format with the intention to
             // specify the duration in minutes, but actually using months
             if (calculatedTripSpeed > 0.01d) {
-                if (calculatedTripSpeed > maxSpeed) {
+                if (calculatedTripSpeed > maxSpeed)
                     return maxSpeed;
-                }
                 // If the speed is lower than the speed we can store, we have to set it to the minSpeed, but > 0
-                if (Math.round(calculatedTripSpeed) < speedFactor / 2) {
-                    return speedFactor / 2;
-                }
-
+                if (Math.round(calculatedTripSpeed) < minSpeed)
+                    return minSpeed;
                 return Math.round(calculatedTripSpeed);
             } else {
                 LOGGER.warn("Unrealistic long duration ignored in way with way ID=" + way.getId() + " : Duration tag value="
@@ -57,7 +53,7 @@ public class FerrySpeedCalculator {
 
         // duration was not present or calculated trip speed was too small
         if (distanceInKm <= 0.3)
-            return speedFactor / 2;
+            return minSpeed;
         else
             // unknown speed -> put penalty on ferry transport
             return unknownSpeed;

--- a/core/src/main/java/com/graphhopper/routing/util/FerrySpeedCalculator.java
+++ b/core/src/main/java/com/graphhopper/routing/util/FerrySpeedCalculator.java
@@ -44,11 +44,8 @@ public class FerrySpeedCalculator {
 
                 return Math.round(calculatedTripSpeed);
             } else {
-                long lastId = way.getNodes().isEmpty() ? -1 : way.getNodes().get(way.getNodes().size() - 1);
-                long firstId = way.getNodes().isEmpty() ? -1 : way.getNodes().get(0);
-                if (firstId != lastId)
-                    LOGGER.warn("Unrealistic long duration ignored in way with way ID=" + way.getId() + " : Duration tag value="
-                            + way.getTag("duration") + " (=" + Math.round(duration / 60d) + " minutes)");
+                LOGGER.warn("Unrealistic long duration ignored in way with way ID=" + way.getId() + " : Duration tag value="
+                        + way.getTag("duration") + " (=" + Math.round(duration / 60d) + " minutes)");
             }
         }
 

--- a/core/src/main/java/com/graphhopper/routing/util/FerrySpeedCalculator.java
+++ b/core/src/main/java/com/graphhopper/routing/util/FerrySpeedCalculator.java
@@ -22,9 +22,9 @@ public class FerrySpeedCalculator {
     public double getSpeed(ReaderWay way) {
         // todo: we should re-consider whether we should deal with ferries by determining (only) a speed at all.
         //       for example this way we cannot account for waiting times for short ferries (speed is too low) or
-        //       'fast' ferries that exceed the max speed for e.g. the foot encoder. Maybe we should add an additional
-        //       encoded value that stores the ferry waiting time and add a more possible speed values to account
-        //       for high ferry speeds for the slow vehicles like foot.
+        //       'fast' ferries that exceed the max speed for e.g. the foot encoder. Maybe we could add an additional
+        //       encoded value that stores the ferry waiting time (maybe just short/medium/long or so) and add a few
+        //       more possible speed values to account for high ferry speeds for the slow vehicles like foot.
 
         // During the reader process we have added the artificial "road_distance" tag and converted the duration tag to
         // an artificial tag called "duration:seconds"

--- a/core/src/main/java/com/graphhopper/routing/util/FerrySpeedCalculator.java
+++ b/core/src/main/java/com/graphhopper/routing/util/FerrySpeedCalculator.java
@@ -8,13 +8,11 @@ public class FerrySpeedCalculator {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(FerrySpeedCalculator.class);
     private final double speedFactor;
-    private final double unknownSpeed, longSpeed, shortSpeed, maxSpeed;
+    private final double unknownSpeed, maxSpeed;
 
-    public FerrySpeedCalculator(double speedFactor, double maxSpeed, double longSpeed, double shortSpeed, double unknownSpeed) {
+    public FerrySpeedCalculator(double speedFactor, double maxSpeed, double unknownSpeed) {
         this.speedFactor = speedFactor;
         this.unknownSpeed = unknownSpeed;
-        this.longSpeed = longSpeed;
-        this.shortSpeed = shortSpeed;
         this.maxSpeed = maxSpeed;
     }
 
@@ -28,7 +26,6 @@ public class FerrySpeedCalculator {
         if (distanceInKm < 0)
             throw new IllegalStateException("The artificial 'road_distance' tag is missing for way: " + way.getId());
         Long duration = way.getTag("duration:seconds", 0L);
-        // seconds to hours
         double durationInHours = duration / 60d / 60d;
         if (durationInHours > 0) {
             // If duration is available we can calculate the speed. We make it slower by a factor of 1.4 to account
@@ -52,21 +49,14 @@ public class FerrySpeedCalculator {
                 if (firstId != lastId)
                     LOGGER.warn("Unrealistic long duration ignored in way with way ID=" + way.getId() + " : Duration tag value="
                             + way.getTag("duration") + " (=" + Math.round(duration / 60d) + " minutes)");
-                durationInHours = 0;
             }
         }
 
-        if (durationInHours == 0) {
-            if (distanceInKm <= 0.3)
-                return speedFactor / 2;
+        // duration was not present or calculated trip speed was too small
+        if (distanceInKm <= 0.3)
+            return speedFactor / 2;
+        else
             // unknown speed -> put penalty on ferry transport
             return unknownSpeed;
-        } else if (durationInHours > 1) {
-            // todo: can never happen because the road_distance is always there... -> longSpeed and shortSpeed are never used!
-            // lengthy ferries should be faster than short trip ferry
-            return longSpeed;
-        } else {
-            return shortSpeed;
-        }
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/util/FerrySpeedCalculator.java
+++ b/core/src/main/java/com/graphhopper/routing/util/FerrySpeedCalculator.java
@@ -5,7 +5,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class FerrySpeedCalculator {
-
     private static final Logger LOGGER = LoggerFactory.getLogger(FerrySpeedCalculator.class);
     private final double unknownSpeed, minSpeed, maxSpeed;
 
@@ -15,47 +14,37 @@ public class FerrySpeedCalculator {
         this.unknownSpeed = unknownSpeed;
     }
 
-    /**
-     * Special handling for ferry ways.
-     */
     public double getSpeed(ReaderWay way) {
-        // todo: we should re-consider whether we should deal with ferries by determining (only) a speed at all.
-        //       for example this way we cannot account for waiting times for short ferries (speed is too low) or
-        //       'fast' ferries that exceed the max speed for e.g. the foot encoder. Maybe we could add an additional
-        //       encoded value that stores the ferry waiting time (maybe just short/medium/long or so) and add a few
-        //       more possible speed values to account for high ferry speeds for the slow vehicles like foot.
+        // todo: We currently face twe problems related to ferry speeds:
+        //       1) We cannot account for waiting times for short ferries (makes the ferry speed slower than we can store)
+        //       2) When the ferry speed is larger than the maximum speed of the encoder (like 15km/h for foot) the
+        //          ferry speed will be faster than we can store.
+        //       Maybe we could add an additional encoded value that stores the ferry waiting time
+        //       (maybe just short/medium/long or so) and add a few more possible speed values to account for high ferry
+        //       speeds for the slow vehicles like foot.
 
-        // During the reader process we have added the artificial "edge_distance" tag and converted the duration tag to
-        // an artificial tag called "duration:seconds"
-        double distanceInKm = way.getTag("edge_distance", -1.0) / 1000;
-        if (distanceInKm < 0)
-            throw new IllegalStateException("The artificial 'edge_distance' tag is missing for way: " + way.getId());
-        Long duration = way.getTag("duration:seconds", 0L);
-        double durationInHours = duration / 60d / 60d;
-        if (durationInHours > 0) {
-            // If duration is available we can calculate the speed. We make it slower by a factor of 1.4 to account
-            // for waiting time.
-            double calculatedTripSpeed = distanceInKm / durationInHours / 1.4;
-            // Plausibility check especially for the case of wrongly used PxM format with the intention to
-            // specify the duration in minutes, but actually using months
-            if (calculatedTripSpeed > 0.01d) {
-                if (calculatedTripSpeed > maxSpeed)
-                    return maxSpeed;
-                // If the speed is lower than the speed we can store, we have to set it to the minSpeed, but > 0
-                if (Math.round(calculatedTripSpeed) < minSpeed)
-                    return minSpeed;
-                return Math.round(calculatedTripSpeed);
-            } else {
-                LOGGER.warn("Unrealistic long duration ignored in way with way ID=" + way.getId() + " : Duration tag value="
-                        + way.getTag("duration") + " (=" + Math.round(duration / 60d) + " minutes), distance=" + distanceInKm + "km");
+        // OSMReader adds the artificial 'speed_from_duration', 'duration:seconds' and 'way_distance' tags that we can
+        // use to set the ferry speed. Otherwise we need to use fallback values.
+        double speedInKmPerHour = way.getTag("speed_from_duration", Double.NaN);
+        if (!Double.isNaN(speedInKmPerHour)) {
+            // we reduce the speed to account for waiting time (we increase the duration by 40%)
+            double speedWithWaitingTime = speedInKmPerHour / 1.4;
+            return Math.round(Math.max(minSpeed, Math.min(speedWithWaitingTime, maxSpeed)));
+        } else {
+            // the speed cannot be derived from the duration tag, we have to take a guess based on the distance.
+            double wayDistance = way.getTag("way_distance", Double.NaN);
+            if (Double.isNaN(wayDistance))
+                // we don't know the distance of this way either. probably a broken way at the border of the map.
+                return unknownSpeed;
+            else if (wayDistance < 300)
+                // use the slowest possible speed for very short ferries
+                return minSpeed;
+            else {
+                LOGGER.warn("Long ferry OSM way without valid duration: " + way.getId() + ", distance: " + wayDistance);
+                // todonow: use the unknown speed for now, but check how many such ferries actually exist and maybe use a
+                //          faster speed for longer ones
+                return unknownSpeed;
             }
         }
-
-        // duration was not present or calculated trip speed was too small
-        if (distanceInKm <= 0.3)
-            return minSpeed;
-        else
-            // unknown speed -> put penalty on ferry transport
-            return unknownSpeed;
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/util/FerrySpeedCalculator.java
+++ b/core/src/main/java/com/graphhopper/routing/util/FerrySpeedCalculator.java
@@ -22,47 +22,47 @@ public class FerrySpeedCalculator {
      * Special handling for ferry ways.
      */
     public double getSpeed(ReaderWay way) {
-        // During the reader process we have converted the duration value into an artificial tag called "duration:seconds".
+        // During the reader process we have added the artificial "point_list" tag and converted the duration tag to
+        // an artificial tag called "duration:seconds"
+        double distanceInKm = way.getTag("road_distance", -1.0) / 1000;
+        if (distanceInKm < 0)
+            throw new IllegalStateException("The artificial 'road_distance' tag is missing for way: " + way.getId());
         Long duration = way.getTag("duration:seconds", 0L);
         // seconds to hours
         double durationInHours = duration / 60d / 60d;
-        // Check if our graphhopper specific artificially created estimated_distance way tag is present
-        Number estimatedLength = way.getTag("estimated_distance", null);
         if (durationInHours > 0) {
-            if (estimatedLength != null) {
-                double estimatedLengthInKm = estimatedLength.doubleValue() / 1000;
-                // If duration AND distance is available we can calculate the speed more precisely
-                // and set both speed to the same value. Factor 1.4 slower because of waiting time!
-                double calculatedTripSpeed = estimatedLengthInKm / durationInHours / 1.4;
-                // Plausibility check especially for the case of wrongly used PxM format with the intention to
-                // specify the duration in minutes, but actually using months
-                if (calculatedTripSpeed > 0.01d) {
-                    if (calculatedTripSpeed > maxSpeed) {
-                        return maxSpeed;
-                    }
-                    // If the speed is lower than the speed we can store, we have to set it to the minSpeed, but > 0
-                    if (Math.round(calculatedTripSpeed) < speedFactor / 2) {
-                        return speedFactor / 2;
-                    }
-
-                    return Math.round(calculatedTripSpeed);
-                } else {
-                    long lastId = way.getNodes().isEmpty() ? -1 : way.getNodes().get(way.getNodes().size() - 1);
-                    long firstId = way.getNodes().isEmpty() ? -1 : way.getNodes().get(0);
-                    if (firstId != lastId)
-                        LOGGER.warn("Unrealistic long duration ignored in way with way ID=" + way.getId() + " : Duration tag value="
-                                + way.getTag("duration") + " (=" + Math.round(duration / 60d) + " minutes)");
-                    durationInHours = 0;
+            // If duration is available we can calculate the speed. We make it slower by a factor of 1.4 to account
+            // for waiting time.
+            double calculatedTripSpeed = distanceInKm / durationInHours / 1.4;
+            // Plausibility check especially for the case of wrongly used PxM format with the intention to
+            // specify the duration in minutes, but actually using months
+            if (calculatedTripSpeed > 0.01d) {
+                if (calculatedTripSpeed > maxSpeed) {
+                    return maxSpeed;
                 }
+                // If the speed is lower than the speed we can store, we have to set it to the minSpeed, but > 0
+                if (Math.round(calculatedTripSpeed) < speedFactor / 2) {
+                    return speedFactor / 2;
+                }
+
+                return Math.round(calculatedTripSpeed);
+            } else {
+                long lastId = way.getNodes().isEmpty() ? -1 : way.getNodes().get(way.getNodes().size() - 1);
+                long firstId = way.getNodes().isEmpty() ? -1 : way.getNodes().get(0);
+                if (firstId != lastId)
+                    LOGGER.warn("Unrealistic long duration ignored in way with way ID=" + way.getId() + " : Duration tag value="
+                            + way.getTag("duration") + " (=" + Math.round(duration / 60d) + " minutes)");
+                durationInHours = 0;
             }
         }
 
         if (durationInHours == 0) {
-            if (estimatedLength != null && estimatedLength.doubleValue() <= 300)
+            if (distanceInKm <= 0.3)
                 return speedFactor / 2;
             // unknown speed -> put penalty on ferry transport
             return unknownSpeed;
         } else if (durationInHours > 1) {
+            // todo: can never happen because the road_distance is always there... -> longSpeed and shortSpeed are never used!
             // lengthy ferries should be faster than short trip ferry
             return longSpeed;
         } else {

--- a/core/src/main/java/com/graphhopper/routing/util/FerrySpeedCalculator.java
+++ b/core/src/main/java/com/graphhopper/routing/util/FerrySpeedCalculator.java
@@ -47,7 +47,7 @@ public class FerrySpeedCalculator {
                 return Math.round(calculatedTripSpeed);
             } else {
                 LOGGER.warn("Unrealistic long duration ignored in way with way ID=" + way.getId() + " : Duration tag value="
-                        + way.getTag("duration") + " (=" + Math.round(duration / 60d) + " minutes)");
+                        + way.getTag("duration") + " (=" + Math.round(duration / 60d) + " minutes), distance=" + distanceInKm + "km");
             }
         }
 

--- a/core/src/main/java/com/graphhopper/routing/util/FerrySpeedCalculator.java
+++ b/core/src/main/java/com/graphhopper/routing/util/FerrySpeedCalculator.java
@@ -15,13 +15,10 @@ public class FerrySpeedCalculator {
     }
 
     public double getSpeed(ReaderWay way) {
-        // todo: We currently face twe problems related to ferry speeds:
-        //       1) We cannot account for waiting times for short ferries (makes the ferry speed slower than we can store)
+        // todo: We currently face two problems related to ferry speeds:
+        //       1) We cannot account for waiting times for short ferries (when we do the ferry speed is slower than the slowest we can store)
         //       2) When the ferry speed is larger than the maximum speed of the encoder (like 15km/h for foot) the
-        //          ferry speed will be faster than we can store.
-        //       Maybe we could add an additional encoded value that stores the ferry waiting time
-        //       (maybe just short/medium/long or so) and add a few more possible speed values to account for high ferry
-        //       speeds for the slow vehicles like foot.
+        //          ferry speed will be faster than what we can store.
 
         // OSMReader adds the artificial 'speed_from_duration', 'duration:seconds' and 'way_distance' tags that we can
         // use to set the ferry speed. Otherwise we need to use fallback values.
@@ -41,8 +38,7 @@ public class FerrySpeedCalculator {
                 // use the slowest possible speed for very short ferries
                 return minSpeed;
             else {
-                // todonow: use the unknown speed for now, but check how many such ferries actually exist and maybe use a
-                //          faster speed for longer ones
+                // todo: distinguish speed based on the distance of the ferry, see #2532
                 return unknownSpeed;
             }
         }

--- a/core/src/main/java/com/graphhopper/routing/util/FerrySpeedCalculator.java
+++ b/core/src/main/java/com/graphhopper/routing/util/FerrySpeedCalculator.java
@@ -31,7 +31,8 @@ public class FerrySpeedCalculator {
             double speedWithWaitingTime = speedInKmPerHour / 1.4;
             return Math.round(Math.max(minSpeed, Math.min(speedWithWaitingTime, maxSpeed)));
         } else {
-            // the speed cannot be derived from the duration tag, we have to take a guess based on the distance.
+            // we have no speed value to work with because there was no valid duration tag.
+            // we have to take a guess based on the distance.
             double wayDistance = way.getTag("way_distance", Double.NaN);
             if (Double.isNaN(wayDistance))
                 // we don't know the distance of this way either. probably a broken way at the border of the map.

--- a/core/src/main/java/com/graphhopper/routing/util/FerrySpeedCalculator.java
+++ b/core/src/main/java/com/graphhopper/routing/util/FerrySpeedCalculator.java
@@ -20,7 +20,13 @@ public class FerrySpeedCalculator {
      * Special handling for ferry ways.
      */
     public double getSpeed(ReaderWay way) {
-        // During the reader process we have added the artificial "point_list" tag and converted the duration tag to
+        // todo: we should re-consider whether we should deal with ferries by determining (only) a speed at all.
+        //       for example this way we cannot account for waiting times for short ferries (speed is too low) or
+        //       'fast' ferries that exceed the max speed for e.g. the foot encoder. Maybe we should add an additional
+        //       encoded value that stores the ferry waiting time and add a more possible speed values to account
+        //       for high ferry speeds for the slow vehicles like foot.
+
+        // During the reader process we have added the artificial "road_distance" tag and converted the duration tag to
         // an artificial tag called "duration:seconds"
         double distanceInKm = way.getTag("road_distance", -1.0) / 1000;
         if (distanceInKm < 0)

--- a/core/src/main/java/com/graphhopper/routing/util/FerrySpeedCalculator.java
+++ b/core/src/main/java/com/graphhopper/routing/util/FerrySpeedCalculator.java
@@ -25,11 +25,11 @@ public class FerrySpeedCalculator {
         //       encoded value that stores the ferry waiting time (maybe just short/medium/long or so) and add a few
         //       more possible speed values to account for high ferry speeds for the slow vehicles like foot.
 
-        // During the reader process we have added the artificial "road_distance" tag and converted the duration tag to
+        // During the reader process we have added the artificial "edge_distance" tag and converted the duration tag to
         // an artificial tag called "duration:seconds"
-        double distanceInKm = way.getTag("road_distance", -1.0) / 1000;
+        double distanceInKm = way.getTag("edge_distance", -1.0) / 1000;
         if (distanceInKm < 0)
-            throw new IllegalStateException("The artificial 'road_distance' tag is missing for way: " + way.getId());
+            throw new IllegalStateException("The artificial 'edge_distance' tag is missing for way: " + way.getId());
         Long duration = way.getTag("duration:seconds", 0L);
         double durationInHours = duration / 60d / 60d;
         if (durationInHours > 0) {

--- a/core/src/main/java/com/graphhopper/routing/util/FerrySpeedCalculator.java
+++ b/core/src/main/java/com/graphhopper/routing/util/FerrySpeedCalculator.java
@@ -41,7 +41,6 @@ public class FerrySpeedCalculator {
                 // use the slowest possible speed for very short ferries
                 return minSpeed;
             else {
-                LOGGER.warn("Long ferry OSM way without valid duration: " + way.getId() + ", distance: " + wayDistance);
                 // todonow: use the unknown speed for now, but check how many such ferries actually exist and maybe use a
                 //          faster speed for longer ones
                 return unknownSpeed;

--- a/core/src/main/java/com/graphhopper/routing/util/MotorcycleFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/MotorcycleFlagEncoder.java
@@ -235,7 +235,7 @@ public class MotorcycleFlagEncoder extends CarFlagEncoder {
     }
 
     private double getBeelineDistance(ReaderWay way) {
-        return way.getTag("estimated_distance", Double.POSITIVE_INFINITY);
+        return way.getTag("beeline_distance", Double.POSITIVE_INFINITY);
     }
 
     /**

--- a/core/src/main/java/com/graphhopper/routing/util/MotorcycleFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/MotorcycleFlagEncoder.java
@@ -25,8 +25,10 @@ import com.graphhopper.routing.util.parsers.helpers.OSMValueExtractor;
 import com.graphhopper.routing.weighting.CurvatureWeighting;
 import com.graphhopper.routing.weighting.PriorityWeighting;
 import com.graphhopper.storage.IntsRef;
+import com.graphhopper.util.DistanceCalcEarth;
 import com.graphhopper.util.EdgeIteratorState;
 import com.graphhopper.util.PMap;
+import com.graphhopper.util.PointList;
 
 import java.util.HashSet;
 import java.util.List;
@@ -235,7 +237,12 @@ public class MotorcycleFlagEncoder extends CarFlagEncoder {
     }
 
     private double getBeelineDistance(ReaderWay way) {
-        return way.getTag("beeline_distance", Double.POSITIVE_INFINITY);
+        PointList pointList = way.getTag("point_list", null);
+        if (pointList == null)
+            throw new IllegalStateException("The artificial 'point_list' tag is missing for way: " + way.getId());
+        if (pointList.size() < 2)
+            throw new IllegalStateException("The artificial 'point_list' tag contained less than two points for way: " + way.getId());
+        return DistanceCalcEarth.DIST_EARTH.calcDist(pointList.getLat(0), pointList.getLon(0), pointList.getLat(pointList.size() - 1), pointList.getLon(pointList.size() - 1));
     }
 
     /**

--- a/core/src/test/java/com/graphhopper/routing/util/Bike2WeightFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/Bike2WeightFlagEncoderTest.java
@@ -92,7 +92,7 @@ public class Bike2WeightFlagEncoderTest extends BikeFlagEncoderTest {
         GraphHopperStorage graph = new GraphBuilder(encodingManager).set3D(true).create();
         ReaderWay way = new ReaderWay(0);
         way.setTag("route", "ferry");
-        way.setTag("road_distance", 500.0);
+        way.setTag("edge_distance", 500.0);
 
         assertNotEquals(EncodingManager.Access.CAN_SKIP, encoder.getAccess(way));
         IntsRef wayFlags = encodingManager.handleWayTags(way, encodingManager.createRelationFlags());

--- a/core/src/test/java/com/graphhopper/routing/util/Bike2WeightFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/Bike2WeightFlagEncoderTest.java
@@ -92,6 +92,7 @@ public class Bike2WeightFlagEncoderTest extends BikeFlagEncoderTest {
         GraphHopperStorage graph = new GraphBuilder(encodingManager).set3D(true).create();
         ReaderWay way = new ReaderWay(0);
         way.setTag("route", "ferry");
+        way.setTag("road_distance", 500.0);
 
         assertNotEquals(EncodingManager.Access.CAN_SKIP, encoder.getAccess(way));
         IntsRef wayFlags = encodingManager.handleWayTags(way, encodingManager.createRelationFlags());

--- a/core/src/test/java/com/graphhopper/routing/util/CarFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/CarFlagEncoderTest.java
@@ -460,10 +460,10 @@ public class CarFlagEncoderTest {
         way.setTag("bicycle", "no");
         // Provide the duration value in seconds:
         way.setTag("duration:seconds", 35L * 60);
-        way.setTag("road_distance", 50000.0);
+        way.setTag("edge_distance", 50000.0);
         // accept
         assertTrue(encoder.getAccess(way).isFerry());
-        // calculate speed from road_distance and duration
+        // calculate speed from edge_distance and duration
         assertEquals(61, encoder.ferrySpeedCalc.getSpeed(way), 1e-1);
 
         //Test for very short and slow 0.5km/h still realisitic ferry
@@ -472,7 +472,7 @@ public class CarFlagEncoderTest {
         way.setTag("motorcar", "yes");
         // Provide the duration of 12 minutes in seconds:
         way.setTag("duration:seconds", 12L * 60);
-        way.setTag("road_distance", 100.0);
+        way.setTag("edge_distance", 100.0);
         // accept
         assertTrue(encoder.getAccess(way).isFerry());
         // We can't store 0.5km/h, but we expect the lowest possible speed (5km/h)
@@ -488,7 +488,7 @@ public class CarFlagEncoderTest {
         way.setTag("motorcar", "yes");
         // Provide the duration of 2 months in seconds:
         way.setTag("duration:seconds", 87900L * 60);
-        way.setTag("road_distance", 100.0);
+        way.setTag("edge_distance", 100.0);
         // accept
         assertTrue(encoder.getAccess(way).isFerry());
         // We have ignored the unrealisitc long duration and take the unknown speed
@@ -642,7 +642,7 @@ public class CarFlagEncoderTest {
     public void testIssue_1256() {
         ReaderWay way = new ReaderWay(1);
         way.setTag("route", "ferry");
-        way.setTag("road_distance", 257.0);
+        way.setTag("edge_distance", 257.0);
 
         CarFlagEncoder lowFactorCar = new CarFlagEncoder(10, 1, 0);
         EncodingManager.create(lowFactorCar);

--- a/core/src/test/java/com/graphhopper/routing/util/CarFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/CarFlagEncoderTest.java
@@ -460,7 +460,7 @@ public class CarFlagEncoderTest {
         way.setTag("bicycle", "no");
         // Provide the duration value in seconds:
         way.setTag("duration:seconds", 35L * 60);
-        way.setTag("road_distance", 50000);
+        way.setTag("road_distance", 50000.0);
         // accept
         assertTrue(encoder.getAccess(way).isFerry());
         // calculate speed from road_distance and duration
@@ -472,7 +472,7 @@ public class CarFlagEncoderTest {
         way.setTag("motorcar", "yes");
         // Provide the duration of 12 minutes in seconds:
         way.setTag("duration:seconds", 12L * 60);
-        way.setTag("road_distance", 100);
+        way.setTag("road_distance", 100.0);
         // accept
         assertTrue(encoder.getAccess(way).isFerry());
         // We can't store 0.5km/h, but we expect the lowest possible speed (5km/h)
@@ -488,7 +488,7 @@ public class CarFlagEncoderTest {
         way.setTag("motorcar", "yes");
         // Provide the duration of 2 months in seconds:
         way.setTag("duration:seconds", 87900L * 60);
-        way.setTag("road_distance", 100);
+        way.setTag("road_distance", 100.0);
         // accept
         assertTrue(encoder.getAccess(way).isFerry());
         // We have ignored the unrealisitc long duration and take the unknown speed
@@ -642,7 +642,7 @@ public class CarFlagEncoderTest {
     public void testIssue_1256() {
         ReaderWay way = new ReaderWay(1);
         way.setTag("route", "ferry");
-        way.setTag("road_distance", 257);
+        way.setTag("road_distance", 257.0);
 
         CarFlagEncoder lowFactorCar = new CarFlagEncoder(10, 1, 0);
         EncodingManager.create(lowFactorCar);

--- a/core/src/test/java/com/graphhopper/routing/util/CarFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/CarFlagEncoderTest.java
@@ -460,10 +460,10 @@ public class CarFlagEncoderTest {
         way.setTag("bicycle", "no");
         // Provide the duration value in seconds:
         way.setTag("duration:seconds", 35L * 60);
-        way.setTag("estimated_distance", 50000);
+        way.setTag("road_distance", 50000);
         // accept
         assertTrue(encoder.getAccess(way).isFerry());
-        // calculate speed from estimated_distance and duration
+        // calculate speed from road_distance and duration
         assertEquals(61, encoder.ferrySpeedCalc.getSpeed(way), 1e-1);
 
         //Test for very short and slow 0.5km/h still realisitic ferry
@@ -472,7 +472,7 @@ public class CarFlagEncoderTest {
         way.setTag("motorcar", "yes");
         // Provide the duration of 12 minutes in seconds:
         way.setTag("duration:seconds", 12L * 60);
-        way.setTag("estimated_distance", 100);
+        way.setTag("road_distance", 100);
         // accept
         assertTrue(encoder.getAccess(way).isFerry());
         // We can't store 0.5km/h, but we expect the lowest possible speed (5km/h)
@@ -488,7 +488,7 @@ public class CarFlagEncoderTest {
         way.setTag("motorcar", "yes");
         // Provide the duration of 2 months in seconds:
         way.setTag("duration:seconds", 87900L * 60);
-        way.setTag("estimated_distance", 100);
+        way.setTag("road_distance", 100);
         // accept
         assertTrue(encoder.getAccess(way).isFerry());
         // We have ignored the unrealisitc long duration and take the unknown speed
@@ -642,7 +642,7 @@ public class CarFlagEncoderTest {
     public void testIssue_1256() {
         ReaderWay way = new ReaderWay(1);
         way.setTag("route", "ferry");
-        way.setTag("estimated_distance", 257);
+        way.setTag("road_distance", 257);
 
         CarFlagEncoder lowFactorCar = new CarFlagEncoder(10, 1, 0);
         EncodingManager.create(lowFactorCar);

--- a/core/src/test/java/com/graphhopper/routing/util/CarFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/CarFlagEncoderTest.java
@@ -21,7 +21,6 @@ import com.graphhopper.reader.ReaderNode;
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.BooleanEncodedValue;
 import com.graphhopper.routing.ev.DecimalEncodedValue;
-import com.graphhopper.routing.ev.EncodedValue;
 import com.graphhopper.routing.ev.Roundabout;
 import com.graphhopper.routing.weighting.FastestWeighting;
 import com.graphhopper.storage.IntsRef;
@@ -31,9 +30,7 @@ import com.graphhopper.util.PMap;
 import org.junit.jupiter.api.Test;
 
 import java.text.DateFormat;
-import java.util.ArrayList;
 import java.util.Date;
-import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -459,40 +456,45 @@ public class CarFlagEncoderTest {
         way.setTag("motorcar", "yes");
         way.setTag("bicycle", "no");
         // Provide the duration value in seconds:
+        way.setTag("way_distance", 50000.0);
+        way.setTag("speed_from_duration", 50 / (35.0 / 60));
         way.setTag("duration:seconds", 35L * 60);
-        way.setTag("edge_distance", 50000.0);
         // accept
         assertTrue(encoder.getAccess(way).isFerry());
-        // calculate speed from edge_distance and duration
-        assertEquals(61, encoder.ferrySpeedCalc.getSpeed(way), 1e-1);
+        IntsRef edgeFlags = em.createEdgeFlags();
+        // calculate speed from tags: speed_from_duration * 1.4 (+ rounded using the speed factor)
+        encoder.handleWayTags(edgeFlags, way);
+        assertEquals(60, encoder.getAverageSpeedEnc().getDecimal(false, edgeFlags));
 
-        //Test for very short and slow 0.5km/h still realisitic ferry
+        //Test for very short and slow 0.5km/h still realistic ferry
         way = new ReaderWay(1);
         way.setTag("route", "ferry");
         way.setTag("motorcar", "yes");
         // Provide the duration of 12 minutes in seconds:
         way.setTag("duration:seconds", 12L * 60);
-        way.setTag("edge_distance", 100.0);
+        way.setTag("way_distance", 100.0);
+        way.setTag("speed_from_duration", 0.1 / (12.0 / 60));
         // accept
         assertTrue(encoder.getAccess(way).isFerry());
         // We can't store 0.5km/h, but we expect the lowest possible speed (5km/h)
-        assertEquals(2.5, encoder.ferrySpeedCalc.getSpeed(way), 1e-1);
+        edgeFlags = em.createEdgeFlags();
+        encoder.handleWayTags(edgeFlags, way);
+        assertEquals(5, encoder.getAverageSpeedEnc().getDecimal(false, edgeFlags));
 
-        IntsRef edgeFlags = em.createEdgeFlags();
+        edgeFlags = em.createEdgeFlags();
         avSpeedEnc.setDecimal(false, edgeFlags, 2.5);
         assertEquals(5, avSpeedEnc.getDecimal(false, edgeFlags), 1e-1);
 
-        //Test for an unrealisitic long duration
+        //Test for missing duration
         way = new ReaderWay(1);
         way.setTag("route", "ferry");
         way.setTag("motorcar", "yes");
-        // Provide the duration of 2 months in seconds:
-        way.setTag("duration:seconds", 87900L * 60);
-        way.setTag("edge_distance", 100.0);
+        way.setTag("way_distance", 100.0);
         // accept
         assertTrue(encoder.getAccess(way).isFerry());
-        // We have ignored the unrealisitc long duration and take the unknown speed
-        assertEquals(2.5, encoder.ferrySpeedCalc.getSpeed(way), 1e-1);
+        encoder.handleWayTags(edgeFlags, way);
+        // We use the unknown speed
+        assertEquals(5, encoder.getAverageSpeedEnc().getDecimal(false, edgeFlags));
 
         way.clearTags();
         way.setTag("route", "ferry");
@@ -642,14 +644,18 @@ public class CarFlagEncoderTest {
     public void testIssue_1256() {
         ReaderWay way = new ReaderWay(1);
         way.setTag("route", "ferry");
-        way.setTag("edge_distance", 257.0);
+        way.setTag("way_distance", 257.0);
 
+        // default is 5km/h minimum speed for car
+        IntsRef edgeFlags = em.createEdgeFlags();
+        encoder.handleWayTags(edgeFlags, way);
+        assertEquals(5, encoder.getAverageSpeedEnc().getDecimal(false, edgeFlags), .1);
+
+        // for a smaller speed factor the minimum speed is also smaller
         CarFlagEncoder lowFactorCar = new CarFlagEncoder(10, 1, 0);
-        EncodingManager.create(lowFactorCar);
-        List<EncodedValue> list = new ArrayList<>();
-        lowFactorCar.setEncodedValueLookup(em);
-        lowFactorCar.createEncodedValues(list);
-        assertEquals(2.5, encoder.ferrySpeedCalc.getSpeed(way), .1);
-        assertEquals(.5, lowFactorCar.ferrySpeedCalc.getSpeed(way), .1);
+        EncodingManager lowFactorEm = EncodingManager.create(lowFactorCar);
+        edgeFlags = lowFactorEm.createEdgeFlags();
+        lowFactorCar.handleWayTags(edgeFlags, way);
+        assertEquals(1, lowFactorCar.getAverageSpeedEnc().getDecimal(false, edgeFlags), .1);
     }
 }

--- a/core/src/test/java/com/graphhopper/routing/util/FerrySpeedCalculatorTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/FerrySpeedCalculatorTest.java
@@ -46,7 +46,8 @@ class FerrySpeedCalculatorTest {
         // unknown speed for longer ones
         checkSpeed(c, null, 1000.0, unknownSpeed);
 
-        // no speed, no distance -> unknown
+        // no speed, no distance -> unknown. this can also happen when the duration tag is valid, but no distance could
+        // be calculated (-> no speed)
         checkSpeed(c, null, null, unknownSpeed);
     }
 

--- a/core/src/test/java/com/graphhopper/routing/util/FerrySpeedCalculatorTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/FerrySpeedCalculatorTest.java
@@ -35,7 +35,7 @@ class FerrySpeedCalculatorTest {
 
         // no distance -> should never happen
         IllegalStateException e = assertThrows(IllegalStateException.class, () -> c.getSpeed(new ReaderWay(0L)));
-        assertEquals("The artificial 'road_distance' tag is missing for way: 0", e.getMessage());
+        assertEquals("The artificial 'edge_distance' tag is missing for way: 0", e.getMessage());
 
         // no duration -> speed depends on distance
         checkSpeed(c, null, 100.0, minSpeed);
@@ -61,7 +61,7 @@ class FerrySpeedCalculatorTest {
         if (duration != null)
             way.setTag("duration:seconds", duration);
         if (distance != null)
-            way.setTag("road_distance", distance);
+            way.setTag("edge_distance", distance);
         assertEquals(expected, calc.getSpeed(way));
     }
 

--- a/core/src/test/java/com/graphhopper/routing/util/FerrySpeedCalculatorTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/FerrySpeedCalculatorTest.java
@@ -22,6 +22,7 @@ import com.graphhopper.reader.ReaderWay;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class FerrySpeedCalculatorTest {
 
@@ -34,11 +35,10 @@ class FerrySpeedCalculatorTest {
         double unknownSpeed = 5;
         FerrySpeedCalculator c = new FerrySpeedCalculator(speedFactor, maxSpeed, longSpeed, shortSpeed, unknownSpeed);
 
-        // no distance -> speed only depends on duration (distinguish between missing/short/long duration)
-        checkSpeed(c, null, null, unknownSpeed);
-        checkSpeed(c, 0L, null, unknownSpeed);
-        checkSpeed(c, 1800L, null, shortSpeed);
-        checkSpeed(c, 7200L, null, longSpeed);
+        // no distance -> should never happen
+        IllegalStateException e = assertThrows(IllegalStateException.class, () -> c.getSpeed(new ReaderWay(0L)));
+        assertEquals("The artificial 'road_distance' tag is missing for way: 0", e.getMessage());
+
         // no duration -> speed depends on distance
         checkSpeed(c, null, 100.0, speedFactor / 2);
         checkSpeed(c, 0L, 100.0, speedFactor / 2);
@@ -63,7 +63,7 @@ class FerrySpeedCalculatorTest {
         if (duration != null)
             way.setTag("duration:seconds", duration);
         if (distance != null)
-            way.setTag("estimated_distance", distance);
+            way.setTag("road_distance", distance);
         assertEquals(expected, calc.getSpeed(way));
     }
 

--- a/core/src/test/java/com/graphhopper/routing/util/FerrySpeedCalculatorTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/FerrySpeedCalculatorTest.java
@@ -30,10 +30,8 @@ class FerrySpeedCalculatorTest {
     void testSpeed() {
         double speedFactor = 2;
         double maxSpeed = 55;
-        double longSpeed = 30;
-        double shortSpeed = 20;
         double unknownSpeed = 5;
-        FerrySpeedCalculator c = new FerrySpeedCalculator(speedFactor, maxSpeed, longSpeed, shortSpeed, unknownSpeed);
+        FerrySpeedCalculator c = new FerrySpeedCalculator(speedFactor, maxSpeed, unknownSpeed);
 
         // no distance -> should never happen
         IllegalStateException e = assertThrows(IllegalStateException.class, () -> c.getSpeed(new ReaderWay(0L)));

--- a/core/src/test/java/com/graphhopper/routing/util/FerrySpeedCalculatorTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/FerrySpeedCalculatorTest.java
@@ -28,18 +28,18 @@ class FerrySpeedCalculatorTest {
 
     @Test
     void testSpeed() {
-        double speedFactor = 2;
+        double minSpeed = 1;
         double maxSpeed = 55;
         double unknownSpeed = 5;
-        FerrySpeedCalculator c = new FerrySpeedCalculator(speedFactor, maxSpeed, unknownSpeed);
+        FerrySpeedCalculator c = new FerrySpeedCalculator(minSpeed, maxSpeed, unknownSpeed);
 
         // no distance -> should never happen
         IllegalStateException e = assertThrows(IllegalStateException.class, () -> c.getSpeed(new ReaderWay(0L)));
         assertEquals("The artificial 'road_distance' tag is missing for way: 0", e.getMessage());
 
         // no duration -> speed depends on distance
-        checkSpeed(c, null, 100.0, speedFactor / 2);
-        checkSpeed(c, 0L, 100.0, speedFactor / 2);
+        checkSpeed(c, null, 100.0, minSpeed);
+        checkSpeed(c, 0L, 100.0, minSpeed);
         checkSpeed(c, null, 1000.0, unknownSpeed);
         checkSpeed(c, 0L, 1000.0, unknownSpeed);
 
@@ -49,10 +49,10 @@ class FerrySpeedCalculatorTest {
         // above max (capped to max)
         checkSpeed(c, 3600L, 90000.0, maxSpeed);
         // below smallest storable non-zero value
-        checkSpeed(c, 7200L, 1000.0, speedFactor / 2);
+        checkSpeed(c, 7200L, 1000.0, minSpeed);
 
         // suspicious slow speed (still depends on distance)
-        checkSpeed(c, 180000L, 100.0, speedFactor / 2);
+        checkSpeed(c, 180000L, 100.0, minSpeed);
         checkSpeed(c, 1800000L, 1000.0, unknownSpeed);
     }
 

--- a/core/src/test/java/com/graphhopper/routing/util/FootFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/FootFlagEncoderTest.java
@@ -250,7 +250,9 @@ public class FootFlagEncoderTest {
         way.setTag("route", "ferry");
         // a bit longer than an hour
         way.setTag("duration:seconds", 4000L);
-        assertEquals(30, footEncoder.ferrySpeedCalc.getSpeed(way), .1);
+        way.setTag("road_distance", 30000.0);
+        // the speed is truncated to maxspeed (=15)
+        assertEquals(15, footEncoder.ferrySpeedCalc.getSpeed(way), .1);
         IntsRef flags = footEncoder.handleWayTags(encodingManager.createEdgeFlags(), way);
         assertEquals(15, footAvgSpeedEnc.getDecimal(false, flags), .1);
     }

--- a/core/src/test/java/com/graphhopper/routing/util/FootFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/FootFlagEncoderTest.java
@@ -249,13 +249,13 @@ public class FootFlagEncoderTest {
     public void testFerrySpeed() {
         ReaderWay way = new ReaderWay(1);
         way.setTag("route", "ferry");
-        // a bit longer than an hour
-        way.setTag("duration:seconds", 4000L);
-        way.setTag("edge_distance", 30000.0);
+        way.setTag("duration:seconds", 1800L);
+        way.setTag("way_distance", 30000.0);
+        way.setTag("speed_from_duration", 30 / 0.5);
         // the speed is truncated to maxspeed (=15)
-        assertEquals(15, footEncoder.ferrySpeedCalc.getSpeed(way), .1);
-        IntsRef flags = footEncoder.handleWayTags(encodingManager.createEdgeFlags(), way);
-        assertEquals(15, footAvgSpeedEnc.getDecimal(false, flags), .1);
+        IntsRef edgeFlags = encodingManager.createEdgeFlags();
+        footEncoder.handleWayTags(edgeFlags, way);
+        assertEquals(15, footEncoder.getAverageSpeedEnc().getDecimal(false, edgeFlags));
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/routing/util/FootFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/FootFlagEncoderTest.java
@@ -250,7 +250,7 @@ public class FootFlagEncoderTest {
         way.setTag("route", "ferry");
         // a bit longer than an hour
         way.setTag("duration:seconds", 4000L);
-        way.setTag("road_distance", 30000.0);
+        way.setTag("edge_distance", 30000.0);
         // the speed is truncated to maxspeed (=15)
         assertEquals(15, footEncoder.ferrySpeedCalc.getSpeed(way), .1);
         IntsRef flags = footEncoder.handleWayTags(encodingManager.createEdgeFlags(), way);

--- a/core/src/test/java/com/graphhopper/routing/util/MotorcycleFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/MotorcycleFlagEncoderTest.java
@@ -21,9 +21,8 @@ import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.BooleanEncodedValue;
 import com.graphhopper.routing.ev.DecimalEncodedValue;
 import com.graphhopper.storage.*;
-import com.graphhopper.util.EdgeIteratorState;
-import com.graphhopper.util.GHUtility;
-import com.graphhopper.util.Helper;
+import com.graphhopper.util.*;
+import com.graphhopper.util.shapes.GHPoint;
 import org.junit.jupiter.api.Test;
 
 import java.text.DateFormat;
@@ -166,7 +165,14 @@ public class MotorcycleFlagEncoderTest {
     private double getBendiness(EdgeIteratorState edge, double beelineDistance) {
         ReaderWay way = new ReaderWay(1);
         way.setTag("highway", "primary");
-        way.setTag("beeline_distance", beelineDistance);
+        // set point_list such that it yields the requested beelineDistance
+        GHPoint point = new GHPoint(11.3, 45.2);
+        GHPoint toPoint = DistanceCalcEarth.DIST_EARTH.projectCoordinate(point.lat, point.lon, beelineDistance, 90);
+        PointList pointList = new PointList();
+        pointList.add(point);
+        pointList.add(toPoint);
+        way.setTag("point_list", pointList);
+
         assertTrue(encoder.getAccess(way).isWay());
         IntsRef flags = encoder.handleWayTags(em.createEdgeFlags(), way);
         edge.setFlags(flags);

--- a/core/src/test/java/com/graphhopper/routing/util/MotorcycleFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/MotorcycleFlagEncoderTest.java
@@ -163,10 +163,10 @@ public class MotorcycleFlagEncoderTest {
         assertTrue(bendinessOfCurvyWay < bendinessOfStraightWay, "The bendiness of the straight road is smaller than the one of the curvy road");
     }
 
-    private double getBendiness(EdgeIteratorState edge, double estimatedDistance) {
+    private double getBendiness(EdgeIteratorState edge, double beelineDistance) {
         ReaderWay way = new ReaderWay(1);
         way.setTag("highway", "primary");
-        way.setTag("estimated_distance", estimatedDistance);
+        way.setTag("beeline_distance", beelineDistance);
         assertTrue(encoder.getAccess(way).isWay());
         IntsRef flags = encoder.handleWayTags(em.createEdgeFlags(), way);
         edge.setFlags(flags);


### PR DESCRIPTION
Work for #2526.

The `estimated_distance` tag is now called `beeline_distance` and represents the straight line distance between the tower nodes of the edge, not the straight line distance between the first and last nodes of the OSM way as `estimated_distance` did (at some point). We can also use this for the bendiness calculation without `applyWayTags` (see #2469). The actual length of the road/edge is now stored in an artificial tag `road_distance` and we get the full point list of the edge by `point_list`.

More comments inline.