### PR TITLE
Move way name parsing from EncodingManager to OSMReader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### 5.0 [not yet released]
 
 - Use routing.instructions to disable instructions on the server side. datareader.instructions is used to disable the
-  name parsing.
+  name parsing (#2537)
 - OSMReader no longer sets the artificial estimated_distance tag, but sets the edge_distance and point_list tags for all
   edges, the way_distance for selected ways and additionally the duration:seconds and speed_from_duration tags when the
   duration tag is present (#2528)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### 5.0 [not yet released]
 
+- Use routing.instructions to disable instructions on the server side. datareader.instructions is used to disable the
+  name parsing.
 - OSMReader no longer sets the artificial estimated_distance tag, but sets the edge_distance and point_list tags for all
   edges, the way_distance for selected ways and additionally the duration:seconds and speed_from_duration tags when the
   duration tag is present (#2528)

--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -463,8 +463,6 @@ public class GraphHopper {
 
         if (encodingManager != null)
             throw new IllegalStateException("Cannot call init twice. EncodingManager was already initialized.");
-        emBuilder.setEnableInstructions(ghConfig.getBool("datareader.instructions", true));
-        emBuilder.setPreferredLanguage(ghConfig.getString("datareader.preferred_language", ""));
         emBuilder.setDateRangeParser(DateRangeParser.createInstance(ghConfig.getString("datareader.date_range_parser_day", "")));
         setProfiles(ghConfig.getProfiles());
         encodingManager = buildEncodingManager(ghConfig);
@@ -493,6 +491,8 @@ public class GraphHopper {
         lmPreparationHandler.init(ghConfig);
 
         // osm import
+        osmReaderConfig.setParseWayNames(ghConfig.getBool("datareader.instructions", true));
+        osmReaderConfig.setPreferredLanguage(ghConfig.getString("datareader.preferred_language", ""));
         osmReaderConfig.setMaxWayPointDistance(ghConfig.getDouble(Routing.INIT_WAY_POINT_MAX_DISTANCE, osmReaderConfig.getMaxWayPointDistance()));
         osmReaderConfig.setWorkerThreads(ghConfig.getInt("datareader.worker_threads", osmReaderConfig.getWorkerThreads()));
 
@@ -504,6 +504,7 @@ public class GraphHopper {
         routerConfig.setMaxVisitedNodes(ghConfig.getInt(Routing.INIT_MAX_VISITED_NODES, routerConfig.getMaxVisitedNodes()));
         routerConfig.setMaxRoundTripRetries(ghConfig.getInt(RoundTrip.INIT_MAX_RETRIES, routerConfig.getMaxRoundTripRetries()));
         routerConfig.setNonChMaxWaypointDistance(ghConfig.getInt(Parameters.NON_CH.MAX_NON_CH_POINT_DISTANCE, routerConfig.getNonChMaxWaypointDistance()));
+        routerConfig.setInstructionsEnabled(ghConfig.getBool(Routing.INIT_INSTRUCTIONS, routerConfig.isInstructionsEnabled()));
         int activeLandmarkCount = ghConfig.getInt(Landmark.ACTIVE_COUNT_DEFAULT, Math.min(8, lmPreparationHandler.getLandmarks()));
         if (activeLandmarkCount > lmPreparationHandler.getLandmarks())
             throw new IllegalArgumentException("Default value for active landmarks " + activeLandmarkCount

--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -491,8 +491,8 @@ public class GraphHopper {
         lmPreparationHandler.init(ghConfig);
 
         // osm import
-        osmReaderConfig.setParseWayNames(ghConfig.getBool("datareader.instructions", true));
-        osmReaderConfig.setPreferredLanguage(ghConfig.getString("datareader.preferred_language", ""));
+        osmReaderConfig.setParseWayNames(ghConfig.getBool("datareader.instructions", osmReaderConfig.isParseWayNames()));
+        osmReaderConfig.setPreferredLanguage(ghConfig.getString("datareader.preferred_language", osmReaderConfig.getPreferredLanguage()));
         osmReaderConfig.setMaxWayPointDistance(ghConfig.getDouble(Routing.INIT_WAY_POINT_MAX_DISTANCE, osmReaderConfig.getMaxWayPointDistance()));
         osmReaderConfig.setWorkerThreads(ghConfig.getInt("datareader.worker_threads", osmReaderConfig.getWorkerThreads()));
 

--- a/core/src/main/java/com/graphhopper/routing/OSMReaderConfig.java
+++ b/core/src/main/java/com/graphhopper/routing/OSMReaderConfig.java
@@ -19,11 +19,39 @@
 package com.graphhopper.routing;
 
 public class OSMReaderConfig {
+    private boolean parseWayNames = true;
+    private String preferredLanguage = "";
     private double maxWayPointDistance = 1;
     private double elevationMaxWayPointDistance = Double.MAX_VALUE;
     private boolean smoothElevation = false;
     private double longEdgeSamplingDistance = Double.MAX_VALUE;
     private int workerThreads = 2;
+
+    public String getPreferredLanguage() {
+        return preferredLanguage;
+    }
+
+    /**
+     * Sets the language used to parse way names. For example if this is set to 'en' we will use the 'name:en' tag
+     * rather than the 'name' tag if it is present. The language code should be given as defined in ISO 639-1 or ISO 639-2.
+     * This setting becomes irrelevant if parseWayNames is set to false.
+     */
+    public OSMReaderConfig setPreferredLanguage(String preferredLanguage) {
+        this.preferredLanguage = preferredLanguage;
+        return this;
+    }
+
+    public boolean isParseWayNames() {
+        return parseWayNames;
+    }
+
+    /**
+     * Enables/disables the parsing of the name and ref tags to set the name of the graph edges
+     */
+    public OSMReaderConfig setParseWayNames(boolean parseWayNames) {
+        this.parseWayNames = parseWayNames;
+        return this;
+    }
 
     public double getMaxWayPointDistance() {
         return maxWayPointDistance;

--- a/core/src/main/java/com/graphhopper/routing/Router.java
+++ b/core/src/main/java/com/graphhopper/routing/Router.java
@@ -278,7 +278,7 @@ public class Router {
     }
 
     private PathMerger createPathMerger(GHRequest request, Weighting weighting, Graph graph) {
-        boolean enableInstructions = request.getHints().getBool(Parameters.Routing.INSTRUCTIONS, encodingManager.isEnableInstructions());
+        boolean enableInstructions = request.getHints().getBool(Parameters.Routing.INSTRUCTIONS, routerConfig.isInstructionsEnabled());
         boolean calcPoints = request.getHints().getBool(Parameters.Routing.CALC_POINTS, routerConfig.isCalcPoints());
         double wayPointMaxDistance = request.getHints().getDouble(Parameters.Routing.WAY_POINT_MAX_DISTANCE, 1d);
         double elevationWayPointMaxDistance = request.getHints().getDouble(ELEVATION_WAY_POINT_MAX_DISTANCE, routerConfig.getElevationWayPointMaxDistance());

--- a/core/src/main/java/com/graphhopper/routing/RouterConfig.java
+++ b/core/src/main/java/com/graphhopper/routing/RouterConfig.java
@@ -26,6 +26,7 @@ public class RouterConfig {
     private int maxRoundTripRetries = 3;
     private int nonChMaxWaypointDistance = Integer.MAX_VALUE;
     private boolean calcPoints = true;
+    private boolean instructionsEnabled = true;
     private boolean simplifyResponse = true;
     private double elevationWayPointMaxDistance = Double.MAX_VALUE;
     private int activeLandmarkCount = 8;
@@ -67,6 +68,14 @@ public class RouterConfig {
      */
     public void setCalcPoints(boolean calcPoints) {
         this.calcPoints = calcPoints;
+    }
+
+    public boolean isInstructionsEnabled() {
+        return instructionsEnabled;
+    }
+
+    public void setInstructionsEnabled(boolean instructionsEnabled) {
+        this.instructionsEnabled = instructionsEnabled;
     }
 
     public boolean isSimplifyResponse() {

--- a/core/src/test/java/com/graphhopper/GraphHopperTest.java
+++ b/core/src/test/java/com/graphhopper/GraphHopperTest.java
@@ -2120,7 +2120,7 @@ public class GraphHopperTest {
     public void simplifyWithInstructionsAndPathDetails() {
         final String profile = "profile";
         GraphHopper hopper = new GraphHopper();
-        hopper.getEncodingManagerBuilder().setEnableInstructions(true)
+        hopper.getEncodingManagerBuilder()
                 .add(new OSMMaxSpeedParser())
                 .add(new CarFlagEncoder());
         hopper.setOSMFile(BAYREUTH).

--- a/core/src/test/java/com/graphhopper/reader/osm/GraphHopperOSMTest.java
+++ b/core/src/test/java/com/graphhopper/reader/osm/GraphHopperOSMTest.java
@@ -388,17 +388,6 @@ public class GraphHopperOSMTest {
         assertEquals(new GHPoint(51.24921503475044, 9.431716451757769), rsp.getPoints().get(0));
         assertEquals(new GHPoint(52.0, 9.0), rsp.getPoints().get(1));
         assertEquals(new GHPoint(51.199999850988384, 9.39999970197677), rsp.getPoints().get(2));
-
-        GHRequest req = new GHRequest(51.2492152, 9.4317166, 51.2, 9.4);
-        req.setProfile(profile);
-        boolean old = instance.getEncodingManager().isEnableInstructions();
-        req.putHint("instructions", true);
-        instance.route(req);
-        assertEquals(old, instance.getEncodingManager().isEnableInstructions());
-
-        req.putHint("instructions", false);
-        instance.route(req);
-        assertEquals(old, instance.getEncodingManager().isEnableInstructions(), "route method should not change instance field");
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/reader/osm/OSMReaderTest.java
+++ b/core/src/test/java/com/graphhopper/reader/osm/OSMReaderTest.java
@@ -927,6 +927,12 @@ public class OSMReaderTest {
         assertEquals(Country.BGR, iter.get(countryEnc));
     }
 
+    @Test
+    public void testFixWayName() {
+        assertEquals("B8, B12", OSMReader.fixWayName("B8;B12"));
+        assertEquals("B8, B12", OSMReader.fixWayName("B8; B12"));
+    }
+
     private AreaIndex<CustomArea> createCountryIndex() {
         return new AreaIndex<>(readCountries());
     }
@@ -956,8 +962,8 @@ public class OSMReaderTest {
             }
 
             footEncoder = new FootFlagEncoder();
-            getEncodingManagerBuilder().add(footEncoder).add(carEncoder).add(bikeEncoder).
-                    setPreferredLanguage(prefLang);
+            getEncodingManagerBuilder().add(footEncoder).add(carEncoder).add(bikeEncoder);
+            getReaderConfig().setPreferredLanguage(prefLang);
         }
 
         @Override

--- a/core/src/test/java/com/graphhopper/routing/util/EncodingManagerTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/EncodingManagerTest.java
@@ -148,12 +148,6 @@ public class EncodingManagerTest {
     }
 
     @Test
-    public void testFixWayName() {
-        assertEquals("B8, B12", EncodingManager.fixWayName("B8;B12"));
-        assertEquals("B8, B12", EncodingManager.fixWayName("B8; B12"));
-    }
-
-    @Test
     public void testCompatibilityBug() {
         EncodingManager manager2 = EncodingManager.create(new DefaultFlagEncoderFactory(), "bike2");
         ReaderWay osmWay = new ReaderWay(1);

--- a/web-api/src/main/java/com/graphhopper/util/Parameters.java
+++ b/web-api/src/main/java/com/graphhopper/util/Parameters.java
@@ -101,6 +101,7 @@ public class Parameters {
          * if true the response will contain turn instructions
          */
         public static final String INSTRUCTIONS = "instructions";
+        public static final String INIT_INSTRUCTIONS = ROUTING_INIT_PREFIX + "instructions";
         /**
          * if true the response will contain a point list
          */


### PR DESCRIPTION
I moved the code that parses the `name/ref` OSM tag of the OSM ways from `EncodingManager#applyWayTags` to `OSMReader`. I also added a new setting to disable instructions on the server side called `routing.instructions`, which is now separated from `datareader.instructions`. The latter now only controls whether the way names shall be parsed or not. It is probably debatable whether we even need `datareader.instructions` and it should probably be better renamed to `datareader.parse_names` or even `osmreader.parse_names`. However renaming `datareader` to `osmreader` is for another issue.