### PR TITLE
Use Weighting instead of access for turn instructions

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/InstructionsFromEdges.java
+++ b/core/src/main/java/com/graphhopper/routing/InstructionsFromEdges.java
@@ -19,6 +19,7 @@ package com.graphhopper.routing;
 
 import com.graphhopper.routing.ev.*;
 import com.graphhopper.routing.util.AccessFilter;
+import com.graphhopper.routing.util.FiniteWeightFilter;
 import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.Graph;
@@ -38,14 +39,12 @@ import static com.graphhopper.routing.util.EncodingManager.getKey;
 public class InstructionsFromEdges implements Path.EdgeVisitor {
 
     private final Weighting weighting;
-    private final FlagEncoder encoder;
     private final NodeAccess nodeAccess;
 
     private final InstructionList ways;
     private final EdgeExplorer outEdgeExplorer;
     private final EdgeExplorer crossingExplorer;
     private final BooleanEncodedValue roundaboutEnc;
-    private final BooleanEncodedValue accessEnc;
     private final BooleanEncodedValue roadClassLinkEnc;
     private final EnumEncodedValue<RoadClass> roadClassEnc;
     private final DecimalEncodedValue maxSpeedEnc;
@@ -86,9 +85,7 @@ public class InstructionsFromEdges implements Path.EdgeVisitor {
 
     public InstructionsFromEdges(Graph graph, Weighting weighting, EncodedValueLookup evLookup,
                                  InstructionList ways) {
-        this.encoder = weighting.getFlagEncoder();
         this.weighting = weighting;
-        this.accessEnc = evLookup.getBooleanEncodedValue(getKey(encoder.toString(), "access"));
         this.roundaboutEnc = evLookup.getBooleanEncodedValue(Roundabout.KEY);
         this.roadClassEnc = evLookup.getEnumEncodedValue(RoadClass.KEY, RoadClass.class);
         this.roadClassLinkEnc = evLookup.getBooleanEncodedValue(RoadClassLink.KEY);
@@ -98,8 +95,8 @@ public class InstructionsFromEdges implements Path.EdgeVisitor {
         prevNode = -1;
         prevInRoundabout = false;
         prevName = null;
-        outEdgeExplorer = graph.createEdgeExplorer(AccessFilter.outEdges(encoder.getAccessEnc()));
-        crossingExplorer = graph.createEdgeExplorer(AccessFilter.allEdges(encoder.getAccessEnc()));
+        outEdgeExplorer = graph.createEdgeExplorer(edge -> Double.isFinite(weighting.calcEdgeWeightWithAccess(edge, false)));
+        crossingExplorer = graph.createEdgeExplorer(new FiniteWeightFilter(weighting));
     }
 
     /**
@@ -252,7 +249,7 @@ public class InstructionsFromEdges implements Path.EdgeVisitor {
                         && (sign < 0) == (prevInstruction.getSign() < 0)
                         && (Math.abs(sign) == Instruction.TURN_SLIGHT_RIGHT || Math.abs(sign) == Instruction.TURN_RIGHT || Math.abs(sign) == Instruction.TURN_SHARP_RIGHT)
                         && (Math.abs(prevInstruction.getSign()) == Instruction.TURN_SLIGHT_RIGHT || Math.abs(prevInstruction.getSign()) == Instruction.TURN_RIGHT || Math.abs(prevInstruction.getSign()) == Instruction.TURN_SHARP_RIGHT)
-                        && edge.get(accessEnc) != edge.getReverse(accessEnc)
+                        && Double.isFinite(weighting.calcEdgeWeightWithAccess(edge, false)) != Double.isFinite(weighting.calcEdgeWeightWithAccess(edge, true))
                         && InstructionsHelper.isNameSimilar(prevInstructionName, name)) {
                     // Chances are good that this is a u-turn, we only need to check if the orientation matches
                     GHPoint point = InstructionsHelper.getPointForOrientationCalculation(edge, nodeAccess);
@@ -330,7 +327,8 @@ public class InstructionsFromEdges implements Path.EdgeVisitor {
         prevOrientation = AngleCalc.ANGLE_CALC.calcOrientation(doublePrevLat, doublePrevLon, prevLat, prevLon);
         int sign = InstructionsHelper.calculateSign(prevLat, prevLon, lat, lon, prevOrientation);
 
-        InstructionsOutgoingEdges outgoingEdges = new InstructionsOutgoingEdges(prevEdge, edge, encoder, maxSpeedEnc, roadClassEnc, roadClassLinkEnc, crossingExplorer, nodeAccess, prevNode, baseNode, adjNode);
+        InstructionsOutgoingEdges outgoingEdges = new InstructionsOutgoingEdges(prevEdge, edge, weighting, maxSpeedEnc,
+                roadClassEnc, roadClassLinkEnc, crossingExplorer, nodeAccess, prevNode, baseNode, adjNode);
         int nrOfPossibleTurns = outgoingEdges.getAllowedTurns();
 
         // there is no other turn possible

--- a/core/src/main/java/com/graphhopper/routing/InstructionsFromEdges.java
+++ b/core/src/main/java/com/graphhopper/routing/InstructionsFromEdges.java
@@ -18,16 +18,12 @@
 package com.graphhopper.routing;
 
 import com.graphhopper.routing.ev.*;
-import com.graphhopper.routing.util.AccessFilter;
 import com.graphhopper.routing.util.FiniteWeightFilter;
-import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.Graph;
 import com.graphhopper.storage.NodeAccess;
 import com.graphhopper.util.*;
 import com.graphhopper.util.shapes.GHPoint;
-
-import static com.graphhopper.routing.util.EncodingManager.getKey;
 
 /**
  * This class calculates instructions from the edges in a Path.

--- a/core/src/main/java/com/graphhopper/routing/InstructionsFromEdges.java
+++ b/core/src/main/java/com/graphhopper/routing/InstructionsFromEdges.java
@@ -18,7 +18,7 @@
 package com.graphhopper.routing;
 
 import com.graphhopper.routing.ev.*;
-import com.graphhopper.routing.util.AccessFilter;
+import com.graphhopper.routing.util.FiniteWeightFilter;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.Graph;
 import com.graphhopper.storage.NodeAccess;
@@ -39,7 +39,7 @@ public class InstructionsFromEdges implements Path.EdgeVisitor {
 
     private final InstructionList ways;
     private final EdgeExplorer outEdgeExplorer;
-    private final EdgeExplorer crossingExplorer;
+    private final EdgeExplorer allExplorer;
     private final BooleanEncodedValue roundaboutEnc;
     private final BooleanEncodedValue roadClassLinkEnc;
     private final EnumEncodedValue<RoadClass> roadClassEnc;
@@ -92,8 +92,7 @@ public class InstructionsFromEdges implements Path.EdgeVisitor {
         prevInRoundabout = false;
         prevName = null;
         outEdgeExplorer = graph.createEdgeExplorer(edge -> Double.isFinite(weighting.calcEdgeWeightWithAccess(edge, false)));
-//        crossingExplorer = graph.createEdgeExplorer(new FiniteWeightFilter(weighting));
-        crossingExplorer = graph.createEdgeExplorer(AccessFilter.allEdges(weighting.getFlagEncoder().getAccessEnc()));
+        allExplorer = graph.createEdgeExplorer();
     }
 
     /**
@@ -201,7 +200,6 @@ public class InstructionsFromEdges implements Path.EdgeVisitor {
 
         } else if (prevInRoundabout) //previously in roundabout but not anymore
         {
-
             prevInstruction.setName(name);
 
             // calc angle between roundabout entrance and exit
@@ -325,7 +323,7 @@ public class InstructionsFromEdges implements Path.EdgeVisitor {
         int sign = InstructionsHelper.calculateSign(prevLat, prevLon, lat, lon, prevOrientation);
 
         InstructionsOutgoingEdges outgoingEdges = new InstructionsOutgoingEdges(prevEdge, edge, weighting, maxSpeedEnc,
-                roadClassEnc, roadClassLinkEnc, crossingExplorer, nodeAccess, prevNode, baseNode, adjNode);
+                roadClassEnc, roadClassLinkEnc, allExplorer, nodeAccess, prevNode, baseNode, adjNode);
         int nrOfPossibleTurns = outgoingEdges.getAllowedTurns();
 
         // there is no other turn possible

--- a/core/src/main/java/com/graphhopper/routing/InstructionsFromEdges.java
+++ b/core/src/main/java/com/graphhopper/routing/InstructionsFromEdges.java
@@ -18,7 +18,7 @@
 package com.graphhopper.routing;
 
 import com.graphhopper.routing.ev.*;
-import com.graphhopper.routing.util.FiniteWeightFilter;
+import com.graphhopper.routing.util.AccessFilter;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.Graph;
 import com.graphhopper.storage.NodeAccess;
@@ -92,7 +92,8 @@ public class InstructionsFromEdges implements Path.EdgeVisitor {
         prevInRoundabout = false;
         prevName = null;
         outEdgeExplorer = graph.createEdgeExplorer(edge -> Double.isFinite(weighting.calcEdgeWeightWithAccess(edge, false)));
-        crossingExplorer = graph.createEdgeExplorer(new FiniteWeightFilter(weighting));
+//        crossingExplorer = graph.createEdgeExplorer(new FiniteWeightFilter(weighting));
+        crossingExplorer = graph.createEdgeExplorer(AccessFilter.allEdges(weighting.getFlagEncoder().getAccessEnc()));
     }
 
     /**

--- a/core/src/main/java/com/graphhopper/routing/InstructionsHelper.java
+++ b/core/src/main/java/com/graphhopper/routing/InstructionsHelper.java
@@ -63,13 +63,9 @@ class InstructionsHelper {
     static boolean isNameSimilar(String name1, String name2) {
         // We don't want two empty names to be similar
         // The idea is, if there are only a random tracks, they usually don't have names
-        if (name1.isEmpty() && name2.isEmpty()) {
+        if (name1.isEmpty() && name2.isEmpty())
             return false;
-        }
-        if (name1.equals(name2)) {
-            return true;
-        }
-        return false;
+        return name1.equals(name2);
     }
 
     static GHPoint getPointForOrientationCalculation(EdgeIteratorState edgeIteratorState, NodeAccess nodeAccess) {

--- a/core/src/main/java/com/graphhopper/routing/InstructionsOutgoingEdges.java
+++ b/core/src/main/java/com/graphhopper/routing/InstructionsOutgoingEdges.java
@@ -74,7 +74,7 @@ class InstructionsOutgoingEdges {
                                      DecimalEncodedValue maxSpeedEnc,
                                      EnumEncodedValue<RoadClass> roadClassEnc,
                                      BooleanEncodedValue roadClassLinkEnc,
-                                     EdgeExplorer crossingExplorer,
+                                     EdgeExplorer allExplorer,
                                      NodeAccess nodeAccess,
                                      int prevNode,
                                      int baseNode,
@@ -87,17 +87,17 @@ class InstructionsOutgoingEdges {
         this.roadClassLinkEnc = roadClassLinkEnc;
         this.nodeAccess = nodeAccess;
 
-        EdgeIteratorState tmpEdge;
-
         visibleAlternativeTurns = new ArrayList<>();
         allowedAlternativeTurns = new ArrayList<>();
-        EdgeIterator edgeIter = crossingExplorer.setBaseNode(baseNode);
+        EdgeIterator edgeIter = allExplorer.setBaseNode(baseNode);
         while (edgeIter.next()) {
             if (edgeIter.getAdjNode() != prevNode && edgeIter.getAdjNode() != adjNode) {
-                tmpEdge = edgeIter.detach(false);
-                visibleAlternativeTurns.add(tmpEdge);
-                if (Double.isFinite(weighting.calcEdgeWeightWithAccess(tmpEdge, false))) {
+                if (Double.isFinite(weighting.calcEdgeWeightWithAccess(edgeIter, false))) {
+                    EdgeIteratorState tmpEdge = edgeIter.detach(false);
                     allowedAlternativeTurns.add(tmpEdge);
+                    visibleAlternativeTurns.add(tmpEdge);
+                } else if (Double.isFinite(weighting.calcEdgeWeightWithAccess(edgeIter, true))) {
+                    visibleAlternativeTurns.add(edgeIter.detach(false));
                 }
             }
         }
@@ -113,12 +113,11 @@ class InstructionsOutgoingEdges {
 
     /**
      * This method calculates the number of all outgoing edges, which could be considered the number of roads you see
-     * at the intersection. This excludes the road your are coming from.
+     * at the intersection. This excludes the road you are coming from and also inaccessible roads.
      */
     public int getVisibleTurns() {
         return 1 + visibleAlternativeTurns.size();
     }
-
 
     /**
      * Checks if the outgoing edges are slower by the provided factor. If they are, this indicates, that we are staying

--- a/core/src/main/java/com/graphhopper/routing/InstructionsOutgoingEdges.java
+++ b/core/src/main/java/com/graphhopper/routing/InstructionsOutgoingEdges.java
@@ -92,6 +92,7 @@ class InstructionsOutgoingEdges {
         EdgeIterator edgeIter = allExplorer.setBaseNode(baseNode);
         while (edgeIter.next()) {
             if (edgeIter.getAdjNode() != prevNode && edgeIter.getAdjNode() != adjNode) {
+                
                 EdgeIteratorState tmpEdge = edgeIter.detach(false);
                 if (Double.isFinite(weighting.calcEdgeWeightWithAccess(tmpEdge, false))) {
                     allowedAlternativeTurns.add(tmpEdge);

--- a/core/src/main/java/com/graphhopper/routing/InstructionsOutgoingEdges.java
+++ b/core/src/main/java/com/graphhopper/routing/InstructionsOutgoingEdges.java
@@ -128,8 +128,8 @@ class InstructionsOutgoingEdges {
         double tmpSpeed = getSpeed(currentEdge);
         double pathSpeed = getSpeed(prevEdge);
 
-        // Speed-Change on the path indicates, that we change road types, show instruction
-        if (pathSpeed != tmpSpeed || pathSpeed < 1) {
+        // speed change indicates that we change road types
+        if (Math.abs(pathSpeed - tmpSpeed) >= 1) {
             return false;
         }
 
@@ -142,8 +142,8 @@ class InstructionsOutgoingEdges {
             }
         }
 
-        // Surrounding streets need to be slower by a factor
-        return maxSurroundingSpeed * factor < pathSpeed;
+        // surrounding streets need to be slower by a factor and call round() so that tiny differences are ignored
+        return Math.round(maxSurroundingSpeed * factor) < Math.round(pathSpeed);
     }
 
     /**

--- a/core/src/main/java/com/graphhopper/routing/InstructionsOutgoingEdges.java
+++ b/core/src/main/java/com/graphhopper/routing/InstructionsOutgoingEdges.java
@@ -97,7 +97,7 @@ class InstructionsOutgoingEdges {
                     allowedAlternativeTurns.add(tmpEdge);
                     visibleAlternativeTurns.add(tmpEdge);
                 } else if (Double.isFinite(weighting.calcEdgeWeightWithAccess(edgeIter, true))) {
-                    visibleAlternativeTurns.add(edgeIter.detach(false));
+                    visibleAlternativeTurns.add(edgeIter.detach(false)); // TODO detach in reverse direction?
                 }
             }
         }

--- a/core/src/main/java/com/graphhopper/routing/InstructionsOutgoingEdges.java
+++ b/core/src/main/java/com/graphhopper/routing/InstructionsOutgoingEdges.java
@@ -62,6 +62,7 @@ class InstructionsOutgoingEdges {
     private final List<EdgeIteratorState> allowedAlternativeTurns;
     // All outgoing edges, including oneways in the wrong direction
     private final List<EdgeIteratorState> visibleAlternativeTurns;
+    private final DecimalEncodedValue avgSpeedEnc;
     private final DecimalEncodedValue maxSpeedEnc;
     private final EnumEncodedValue<RoadClass> roadClassEnc;
     private final BooleanEncodedValue roadClassLinkEnc;
@@ -82,6 +83,7 @@ class InstructionsOutgoingEdges {
         this.prevEdge = prevEdge;
         this.currentEdge = currentEdge;
         this.weighting = weighting;
+        this.avgSpeedEnc = weighting.getFlagEncoder().getAverageSpeedEnc();
         this.maxSpeedEnc = maxSpeedEnc;
         this.roadClassEnc = roadClassEnc;
         this.roadClassLinkEnc = roadClassLinkEnc;
@@ -153,7 +155,7 @@ class InstructionsOutgoingEdges {
     private double getSpeed(EdgeIteratorState edge) {
         double maxSpeed = edge.get(maxSpeedEnc);
         if (Double.isInfinite(maxSpeed))
-            return edge.getDistance() / weighting.calcEdgeMillis(edge, false) * 3600;
+            return edge.get(avgSpeedEnc); // TODO NOW PERF edge.getDistance() / weighting.calcEdgeMillis(edge, false) * 3600;
         return maxSpeed;
     }
 

--- a/core/src/main/java/com/graphhopper/routing/InstructionsOutgoingEdges.java
+++ b/core/src/main/java/com/graphhopper/routing/InstructionsOutgoingEdges.java
@@ -62,7 +62,6 @@ class InstructionsOutgoingEdges {
     private final List<EdgeIteratorState> allowedAlternativeTurns;
     // All outgoing edges, including oneways in the wrong direction
     private final List<EdgeIteratorState> visibleAlternativeTurns;
-    private final DecimalEncodedValue avgSpeedEnc;
     private final DecimalEncodedValue maxSpeedEnc;
     private final EnumEncodedValue<RoadClass> roadClassEnc;
     private final BooleanEncodedValue roadClassLinkEnc;
@@ -83,7 +82,6 @@ class InstructionsOutgoingEdges {
         this.prevEdge = prevEdge;
         this.currentEdge = currentEdge;
         this.weighting = weighting;
-        this.avgSpeedEnc = weighting.getFlagEncoder().getAverageSpeedEnc();
         this.maxSpeedEnc = maxSpeedEnc;
         this.roadClassEnc = roadClassEnc;
         this.roadClassLinkEnc = roadClassLinkEnc;
@@ -155,7 +153,7 @@ class InstructionsOutgoingEdges {
     private double getSpeed(EdgeIteratorState edge) {
         double maxSpeed = edge.get(maxSpeedEnc);
         if (Double.isInfinite(maxSpeed))
-            return edge.get(avgSpeedEnc); // TODO NOW PERF edge.getDistance() / weighting.calcEdgeMillis(edge, false) * 3600;
+            return edge.getDistance() / weighting.calcEdgeMillis(edge, false) * 3600;
         return maxSpeed;
     }
 

--- a/core/src/main/java/com/graphhopper/routing/InstructionsOutgoingEdges.java
+++ b/core/src/main/java/com/graphhopper/routing/InstructionsOutgoingEdges.java
@@ -92,13 +92,12 @@ class InstructionsOutgoingEdges {
         EdgeIterator edgeIter = allExplorer.setBaseNode(baseNode);
         while (edgeIter.next()) {
             if (edgeIter.getAdjNode() != prevNode && edgeIter.getAdjNode() != adjNode) {
-                
-                EdgeIteratorState tmpEdge = edgeIter.detach(false);
-                if (Double.isFinite(weighting.calcEdgeWeightWithAccess(tmpEdge, false))) {
+                if (Double.isFinite(weighting.calcEdgeWeightWithAccess(edgeIter, false))) {
+                    EdgeIteratorState tmpEdge = edgeIter.detach(false);
                     allowedAlternativeTurns.add(tmpEdge);
                     visibleAlternativeTurns.add(tmpEdge);
-                } else if (Double.isFinite(weighting.calcEdgeWeightWithAccess(tmpEdge, true))) {
-                    visibleAlternativeTurns.add(tmpEdge);
+                } else if (Double.isFinite(weighting.calcEdgeWeightWithAccess(edgeIter, true))) {
+                    visibleAlternativeTurns.add(edgeIter.detach(false));
                 }
             }
         }

--- a/core/src/main/java/com/graphhopper/routing/InstructionsOutgoingEdges.java
+++ b/core/src/main/java/com/graphhopper/routing/InstructionsOutgoingEdges.java
@@ -92,12 +92,12 @@ class InstructionsOutgoingEdges {
         EdgeIterator edgeIter = allExplorer.setBaseNode(baseNode);
         while (edgeIter.next()) {
             if (edgeIter.getAdjNode() != prevNode && edgeIter.getAdjNode() != adjNode) {
-                if (Double.isFinite(weighting.calcEdgeWeightWithAccess(edgeIter, false))) {
-                    EdgeIteratorState tmpEdge = edgeIter.detach(false);
+                EdgeIteratorState tmpEdge = edgeIter.detach(false);
+                if (Double.isFinite(weighting.calcEdgeWeightWithAccess(tmpEdge, false))) {
                     allowedAlternativeTurns.add(tmpEdge);
                     visibleAlternativeTurns.add(tmpEdge);
-                } else if (Double.isFinite(weighting.calcEdgeWeightWithAccess(edgeIter, true))) {
-                    visibleAlternativeTurns.add(edgeIter.detach(false)); // TODO detach in reverse direction?
+                } else if (Double.isFinite(weighting.calcEdgeWeightWithAccess(tmpEdge, true))) {
+                    visibleAlternativeTurns.add(tmpEdge);
                 }
             }
         }

--- a/core/src/main/java/com/graphhopper/routing/util/FiniteWeightFilter.java
+++ b/core/src/main/java/com/graphhopper/routing/util/FiniteWeightFilter.java
@@ -18,6 +18,7 @@
 
 package com.graphhopper.routing.util;
 
+import com.graphhopper.routing.ev.BooleanEncodedValue;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.util.EdgeIteratorState;
 
@@ -26,13 +27,17 @@ import com.graphhopper.util.EdgeIteratorState;
  */
 public class FiniteWeightFilter implements EdgeFilter {
     private final Weighting weighting;
+//    private final BooleanEncodedValue accessEnc;
 
     public FiniteWeightFilter(Weighting weighting) {
         this.weighting = weighting;
+//        this.accessEnc = weighting.getFlagEncoder().getAccessEnc();
     }
 
     @Override
     public final boolean accept(EdgeIteratorState edgeState) {
+//        return edgeState.get(accessEnc) && Double.isFinite(weighting.calcEdgeWeight(edgeState, false))
+//                || edgeState.getReverse(accessEnc) && Double.isFinite(weighting.calcEdgeWeight(edgeState, true));
         return Double.isFinite(weighting.calcEdgeWeightWithAccess(edgeState, false)) ||
                 Double.isFinite(weighting.calcEdgeWeightWithAccess(edgeState, true));
     }

--- a/core/src/main/java/com/graphhopper/routing/util/FiniteWeightFilter.java
+++ b/core/src/main/java/com/graphhopper/routing/util/FiniteWeightFilter.java
@@ -18,7 +18,6 @@
 
 package com.graphhopper.routing.util;
 
-import com.graphhopper.routing.ev.BooleanEncodedValue;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.util.EdgeIteratorState;
 
@@ -27,17 +26,13 @@ import com.graphhopper.util.EdgeIteratorState;
  */
 public class FiniteWeightFilter implements EdgeFilter {
     private final Weighting weighting;
-//    private final BooleanEncodedValue accessEnc;
 
     public FiniteWeightFilter(Weighting weighting) {
         this.weighting = weighting;
-//        this.accessEnc = weighting.getFlagEncoder().getAccessEnc();
     }
 
     @Override
     public final boolean accept(EdgeIteratorState edgeState) {
-//        return edgeState.get(accessEnc) && Double.isFinite(weighting.calcEdgeWeight(edgeState, false))
-//                || edgeState.getReverse(accessEnc) && Double.isFinite(weighting.calcEdgeWeight(edgeState, true));
         return Double.isFinite(weighting.calcEdgeWeightWithAccess(edgeState, false)) ||
                 Double.isFinite(weighting.calcEdgeWeightWithAccess(edgeState, true));
     }

--- a/core/src/test/java/com/graphhopper/GraphHopperTest.java
+++ b/core/src/test/java/com/graphhopper/GraphHopperTest.java
@@ -1196,7 +1196,7 @@ public class GraphHopperTest {
         assertEquals(103, res.getPoints().size());
 
         InstructionList il = res.getInstructions();
-        assertEquals(19, il.size());
+        assertEquals(21, il.size());
 
         assertEquals("continue onto Obere Landstraße", il.get(0).getTurnDescription(tr));
         assertEquals(69.28, (Double) il.get(0).getExtraInfoJSON().get("heading"), .01);

--- a/core/src/test/java/com/graphhopper/GraphHopperTest.java
+++ b/core/src/test/java/com/graphhopper/GraphHopperTest.java
@@ -1196,7 +1196,7 @@ public class GraphHopperTest {
         assertEquals(103, res.getPoints().size());
 
         InstructionList il = res.getInstructions();
-        assertEquals(21, il.size());
+        assertEquals(19, il.size());
 
         assertEquals("continue onto Obere Landstraße", il.get(0).getTurnDescription(tr));
         assertEquals(69.28, (Double) il.get(0).getExtraInfoJSON().get("heading"), .01);
@@ -1206,6 +1206,7 @@ public class GraphHopperTest {
         assertEquals("turn right onto Margarethenstraße", il.get(3).getTurnDescription(tr));
         assertEquals("keep left onto Hoher Markt", il.get(4).getTurnDescription(tr));
         assertEquals("turn right onto Wegscheid", il.get(6).getTurnDescription(tr));
+        assertEquals("continue onto Wegscheid", il.get(7).getTurnDescription(tr));
         assertEquals("turn right onto Ringstraße, L73", il.get(8).getTurnDescription(tr));
         assertEquals("keep left onto Eyblparkstraße", il.get(9).getTurnDescription(tr));
         assertEquals("keep left onto Austraße", il.get(10).getTurnDescription(tr));

--- a/core/src/test/java/com/graphhopper/routing/PathTest.java
+++ b/core/src/test/java/com/graphhopper/routing/PathTest.java
@@ -88,18 +88,13 @@ public class PathTest {
         assertEquals(3000.0, tmp.getDistance(), 0.0);
         assertEquals(504000L, tmp.getTime());
         assertEquals("continue", tmp.getTurnDescription(tr));
-//        assertEquals("[0, 6]", tmp.get("interval").toString());
         assertEquals(6, tmp.getLength());
-//        System.out.println(tmp.getPoints());
-
 
         tmp = instr.get(1);
         assertEquals(0.0, tmp.getDistance(), 0.0);
         assertEquals(0L, tmp.getTime());
         assertEquals("arrive at destination", tmp.getTurnDescription(tr));
-//        assertEquals("[6, 6]", tmp.get("interval").toString());
         assertEquals(0, tmp.getLength());
-//        System.out.println(tmp.getPoints());
 
         int acc = 0;
         for (Instruction instruction : instr) {

--- a/core/src/test/java/com/graphhopper/util/InstructionListTest.java
+++ b/core/src/test/java/com/graphhopper/util/InstructionListTest.java
@@ -240,7 +240,7 @@ public class InstructionListTest {
     @Test
     public void testNoInstructionIfSlightTurnAndAlternativeIsSharp() {
         Graph g = new GraphBuilder(carManager).create();
-        // Real World Example: https://graphhopper.com/maps/?point=51.734514%2C9.225571&point=51.734643%2C9.22541
+        // real world example: https://graphhopper.com/maps/?point=51.734514%2C9.225571&point=51.734643%2C9.22541
         // https://github.com/graphhopper/graphhopper/issues/1441
         // From 1 to 3
         //
@@ -269,7 +269,7 @@ public class InstructionListTest {
     @Test
     public void testNoInstructionIfSlightTurnAndAlternativeIsSharp2() {
         Graph g = new GraphBuilder(carManager).create();
-        // Real World Example: https://graphhopper.com/maps/?point=48.748493%2C9.322455&point=48.748776%2C9.321889
+        // real world example: https://graphhopper.com/maps/?point=48.748493%2C9.322455&point=48.748776%2C9.321889
         // https://github.com/graphhopper/graphhopper/issues/1441
         // From 1 to 3
         //
@@ -301,7 +301,7 @@ public class InstructionListTest {
         EncodingManager tmpEM = new EncodingManager.Builder().add(bike).build();
         EnumEncodedValue<RoadClass> rcEV = tmpEM.getEnumEncodedValue(RoadClass.KEY, RoadClass.class);
         Graph g = new GraphBuilder(tmpEM).create();
-        // Real World Example: https://graphhopper.com/maps/?point=48.411549,15.599567&point=48.411663%2C15.600527&profile=bike
+        // real world example: https://graphhopper.com/maps/?point=48.411549,15.599567&point=48.411663%2C15.600527&profile=bike
         // From 1 to 3
 
         //          3
@@ -339,7 +339,7 @@ public class InstructionListTest {
         EncodingManager tmpEM = new EncodingManager.Builder().add(bike).build();
         EnumEncodedValue<RoadClass> rcEV = tmpEM.getEnumEncodedValue(RoadClass.KEY, RoadClass.class);
         Graph g = new GraphBuilder(tmpEM).create();
-        // Real World Example: https://graphhopper.com/maps/?point=48.412169%2C15.604888&point=48.412251%2C15.60543&profile=bike
+        // real world example: https://graphhopper.com/maps/?point=48.412169%2C15.604888&point=48.412251%2C15.60543&profile=bike
         // From 1 to 4
 
         //      3
@@ -376,7 +376,7 @@ public class InstructionListTest {
         FootFlagEncoder foot = new FootFlagEncoder();
         EncodingManager tmpEM = new EncodingManager.Builder().add(foot).build();
         Graph g = new GraphBuilder(tmpEM).create();
-        // Real World Example: https://graphhopper.com/maps/?point=43.729379,7.417697&point=43.729798,7.417263&profile=foot
+        // real world example: https://graphhopper.com/maps/?point=43.729379,7.417697&point=43.729798,7.417263&profile=foot
         // From 4 to 3 and 4 to 1
 
         //    1  3

--- a/core/src/test/java/com/graphhopper/util/InstructionListTest.java
+++ b/core/src/test/java/com/graphhopper/util/InstructionListTest.java
@@ -58,7 +58,7 @@ public class InstructionListTest {
         carManager = EncodingManager.create(carEncoder);
     }
 
-    public static List<String> getTurnDescriptions(InstructionList instructionList) {
+    private static List<String> getTurnDescriptions(InstructionList instructionList) {
         return getTurnDescriptions(instructionList, usTR);
     }
 
@@ -376,7 +376,7 @@ public class InstructionListTest {
         FootFlagEncoder foot = new FootFlagEncoder();
         EncodingManager tmpEM = new EncodingManager.Builder().add(foot).build();
         Graph g = new GraphBuilder(tmpEM).create();
-        // Real World Example: https://graphhopper.com/maps/?point=43.729379%252C7.417697&point=43.729798%252C7.417263&profile=foot
+        // Real World Example: https://graphhopper.com/maps/?point=43.729379,7.417697&point=43.729798,7.417263&profile=foot
         // From 4 to 3 and 4 to 1
 
         //    1  3


### PR DESCRIPTION
One more change for #2463. 

 - [x] show in test that this also improves the instructions for custom profiles (where access from the base-FlagEncoder is different)
 - [x] investigate why routingCH.mean is 20% slower