### PR TITLE
Fix Potential HashMap Flaky Test

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -80,6 +80,7 @@ Here is an overview:
  * zstadler, multiple fixes and car4wd
  * samruston, improved point hint matching
  * shunfan-shao, fix potential flaky tests
+ * jchen8460, fix another potential flaky test
 
 ## Translations
 

--- a/reader-gtfs/src/test/java/com/graphhopper/gtfs/TransfersTest.java
+++ b/reader-gtfs/src/test/java/com/graphhopper/gtfs/TransfersTest.java
@@ -75,12 +75,10 @@ public class TransfersTest {
     public void testInternalTransfersByToRouteIfRouteSpecific() {
         List<Transfer> transfersToStop = sampleFeed.getTransfersToStop("BEATTY_AIRPORT", "AB");
         assertEquals(5, transfersToStop.size());
-        Set<String> ids = new HashSet<>(Arrays.asList("AB", "FUNNY_BLOCK_AB", "STBA", "AAMV", "ABBFC")); 
-        assertTrue(ids.remove(transfersToStop.get(0).from_route_id));
-        assertTrue(ids.remove(transfersToStop.get(1).from_route_id));
-        assertTrue(ids.remove(transfersToStop.get(2).from_route_id));
-        assertTrue(ids.remove(transfersToStop.get(3).from_route_id));
-        assertTrue(ids.remove(transfersToStop.get(4).from_route_id));
+        Set<String> actualIds = new HashSet<>();
+        transfersToStop.forEach((route) -> actualIds.add(route.from_route_id));
+        Set<String> expectedIds = new HashSet<>(Arrays.asList("AB", "FUNNY_BLOCK_AB", "STBA", "AAMV", "ABBFC")); 
+        assertEquals(expectedIds, actualIds);
     }
 
 }

--- a/reader-gtfs/src/test/java/com/graphhopper/gtfs/TransfersTest.java
+++ b/reader-gtfs/src/test/java/com/graphhopper/gtfs/TransfersTest.java
@@ -29,6 +29,9 @@ import org.junit.jupiter.api.TestInstance;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
+import java.util.HashSet;
+import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -72,11 +75,12 @@ public class TransfersTest {
     public void testInternalTransfersByToRouteIfRouteSpecific() {
         List<Transfer> transfersToStop = sampleFeed.getTransfersToStop("BEATTY_AIRPORT", "AB");
         assertEquals(5, transfersToStop.size());
-        assertEquals("AB", transfersToStop.get(0).from_route_id);
-        assertEquals("FUNNY_BLOCK_AB", transfersToStop.get(1).from_route_id);
-        assertEquals("STBA", transfersToStop.get(2).from_route_id);
-        assertEquals("AAMV", transfersToStop.get(3).from_route_id);
-        assertEquals("ABBFC", transfersToStop.get(4).from_route_id);
+        Set<String> ids = new HashSet<>(Arrays.asList("AB", "FUNNY_BLOCK_AB", "STBA", "AAMV", "ABBFC")); 
+        assertTrue(ids.remove(transfersToStop.get(0).from_route_id));
+        assertTrue(ids.remove(transfersToStop.get(1).from_route_id));
+        assertTrue(ids.remove(transfersToStop.get(2).from_route_id));
+        assertTrue(ids.remove(transfersToStop.get(3).from_route_id));
+        assertTrue(ids.remove(transfersToStop.get(4).from_route_id));
     }
 
 }


### PR DESCRIPTION
**Description**
The test `com.graphhopper.gtfs.TransfersTest.testInternalTransfersByToRouteIfRouteSpecific` could potentially fail because `HashMap` does not guarantee a specific iteration order (found by [NonDex](https://github.com/TestingResearchIllinois/NonDex)).

As a result, `List<Transfer> transfersToStop` does not have a guaranteed ordering because it is created by iterating through a`HashMap`. 

**Solution**
To solve this issue, I made a `HashSet` of all the expected route ids and a `HashSet` of the actual route ids from the list and asserted that they are equal. This will remove the test's dependency on the ordering of `List<Transfer> transfersToStop`.
