### PR TITLE
Replace EncodingManager with TagParserManager where it is needed

### DIFF
--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -766,7 +766,7 @@ public class GraphHopper {
 
         GHDirectory directory = new GHDirectory(ghLocation, dataAccessDefaultType);
         directory.configure(dataAccessConfig);
-        ghStorage = new GraphBuilder(tagParserManager.getEncodingManager())
+        ghStorage = new GraphBuilder(tagParserManager)
                 .setDir(directory)
                 .set3D(hasElevation())
                 .withTurnCosts(tagParserManager.needsTurnCostsSupport())

--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -87,8 +87,8 @@ public class GraphHopper {
     private String customAreasDirectory = "";
     // for graph:
     private GraphHopperStorage ghStorage;
-    private final EncodingManager.Builder emBuilder = new EncodingManager.Builder();
-    private EncodingManager encodingManager;
+    private final TagParserManager.Builder emBuilder = new TagParserManager.Builder();
+    private TagParserManager tagParserManager;
     private int defaultSegmentSize = -1;
     private String ghLocation = "";
     private DAType dataAccessDefaultType = DAType.RAM_STORE;
@@ -122,14 +122,14 @@ public class GraphHopper {
     private TagParserFactory tagParserFactory = new DefaultTagParserFactory();
     private PathDetailsBuilderFactory pathBuilderFactory = new PathDetailsBuilderFactory();
 
-    public EncodingManager.Builder getEncodingManagerBuilder() {
+    public TagParserManager.Builder getTagParserManagerBuilder() {
         return emBuilder;
     }
 
-    public EncodingManager getEncodingManager() {
-        if (encodingManager == null)
+    public TagParserManager getTagParserManager() {
+        if (tagParserManager == null)
             throw new IllegalStateException("EncodingManager not yet built");
-        return encodingManager;
+        return tagParserManager;
     }
 
     public ElevationProvider getElevationProvider() {
@@ -221,7 +221,7 @@ public class GraphHopper {
     public GraphHopper setProfiles(List<Profile> profiles) {
         if (!profilesByName.isEmpty())
             throw new IllegalArgumentException("Cannot initialize profiles multiple times");
-        if (encodingManager != null)
+        if (tagParserManager != null)
             throw new IllegalArgumentException("Cannot set profiles after EncodingManager was built");
         for (Profile profile : profiles) {
             Profile previous = this.profilesByName.put(profile.getName(), profile);
@@ -461,11 +461,11 @@ public class GraphHopper {
         if (!ghConfig.getString("spatial_rules.max_bbox", "").isEmpty())
             throw new IllegalArgumentException("spatial_rules.max_bbox has been deprecated. There is no replacement, all custom areas will be considered.");
 
-        if (encodingManager != null)
+        if (tagParserManager != null)
             throw new IllegalStateException("Cannot call init twice. EncodingManager was already initialized.");
         emBuilder.setDateRangeParser(DateRangeParser.createInstance(ghConfig.getString("datareader.date_range_parser_day", "")));
         setProfiles(ghConfig.getProfiles());
-        encodingManager = buildEncodingManager(ghConfig);
+        tagParserManager = buildEncodingManager(ghConfig);
 
         if (ghConfig.getString("graph.locktype", "native").equals("simple"))
             lockFactory = new SimpleFSLockFactory();
@@ -514,7 +514,7 @@ public class GraphHopper {
         return this;
     }
 
-    private EncodingManager buildEncodingManager(GraphHopperConfig ghConfig) {
+    private TagParserManager buildEncodingManager(GraphHopperConfig ghConfig) {
         if (profilesByName.isEmpty())
             throw new IllegalStateException("no profiles exist but assumed to create EncodingManager. E.g. provide them in GraphHopperConfig when calling GraphHopper.init");
 
@@ -686,7 +686,7 @@ public class GraphHopper {
         AreaIndex<CustomArea> areaIndex = new AreaIndex<>(customAreas);
 
         logger.info("start creating graph from " + osmFile);
-        OSMReader reader = new OSMReader(ghStorage.getBaseGraph(), encodingManager, osmReaderConfig).setFile(_getOSMFile()).
+        OSMReader reader = new OSMReader(ghStorage.getBaseGraph(), tagParserManager, osmReaderConfig).setFile(_getOSMFile()).
                 setAreaIndex(areaIndex).
                 setElevationProvider(eleProvider).
                 setCountryRuleFactory(countryRuleFactory);
@@ -757,19 +757,19 @@ public class GraphHopper {
 
         if (!allowWrites && dataAccessDefaultType.isMMap())
             dataAccessDefaultType = DAType.MMAP_RO;
-        if (encodingManager == null) {
+        if (tagParserManager == null) {
             StorableProperties properties = new StorableProperties(new GHDirectory(ghLocation, dataAccessDefaultType));
-            encodingManager = properties.loadExisting()
-                    ? EncodingManager.create(emBuilder, encodedValueFactory, flagEncoderFactory, properties)
+            tagParserManager = properties.loadExisting()
+                    ? TagParserManager.create(emBuilder, encodedValueFactory, flagEncoderFactory, properties)
                     : buildEncodingManager(new GraphHopperConfig());
         }
 
         GHDirectory directory = new GHDirectory(ghLocation, dataAccessDefaultType);
         directory.configure(dataAccessConfig);
-        ghStorage = new GraphBuilder(encodingManager)
+        ghStorage = new GraphBuilder(tagParserManager.getEncodingManager())
                 .setDir(directory)
                 .set3D(hasElevation())
-                .withTurnCosts(encodingManager.needsTurnCostsSupport())
+                .withTurnCosts(tagParserManager.needsTurnCostsSupport())
                 .setSegmentSize(defaultSegmentSize)
                 .build();
         checkProfilesConsistency();
@@ -802,7 +802,7 @@ public class GraphHopper {
     }
 
     private void checkProfilesConsistency() {
-        EncodingManager encodingManager = getEncodingManager();
+        TagParserManager encodingManager = getTagParserManager();
         for (Profile profile : profilesByName.values()) {
             if (!encodingManager.hasEncoder(profile.getVehicle())) {
                 throw new IllegalArgumentException("Unknown vehicle '" + profile.getVehicle() + "' in profile: " + profile + ". Make sure all vehicles used in 'profiles' exist in 'graph.flag_encoders'");
@@ -959,7 +959,7 @@ public class GraphHopper {
     }
 
     protected WeightingFactory createWeightingFactory() {
-        return new DefaultWeightingFactory(ghStorage.getBaseGraph(), getEncodingManager());
+        return new DefaultWeightingFactory(ghStorage.getBaseGraph(), getTagParserManager().getEncodingManager());
     }
 
     public GHResponse route(GHRequest request) {
@@ -1114,7 +1114,7 @@ public class GraphHopper {
         for (Profile profile : profilesByName.values()) {
             // if turn costs are enabled use u-turn costs of zero as we only want to make sure the graph is fully connected assuming finite u-turn costs
             Weighting weighting = createWeighting(profile, new PMap().putObject(Parameters.Routing.U_TURN_COSTS, 0));
-            jobs.add(new PrepareJob(encodingManager.getBooleanEncodedValue(Subnetwork.key(profile.getName())), weighting));
+            jobs.add(new PrepareJob(tagParserManager.getBooleanEncodedValue(Subnetwork.key(profile.getName())), weighting));
         }
         return jobs;
     }

--- a/core/src/main/java/com/graphhopper/routing/ch/CHPreparationHandler.java
+++ b/core/src/main/java/com/graphhopper/routing/ch/CHPreparationHandler.java
@@ -122,7 +122,7 @@ public class CHPreparationHandler {
         }
         LOGGER.info("Creating CH preparations, {}", getMemInfo());
         List<PrepareContractionHierarchies> preparations = chConfigs.stream()
-                .map(c -> createCHPreparation(ghStorage, c))
+                .map(c -> createCHPreparation(ghStorage.getBaseGraph(), c))
                 .collect(Collectors.toList());
         Map<String, PrepareContractionHierarchies.Result> results = Collections.synchronizedMap(new LinkedHashMap<>());
         List<Callable<String>> callables = new ArrayList<>(preparations.size());
@@ -148,8 +148,8 @@ public class CHPreparationHandler {
         return results;
     }
 
-    private PrepareContractionHierarchies createCHPreparation(GraphHopperStorage ghStorage, CHConfig chConfig) {
-        PrepareContractionHierarchies pch = PrepareContractionHierarchies.fromGraph(ghStorage.getBaseGraph(), chConfig);
+    private PrepareContractionHierarchies createCHPreparation(BaseGraph graph, CHConfig chConfig) {
+        PrepareContractionHierarchies pch = PrepareContractionHierarchies.fromGraph(graph, chConfig);
         pch.setParams(pMap);
         return pch;
     }

--- a/core/src/main/java/com/graphhopper/routing/util/EncodingManager.java
+++ b/core/src/main/java/com/graphhopper/routing/util/EncodingManager.java
@@ -17,12 +17,10 @@
  */
 package com.graphhopper.routing.util;
 
-import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.reader.osm.conditional.DateRangeParser;
 import com.graphhopper.routing.ev.*;
 import com.graphhopper.routing.util.parsers.*;
 import com.graphhopper.storage.IntsRef;
-import com.graphhopper.util.EdgeIteratorState;
 import com.graphhopper.util.PMap;
 
 import java.util.*;
@@ -380,11 +378,6 @@ public class EncodingManager implements EncodedValueLookup {
     @Override
     public int hashCode() {
         return Objects.hash(edgeEncoders, encodedValueMap);
-    }
-
-    public void applyWayTags(ReaderWay way, EdgeIteratorState edge) {
-        for (AbstractFlagEncoder encoder : edgeEncoders)
-            encoder.applyWayTags(way, edge);
     }
 
     public List<FlagEncoder> fetchEdgeEncoders() {

--- a/core/src/main/java/com/graphhopper/routing/util/EncodingManager.java
+++ b/core/src/main/java/com/graphhopper/routing/util/EncodingManager.java
@@ -38,7 +38,7 @@ import static com.graphhopper.util.Helper.toLowerCase;
  * @author Nop
  */
 public class EncodingManager implements EncodedValueLookup {
-    private final List<AbstractFlagEncoder> edgeEncoders;
+    private final List<FlagEncoder> edgeEncoders;
     private final Map<String, EncodedValue> encodedValueMap;
     private final Map<String, TurnCostParser> turnCostParsers;
     private final EncodedValue.InitializerConfig turnCostConfig;
@@ -87,7 +87,7 @@ public class EncodingManager implements EncodedValueLookup {
     }
 
     public EncodingManager(
-            List<AbstractFlagEncoder> edgeEncoders,
+            List<FlagEncoder> edgeEncoders,
             Map<String, EncodedValue> encodedValueMap,
             Map<String, TurnCostParser> turnCostParsers,
             EncodedValue.InitializerConfig turnCostConfig,
@@ -187,7 +187,7 @@ public class EncodingManager implements EncodedValueLookup {
             if (dateRangeParser == null)
                 dateRangeParser = new DateRangeParser(DateRangeParser.createCalendar());
 
-            for (AbstractFlagEncoder encoder : flagEncoderMap.values()) {
+            for (FlagEncoder encoder : flagEncoderMap.values()) {
                 if (encoder instanceof RoadsFlagEncoder) {
                     // TODO Later these EncodedValues can be added independently of RoadsFlagEncoder. Maybe add a foot_access and hgv_access? and remove the others "xy$access"
                     if (!em.hasEncodedValue("car_access"))
@@ -290,7 +290,7 @@ public class EncodingManager implements EncodedValueLookup {
                 return encoder;
         }
         if (throwExc)
-            throw new IllegalArgumentException("FlagEncoder for " + name + " not found. Existing: " + toFlagEncodersAsString());
+            throw new IllegalArgumentException("FlagEncoder for " + name + " not found. Existing: " + edgeEncoders.stream().map(FlagEncoder::toString).collect(Collectors.joining(",")));
         return null;
     }
 
@@ -322,35 +322,6 @@ public class EncodingManager implements EncodedValueLookup {
                 str.append(",");
 
             str.append(encoder.toString());
-        }
-
-        return str.toString();
-    }
-
-    public String toFlagEncodersAsString() {
-        StringBuilder str = new StringBuilder();
-        for (AbstractFlagEncoder encoder : edgeEncoders) {
-            if (str.length() > 0)
-                str.append(",");
-
-            str.append(encoder.toString())
-                    .append("|")
-                    .append(encoder.getPropertiesString());
-        }
-
-        return str.toString();
-    }
-
-    public String toEncodedValuesAsString() {
-        StringBuilder str = new StringBuilder();
-        for (EncodedValue ev : encodedValueMap.values()) {
-            if (!isSharedEncodedValues(ev))
-                continue;
-
-            if (str.length() > 0)
-                str.append(",");
-
-            str.append(ev.toString());
         }
 
         return str.toString();

--- a/core/src/main/java/com/graphhopper/routing/util/TagParserManager.java
+++ b/core/src/main/java/com/graphhopper/routing/util/TagParserManager.java
@@ -17,11 +17,15 @@
  */
 package com.graphhopper.routing.util;
 
+import com.graphhopper.reader.OSMTurnRelation;
+import com.graphhopper.reader.ReaderRelation;
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.reader.osm.conditional.DateRangeParser;
 import com.graphhopper.routing.ev.*;
 import com.graphhopper.routing.util.parsers.*;
+import com.graphhopper.storage.Graph;
 import com.graphhopper.storage.IntsRef;
+import com.graphhopper.storage.StorableProperties;
 import com.graphhopper.util.EdgeIteratorState;
 import com.graphhopper.util.PMap;
 
@@ -29,6 +33,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static com.graphhopper.util.Helper.toLowerCase;
+import static java.util.Collections.emptyMap;
 
 /**
  * Manager class to register encoder, assign their flag values and check objects with all encoders
@@ -39,22 +44,26 @@ import static com.graphhopper.util.Helper.toLowerCase;
  * @author Peter Karich
  * @author Nop
  */
-public class EncodingManager implements EncodedValueLookup {
-    private final List<AbstractFlagEncoder> edgeEncoders;
-    private final Map<String, EncodedValue> encodedValueMap;
-    private final Map<String, TurnCostParser> turnCostParsers;
+public class TagParserManager implements EncodedValueLookup {
+    private final List<AbstractFlagEncoder> edgeEncoders = new ArrayList<>();
+    private final Map<String, EncodedValue> encodedValueMap = new LinkedHashMap<>();
+    private final List<RelationTagParser> relationTagParsers = new ArrayList<>();
+    private final List<TagParser> edgeTagParsers = new ArrayList<>();
+    private final Map<String, TurnCostParser> turnCostParsers = new LinkedHashMap<>();
     private final EncodedValue.InitializerConfig turnCostConfig;
+    private final EncodedValue.InitializerConfig relationConfig;
     private final EncodedValue.InitializerConfig edgeConfig;
+    private EncodingManager encodingManager;
 
     /**
      * Instantiate manager with the given list of encoders. The manager knows several default
      * encoders using DefaultFlagEncoderFactory.
      */
-    public static EncodingManager create(String flagEncodersStr) {
+    public static TagParserManager create(String flagEncodersStr) {
         return create(new DefaultFlagEncoderFactory(), flagEncodersStr);
     }
 
-    public static EncodingManager create(FlagEncoderFactory factory, String flagEncodersStr) {
+    public static TagParserManager create(FlagEncoderFactory factory, String flagEncodersStr) {
         return createBuilder(Arrays.stream(flagEncodersStr.split(",")).filter(s -> !s.trim().isEmpty()).
                 map(s -> parseEncoderString(factory, s)).collect(Collectors.toList())).build();
     }
@@ -62,23 +71,39 @@ public class EncodingManager implements EncodedValueLookup {
     /**
      * Instantiate manager with the given list of encoders.
      */
-    public static EncodingManager create(FlagEncoder... flagEncoders) {
+    public static TagParserManager create(FlagEncoder... flagEncoders) {
         return create(Arrays.asList(flagEncoders));
     }
 
     /**
      * Instantiate manager with the given list of encoders.
      */
-    public static EncodingManager create(List<? extends FlagEncoder> flagEncoders) {
+    public static TagParserManager create(List<? extends FlagEncoder> flagEncoders) {
         return createBuilder(flagEncoders).build();
     }
 
-    private static EncodingManager.Builder createBuilder(List<? extends FlagEncoder> flagEncoders) {
+    private static TagParserManager.Builder createBuilder(List<? extends FlagEncoder> flagEncoders) {
         Builder builder = new Builder();
         for (FlagEncoder flagEncoder : flagEncoders) {
             builder.add(flagEncoder);
         }
         return builder;
+    }
+
+    /**
+     * Create the EncodingManager from the provided GraphHopper location. Throws an
+     * IllegalStateException if it fails. Used if no EncodingManager specified on load.
+     */
+    public static TagParserManager create(TagParserManager.Builder builder, EncodedValueFactory evFactory, FlagEncoderFactory flagEncoderFactory, StorableProperties properties) {
+        String encodedValuesStr = properties.get("graph.encoded_values");
+        for (String evString : encodedValuesStr.split(",")) {
+            builder.addIfAbsent(evFactory, evString);
+        }
+        String flagEncoderValuesStr = properties.get("graph.flag_encoders");
+        for (String encoderString : flagEncoderValuesStr.split(",")) {
+            builder.addIfAbsent(flagEncoderFactory, encoderString);
+        }
+        return builder.build();
     }
 
     /**
@@ -88,35 +113,74 @@ public class EncodingManager implements EncodedValueLookup {
         return new Builder();
     }
 
-    public EncodingManager(
-            List<AbstractFlagEncoder> edgeEncoders,
-            Map<String, EncodedValue> encodedValueMap,
-            Map<String, TurnCostParser> turnCostParsers,
-            EncodedValue.InitializerConfig turnCostConfig,
-            EncodedValue.InitializerConfig edgeConfig) {
-        this.edgeEncoders = edgeEncoders;
-        this.encodedValueMap = encodedValueMap;
-        this.turnCostParsers = turnCostParsers;
-        this.turnCostConfig = turnCostConfig;
-        this.edgeConfig = edgeConfig;
+    private TagParserManager() {
+        this.turnCostConfig = new EncodedValue.InitializerConfig();
+        this.relationConfig = new EncodedValue.InitializerConfig();
+        this.edgeConfig = new EncodedValue.InitializerConfig();
     }
 
-    private EncodingManager() {
-        this(
-                new ArrayList<>(), new LinkedHashMap<>(),
-                new LinkedHashMap<>(), new EncodedValue.InitializerConfig(),
-                new EncodedValue.InitializerConfig()
-        );
+    public EncodingManager getEncodingManager() {
+        return encodingManager;
+    }
+
+    public void releaseParsers() {
+        turnCostParsers.clear();
+        edgeTagParsers.clear();
+        relationTagParsers.clear();
     }
 
     public static class Builder {
-        private EncodingManager em;
+        private TagParserManager em;
         private DateRangeParser dateRangeParser;
         private final Map<String, AbstractFlagEncoder> flagEncoderMap = new LinkedHashMap<>();
         private final Map<String, EncodedValue> encodedValueMap = new LinkedHashMap<>();
+        private final Set<TagParser> tagParserSet = new LinkedHashSet<>();
+        private final List<TurnCostParser> turnCostParsers = new ArrayList<>();
+        private final List<RelationTagParser> relationTagParsers = new ArrayList<>();
 
         public Builder() {
-            em = new EncodingManager();
+            em = new TagParserManager();
+        }
+
+        public boolean addIfAbsent(FlagEncoderFactory factory, String flagEncoderString) {
+            check();
+            String key = flagEncoderString.split("\\|")[0].trim();
+            if (flagEncoderMap.containsKey(key))
+                return false;
+            FlagEncoder fe = parseEncoderString(factory, flagEncoderString);
+            flagEncoderMap.put(fe.toString(), (AbstractFlagEncoder) fe);
+            return true;
+        }
+
+        public boolean addIfAbsent(EncodedValueFactory factory, String encodedValueString) {
+            check();
+            String key = encodedValueString.split("\\|")[0].trim();
+            if (encodedValueMap.containsKey(key))
+                return false;
+            EncodedValue ev = parseEncodedValueString(factory, encodedValueString);
+            encodedValueMap.put(ev.getName(), ev);
+            return true;
+        }
+
+        public boolean addIfAbsent(TagParserFactory factory, String tagParserString) {
+            check();
+            tagParserString = tagParserString.trim();
+            if (tagParserString.isEmpty()) return false;
+
+            TagParser tagParser = parseEncodedValueString(factory, tagParserString);
+            return tagParserSet.add(tagParser);
+        }
+
+        public Builder addTurnCostParser(TurnCostParser parser) {
+            check();
+            turnCostParsers.add(parser);
+            return this;
+        }
+
+        public Builder addRelationTagParser(RelationTagParser tagParser) {
+            check();
+            relationTagParsers.add(tagParser);
+            return this;
         }
 
         public Builder add(FlagEncoder encoder) {
@@ -135,6 +199,24 @@ public class EncodingManager implements EncodedValueLookup {
             return this;
         }
 
+        /**
+         * This method adds the specified TagParser and automatically adds EncodedValues as requested in
+         * createEncodedValues.
+         */
+        public Builder add(TagParser tagParser) {
+            check();
+            if (!tagParserSet.add(tagParser))
+                throw new IllegalArgumentException("TagParser already exists: " + tagParser);
+
+            return this;
+        }
+
+        public Builder setDateRangeParser(DateRangeParser dateRangeParser) {
+            check();
+            this.dateRangeParser = dateRangeParser;
+            return this;
+        }
+
         private void check() {
             if (em == null)
                 throw new IllegalStateException("Cannot call method after Builder.build() was called");
@@ -149,6 +231,18 @@ public class EncodingManager implements EncodedValueLookup {
             for (EncodedValue ev : list) {
                 em.addEncodedValue(ev, withNamespace);
             }
+            em.edgeTagParsers.add(tagParser);
+        }
+
+        private void _addRelationTagParser(RelationTagParser tagParser) {
+            List<EncodedValue> list = new ArrayList<>();
+            tagParser.createRelationEncodedValues(em, list);
+            for (EncodedValue ev : list) {
+                ev.init(em.relationConfig);
+            }
+            em.relationTagParsers.add(tagParser);
+
+            _addEdgeTagParser(tagParser, false);
         }
 
         private void _addTurnCostParser(TurnCostParser parser) {
@@ -164,8 +258,16 @@ public class EncodingManager implements EncodedValueLookup {
             em.turnCostParsers.put(parser.getName(), parser);
         }
 
-        public EncodingManager build() {
+        public TagParserManager build() {
             check();
+
+            for (RelationTagParser tagParser : relationTagParsers) {
+                _addRelationTagParser(tagParser);
+            }
+
+            for (TagParser tagParser : tagParserSet) {
+                _addEdgeTagParser(tagParser, false);
+            }
 
             for (EncodedValue ev : encodedValueMap.values()) {
                 em.addEncodedValue(ev, false);
@@ -198,20 +300,24 @@ public class EncodingManager implements EncodedValueLookup {
                         _addEdgeTagParser(new DefaultTagParserFactory().create("bike_access", new PMap()), false);
                 } else if (encoder instanceof BikeCommonFlagEncoder) {
                     if (!em.hasEncodedValue(RouteNetwork.key("bike")))
-                        _addEdgeTagParser(new OSMBikeNetworkTagParser(), false);
+                        _addRelationTagParser(new OSMBikeNetworkTagParser());
                     if (!em.hasEncodedValue(GetOffBike.KEY))
                         _addEdgeTagParser(new OSMGetOffBikeParser(), false);
                     if (!em.hasEncodedValue(Smoothness.KEY))
                         _addEdgeTagParser(new OSMSmoothnessParser(), false);
                 } else if (encoder instanceof FootFlagEncoder) {
                     if (!em.hasEncodedValue(RouteNetwork.key("foot")))
-                        _addEdgeTagParser(new OSMFootNetworkTagParser(), false);
+                        _addRelationTagParser(new OSMFootNetworkTagParser());
                 }
             }
 
             for (AbstractFlagEncoder encoder : flagEncoderMap.values()) {
                 encoder.init(dateRangeParser);
                 em.addEncoder(encoder);
+            }
+
+            for (TurnCostParser parser : turnCostParsers) {
+                _addTurnCostParser(parser);
             }
 
             // FlagEncoder can demand TurnCostParsers => add them after the explicitly added ones
@@ -223,7 +329,10 @@ public class EncodingManager implements EncodedValueLookup {
             if (em.encodedValueMap.isEmpty())
                 throw new IllegalStateException("No EncodedValues found");
 
-            EncodingManager tmp = em;
+            em.encodingManager = new EncodingManager(em.edgeEncoders, em.encodedValueMap,
+                    em.turnCostParsers, em.turnCostConfig, em.edgeConfig);
+
+            TagParserManager tmp = em;
             em = null;
             return tmp;
         }
@@ -244,6 +353,29 @@ public class EncodingManager implements EncodedValueLookup {
         }
         PMap configuration = new PMap(entryVal);
         return factory.createFlagEncoder(encoderString, configuration);
+    }
+
+    static EncodedValue parseEncodedValueString(EncodedValueFactory factory, String encodedValueString) {
+        if (!encodedValueString.equals(toLowerCase(encodedValueString)))
+            throw new IllegalArgumentException("Use lower case for EncodedValues: " + encodedValueString);
+
+        encodedValueString = encodedValueString.trim();
+        if (encodedValueString.isEmpty())
+            throw new IllegalArgumentException("EncodedValue cannot be empty. " + encodedValueString);
+
+        EncodedValue evObject = factory.create(encodedValueString);
+        PMap map = new PMap(encodedValueString);
+        if (!map.has("version"))
+            throw new IllegalArgumentException("EncodedValue must have a version specified but it was " + encodedValueString);
+        return evObject;
+    }
+
+    private static TagParser parseEncodedValueString(TagParserFactory factory, String tagParserString) {
+        if (!tagParserString.equals(toLowerCase(tagParserString)))
+            throw new IllegalArgumentException("Use lower case for TagParser: " + tagParserString);
+
+        PMap map = new PMap(tagParserString);
+        return factory.create(tagParserString, map);
     }
 
     public int getIntsForFlags() {
@@ -296,24 +428,46 @@ public class EncodingManager implements EncodedValueLookup {
         return null;
     }
 
-    public enum Access {
-        WAY, FERRY, OTHER, CAN_SKIP;
+    /**
+     * Determine whether a way is routable for one of the added encoders.
+     *
+     * @return if at least one encoder consumes the specified way
+     */
+    public boolean acceptWay(ReaderWay way) {
+        return edgeEncoders.stream().anyMatch(encoder -> !encoder.getAccess(way).equals(EncodingManager.Access.CAN_SKIP));
+    }
 
-        public boolean isFerry() {
-            return this.ordinal() == FERRY.ordinal();
+    public IntsRef handleRelationTags(ReaderRelation relation, IntsRef relFlags) {
+        for (RelationTagParser relParser : relationTagParsers) {
+            relParser.handleRelationTags(relFlags, relation);
         }
+        return relFlags;
+    }
 
-        public boolean isWay() {
-            return this.ordinal() == WAY.ordinal();
+    public void handleTurnRelationTags(OSMTurnRelation turnRelation, TurnCostParser.ExternalInternalMap map, Graph graph) {
+        for (TurnCostParser parser : turnCostParsers.values()) {
+            parser.handleTurnRelationTags(turnRelation, map, graph);
         }
+    }
 
-        public boolean isOther() {
-            return this.ordinal() == OTHER.ordinal();
+    /**
+     * Processes way properties of different kind to determine speed and direction.
+     *
+     * @param relationFlags The preprocessed relation flags is used to influence the way properties.
+     */
+    public IntsRef handleWayTags(ReaderWay way, IntsRef relationFlags) {
+        IntsRef edgeFlags = createEdgeFlags();
+        for (TagParser parser : edgeTagParsers) {
+            parser.handleWayTags(edgeFlags, way, relationFlags);
         }
-
-        public boolean canSkip() {
-            return this.ordinal() == CAN_SKIP.ordinal();
+        for (AbstractFlagEncoder encoder : edgeEncoders) {
+            encoder.handleWayTags(edgeFlags, way);
+            if (!edgeFlags.isEmpty()) {
+                Map<String, Object> nodeTags = way.getTag("node_tags", emptyMap());
+                encoder.handleNodeTags(edgeFlags, nodeTags);
+            }
         }
+        return edgeFlags;
     }
 
     @Override
@@ -372,7 +526,7 @@ public class EncodingManager implements EncodedValueLookup {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        EncodingManager that = (EncodingManager) o;
+        TagParserManager that = (TagParserManager) o;
         return edgeEncoders.equals(that.edgeEncoders) &&
                 encodedValueMap.equals(that.encodedValueMap);
     }

--- a/core/src/main/java/com/graphhopper/routing/util/TagParserManager.java
+++ b/core/src/main/java/com/graphhopper/routing/util/TagParserManager.java
@@ -32,6 +32,7 @@ import com.graphhopper.util.PMap;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static com.graphhopper.routing.util.EncodingManager.isValidEncodedValue;
 import static com.graphhopper.util.Helper.toLowerCase;
 import static java.util.Collections.emptyMap;
 
@@ -329,7 +330,7 @@ public class TagParserManager implements EncodedValueLookup {
             if (em.encodedValueMap.isEmpty())
                 throw new IllegalStateException("No EncodedValues found");
 
-            em.encodingManager = new EncodingManager(em.edgeEncoders, em.encodedValueMap,
+            em.encodingManager = new EncodingManager(new ArrayList<>(em.edgeEncoders), em.encodedValueMap,
                     em.turnCostParsers, em.turnCostConfig, em.edgeConfig);
 
             TagParserManager tmp = em;
@@ -598,68 +599,4 @@ public class TagParserManager implements EncodedValueLookup {
         return isValidEncodedValue(ev.getName()) && !ev.getName().contains(SPECIAL_SEPARATOR);
     }
 
-    /**
-     * All EncodedValue names that are created from a FlagEncoder should use this method to mark them as
-     * "none-shared" across the other FlagEncoders.
-     */
-    public static String getKey(FlagEncoder encoder, String str) {
-        return getKey(encoder.toString(), str);
-    }
-
-    public static String getKey(String prefix, String str) {
-        return prefix + SPECIAL_SEPARATOR + str;
-    }
-
-    // copied from janino
-    private static final Set<String> KEYWORDS = new HashSet<>(Arrays.asList(
-            "first_match",
-            "abstract", "assert",
-            "boolean", "break", "byte",
-            "case", "catch", "char", "class", "const", "continue",
-            "default", "do", "double",
-            "else", "enum", "extends",
-            "false", "final", "finally", "float", "for",
-            "goto",
-            "if", "implements", "import", "instanceof", "int", "interface",
-            "long",
-            "native", "new", "non-sealed", "null",
-            "package", "permits", "private", "protected", "public",
-            "record", "return",
-            "sealed", "short", "static", "strictfp", "super", "switch", "synchronized",
-            "this", "throw", "throws", "transient", "true", "try",
-            "var", "void", "volatile",
-            "while",
-            "yield",
-            "_"
-    ));
-
-    public static boolean isValidEncodedValue(String name) {
-        // first character must be a lower case letter
-        if (name.isEmpty() || !isLowerLetter(name.charAt(0)) || KEYWORDS.contains(name)) return false;
-
-        int dollarCount = 0, underscoreCount = 0;
-        for (int i = 1; i < name.length(); i++) {
-            char c = name.charAt(i);
-            if (c == '$') {
-                if (dollarCount > 0) return false;
-                dollarCount++;
-            } else if (c == '_') {
-                if (underscoreCount > 0) return false;
-                underscoreCount++;
-            } else if (!isLowerLetter(c) && !isNumber(c)) {
-                return false;
-            } else {
-                underscoreCount = 0;
-            }
-        }
-        return true;
-    }
-
-    private static boolean isNumber(char c) {
-        return c >= '0' && c <= '9';
-    }
-
-    private static boolean isLowerLetter(char c) {
-        return c >= 'a' && c <= 'z';
-    }
 }

--- a/core/src/main/java/com/graphhopper/storage/GraphBuilder.java
+++ b/core/src/main/java/com/graphhopper/storage/GraphBuilder.java
@@ -17,7 +17,7 @@
  */
 package com.graphhopper.storage;
 
-import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.routing.util.TagParserManager;
 
 /**
  * Used to build {@link GraphHopperStorage}
@@ -26,20 +26,20 @@ import com.graphhopper.routing.util.EncodingManager;
  * @author easbar
  */
 public class GraphBuilder {
-    private final EncodingManager encodingManager;
+    private final TagParserManager tagParserManager;
     private Directory dir = new RAMDirectory();
     private boolean elevation;
     private boolean turnCosts;
     private long bytes = 100;
     private int segmentSize = -1;
 
-    public static GraphBuilder start(EncodingManager encodingManager) {
-        return new GraphBuilder(encodingManager);
+    public static GraphBuilder start(TagParserManager tagParserManager) {
+        return new GraphBuilder(tagParserManager);
     }
 
-    public GraphBuilder(EncodingManager encodingManager) {
-        this.encodingManager = encodingManager;
-        this.turnCosts = encodingManager.needsTurnCostsSupport();
+    public GraphBuilder(TagParserManager tagParserManager) {
+        this.tagParserManager = tagParserManager;
+        this.turnCosts = tagParserManager.needsTurnCostsSupport();
     }
 
     public GraphBuilder setDir(Directory dir) {
@@ -84,7 +84,7 @@ public class GraphBuilder {
      * {@link #create} directly.
      */
     public GraphHopperStorage build() {
-        return new GraphHopperStorage(dir, encodingManager, elevation, turnCosts, segmentSize);
+        return new GraphHopperStorage(dir, tagParserManager, elevation, turnCosts, segmentSize);
     }
 
     /**

--- a/core/src/main/java/com/graphhopper/storage/GraphHopperStorage.java
+++ b/core/src/main/java/com/graphhopper/storage/GraphHopperStorage.java
@@ -20,6 +20,7 @@ package com.graphhopper.storage;
 import com.graphhopper.routing.util.AllEdgesIterator;
 import com.graphhopper.routing.util.EdgeFilter;
 import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.routing.util.TagParserManager;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.util.Constants;
 import com.graphhopper.util.EdgeExplorer;
@@ -39,21 +40,21 @@ import java.io.Closeable;
  */
 public final class GraphHopperStorage implements Graph, Closeable {
     private final Directory dir;
-    private final EncodingManager encodingManager;
+    private final TagParserManager tagParserManager;
     private final StorableProperties properties;
     private final BaseGraph baseGraph;
 
     /**
      * Use {@link GraphBuilder} to create a graph
      */
-    public GraphHopperStorage(Directory dir, EncodingManager encodingManager, boolean withElevation, boolean withTurnCosts, int segmentSize) {
-        if (encodingManager == null)
+    public GraphHopperStorage(Directory dir, TagParserManager tagParserManager, boolean withElevation, boolean withTurnCosts, int segmentSize) {
+        if (tagParserManager == null)
             throw new IllegalArgumentException("EncodingManager needs to be non-null since 0.7. Create one using EncodingManager.create or EncodingManager.create(flagEncoderFactory, ghLocation)");
 
-        this.encodingManager = encodingManager;
+        this.tagParserManager = tagParserManager;
         this.dir = dir;
         this.properties = new StorableProperties(dir);
-        baseGraph = new BaseGraph(dir, encodingManager.getIntsForFlags(), withElevation, withTurnCosts, segmentSize);
+        baseGraph = new BaseGraph(dir, tagParserManager.getIntsForFlags(), withElevation, withTurnCosts, segmentSize);
     }
 
     /**
@@ -68,21 +69,25 @@ public final class GraphHopperStorage implements Graph, Closeable {
      */
     public GraphHopperStorage create(long byteCount) {
         baseGraph.checkNotInitialized();
-        if (encodingManager == null)
+        if (tagParserManager == null)
             throw new IllegalStateException("EncodingManager can only be null if you call loadExisting");
 
         dir.create();
 
         properties.create(100);
-        properties.put("graph.encoded_values", encodingManager.toEncodedValuesAsString());
-        properties.put("graph.flag_encoders", encodingManager.toFlagEncodersAsString());
+        properties.put("graph.encoded_values", tagParserManager.toEncodedValuesAsString());
+        properties.put("graph.flag_encoders", tagParserManager.toFlagEncodersAsString());
 
         baseGraph.create(Math.max(byteCount, 100));
         return this;
     }
 
+    public TagParserManager getTagParserManager() {
+        return tagParserManager;
+    }
+
     public EncodingManager getEncodingManager() {
-        return encodingManager;
+        return tagParserManager.getEncodingManager();
     }
 
     public StorableProperties getProperties() {
@@ -98,17 +103,17 @@ public final class GraphHopperStorage implements Graph, Closeable {
             // check encoding for compatibility
             String flagEncodersStr = properties.get("graph.flag_encoders");
 
-            if (!encodingManager.toFlagEncodersAsString().equalsIgnoreCase(flagEncodersStr)) {
+            if (!tagParserManager.toFlagEncodersAsString().equalsIgnoreCase(flagEncodersStr)) {
                 throw new IllegalStateException("Encoding does not match:"
-                        + "\nGraphhopper config: " + encodingManager.toFlagEncodersAsString()
+                        + "\nGraphhopper config: " + tagParserManager.toFlagEncodersAsString()
                         + "\nGraph: " + flagEncodersStr
                         + "\nChange configuration to match the graph or delete " + dir.getLocation());
             }
 
             String encodedValueStr = properties.get("graph.encoded_values");
-            if (!encodingManager.toEncodedValuesAsString().equalsIgnoreCase(encodedValueStr)) {
+            if (!tagParserManager.toEncodedValuesAsString().equalsIgnoreCase(encodedValueStr)) {
                 throw new IllegalStateException("Encoded values do not match:"
-                        + "\nGraphhopper config: " + encodingManager.toEncodedValuesAsString()
+                        + "\nGraphhopper config: " + tagParserManager.toEncodedValuesAsString()
                         + "\nGraph: " + encodedValueStr
                         + "\nChange configuration to match the graph or delete " + dir.getLocation());
             }
@@ -157,7 +162,7 @@ public final class GraphHopperStorage implements Graph, Closeable {
 
     @Override
     public String toString() {
-        return encodingManager
+        return tagParserManager
                 + "|" + getDirectory().getDefaultType()
                 + "|" + baseGraph.nodeAccess.getDimension() + "D"
                 + "|" + (baseGraph.supportsTurnCosts() ? baseGraph.turnCostStorage : "no_turn_cost")

--- a/core/src/main/java/com/graphhopper/util/GHUtility.java
+++ b/core/src/main/java/com/graphhopper/util/GHUtility.java
@@ -417,7 +417,7 @@ public class GHUtility {
     public static GraphHopperStorage newStorage(GraphHopperStorage store) {
         Directory outdir = guessDirectory(store);
         boolean is3D = store.getNodeAccess().is3D();
-        return new GraphBuilder(store.getEncodingManager())
+        return new GraphBuilder(store.getTagParserManager())
                 .withTurnCosts(store.getTurnCostStorage() != null)
                 .set3D(is3D)
                 .setDir(outdir)

--- a/core/src/test/java/com/graphhopper/GraphHopperProfileTest.java
+++ b/core/src/test/java/com/graphhopper/GraphHopperProfileTest.java
@@ -62,7 +62,7 @@ public class GraphHopperProfileTest {
     @Test
     public void vehicleDoesNotExist_error() {
         final GraphHopper hopper = new GraphHopper();
-        hopper.getEncodingManagerBuilder().add(new CarFlagEncoder());
+        hopper.getTagParserManagerBuilder().add(new CarFlagEncoder());
         hopper.setGraphHopperLocation(GH_LOCATION).setStoreOnFlush(false).
                 setProfiles(new Profile("profile").setVehicle("your_car"));
         assertIllegalArgument(hopper::load, "entry in encoder list not supported: your_car");

--- a/core/src/test/java/com/graphhopper/GraphHopperTest.java
+++ b/core/src/test/java/com/graphhopper/GraphHopperTest.java
@@ -1048,7 +1048,7 @@ public class GraphHopperTest {
                 setStoreOnFlush(true);
 
         if (!withTunnelInterpolation) {
-            hopper.getEncodingManagerBuilder().add(new OSMRoadEnvironmentParser() {
+            hopper.getTagParserManagerBuilder().add(new OSMRoadEnvironmentParser() {
                 @Override
                 public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay readerWay, IntsRef relationFlags) {
                     // do not change RoadEnvironment to avoid triggering tunnel interpolation
@@ -1322,7 +1322,7 @@ public class GraphHopperTest {
                 new CHProfile(profile2)
         );
         hopper.importOrLoad();
-        String str = hopper.getEncodingManager().toString();
+        String str = hopper.getTagParserManager().toString();
         GHResponse rsp = hopper.route(new GHRequest(43.73005, 7.415707, 43.741522, 7.42826)
                 .setProfile("profile2"));
         ResponsePath res = rsp.getBest();
@@ -2121,7 +2121,7 @@ public class GraphHopperTest {
     public void simplifyWithInstructionsAndPathDetails() {
         final String profile = "profile";
         GraphHopper hopper = new GraphHopper();
-        hopper.getEncodingManagerBuilder()
+        hopper.getTagParserManagerBuilder()
                 .add(new OSMMaxSpeedParser())
                 .add(new CarFlagEncoder());
         hopper.setOSMFile(BAYREUTH).
@@ -2278,7 +2278,7 @@ public class GraphHopperTest {
                 setMinNetworkSize(200);
         hopper.importOrLoad();
         Weighting weighting = hopper.createWeighting(hopper.getProfile(profile), new PMap());
-        EdgeFilter edgeFilter = new DefaultSnapFilter(weighting, hopper.getEncodingManager().getBooleanEncodedValue(Subnetwork.key(profile)));
+        EdgeFilter edgeFilter = new DefaultSnapFilter(weighting, hopper.getTagParserManager().getBooleanEncodedValue(Subnetwork.key(profile)));
         LocationIndexTree locationIndex = ((LocationIndexTree) hopper.getLocationIndex());
         locationIndex.setMaxRegionSearch(6); // have to increase the default search radius to find our snap
         Snap snap = locationIndex.findClosest(51.229248, 12.328892, edgeFilter);
@@ -2301,7 +2301,7 @@ public class GraphHopperTest {
                 setMinNetworkSize(200);
         hopper.importOrLoad();
         Weighting weighting = hopper.createWeighting(hopper.getProfile(profile), new PMap());
-        EdgeFilter edgeFilter = new DefaultSnapFilter(weighting, hopper.getEncodingManager().getBooleanEncodedValue(Subnetwork.key(profile)));
+        EdgeFilter edgeFilter = new DefaultSnapFilter(weighting, hopper.getTagParserManager().getBooleanEncodedValue(Subnetwork.key(profile)));
         Snap snap = hopper.getLocationIndex().findClosest(51.229248, 12.328892, edgeFilter);
         if (snap.isValid()) {
             assertTrue(snap.getQueryDistance() < 3_000);

--- a/core/src/test/java/com/graphhopper/reader/dem/BridgeElevationInterpolatorTest.java
+++ b/core/src/test/java/com/graphhopper/reader/dem/BridgeElevationInterpolatorTest.java
@@ -73,7 +73,7 @@ public class BridgeElevationInterpolatorTest extends EdgeElevationInterpolatorTe
         na.setNode(8, 30, 10, 10);
         na.setNode(9, 40, 10, 0);
 
-        FlagEncoder encoder = encodingManager.getEncoder("car");
+        FlagEncoder encoder = tagParserManager.getEncoder("car");
         EdgeIteratorState edge01, edge12, edge23, edge34, edge56, edge67, edge78, edge89, edge17, edge27, edge37;
         GHUtility.setSpeed(60, 60, encoder,
                 edge01 = graph.edge(0, 1).setDistance(10),
@@ -90,20 +90,20 @@ public class BridgeElevationInterpolatorTest extends EdgeElevationInterpolatorTe
 
         edge17.setWayGeometry(Helper.createPointList3D(12, 2, 200, 14, 4, 400, 16, 6, 600, 18, 8, 800));
 
-        IntsRef relFlags = encodingManager.createRelationFlags();
-        edge01.setFlags(encodingManager.handleWayTags(normalWay, relFlags));
-        edge12.setFlags(encodingManager.handleWayTags(normalWay, relFlags));
-        edge23.setFlags(encodingManager.handleWayTags(normalWay, relFlags));
-        edge34.setFlags(encodingManager.handleWayTags(normalWay, relFlags));
+        IntsRef relFlags = tagParserManager.createRelationFlags();
+        edge01.setFlags(tagParserManager.handleWayTags(normalWay, relFlags));
+        edge12.setFlags(tagParserManager.handleWayTags(normalWay, relFlags));
+        edge23.setFlags(tagParserManager.handleWayTags(normalWay, relFlags));
+        edge34.setFlags(tagParserManager.handleWayTags(normalWay, relFlags));
 
-        edge56.setFlags(encodingManager.handleWayTags(normalWay, relFlags));
-        edge67.setFlags(encodingManager.handleWayTags(interpolatableWay, relFlags));
-        edge78.setFlags(encodingManager.handleWayTags(interpolatableWay, relFlags));
-        edge89.setFlags(encodingManager.handleWayTags(normalWay, relFlags));
+        edge56.setFlags(tagParserManager.handleWayTags(normalWay, relFlags));
+        edge67.setFlags(tagParserManager.handleWayTags(interpolatableWay, relFlags));
+        edge78.setFlags(tagParserManager.handleWayTags(interpolatableWay, relFlags));
+        edge89.setFlags(tagParserManager.handleWayTags(normalWay, relFlags));
 
-        edge17.setFlags(encodingManager.handleWayTags(interpolatableWay, relFlags));
-        edge27.setFlags(encodingManager.handleWayTags(interpolatableWay, relFlags));
-        edge37.setFlags(encodingManager.handleWayTags(interpolatableWay, relFlags));
+        edge17.setFlags(tagParserManager.handleWayTags(interpolatableWay, relFlags));
+        edge27.setFlags(tagParserManager.handleWayTags(interpolatableWay, relFlags));
+        edge37.setFlags(tagParserManager.handleWayTags(interpolatableWay, relFlags));
 
         final GHIntHashSet outerNodeIds = new GHIntHashSet();
         final GHIntHashSet innerNodeIds = new GHIntHashSet();

--- a/core/src/test/java/com/graphhopper/reader/dem/EdgeElevationInterpolatorTest.java
+++ b/core/src/test/java/com/graphhopper/reader/dem/EdgeElevationInterpolatorTest.java
@@ -23,8 +23,8 @@ import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.EnumEncodedValue;
 import com.graphhopper.routing.ev.RoadEnvironment;
 import com.graphhopper.routing.util.CarFlagEncoder;
-import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.routing.util.FootFlagEncoder;
+import com.graphhopper.routing.util.TagParserManager;
 import com.graphhopper.storage.BaseGraph;
 import com.graphhopper.storage.IntsRef;
 import com.graphhopper.util.EdgeIteratorState;
@@ -42,19 +42,18 @@ public abstract class EdgeElevationInterpolatorTest {
 
     protected BaseGraph graph;
     protected EnumEncodedValue<RoadEnvironment> roadEnvEnc;
-    protected EncodingManager encodingManager;
+    protected TagParserManager tagParserManager;
     protected IntsRef relFlags;
     protected EdgeElevationInterpolator edgeElevationInterpolator;
 
     @SuppressWarnings("resource")
     @BeforeEach
     public void setUp() {
-        graph = new BaseGraph.Builder(
-                encodingManager = new EncodingManager.Builder().add(new CarFlagEncoder()).add(new FootFlagEncoder()).build()
-        ).set3D(true).create();
-        roadEnvEnc = encodingManager.getEnumEncodedValue(RoadEnvironment.KEY, RoadEnvironment.class);
+        tagParserManager = new TagParserManager.Builder().add(new CarFlagEncoder()).add(new FootFlagEncoder()).build();
+        graph = new BaseGraph.Builder(tagParserManager.getEncodingManager()).set3D(true).create();
+        roadEnvEnc = tagParserManager.getEnumEncodedValue(RoadEnvironment.KEY, RoadEnvironment.class);
         edgeElevationInterpolator = createEdgeElevationInterpolator();
-        relFlags = encodingManager.createRelationFlags();
+        relFlags = tagParserManager.createRelationFlags();
         interpolatableWay = createInterpolatableWay();
         normalWay = new ReaderWay(0);
         normalWay.setTag("highway", "primary");

--- a/core/src/test/java/com/graphhopper/reader/dem/TunnelElevationInterpolatorTest.java
+++ b/core/src/test/java/com/graphhopper/reader/dem/TunnelElevationInterpolatorTest.java
@@ -63,14 +63,14 @@ public class TunnelElevationInterpolatorTest extends EdgeElevationInterpolatorTe
         na.setNode(3, 30, 0, 20);
         na.setNode(4, 40, 0, 0);
 
-        FlagEncoder encoder = encodingManager.getEncoder("car");
+        FlagEncoder encoder = tagParserManager.getEncoder("car");
         EdgeIteratorState edge01 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(10));
         EdgeIteratorState edge12 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(10));
         EdgeIteratorState edge34 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 4).setDistance(10));
 
-        edge01.setFlags(encodingManager.handleWayTags(interpolatableWay, relFlags));
-        edge12.setFlags(encodingManager.handleWayTags(interpolatableWay, relFlags));
-        edge34.setFlags(encodingManager.handleWayTags(interpolatableWay, relFlags));
+        edge01.setFlags(tagParserManager.handleWayTags(interpolatableWay, relFlags));
+        edge12.setFlags(tagParserManager.handleWayTags(interpolatableWay, relFlags));
+        edge34.setFlags(tagParserManager.handleWayTags(interpolatableWay, relFlags));
 
         final GHIntHashSet outerNodeIds = new GHIntHashSet();
         final GHIntHashSet innerNodeIds = new GHIntHashSet();
@@ -103,16 +103,16 @@ public class TunnelElevationInterpolatorTest extends EdgeElevationInterpolatorTe
         na.setNode(3, 30, 0, 20);
         na.setNode(4, 40, 0, 00);
 
-        FlagEncoder encoder = encodingManager.getEncoder("car");
+        FlagEncoder encoder = tagParserManager.getEncoder("car");
         EdgeIteratorState edge01 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(10));
         EdgeIteratorState edge12 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(10));
         EdgeIteratorState edge23 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 3).setDistance(10));
         EdgeIteratorState edge34 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 4).setDistance(10));
 
-        edge01.setFlags(encodingManager.handleWayTags(interpolatableWay, relFlags));
-        edge12.setFlags(encodingManager.handleWayTags(interpolatableWay, relFlags));
-        edge23.setFlags(encodingManager.handleWayTags(normalWay, relFlags));
-        edge34.setFlags(encodingManager.handleWayTags(interpolatableWay, relFlags));
+        edge01.setFlags(tagParserManager.handleWayTags(interpolatableWay, relFlags));
+        edge12.setFlags(tagParserManager.handleWayTags(interpolatableWay, relFlags));
+        edge23.setFlags(tagParserManager.handleWayTags(normalWay, relFlags));
+        edge34.setFlags(tagParserManager.handleWayTags(interpolatableWay, relFlags));
 
         final GHIntHashSet outerNodeIds = new GHIntHashSet();
         final GHIntHashSet innerNodeIds = new GHIntHashSet();
@@ -145,16 +145,16 @@ public class TunnelElevationInterpolatorTest extends EdgeElevationInterpolatorTe
         na.setNode(3, 30, 0, 30);
         na.setNode(4, 40, 0, 40);
 
-        FlagEncoder encoder = encodingManager.getEncoder("car");
+        FlagEncoder encoder = tagParserManager.getEncoder("car");
         EdgeIteratorState edge01 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(10));
         EdgeIteratorState edge12 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(10));
         EdgeIteratorState edge23 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 3).setDistance(10));
         EdgeIteratorState edge34 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 4).setDistance(10));
 
-        edge01.setFlags(encodingManager.handleWayTags(normalWay, relFlags));
-        edge12.setFlags(encodingManager.handleWayTags(interpolatableWay, relFlags));
-        edge23.setFlags(encodingManager.handleWayTags(interpolatableWay, relFlags));
-        edge34.setFlags(encodingManager.handleWayTags(normalWay, relFlags));
+        edge01.setFlags(tagParserManager.handleWayTags(normalWay, relFlags));
+        edge12.setFlags(tagParserManager.handleWayTags(interpolatableWay, relFlags));
+        edge23.setFlags(tagParserManager.handleWayTags(interpolatableWay, relFlags));
+        edge34.setFlags(tagParserManager.handleWayTags(normalWay, relFlags));
 
         final GHIntHashSet outerNodeIds = new GHIntHashSet();
         final GHIntHashSet innerNodeIds = new GHIntHashSet();
@@ -196,7 +196,7 @@ public class TunnelElevationInterpolatorTest extends EdgeElevationInterpolatorTe
         na.setNode(6, 30, 10, 30);
         na.setNode(7, 40, 10, 40);
 
-        FlagEncoder encoder = encodingManager.getEncoder("car");
+        FlagEncoder encoder = tagParserManager.getEncoder("car");
         EdgeIteratorState edge01 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(10));
         EdgeIteratorState edge12 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(10));
         EdgeIteratorState edge23 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 3).setDistance(10));
@@ -205,13 +205,13 @@ public class TunnelElevationInterpolatorTest extends EdgeElevationInterpolatorTe
         EdgeIteratorState edge56 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(5, 6).setDistance(10));
         EdgeIteratorState edge67 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(6, 7).setDistance(10));
 
-        edge01.setFlags(encodingManager.handleWayTags(normalWay, relFlags));
-        edge12.setFlags(encodingManager.handleWayTags(interpolatableWay, relFlags));
-        edge23.setFlags(encodingManager.handleWayTags(interpolatableWay, relFlags));
-        edge34.setFlags(encodingManager.handleWayTags(normalWay, relFlags));
-        edge25.setFlags(encodingManager.handleWayTags(interpolatableWay, relFlags));
-        edge56.setFlags(encodingManager.handleWayTags(interpolatableWay, relFlags));
-        edge67.setFlags(encodingManager.handleWayTags(normalWay, relFlags));
+        edge01.setFlags(tagParserManager.handleWayTags(normalWay, relFlags));
+        edge12.setFlags(tagParserManager.handleWayTags(interpolatableWay, relFlags));
+        edge23.setFlags(tagParserManager.handleWayTags(interpolatableWay, relFlags));
+        edge34.setFlags(tagParserManager.handleWayTags(normalWay, relFlags));
+        edge25.setFlags(tagParserManager.handleWayTags(interpolatableWay, relFlags));
+        edge56.setFlags(tagParserManager.handleWayTags(interpolatableWay, relFlags));
+        edge67.setFlags(tagParserManager.handleWayTags(normalWay, relFlags));
 
         final GHIntHashSet outerNodeIds = new GHIntHashSet();
         final GHIntHashSet innerNodeIds = new GHIntHashSet();
@@ -258,7 +258,7 @@ public class TunnelElevationInterpolatorTest extends EdgeElevationInterpolatorTe
         na.setNode(8, 30, 10, 10);
         na.setNode(9, 40, 10, 0);
 
-        FlagEncoder encoder = encodingManager.getEncoder("car");
+        FlagEncoder encoder = tagParserManager.getEncoder("car");
         EdgeIteratorState edge01, edge12, edge23, edge34, edge56, edge67, edge78, edge89, edge27;
         GHUtility.setSpeed(60, 60, encoder,
                 edge01 = graph.edge(0, 1).setDistance(10),
@@ -271,17 +271,17 @@ public class TunnelElevationInterpolatorTest extends EdgeElevationInterpolatorTe
                 edge89 = graph.edge(8, 9).setDistance(10),
                 edge27 = graph.edge(2, 7).setDistance(10));
 
-        edge01.setFlags(encodingManager.handleWayTags(normalWay, relFlags));
-        edge12.setFlags(encodingManager.handleWayTags(interpolatableWay, relFlags));
-        edge23.setFlags(encodingManager.handleWayTags(interpolatableWay, relFlags));
-        edge34.setFlags(encodingManager.handleWayTags(normalWay, relFlags));
+        edge01.setFlags(tagParserManager.handleWayTags(normalWay, relFlags));
+        edge12.setFlags(tagParserManager.handleWayTags(interpolatableWay, relFlags));
+        edge23.setFlags(tagParserManager.handleWayTags(interpolatableWay, relFlags));
+        edge34.setFlags(tagParserManager.handleWayTags(normalWay, relFlags));
 
-        edge56.setFlags(encodingManager.handleWayTags(normalWay, relFlags));
-        edge67.setFlags(encodingManager.handleWayTags(interpolatableWay, relFlags));
-        edge78.setFlags(encodingManager.handleWayTags(interpolatableWay, relFlags));
-        edge89.setFlags(encodingManager.handleWayTags(normalWay, relFlags));
+        edge56.setFlags(tagParserManager.handleWayTags(normalWay, relFlags));
+        edge67.setFlags(tagParserManager.handleWayTags(interpolatableWay, relFlags));
+        edge78.setFlags(tagParserManager.handleWayTags(interpolatableWay, relFlags));
+        edge89.setFlags(tagParserManager.handleWayTags(normalWay, relFlags));
 
-        edge27.setFlags(encodingManager.handleWayTags(interpolatableWay, relFlags));
+        edge27.setFlags(tagParserManager.handleWayTags(interpolatableWay, relFlags));
 
         final GHIntHashSet outerNodeIds = new GHIntHashSet();
         final GHIntHashSet innerNodeIds = new GHIntHashSet();

--- a/core/src/test/java/com/graphhopper/reader/osm/OSMReaderTest.java
+++ b/core/src/test/java/com/graphhopper/reader/osm/OSMReaderTest.java
@@ -998,7 +998,7 @@ public class OSMReaderTest {
 
         @Override
         protected void importOSM() {
-            GraphHopperStorage tmpGraph = new GraphBuilder(getTagParserManager().getEncodingManager()).set3D(hasElevation()).withTurnCosts(getTagParserManager().needsTurnCostsSupport()).build();
+            GraphHopperStorage tmpGraph = new GraphBuilder(getTagParserManager()).set3D(hasElevation()).withTurnCosts(getTagParserManager().needsTurnCostsSupport()).build();
             setGraphHopperStorage(tmpGraph);
             super.importOSM();
             carAccessEnc = carEncoder.getAccessEnc();

--- a/core/src/test/java/com/graphhopper/reader/osm/OSMReaderTest.java
+++ b/core/src/test/java/com/graphhopper/reader/osm/OSMReaderTest.java
@@ -401,7 +401,7 @@ public class OSMReaderTest {
     public void testFords() {
         CarFlagEncoder car = new CarFlagEncoder(new PMap("block_fords=true"));
         GraphHopper hopper = new GraphHopper();
-        hopper.getEncodingManagerBuilder().add(car);
+        hopper.getTagParserManagerBuilder().add(car);
         hopper.setOSMFile(getClass().getResource("test-barriers3.xml").getFile()).
                 setGraphHopperLocation(dir).
                 setProfiles(
@@ -412,7 +412,7 @@ public class OSMReaderTest {
         Graph graph = hopper.getGraphHopperStorage();
         // our way is split into five edges, because there are two ford nodes
         assertEquals(5, graph.getEdges());
-        FlagEncoder encoder = hopper.getEncodingManager().fetchEdgeEncoders().get(0);
+        FlagEncoder encoder = hopper.getTagParserManager().fetchEdgeEncoders().get(0);
         int blocked = 0;
         int notBlocked = 0;
         AllEdgesIterator edge = graph.getAllEdges();
@@ -495,7 +495,7 @@ public class OSMReaderTest {
 
     @Test
     public void testRelation() {
-        EncodingManager manager = EncodingManager.create("bike");
+        TagParserManager manager = TagParserManager.create("bike");
         ReaderRelation osmRel = new ReaderRelation(1);
         osmRel.add(new ReaderRelation.Member(ReaderRelation.WAY, 1, ""));
         osmRel.add(new ReaderRelation.Member(ReaderRelation.WAY, 2, ""));
@@ -549,7 +549,7 @@ public class OSMReaderTest {
         // (2-3)->(3-4) only_straight_on = (2-3)->(3-8) restricted
         // (4-3)->(3-8) no_right_turn = (4-3)->(3-8) restricted
         // (2-3)->(3-8) no_entry = (2-3)->(3-8) restricted
-        DecimalEncodedValue carTCEnc = hopper.getEncodingManager().getDecimalEncodedValue(TurnCost.key("car"));
+        DecimalEncodedValue carTCEnc = hopper.getTagParserManager().getDecimalEncodedValue(TurnCost.key("car"));
         assertTrue(tcStorage.get(carTCEnc, edge2_3, n3, edge3_8) > 0);
         assertTrue(tcStorage.get(carTCEnc, edge4_3, n3, edge3_8) > 0);
         assertTrue(tcStorage.get(carTCEnc, edge2_3, n3, edge3_8) > 0);
@@ -571,7 +571,7 @@ public class OSMReaderTest {
         assertTrue(tcStorage.get(carTCEnc, edge4_5, n5, edge5_6) == 0);
         assertTrue(tcStorage.get(carTCEnc, edge4_5, n5, edge5_1) > 0);
 
-        DecimalEncodedValue bikeTCEnc = hopper.getEncodingManager().getDecimalEncodedValue(TurnCost.key("bike"));
+        DecimalEncodedValue bikeTCEnc = hopper.getTagParserManager().getDecimalEncodedValue(TurnCost.key("bike"));
         assertTrue(tcStorage.get(bikeTCEnc, edge4_5, n5, edge5_6) == 0);
 
         int n10 = AbstractGraphStorageTester.getIdOf(graph, 40, 10);
@@ -592,12 +592,12 @@ public class OSMReaderTest {
     public void testRoadAttributes() {
         String fileRoadAttributes = "test-road-attributes.xml";
         GraphHopper hopper = new GraphHopperFacade(fileRoadAttributes);
-        hopper.getEncodingManagerBuilder().add(new OSMMaxWidthParser()).add(new OSMMaxHeightParser()).add(new OSMMaxWeightParser());
+        hopper.getTagParserManagerBuilder().add(new OSMMaxWidthParser()).add(new OSMMaxHeightParser()).add(new OSMMaxWeightParser());
         hopper.importOrLoad();
 
-        DecimalEncodedValue widthEnc = hopper.getEncodingManager().getDecimalEncodedValue(MaxWidth.KEY);
-        DecimalEncodedValue heightEnc = hopper.getEncodingManager().getDecimalEncodedValue(MaxHeight.KEY);
-        DecimalEncodedValue weightEnc = hopper.getEncodingManager().getDecimalEncodedValue(MaxWeight.KEY);
+        DecimalEncodedValue widthEnc = hopper.getTagParserManager().getDecimalEncodedValue(MaxWidth.KEY);
+        DecimalEncodedValue heightEnc = hopper.getTagParserManager().getDecimalEncodedValue(MaxHeight.KEY);
+        DecimalEncodedValue weightEnc = hopper.getTagParserManager().getDecimalEncodedValue(MaxWeight.KEY);
 
         Graph graph = hopper.getGraphHopperStorage();
         assertEquals(5, graph.getNodes());
@@ -676,7 +676,7 @@ public class OSMReaderTest {
         BikeFlagEncoder bike = new BikeFlagEncoder(4, 2, 24, false);
 
         GraphHopper hopper = new GraphHopper();
-        hopper.getEncodingManagerBuilder().add(bike).add(truck).add(car);
+        hopper.getTagParserManagerBuilder().add(bike).add(truck).add(car);
         hopper.setOSMFile(getClass().getResource("test-multi-profile-turn-restrictions.xml").getFile()).
                 setGraphHopperLocation(dir).
                 setProfiles(
@@ -685,7 +685,7 @@ public class OSMReaderTest {
                         new Profile("truck").setVehicle("truck").setWeighting("fastest")
                 ).
                 importOrLoad();
-        EncodingManager manager = hopper.getEncodingManager();
+        EncodingManager manager = hopper.getTagParserManager().getEncodingManager();
         DecimalEncodedValue carTCEnc = manager.getDecimalEncodedValue(TurnCost.key("car"));
         DecimalEncodedValue truckTCEnc = manager.getDecimalEncodedValue(TurnCost.key("truck"));
         DecimalEncodedValue bikeTCEnc = manager.getDecimalEncodedValue(TurnCost.key("bike"));
@@ -750,7 +750,7 @@ public class OSMReaderTest {
         // (2-3)->(3-4) only_straight_on except bicycle = (2-3)->(3-8) restricted for car
         // (4-3)->(3-8) no_right_turn dedicated to motorcar = (4-3)->(3-8) restricted for car
 
-        DecimalEncodedValue carTCEnc = hopper.getEncodingManager().getDecimalEncodedValue(TurnCost.key("car"));
+        DecimalEncodedValue carTCEnc = hopper.getTagParserManager().getDecimalEncodedValue(TurnCost.key("car"));
         assertTrue(tcStorage.get(carTCEnc, edge2_3, n3, edge3_8) > 0);
         assertTrue(tcStorage.get(carTCEnc, edge4_3, n3, edge3_8) > 0);
         assertEquals(0, tcStorage.get(carTCEnc, edge2_3, n3, edge3_4), .1);
@@ -759,7 +759,7 @@ public class OSMReaderTest {
         assertEquals(0, tcStorage.get(carTCEnc, edge4_3, n3, edge3_2), .1);
         assertEquals(0, tcStorage.get(carTCEnc, edge8_3, n3, edge3_2), .1);
 
-        DecimalEncodedValue bikeTCEnc = hopper.getEncodingManager().getDecimalEncodedValue(TurnCost.key("bike"));
+        DecimalEncodedValue bikeTCEnc = hopper.getTagParserManager().getDecimalEncodedValue(TurnCost.key("bike"));
         assertEquals(0, tcStorage.get(bikeTCEnc, edge2_3, n3, edge3_8), .1);
         assertEquals(0, tcStorage.get(bikeTCEnc, edge4_3, n3, edge3_8), .1);
         assertEquals(0, tcStorage.get(bikeTCEnc, edge2_3, n3, edge3_4), .1);
@@ -806,8 +806,8 @@ public class OSMReaderTest {
         int edge4_5 = GHUtility.getEdge(graph, n4, n5).getEdge();
         int edge5_1 = GHUtility.getEdge(graph, n5, n1).getEdge();
 
-        DecimalEncodedValue carTCEnc = hopper.getEncodingManager().getDecimalEncodedValue(TurnCost.key("car"));
-        DecimalEncodedValue bikeTCEnc = hopper.getEncodingManager().getDecimalEncodedValue(TurnCost.key("bike"));
+        DecimalEncodedValue carTCEnc = hopper.getTagParserManager().getDecimalEncodedValue(TurnCost.key("car"));
+        DecimalEncodedValue bikeTCEnc = hopper.getTagParserManager().getDecimalEncodedValue(TurnCost.key("bike"));
 
         // (1-2)->(2-3) no_right_turn for motorcar and bus
         assertTrue(tcStorage.get(carTCEnc, edge1_2, n2, edge2_3) > 0);
@@ -918,9 +918,9 @@ public class OSMReaderTest {
 
     @Test
     public void testCountries() throws IOException {
-        EncodingManager em = EncodingManager.create("car");
+        TagParserManager em = TagParserManager.create("car");
         EnumEncodedValue<RoadAccess> roadAccessEnc = em.getEnumEncodedValue(RoadAccess.KEY, RoadAccess.class);
-        BaseGraph graph = new BaseGraph.Builder(em).create();
+        BaseGraph graph = new BaseGraph.Builder(em.getEncodingManager()).create();
         OSMReader reader = new OSMReader(graph, em, new OSMReaderConfig());
         reader.setCountryRuleFactory(new CountryRuleFactory());
         reader.setAreaIndex(createCountryIndex());
@@ -940,12 +940,12 @@ public class OSMReaderTest {
     @Test
     public void testCurvedWayAlongBorder() throws IOException {
         // see https://discuss.graphhopper.com/t/country-of-way-is-wrong-on-road-near-border-with-curvature/6908/2
-        EncodingManager em = EncodingManager.start()
+        TagParserManager em = TagParserManager.start()
                 .add(new CarFlagEncoder())
                 .add(new CountryParser())
                 .build();
         EnumEncodedValue<Country> countryEnc = em.getEnumEncodedValue(Country.KEY, Country.class);
-        BaseGraph graph = new BaseGraph.Builder(em).create();
+        BaseGraph graph = new BaseGraph.Builder(em.getEncodingManager()).create();
         OSMReader reader = new OSMReader(graph, em, new OSMReaderConfig());
         reader.setCountryRuleFactory(new CountryRuleFactory());
         reader.setAreaIndex(createCountryIndex());
@@ -992,13 +992,13 @@ public class OSMReaderTest {
             }
 
             footEncoder = new FootFlagEncoder();
-            getEncodingManagerBuilder().add(footEncoder).add(carEncoder).add(bikeEncoder);
+            getTagParserManagerBuilder().add(footEncoder).add(carEncoder).add(bikeEncoder);
             getReaderConfig().setPreferredLanguage(prefLang);
         }
 
         @Override
         protected void importOSM() {
-            GraphHopperStorage tmpGraph = new GraphBuilder(getEncodingManager()).set3D(hasElevation()).withTurnCosts(getEncodingManager().needsTurnCostsSupport()).build();
+            GraphHopperStorage tmpGraph = new GraphBuilder(getTagParserManager().getEncodingManager()).set3D(hasElevation()).withTurnCosts(getTagParserManager().needsTurnCostsSupport()).build();
             setGraphHopperStorage(tmpGraph);
             super.importOSM();
             carAccessEnc = carEncoder.getAccessEnc();

--- a/core/src/test/java/com/graphhopper/routing/DefaultBidirPathExtractorTest.java
+++ b/core/src/test/java/com/graphhopper/routing/DefaultBidirPathExtractorTest.java
@@ -25,8 +25,8 @@ import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.routing.weighting.DefaultTurnCostProvider;
 import com.graphhopper.routing.weighting.FastestWeighting;
+import com.graphhopper.storage.BaseGraph;
 import com.graphhopper.storage.Graph;
-import com.graphhopper.storage.GraphBuilder;
 import com.graphhopper.storage.TurnCostStorage;
 import com.graphhopper.util.EdgeIterator;
 import com.graphhopper.util.GHUtility;
@@ -42,8 +42,8 @@ public class DefaultBidirPathExtractorTest {
     private final FlagEncoder carEncoder = new CarFlagEncoder(5, 5, 10);
     private final EncodingManager encodingManager = EncodingManager.create(carEncoder);
 
-    Graph createGraph() {
-        return new GraphBuilder(encodingManager).create();
+    BaseGraph createGraph() {
+        return new BaseGraph.Builder(encodingManager).create();
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/routing/HeadingRoutingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/HeadingRoutingTest.java
@@ -25,7 +25,11 @@ import com.graphhopper.config.Profile;
 import com.graphhopper.routing.ev.Subnetwork;
 import com.graphhopper.routing.util.CarFlagEncoder;
 import com.graphhopper.routing.util.EncodingManager;
-import com.graphhopper.storage.*;
+import com.graphhopper.routing.util.FlagEncoder;
+import com.graphhopper.storage.BaseGraph;
+import com.graphhopper.storage.Graph;
+import com.graphhopper.storage.NodeAccess;
+import com.graphhopper.storage.RAMDirectory;
 import com.graphhopper.storage.index.LocationIndexTree;
 import com.graphhopper.util.EdgeIteratorState;
 import com.graphhopper.util.GHUtility;
@@ -52,8 +56,10 @@ class HeadingRoutingTest {
     @Test
     public void headingTest1() {
         // Test enforce start direction
-        GraphHopperStorage graph = createSquareGraph();
-        Router router = createRouter(graph);
+        CarFlagEncoder carEncoder = new CarFlagEncoder();
+        EncodingManager encodingManager = new EncodingManager.Builder().add(carEncoder).add(Subnetwork.create("profile")).build();
+        BaseGraph graph = createSquareGraph(encodingManager);
+        Router router = createRouter(graph, encodingManager);
 
         // Start in middle of edge 4-5
         GHPoint start = new GHPoint(0.0015, 0.002);
@@ -73,8 +79,10 @@ class HeadingRoutingTest {
     @Test
     public void headingTest2() {
         // Test enforce south start direction and east end direction
-        GraphHopperStorage graph = createSquareGraph();
-        Router router = createRouter(graph);
+        FlagEncoder carEncoder = new CarFlagEncoder();
+        EncodingManager encodingManager = new EncodingManager.Builder().add(carEncoder).add(Subnetwork.create("profile")).build();
+        BaseGraph graph = createSquareGraph(encodingManager);
+        Router router = createRouter(graph, encodingManager);
 
         // Start in middle of edge 4-5
         GHPoint start = new GHPoint(0.0015, 0.002);
@@ -98,8 +106,10 @@ class HeadingRoutingTest {
 
     @Test
     public void headingTest3() {
-        GraphHopperStorage graph = createSquareGraph();
-        Router router = createRouter(graph);
+        FlagEncoder carEncoder = new CarFlagEncoder();
+        EncodingManager encodingManager = new EncodingManager.Builder().add(carEncoder).add(Subnetwork.create("profile")).build();
+        BaseGraph graph = createSquareGraph(encodingManager);
+        Router router = createRouter(graph, encodingManager);
 
         // Start in middle of edge 4-5
         GHPoint start = new GHPoint(0.0015, 0.002);
@@ -121,8 +131,10 @@ class HeadingRoutingTest {
     @Test
     public void headingTest4() {
         // Test straight via routing
-        GraphHopperStorage graph = createSquareGraph();
-        Router router = createRouter(graph);
+        FlagEncoder carEncoder = new CarFlagEncoder();
+        EncodingManager encodingManager = new EncodingManager.Builder().add(carEncoder).add(Subnetwork.create("profile")).build();
+        BaseGraph graph = createSquareGraph(encodingManager);
+        Router router = createRouter(graph, encodingManager);
 
         // Start in middle of edge 4-5
         GHPoint start = new GHPoint(0.0015, 0.002);
@@ -144,8 +156,10 @@ class HeadingRoutingTest {
     @Test
     public void headingTest5() {
         // Test independence of previous enforcement for subsequent paths
-        GraphHopperStorage graph = createSquareGraph();
-        Router router = createRouter(graph);
+        FlagEncoder carEncoder = new CarFlagEncoder();
+        EncodingManager encodingManager = new EncodingManager.Builder().add(carEncoder).add(Subnetwork.create("profile")).build();
+        BaseGraph graph = createSquareGraph(encodingManager);
+        Router router = createRouter(graph, encodingManager);
 
         // Start in middle of edge 4-5
         GHPoint start = new GHPoint(0.0015, 0.002);
@@ -166,8 +180,10 @@ class HeadingRoutingTest {
 
     @Test
     public void testHeadingWithSnapFilter() {
-        GraphHopperStorage graph = createSquareGraphWithTunnel();
-        Router router = createRouter(graph);
+        FlagEncoder carEncoder = new CarFlagEncoder();
+        EncodingManager encodingManager = new EncodingManager.Builder().add(carEncoder).add(Subnetwork.create("profile")).build();
+        BaseGraph graph = createSquareGraphWithTunnel(encodingManager);
+        Router router = createRouter(graph, encodingManager);
         // Start at 8 (slightly north to make it independent on some edge ordering and always use 8-3 or 3-8 as fallback)
         GHPoint start = new GHPoint(0.0011, 0.001);
         // End at middle of edge 2-3
@@ -226,8 +242,10 @@ class HeadingRoutingTest {
 
     @Test
     public void testHeadingWithSnapFilter2() {
-        GraphHopperStorage graph = createSquareGraphWithTunnel();
-        Router router = createRouter(graph);
+        FlagEncoder carEncoder = new CarFlagEncoder();
+        EncodingManager encodingManager = new EncodingManager.Builder().add(carEncoder).add(Subnetwork.create("profile")).build();
+        BaseGraph graph = createSquareGraphWithTunnel(encodingManager);
+        Router router = createRouter(graph, encodingManager);
         // Start at 8 (slightly east to snap to edge 1->5 per default)
         GHPoint start = new GHPoint(0.001, 0.0011);
         // End at middle of edge 2-3
@@ -257,8 +275,10 @@ class HeadingRoutingTest {
     @Test
     public void headingTest6() {
         // Test if snaps at tower nodes are ignored
-        GraphHopperStorage graph = createSquareGraph();
-        Router router = createRouter(graph);
+        FlagEncoder carEncoder = new CarFlagEncoder();
+        EncodingManager encodingManager = new EncodingManager.Builder().add(carEncoder).add(Subnetwork.create("profile")).build();
+        BaseGraph graph = createSquareGraph(encodingManager);
+        Router router = createRouter(graph, encodingManager);
 
         // QueryPoints directly on TowerNodes
         GHPoint start = new GHPoint(0, 0);
@@ -275,19 +295,18 @@ class HeadingRoutingTest {
         assertArrayEquals(new int[]{0, 1, 2, 3, 4}, calcNodes(graph, response.getAll().get(0)));
     }
 
-    private Router createRouter(GraphHopperStorage graph) {
+    private Router createRouter(BaseGraph graph, EncodingManager encodingManager) {
         LocationIndexTree locationIndex = new LocationIndexTree(graph, new RAMDirectory());
         locationIndex.prepareIndex();
         Map<String, Profile> profilesByName = new HashMap<>();
         profilesByName.put("profile", new Profile("profile").setVehicle("car").setWeighting("fastest"));
-        return new Router(graph.getBaseGraph(), graph.getEncodingManager(), locationIndex, profilesByName, new PathDetailsBuilderFactory(), new TranslationMap().doImport(), new RouterConfig(),
-                new DefaultWeightingFactory(graph.getBaseGraph(), graph.getEncodingManager()), Collections.emptyMap(), Collections.emptyMap());
+        return new Router(graph.getBaseGraph(), encodingManager, locationIndex, profilesByName, new PathDetailsBuilderFactory(), new TranslationMap().doImport(), new RouterConfig(),
+                new DefaultWeightingFactory(graph.getBaseGraph(), encodingManager), Collections.emptyMap(), Collections.emptyMap());
     }
 
-    private GraphHopperStorage createSquareGraph() {
-        CarFlagEncoder carEncoder = new CarFlagEncoder();
-        EncodingManager encodingManager = new EncodingManager.Builder().add(carEncoder).add(Subnetwork.create("profile")).build();
-        GraphHopperStorage g = new GraphBuilder(encodingManager).create();
+    private BaseGraph createSquareGraph(EncodingManager encodingManager) {
+        BaseGraph g = new BaseGraph.Builder(encodingManager).create();
+        FlagEncoder carEncoder = encodingManager.getEncoder("car");
 
         // 2---3---4
         // |   |   |
@@ -322,10 +341,9 @@ class HeadingRoutingTest {
         return g;
     }
 
-    private GraphHopperStorage createSquareGraphWithTunnel() {
-        CarFlagEncoder carEncoder = new CarFlagEncoder();
-        EncodingManager encodingManager = new EncodingManager.Builder().add(carEncoder).add(Subnetwork.create("profile")).build();
-        GraphHopperStorage g = new GraphBuilder(encodingManager).create();
+    private BaseGraph createSquareGraphWithTunnel(EncodingManager encodingManager) {
+        BaseGraph g = new BaseGraph.Builder(encodingManager).create();
+        FlagEncoder carEncoder = encodingManager.getEncoder("car");
 
         // 2----3---4
         // |    |   |

--- a/core/src/test/java/com/graphhopper/routing/PathTest.java
+++ b/core/src/test/java/com/graphhopper/routing/PathTest.java
@@ -23,10 +23,7 @@ import com.graphhopper.routing.util.*;
 import com.graphhopper.routing.weighting.FastestWeighting;
 import com.graphhopper.routing.weighting.ShortestWeighting;
 import com.graphhopper.routing.weighting.Weighting;
-import com.graphhopper.storage.Graph;
-import com.graphhopper.storage.GraphBuilder;
-import com.graphhopper.storage.IntsRef;
-import com.graphhopper.storage.NodeAccess;
+import com.graphhopper.storage.*;
 import com.graphhopper.util.*;
 import com.graphhopper.util.details.PathDetail;
 import com.graphhopper.util.details.PathDetailsBuilderFactory;
@@ -56,7 +53,7 @@ public class PathTest {
 
     @Test
     public void testFound() {
-        Graph g = new GraphBuilder(carManager).create();
+        BaseGraph g = new BaseGraph.Builder(carManager).create();
         Path p = new Path(g);
         assertFalse(p.isFound());
         assertEquals(0, p.getDistance(), 1e-7);
@@ -65,7 +62,7 @@ public class PathTest {
 
     @Test
     public void testWayList() {
-        Graph g = new GraphBuilder(carManager).create();
+        BaseGraph g = new BaseGraph.Builder(carManager).create();
         NodeAccess na = g.getNodeAccess();
         na.setNode(0, 0.0, 0.1);
         na.setNode(1, 1.0, 0.1);
@@ -160,7 +157,7 @@ public class PathTest {
 
     @Test
     public void testFindInstruction() {
-        Graph g = new GraphBuilder(carManager).create();
+        BaseGraph g = new BaseGraph.Builder(carManager).create();
         NodeAccess na = g.getNodeAccess();
         na.setNode(0, 0.0, 0.0);
         na.setNode(1, 5.0, 0.0);
@@ -468,7 +465,7 @@ public class PathTest {
 
     @Test
     public void testCalcInstructionsRoundaboutIssue353() {
-        final Graph graph = new GraphBuilder(carManager).create();
+        final BaseGraph graph = new BaseGraph.Builder(carManager).create();
         final NodeAccess na = graph.getNodeAccess();
 
         //
@@ -579,7 +576,7 @@ public class PathTest {
 
     @Test
     public void testCalcInstructionForForkWithSameName() {
-        final Graph graph = new GraphBuilder(carManager).create();
+        final BaseGraph graph = new BaseGraph.Builder(carManager).create();
         final NodeAccess na = graph.getNodeAccess();
 
         // Actual example: point=48.982618%2C13.122021&point=48.982336%2C13.121002
@@ -611,7 +608,7 @@ public class PathTest {
 
     @Test
     public void testCalcInstructionForMotorwayFork() {
-        final Graph graph = new GraphBuilder(carManager).create();
+        final BaseGraph graph = new BaseGraph.Builder(carManager).create();
         final NodeAccess na = graph.getNodeAccess();
 
         // Actual example: point=48.909071%2C8.647136&point=48.908789%2C8.649244
@@ -643,7 +640,7 @@ public class PathTest {
 
     @Test
     public void testCalcInstructionsEnterMotorway() {
-        final Graph graph = new GraphBuilder(carManager).create();
+        final BaseGraph graph = new BaseGraph.Builder(carManager).create();
         final NodeAccess na = graph.getNodeAccess();
 
         // Actual example: point=48.630533%2C9.459416&point=48.630544%2C9.459829
@@ -672,7 +669,7 @@ public class PathTest {
 
     @Test
     public void testCalcInstructionsMotorwayJunction() {
-        final Graph g = new GraphBuilder(carManager).create();
+        final BaseGraph g = new BaseGraph.Builder(carManager).create();
         final NodeAccess na = g.getNodeAccess();
 
         // Actual example: point=48.70672%2C9.164266&point=48.706805%2C9.162995
@@ -702,7 +699,7 @@ public class PathTest {
 
     @Test
     public void testCalcInstructionsOntoOneway() {
-        final Graph g = new GraphBuilder(carManager).create();
+        final BaseGraph g = new BaseGraph.Builder(carManager).create();
         final NodeAccess na = g.getNodeAccess();
 
         // Actual example: point=-33.824566%2C151.187834&point=-33.82441%2C151.188231
@@ -731,7 +728,7 @@ public class PathTest {
 
     @Test
     public void testCalcInstructionIssue1047() {
-        final Graph g = new GraphBuilder(carManager).create();
+        final BaseGraph g = new BaseGraph.Builder(carManager).create();
         final NodeAccess na = g.getNodeAccess();
 
         // Actual example: point=51.367105%2C14.491246&point=51.369048%2C14.483092
@@ -772,7 +769,7 @@ public class PathTest {
 
     @Test
     public void testCalcInstructionContinueLeavingStreet() {
-        final Graph g = new GraphBuilder(carManager).create();
+        final BaseGraph g = new BaseGraph.Builder(carManager).create();
         final NodeAccess na = g.getNodeAccess();
 
         // When leaving the current street via a Continue, we should show it
@@ -800,7 +797,7 @@ public class PathTest {
 
     @Test
     public void testCalcInstructionSlightTurn() {
-        final Graph g = new GraphBuilder(carManager).create();
+        final BaseGraph g = new BaseGraph.Builder(carManager).create();
         final NodeAccess na = g.getNodeAccess();
 
         // Real Situation: point=48.411927%2C15.599197&point=48.412094%2C15.598816
@@ -830,7 +827,7 @@ public class PathTest {
 
     @Test
     public void testUTurnLeft() {
-        final Graph g = new GraphBuilder(carManager).create();
+        final BaseGraph g = new BaseGraph.Builder(carManager).create();
         final NodeAccess na = g.getNodeAccess();
 
         // Real Situation: point=48.402116%2C9.994367&point=48.402198%2C9.99507
@@ -868,7 +865,7 @@ public class PathTest {
 
     @Test
     public void testUTurnRight() {
-        final Graph g = new GraphBuilder(carManager).create();
+        final BaseGraph g = new BaseGraph.Builder(carManager).create();
         final NodeAccess na = g.getNodeAccess();
 
         // Real Situation: point=-33.885758,151.181472&point=-33.885692,151.181445
@@ -936,7 +933,7 @@ public class PathTest {
 
     @Test
     public void testCalcInstructionsForSlightTurnOntoDifferentStreet() {
-        final Graph g = new GraphBuilder(carManager).create();
+        final BaseGraph g = new BaseGraph.Builder(carManager).create();
         final NodeAccess na = g.getNodeAccess();
 
         // Actual example: point=48.76445%2C8.679054&point=48.764152%2C8.678722
@@ -985,7 +982,7 @@ public class PathTest {
     }
 
     private Graph generatePathDetailsGraph() {
-        final Graph graph = new GraphBuilder(carManager).create();
+        final BaseGraph graph = new BaseGraph.Builder(carManager).create();
         final NodeAccess na = graph.getNodeAccess();
 
         na.setNode(1, 52.514, 13.348);

--- a/core/src/test/java/com/graphhopper/routing/PathTest.java
+++ b/core/src/test/java/com/graphhopper/routing/PathTest.java
@@ -44,7 +44,8 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 public class PathTest {
     private final FlagEncoder encoder = new CarFlagEncoder();
-    private final EncodingManager carManager = EncodingManager.create(encoder);
+    private final TagParserManager tagParserManager = TagParserManager.create(encoder);
+    private final EncodingManager carManager = tagParserManager.getEncodingManager();
     private final BooleanEncodedValue carAccessEnc = encoder.getAccessEnc();
     private final DecimalEncodedValue carAvSpeedEnv = encoder.getAverageSpeedEnc();
     private final EncodingManager mixedEncoders = EncodingManager.create(new CarFlagEncoder(), new FootFlagEncoder());
@@ -1001,21 +1002,21 @@ public class PathTest {
         EdgeIteratorState tmpEdge;
         tmpEdge = GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(5)).setName("1-2");
         assertNotEquals(EncodingManager.Access.CAN_SKIP, ((CarFlagEncoder) encoder).getAccess(w));
-        IntsRef relFlags = carManager.createRelationFlags();
-        tmpEdge.setFlags(carManager.handleWayTags(w, relFlags));
+        IntsRef relFlags = tagParserManager.createRelationFlags();
+        tmpEdge.setFlags(tagParserManager.handleWayTags(w, relFlags));
         tmpEdge = GHUtility.setSpeed(60, true, true, encoder, graph.edge(4, 5).setDistance(5)).setName("4-5");
-        tmpEdge.setFlags(carManager.handleWayTags(w, relFlags));
+        tmpEdge.setFlags(tagParserManager.handleWayTags(w, relFlags));
 
         w.setTag("maxspeed", "100");
         tmpEdge = GHUtility.setSpeed(60, true, true, encoder, graph.edge(2, 3).setDistance(5)).setName("2-3");
-        tmpEdge.setFlags(carManager.handleWayTags(w, relFlags));
+        tmpEdge.setFlags(tagParserManager.handleWayTags(w, relFlags));
 
         w.setTag("maxspeed", "10");
         tmpEdge = GHUtility.setSpeed(60, true, true, encoder, graph.edge(3, 4).setDistance(10)).setName("3-4");
-        tmpEdge.setFlags(carManager.handleWayTags(w, relFlags));
+        tmpEdge.setFlags(tagParserManager.handleWayTags(w, relFlags));
 
         tmpEdge = GHUtility.setSpeed(60, true, true, encoder, graph.edge(5, 6).setDistance(0.01)).setName("3-4");
-        tmpEdge.setFlags(carManager.handleWayTags(w, relFlags));
+        tmpEdge.setFlags(tagParserManager.handleWayTags(w, relFlags));
 
         return graph;
     }

--- a/core/src/test/java/com/graphhopper/routing/PathTest.java
+++ b/core/src/test/java/com/graphhopper/routing/PathTest.java
@@ -23,7 +23,10 @@ import com.graphhopper.routing.util.*;
 import com.graphhopper.routing.weighting.FastestWeighting;
 import com.graphhopper.routing.weighting.ShortestWeighting;
 import com.graphhopper.routing.weighting.Weighting;
-import com.graphhopper.storage.*;
+import com.graphhopper.storage.BaseGraph;
+import com.graphhopper.storage.Graph;
+import com.graphhopper.storage.IntsRef;
+import com.graphhopper.storage.NodeAccess;
 import com.graphhopper.util.*;
 import com.graphhopper.util.details.PathDetail;
 import com.graphhopper.util.details.PathDetailsBuilderFactory;
@@ -1019,7 +1022,7 @@ public class PathTest {
     }
 
     private static class RoundaboutGraph {
-        final Graph g;
+        final BaseGraph g;
         final NodeAccess na;
         final EdgeIteratorState edge3to6, edge3to9;
         final EncodingManager em;
@@ -1028,7 +1031,7 @@ public class PathTest {
 
         private RoundaboutGraph(EncodingManager em) {
             this.em = em;
-            g = new GraphBuilder(em).create();
+            g = new BaseGraph.Builder(em).create();
             na = g.getNodeAccess();
             //                                       18
             //      8                 14              |

--- a/core/src/test/java/com/graphhopper/routing/PriorityRoutingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/PriorityRoutingTest.java
@@ -29,8 +29,7 @@ import com.graphhopper.routing.weighting.PriorityWeighting;
 import com.graphhopper.routing.weighting.TurnCostProvider;
 import com.graphhopper.routing.weighting.custom.CustomModelParser;
 import com.graphhopper.routing.weighting.custom.CustomWeighting;
-import com.graphhopper.storage.GraphBuilder;
-import com.graphhopper.storage.GraphHopperStorage;
+import com.graphhopper.storage.BaseGraph;
 import com.graphhopper.storage.NodeAccess;
 import com.graphhopper.util.CustomModel;
 import com.graphhopper.util.DistanceCalcEarth;
@@ -46,7 +45,7 @@ public class PriorityRoutingTest {
     void testMaxPriority() {
         BikeFlagEncoder encoder = new BikeFlagEncoder();
         EncodingManager em = EncodingManager.create(encoder);
-        GraphHopperStorage graph = new GraphBuilder(em).create();
+        BaseGraph graph = new BaseGraph.Builder(em).create();
         NodeAccess na = graph.getNodeAccess();
         na.setNode(0, 48.0, 11.0);
         na.setNode(1, 48.1, 11.1);
@@ -102,7 +101,7 @@ public class PriorityRoutingTest {
         }
     }
 
-    private EdgeIteratorState maxSpeedEdge(EncodingManager em, GraphHopperStorage graph, int p, int q, FlagEncoder encoder, double prio) {
+    private EdgeIteratorState maxSpeedEdge(EncodingManager em, BaseGraph graph, int p, int q, FlagEncoder encoder, double prio) {
         BooleanEncodedValue accessEnc = encoder.getAccessEnc();
         DecimalEncodedValue speedEnc = encoder.getAverageSpeedEnc();
         DecimalEncodedValue priorityEnc = em.getDecimalEncodedValue(EncodingManager.getKey(encoder, "priority"));
@@ -115,7 +114,7 @@ public class PriorityRoutingTest {
                 .setDistance(calcDist(graph, p, q));
     }
 
-    private double calcDist(GraphHopperStorage graph, int p, int q) {
+    private double calcDist(BaseGraph graph, int p, int q) {
         NodeAccess na = graph.getNodeAccess();
         return DistanceCalcEarth.DIST_EARTH.calcDist(na.getLat(p), na.getLon(p), na.getLat(q), na.getLon(q));
     }

--- a/core/src/test/java/com/graphhopper/routing/TrafficChangeWithNodeOrderingReusingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/TrafficChangeWithNodeOrderingReusingTest.java
@@ -4,8 +4,8 @@ import com.graphhopper.reader.osm.OSMReader;
 import com.graphhopper.routing.ch.CHRoutingAlgorithmFactory;
 import com.graphhopper.routing.ch.PrepareContractionHierarchies;
 import com.graphhopper.routing.util.CarFlagEncoder;
-import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.routing.util.FlagEncoder;
+import com.graphhopper.routing.util.TagParserManager;
 import com.graphhopper.routing.util.TraversalMode;
 import com.graphhopper.routing.weighting.AbstractWeighting;
 import com.graphhopper.routing.weighting.FastestWeighting;
@@ -45,17 +45,17 @@ public class TrafficChangeWithNodeOrderingReusingTest {
     private static class Fixture {
         private final int maxDeviationPercentage;
         private final BaseGraph graph;
-        private final EncodingManager em;
+        private final TagParserManager em;
         private final CHConfig baseCHConfig;
         private final CHConfig trafficCHConfig;
 
         public Fixture(int maxDeviationPercentage) {
             this.maxDeviationPercentage = maxDeviationPercentage;
             FlagEncoder encoder = new CarFlagEncoder();
-            em = EncodingManager.create(encoder);
+            em = TagParserManager.create(encoder);
             baseCHConfig = CHConfig.nodeBased("base", new FastestWeighting(encoder));
             trafficCHConfig = CHConfig.nodeBased("traffic", new RandomDeviationWeighting(baseCHConfig.getWeighting(), maxDeviationPercentage));
-            graph = new BaseGraph.Builder(em).create();
+            graph = new BaseGraph.Builder(em.getEncodingManager()).create();
         }
 
         @Override

--- a/core/src/test/java/com/graphhopper/routing/util/AbstractBikeFlagEncoderTester.java
+++ b/core/src/test/java/com/graphhopper/routing/util/AbstractBikeFlagEncoderTester.java
@@ -38,14 +38,14 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 public abstract class AbstractBikeFlagEncoderTester {
     protected BikeCommonFlagEncoder encoder;
-    protected EncodingManager encodingManager;
+    protected TagParserManager encodingManager;
     protected BooleanEncodedValue roundaboutEnc;
     protected DecimalEncodedValue priorityEnc;
     protected DecimalEncodedValue avgSpeedEnc;
 
     @BeforeEach
     public void setUp() {
-        encodingManager = EncodingManager.create(encoder = createBikeEncoder());
+        encodingManager = TagParserManager.create(encoder = createBikeEncoder());
         roundaboutEnc = encodingManager.getBooleanEncodedValue(Roundabout.KEY);
         priorityEnc = encodingManager.getDecimalEncodedValue(EncodingManager.getKey(encoder, "priority"));
         avgSpeedEnc = encoder.getAverageSpeedEnc();

--- a/core/src/test/java/com/graphhopper/routing/util/Bike2WeightFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/Bike2WeightFlagEncoderTest.java
@@ -36,7 +36,7 @@ public class Bike2WeightFlagEncoderTest extends BikeFlagEncoderTest {
     }
 
     private Graph initExampleGraph() {
-        GraphHopperStorage gs = new GraphBuilder(encodingManager).set3D(true).create();
+        GraphHopperStorage gs = new GraphBuilder(encodingManager.getEncodingManager()).set3D(true).create();
         NodeAccess na = gs.getNodeAccess();
         // 50--(0.0001)-->49--(0.0004)-->55--(0.0005)-->60
         na.setNode(0, 51.1, 12.001, 50);
@@ -89,7 +89,7 @@ public class Bike2WeightFlagEncoderTest extends BikeFlagEncoderTest {
 
     @Test
     public void testRoutingFailsWithInvalidGraph_issue665() {
-        GraphHopperStorage graph = new GraphBuilder(encodingManager).set3D(true).create();
+        GraphHopperStorage graph = new GraphBuilder(encodingManager.getEncodingManager()).set3D(true).create();
         ReaderWay way = new ReaderWay(0);
         way.setTag("route", "ferry");
         way.setTag("edge_distance", 500.0);

--- a/core/src/test/java/com/graphhopper/routing/util/Bike2WeightFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/Bike2WeightFlagEncoderTest.java
@@ -19,7 +19,10 @@ package com.graphhopper.routing.util;
 
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.BooleanEncodedValue;
-import com.graphhopper.storage.*;
+import com.graphhopper.storage.BaseGraph;
+import com.graphhopper.storage.Graph;
+import com.graphhopper.storage.IntsRef;
+import com.graphhopper.storage.NodeAccess;
 import com.graphhopper.util.*;
 import org.junit.jupiter.api.Test;
 
@@ -36,7 +39,7 @@ public class Bike2WeightFlagEncoderTest extends BikeFlagEncoderTest {
     }
 
     private Graph initExampleGraph() {
-        GraphHopperStorage gs = new GraphBuilder(encodingManager.getEncodingManager()).set3D(true).create();
+        BaseGraph gs = new BaseGraph.Builder(encodingManager.getEncodingManager()).set3D(true).create();
         NodeAccess na = gs.getNodeAccess();
         // 50--(0.0001)-->49--(0.0004)-->55--(0.0005)-->60
         na.setNode(0, 51.1, 12.001, 50);
@@ -89,7 +92,7 @@ public class Bike2WeightFlagEncoderTest extends BikeFlagEncoderTest {
 
     @Test
     public void testRoutingFailsWithInvalidGraph_issue665() {
-        GraphHopperStorage graph = new GraphBuilder(encodingManager.getEncodingManager()).set3D(true).create();
+        BaseGraph graph = new BaseGraph.Builder(encodingManager.getEncodingManager()).set3D(true).create();
         ReaderWay way = new ReaderWay(0);
         way.setTag("route", "ferry");
         way.setTag("edge_distance", 500.0);

--- a/core/src/test/java/com/graphhopper/routing/util/CarFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/CarFlagEncoderTest.java
@@ -39,11 +39,11 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 public class CarFlagEncoderTest {
     final CarFlagEncoder encoder = createEncoder();
-    private final EncodingManager em = new EncodingManager.Builder().
+    private final TagParserManager tpm = new TagParserManager.Builder().
             add(encoder).
             add(new BikeFlagEncoder()).add(new FootFlagEncoder()).build();
 
-    private final BooleanEncodedValue roundaboutEnc = em.getBooleanEncodedValue(Roundabout.KEY);
+    private final BooleanEncodedValue roundaboutEnc = tpm.getBooleanEncodedValue(Roundabout.KEY);
     private final DecimalEncodedValue avSpeedEnc = encoder.getAverageSpeedEnc();
     private final BooleanEncodedValue accessEnc = encoder.getAccessEnc();
 
@@ -160,31 +160,31 @@ public class CarFlagEncoderTest {
     public void testOneway() {
         ReaderWay way = new ReaderWay(1);
         way.setTag("highway", "primary");
-        IntsRef flags = encoder.handleWayTags(em.createEdgeFlags(), way);
+        IntsRef flags = encoder.handleWayTags(tpm.createEdgeFlags(), way);
         assertTrue(accessEnc.getBool(false, flags));
         assertTrue(accessEnc.getBool(true, flags));
         way.setTag("oneway", "yes");
-        flags = encoder.handleWayTags(em.createEdgeFlags(), way);
+        flags = encoder.handleWayTags(tpm.createEdgeFlags(), way);
         assertTrue(accessEnc.getBool(false, flags));
         assertFalse(accessEnc.getBool(true, flags));
         way.clearTags();
 
         way.setTag("highway", "tertiary");
-        flags = encoder.handleWayTags(em.createEdgeFlags(), way);
+        flags = encoder.handleWayTags(tpm.createEdgeFlags(), way);
         assertTrue(accessEnc.getBool(false, flags));
         assertTrue(accessEnc.getBool(true, flags));
         way.clearTags();
 
         way.setTag("highway", "tertiary");
         way.setTag("vehicle:forward", "no");
-        flags = encoder.handleWayTags(em.createEdgeFlags(), way);
+        flags = encoder.handleWayTags(tpm.createEdgeFlags(), way);
         assertFalse(accessEnc.getBool(false, flags));
         assertTrue(accessEnc.getBool(true, flags));
         way.clearTags();
 
         way.setTag("highway", "tertiary");
         way.setTag("vehicle:backward", "no");
-        flags = encoder.handleWayTags(em.createEdgeFlags(), way);
+        flags = encoder.handleWayTags(tpm.createEdgeFlags(), way);
         assertTrue(accessEnc.getBool(false, flags));
         assertFalse(accessEnc.getBool(true, flags));
         way.clearTags();
@@ -192,7 +192,7 @@ public class CarFlagEncoderTest {
         // This is no one way
         way.setTag("highway", "tertiary");
         way.setTag("vehicle:backward", "designated");
-        flags = encoder.handleWayTags(em.createEdgeFlags(), way);
+        flags = encoder.handleWayTags(tpm.createEdgeFlags(), way);
         assertTrue(accessEnc.getBool(false, flags));
         assertTrue(accessEnc.getBool(true, flags));
         way.clearTags();
@@ -200,28 +200,28 @@ public class CarFlagEncoderTest {
 
     @Test
     public void testDestinationTag() {
-        IntsRef relFlags = em.createRelationFlags();
+        IntsRef relFlags = tpm.createRelationFlags();
 
         FastestWeighting weighting = new FastestWeighting(encoder);
-        FastestWeighting bikeWeighting = new FastestWeighting(em.getEncoder("bike"));
+        FastestWeighting bikeWeighting = new FastestWeighting(tpm.getEncoder("bike"));
 
         ReaderWay way = new ReaderWay(1);
         way.setTag("highway", "secondary");
         assertNotEquals(EncodingManager.Access.CAN_SKIP, encoder.getAccess(way));
-        IntsRef edgeFlags = em.handleWayTags(way, relFlags);
+        IntsRef edgeFlags = tpm.handleWayTags(way, relFlags);
         assertEquals(60, weighting.calcEdgeWeight(GHUtility.createMockedEdgeIteratorState(1000, edgeFlags), false), 0.1);
         assertEquals(200, bikeWeighting.calcEdgeWeight(GHUtility.createMockedEdgeIteratorState(1000, edgeFlags), false), 0.1);
 
         // no change for bike!
         way.setTag("motor_vehicle", "destination");
-        edgeFlags = em.handleWayTags(way, relFlags);
+        edgeFlags = tpm.handleWayTags(way, relFlags);
         assertEquals(600, weighting.calcEdgeWeight(GHUtility.createMockedEdgeIteratorState(1000, edgeFlags), false), 0.1);
         assertEquals(200, bikeWeighting.calcEdgeWeight(GHUtility.createMockedEdgeIteratorState(1000, edgeFlags), false), 0.1);
 
         way = new ReaderWay(1);
         way.setTag("highway", "secondary");
         way.setTag("vehicle", "destination");
-        edgeFlags = em.handleWayTags(way, relFlags);
+        edgeFlags = tpm.handleWayTags(way, relFlags);
         assertEquals(600, weighting.calcEdgeWeight(GHUtility.createMockedEdgeIteratorState(1000, edgeFlags), false), 0.1);
         assertEquals(200, bikeWeighting.calcEdgeWeight(GHUtility.createMockedEdgeIteratorState(1000, edgeFlags), false), 0.1);
     }
@@ -231,7 +231,7 @@ public class CarFlagEncoderTest {
         // allow private access
         CarFlagEncoder carEncoder = new CarFlagEncoder(new PMap("block_private=false"));
         FlagEncoder bikeEncoder = new BikeFlagEncoder(new PMap("block_private=false"));
-        EncodingManager em = new EncodingManager.Builder().add(carEncoder).add(bikeEncoder).build();
+        TagParserManager em = new TagParserManager.Builder().add(carEncoder).add(bikeEncoder).build();
 
         FastestWeighting weighting = new FastestWeighting(carEncoder);
         FastestWeighting bikeWeighting = new FastestWeighting(bikeEncoder);
@@ -257,7 +257,7 @@ public class CarFlagEncoderTest {
 
     @Test
     public void testSetAccess() {
-        IntsRef edgeFlags = em.createEdgeFlags();
+        IntsRef edgeFlags = tpm.createEdgeFlags();
         accessEnc.setBool(false, edgeFlags, true);
         accessEnc.setBool(true, edgeFlags, true);
         assertTrue(accessEnc.getBool(false, edgeFlags));
@@ -283,33 +283,33 @@ public class CarFlagEncoderTest {
         ReaderWay way = new ReaderWay(1);
         way.setTag("highway", "trunk");
         way.setTag("maxspeed", "500");
-        IntsRef relFlags = em.createRelationFlags();
-        IntsRef edgeFlags = em.handleWayTags(way, relFlags);
+        IntsRef relFlags = tpm.createRelationFlags();
+        IntsRef edgeFlags = tpm.handleWayTags(way, relFlags);
         assertEquals(140, avSpeedEnc.getDecimal(false, edgeFlags), 1e-1);
 
         way = new ReaderWay(1);
         way.setTag("highway", "primary");
         way.setTag("maxspeed:backward", "10");
         way.setTag("maxspeed:forward", "20");
-        edgeFlags = em.handleWayTags(way, relFlags);
+        edgeFlags = tpm.handleWayTags(way, relFlags);
         assertEquals(10, avSpeedEnc.getDecimal(false, edgeFlags), 1e-1);
 
         way = new ReaderWay(1);
         way.setTag("highway", "primary");
         way.setTag("maxspeed:forward", "20");
-        edgeFlags = em.handleWayTags(way, relFlags);
+        edgeFlags = tpm.handleWayTags(way, relFlags);
         assertEquals(20, avSpeedEnc.getDecimal(false, edgeFlags), 1e-1);
 
         way = new ReaderWay(1);
         way.setTag("highway", "primary");
         way.setTag("maxspeed:backward", "20");
-        edgeFlags = em.handleWayTags(way, relFlags);
+        edgeFlags = tpm.handleWayTags(way, relFlags);
         assertEquals(20, avSpeedEnc.getDecimal(false, edgeFlags), 1e-1);
 
         way = new ReaderWay(1);
         way.setTag("highway", "motorway");
         way.setTag("maxspeed", "none");
-        edgeFlags = em.handleWayTags(way, relFlags);
+        edgeFlags = tpm.handleWayTags(way, relFlags);
         assertEquals(135, avSpeedEnc.getDecimal(false, edgeFlags), .1);
     }
 
@@ -319,52 +319,52 @@ public class CarFlagEncoderTest {
         ReaderWay way = new ReaderWay(1);
         way.setTag("highway", "trunk");
         way.setTag("maxspeed", "110");
-        IntsRef edgeFlags = encoder.handleWayTags(em.createEdgeFlags(), way);
+        IntsRef edgeFlags = encoder.handleWayTags(tpm.createEdgeFlags(), way);
         assertEquals(100, avSpeedEnc.getDecimal(false, edgeFlags), 1e-1);
 
         way.clearTags();
         way.setTag("highway", "residential");
         way.setTag("surface", "cobblestone");
-        edgeFlags = encoder.handleWayTags(em.createEdgeFlags(), way);
+        edgeFlags = encoder.handleWayTags(tpm.createEdgeFlags(), way);
         assertEquals(30, avSpeedEnc.getDecimal(false, edgeFlags), 1e-1);
 
         way.clearTags();
         way.setTag("highway", "track");
-        edgeFlags = encoder.handleWayTags(em.createEdgeFlags(), way);
+        edgeFlags = encoder.handleWayTags(tpm.createEdgeFlags(), way);
         assertEquals(15, avSpeedEnc.getDecimal(false, edgeFlags), 1e-1);
 
         way.clearTags();
         way.setTag("highway", "track");
         way.setTag("tracktype", "grade1");
-        edgeFlags = encoder.handleWayTags(em.createEdgeFlags(), way);
+        edgeFlags = encoder.handleWayTags(tpm.createEdgeFlags(), way);
         assertEquals(20, avSpeedEnc.getDecimal(false, edgeFlags), 1e-1);
 
         way.clearTags();
         way.setTag("highway", "secondary");
         way.setTag("surface", "compacted");
-        edgeFlags = encoder.handleWayTags(em.createEdgeFlags(), way);
+        edgeFlags = encoder.handleWayTags(tpm.createEdgeFlags(), way);
         assertEquals(30, avSpeedEnc.getDecimal(false, edgeFlags), 1e-1);
 
         way.clearTags();
         way.setTag("highway", "secondary");
         way.setTag("motorroad", "yes");
-        edgeFlags = encoder.handleWayTags(em.createEdgeFlags(), way);
+        edgeFlags = encoder.handleWayTags(tpm.createEdgeFlags(), way);
         assertEquals(90, avSpeedEnc.getDecimal(false, edgeFlags), 1e-1);
 
         way.clearTags();
         way.setTag("highway", "motorway");
         way.setTag("motorroad", "yes"); // this tag should be ignored
-        edgeFlags = encoder.handleWayTags(em.createEdgeFlags(), way);
+        edgeFlags = encoder.handleWayTags(tpm.createEdgeFlags(), way);
         assertEquals(100, avSpeedEnc.getDecimal(false, edgeFlags), 1e-1);
 
         way.clearTags();
         way.setTag("highway", "motorway_link");
         way.setTag("motorroad", "yes"); // this tag should be ignored
-        edgeFlags = encoder.handleWayTags(em.createEdgeFlags(), way);
+        edgeFlags = encoder.handleWayTags(tpm.createEdgeFlags(), way);
         assertEquals(70, avSpeedEnc.getDecimal(false, edgeFlags), 1e-1);
 
         try {
-            avSpeedEnc.setDecimal(false, em.createEdgeFlags(), -1);
+            avSpeedEnc.setDecimal(false, tpm.createEdgeFlags(), -1);
             assertTrue(false);
         } catch (IllegalArgumentException ex) {
         }
@@ -372,14 +372,14 @@ public class CarFlagEncoderTest {
 
     @Test
     public void testSetSpeed() {
-        IntsRef edgeFlags = em.createEdgeFlags();
+        IntsRef edgeFlags = tpm.createEdgeFlags();
         avSpeedEnc.setDecimal(false, edgeFlags, 10);
         assertEquals(10, avSpeedEnc.getDecimal(false, edgeFlags), 1e-1);
     }
 
     @Test
     public void testSetSpeed0_issue367() {
-        IntsRef edgeFlags = em.createEdgeFlags();
+        IntsRef edgeFlags = tpm.createEdgeFlags();
         accessEnc.setBool(false, edgeFlags, true);
         accessEnc.setBool(true, edgeFlags, true);
 
@@ -398,7 +398,7 @@ public class CarFlagEncoderTest {
 
     @Test
     public void testRoundabout() {
-        IntsRef edgeFlags = em.createEdgeFlags();
+        IntsRef edgeFlags = tpm.createEdgeFlags();
         accessEnc.setBool(false, edgeFlags, true);
         accessEnc.setBool(true, edgeFlags, true);
         roundaboutEnc.setBool(false, edgeFlags, true);
@@ -413,7 +413,7 @@ public class CarFlagEncoderTest {
 
         ReaderWay way = new ReaderWay(1);
         way.setTag("highway", "motorway");
-        edgeFlags = encoder.handleWayTags(em.createEdgeFlags(), way);
+        edgeFlags = encoder.handleWayTags(tpm.createEdgeFlags(), way);
         assertTrue(accessEnc.getBool(false, edgeFlags));
         assertTrue(accessEnc.getBool(true, edgeFlags));
         assertFalse(roundaboutEnc.getBool(false, edgeFlags));
@@ -461,7 +461,7 @@ public class CarFlagEncoderTest {
         way.setTag("duration:seconds", 35L * 60);
         // accept
         assertTrue(encoder.getAccess(way).isFerry());
-        IntsRef edgeFlags = em.createEdgeFlags();
+        IntsRef edgeFlags = tpm.createEdgeFlags();
         // calculate speed from tags: speed_from_duration * 1.4 (+ rounded using the speed factor)
         encoder.handleWayTags(edgeFlags, way);
         assertEquals(60, encoder.getAverageSpeedEnc().getDecimal(false, edgeFlags));
@@ -477,11 +477,11 @@ public class CarFlagEncoderTest {
         // accept
         assertTrue(encoder.getAccess(way).isFerry());
         // We can't store 0.5km/h, but we expect the lowest possible speed (5km/h)
-        edgeFlags = em.createEdgeFlags();
+        edgeFlags = tpm.createEdgeFlags();
         encoder.handleWayTags(edgeFlags, way);
         assertEquals(5, encoder.getAverageSpeedEnc().getDecimal(false, edgeFlags));
 
-        edgeFlags = em.createEdgeFlags();
+        edgeFlags = tpm.createEdgeFlags();
         avSpeedEnc.setDecimal(false, edgeFlags, 2.5);
         assertEquals(5, avSpeedEnc.getDecimal(false, edgeFlags), 1e-1);
 
@@ -623,11 +623,11 @@ public class CarFlagEncoderTest {
         way.setTag("sac_scale", "hiking");
 
         assertEquals(EncodingManager.Access.CAN_SKIP, encoder.getAccess(way));
-        assertNotEquals(EncodingManager.Access.CAN_SKIP, ((BikeFlagEncoder) em.getEncoder("bike")).getAccess(way));
-        IntsRef edgeFlags = em.handleWayTags(way, em.createRelationFlags());
+        assertNotEquals(EncodingManager.Access.CAN_SKIP, ((BikeFlagEncoder) tpm.getEncoder("bike")).getAccess(way));
+        IntsRef edgeFlags = tpm.handleWayTags(way, tpm.createRelationFlags());
         assertFalse(accessEnc.getBool(true, edgeFlags));
         assertFalse(accessEnc.getBool(false, edgeFlags));
-        BooleanEncodedValue bikeAccessEnc = em.getEncoder("bike").getAccessEnc();
+        BooleanEncodedValue bikeAccessEnc = tpm.getEncoder("bike").getAccessEnc();
         assertTrue(bikeAccessEnc.getBool(true, edgeFlags));
         assertTrue(bikeAccessEnc.getBool(false, edgeFlags));
     }
@@ -647,7 +647,7 @@ public class CarFlagEncoderTest {
         way.setTag("edge_distance", 257.0);
 
         // default is 5km/h minimum speed for car
-        IntsRef edgeFlags = em.createEdgeFlags();
+        IntsRef edgeFlags = tpm.createEdgeFlags();
         encoder.handleWayTags(edgeFlags, way);
         assertEquals(5, encoder.getAverageSpeedEnc().getDecimal(false, edgeFlags), .1);
 

--- a/core/src/test/java/com/graphhopper/routing/util/EncodingManagerTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/EncodingManagerTest.java
@@ -17,12 +17,6 @@
  */
 package com.graphhopper.routing.util;
 
-import com.graphhopper.reader.ReaderRelation;
-import com.graphhopper.reader.ReaderWay;
-import com.graphhopper.routing.ev.BooleanEncodedValue;
-import com.graphhopper.routing.ev.Roundabout;
-import com.graphhopper.routing.ev.RouteNetwork;
-import com.graphhopper.storage.IntsRef;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -58,121 +52,6 @@ public class EncodingManagerTest {
     }
 
     @Test
-    public void testToDetailsString() {
-        FlagEncoder encoder = new AbstractFlagEncoder(1, 2.0, 0) {
-            @Override
-            public TransportationMode getTransportationMode() {
-                return TransportationMode.BIKE;
-            }
-
-            @Override
-            protected String getPropertiesString() {
-                return "my_properties";
-            }
-
-            @Override
-            public EncodingManager.Access getAccess(ReaderWay way) {
-                return EncodingManager.Access.WAY;
-            }
-
-            @Override
-            public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay way) {
-                return edgeFlags;
-            }
-
-            @Override
-            public String getName() {
-                return "new_encoder";
-            }
-        };
-
-        EncodingManager subject = EncodingManager.create(encoder);
-
-        assertEquals("new_encoder|my_properties", subject.toFlagEncodersAsString());
-    }
-
-    @Test
-    public void testCombineRelations() {
-        ReaderWay osmWay = new ReaderWay(1);
-        osmWay.setTag("highway", "track");
-        ReaderRelation osmRel = new ReaderRelation(1);
-
-        BikeFlagEncoder defaultBike = new BikeFlagEncoder();
-        BikeFlagEncoder lessRelationCodes = new BikeFlagEncoder() {
-            @Override
-            public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay way) {
-                if (bikeRouteEnc.getEnum(false, edgeFlags) != RouteNetwork.MISSING)
-                    priorityEnc.setDecimal(false, edgeFlags, PriorityCode.getFactor(2));
-                return edgeFlags;
-            }
-
-            @Override
-            public String getName() {
-                return "less_relations_bits";
-            }
-        };
-        TagParserManager manager = new TagParserManager.Builder().add(lessRelationCodes).add(defaultBike).build();
-
-        // relation code is PREFER
-        osmRel.setTag("route", "bicycle");
-        osmRel.setTag("network", "lcn");
-        IntsRef relFlags = manager.handleRelationTags(osmRel, manager.createRelationFlags());
-        IntsRef edgeFlags = manager.handleWayTags(osmWay, relFlags);
-
-        assertTrue(defaultBike.priorityEnc.getDecimal(false, edgeFlags)
-                > lessRelationCodes.priorityEnc.getDecimal(false, edgeFlags));
-    }
-
-    @Test
-    public void testMixBikeTypesAndRelationCombination() {
-        ReaderWay osmWay = new ReaderWay(1);
-        osmWay.setTag("highway", "track");
-        osmWay.setTag("tracktype", "grade1");
-
-        ReaderRelation osmRel = new ReaderRelation(1);
-
-        BikeFlagEncoder bikeEncoder = new BikeFlagEncoder();
-        MountainBikeFlagEncoder mtbEncoder = new MountainBikeFlagEncoder();
-        TagParserManager manager = TagParserManager.create(bikeEncoder, mtbEncoder);
-
-        // relation code for network rcn is NICE for bike and PREFER for mountainbike
-        osmRel.setTag("route", "bicycle");
-        osmRel.setTag("network", "rcn");
-        IntsRef relFlags = manager.handleRelationTags(osmRel, manager.createRelationFlags());
-        IntsRef edgeFlags = manager.handleWayTags(osmWay, relFlags);
-
-        // bike: uninfluenced speed for grade but via network => NICE
-        // mtb: uninfluenced speed only PREFER
-        assertTrue(bikeEncoder.priorityEnc.getDecimal(false, edgeFlags)
-                > mtbEncoder.priorityEnc.getDecimal(false, edgeFlags));
-    }
-
-    @Test
-    public void testCompatibilityBug() {
-        TagParserManager manager2 = TagParserManager.create(new DefaultFlagEncoderFactory(), "bike2");
-        ReaderWay osmWay = new ReaderWay(1);
-        osmWay.setTag("highway", "footway");
-        osmWay.setTag("name", "test");
-
-        BikeFlagEncoder singleBikeEnc = (BikeFlagEncoder) manager2.getEncoder("bike2");
-        IntsRef flags = manager2.handleWayTags(osmWay, manager2.createRelationFlags());
-        double singleSpeed = singleBikeEnc.avgSpeedEnc.getDecimal(false, flags);
-        assertEquals(4, singleSpeed, 1e-3);
-        assertEquals(singleSpeed, singleBikeEnc.avgSpeedEnc.getDecimal(true, flags), 1e-3);
-
-        TagParserManager manager = TagParserManager.create(new DefaultFlagEncoderFactory(), "bike2,bike,foot");
-        FootFlagEncoder foot = (FootFlagEncoder) manager.getEncoder("foot");
-        BikeFlagEncoder bike = (BikeFlagEncoder) manager.getEncoder("bike2");
-
-        flags = manager.handleWayTags(osmWay, manager.createRelationFlags());
-        assertEquals(singleSpeed, bike.avgSpeedEnc.getDecimal(false, flags), 1e-2);
-        assertEquals(singleSpeed, bike.avgSpeedEnc.getDecimal(true, flags), 1e-2);
-
-        assertEquals(5, foot.avgSpeedEnc.getDecimal(false, flags), 1e-2);
-        assertEquals(5, foot.avgSpeedEnc.getDecimal(true, flags), 1e-2);
-    }
-
-    @Test
     public void testSupportFords() {
         // 1) no encoder crossing fords
         String flagEncoderStrings = "car,bike,foot";
@@ -197,34 +76,6 @@ public class EncodingManagerTest {
         assertTrue(((CarFlagEncoder) manager.getEncoder("car")).isBlockFords());
         assertFalse(((BikeFlagEncoder) manager.getEncoder("bike")).isBlockFords());
         assertFalse(((FootFlagEncoder) manager.getEncoder("foot")).isBlockFords());
-    }
-
-    @Test
-    public void testSharedEncodedValues() {
-        TagParserManager manager = TagParserManager.create("car,foot,bike,motorcycle,mtb");
-
-        BooleanEncodedValue roundaboutEnc = manager.getBooleanEncodedValue(Roundabout.KEY);
-        for (FlagEncoder tmp : manager.fetchEdgeEncoders()) {
-            BooleanEncodedValue accessEnc = tmp.getAccessEnc();
-
-            ReaderWay way = new ReaderWay(1);
-            way.setTag("highway", "primary");
-            way.setTag("junction", "roundabout");
-            IntsRef edgeFlags = manager.handleWayTags(way, manager.createRelationFlags());
-            assertTrue(accessEnc.getBool(false, edgeFlags));
-            if (!(tmp instanceof FootFlagEncoder))
-                assertFalse(accessEnc.getBool(true, edgeFlags), tmp.toString());
-            assertTrue(roundaboutEnc.getBool(false, edgeFlags), tmp.toString());
-
-            way.clearTags();
-            way.setTag("highway", "tertiary");
-            way.setTag("junction", "circular");
-            edgeFlags = manager.handleWayTags(way, manager.createRelationFlags());
-            assertTrue(accessEnc.getBool(false, edgeFlags));
-            if (!(tmp instanceof FootFlagEncoder))
-                assertFalse(accessEnc.getBool(true, edgeFlags), tmp.toString());
-            assertTrue(roundaboutEnc.getBool(false, edgeFlags), tmp.toString());
-        }
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/routing/util/EncodingManagerTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/EncodingManagerTest.java
@@ -111,7 +111,7 @@ public class EncodingManagerTest {
                 return "less_relations_bits";
             }
         };
-        EncodingManager manager = new EncodingManager.Builder().add(lessRelationCodes).add(defaultBike).build();
+        TagParserManager manager = new TagParserManager.Builder().add(lessRelationCodes).add(defaultBike).build();
 
         // relation code is PREFER
         osmRel.setTag("route", "bicycle");
@@ -133,7 +133,7 @@ public class EncodingManagerTest {
 
         BikeFlagEncoder bikeEncoder = new BikeFlagEncoder();
         MountainBikeFlagEncoder mtbEncoder = new MountainBikeFlagEncoder();
-        EncodingManager manager = EncodingManager.create(bikeEncoder, mtbEncoder);
+        TagParserManager manager = TagParserManager.create(bikeEncoder, mtbEncoder);
 
         // relation code for network rcn is NICE for bike and PREFER for mountainbike
         osmRel.setTag("route", "bicycle");
@@ -149,7 +149,7 @@ public class EncodingManagerTest {
 
     @Test
     public void testCompatibilityBug() {
-        EncodingManager manager2 = EncodingManager.create(new DefaultFlagEncoderFactory(), "bike2");
+        TagParserManager manager2 = TagParserManager.create(new DefaultFlagEncoderFactory(), "bike2");
         ReaderWay osmWay = new ReaderWay(1);
         osmWay.setTag("highway", "footway");
         osmWay.setTag("name", "test");
@@ -160,7 +160,7 @@ public class EncodingManagerTest {
         assertEquals(4, singleSpeed, 1e-3);
         assertEquals(singleSpeed, singleBikeEnc.avgSpeedEnc.getDecimal(true, flags), 1e-3);
 
-        EncodingManager manager = EncodingManager.create(new DefaultFlagEncoderFactory(), "bike2,bike,foot");
+        TagParserManager manager = TagParserManager.create(new DefaultFlagEncoderFactory(), "bike2,bike,foot");
         FootFlagEncoder foot = (FootFlagEncoder) manager.getEncoder("foot");
         BikeFlagEncoder bike = (BikeFlagEncoder) manager.getEncoder("bike2");
 
@@ -176,7 +176,7 @@ public class EncodingManagerTest {
     public void testSupportFords() {
         // 1) no encoder crossing fords
         String flagEncoderStrings = "car,bike,foot";
-        EncodingManager manager = EncodingManager.create(new DefaultFlagEncoderFactory(), flagEncoderStrings);
+        EncodingManager manager = EncodingManager.create(flagEncoderStrings);
 
         assertFalse(((CarFlagEncoder) manager.getEncoder("car")).isBlockFords());
         assertFalse(((BikeFlagEncoder) manager.getEncoder("bike")).isBlockFords());
@@ -184,7 +184,7 @@ public class EncodingManagerTest {
 
         // 2) two encoders crossing fords
         flagEncoderStrings = "car, bike|block_fords=true, foot|block_fords=false";
-        manager = EncodingManager.create(new DefaultFlagEncoderFactory(), flagEncoderStrings);
+        manager = EncodingManager.create(flagEncoderStrings);
 
         assertFalse(((CarFlagEncoder) manager.getEncoder("car")).isBlockFords());
         assertTrue(((BikeFlagEncoder) manager.getEncoder("bike")).isBlockFords());
@@ -192,7 +192,7 @@ public class EncodingManagerTest {
 
         // 2) Try combined with another tag
         flagEncoderStrings = "car|turn_costs=true|block_fords=true, bike, foot|block_fords=false";
-        manager = EncodingManager.create(new DefaultFlagEncoderFactory(), flagEncoderStrings);
+        manager = EncodingManager.create(flagEncoderStrings);
 
         assertTrue(((CarFlagEncoder) manager.getEncoder("car")).isBlockFords());
         assertFalse(((BikeFlagEncoder) manager.getEncoder("bike")).isBlockFords());
@@ -201,7 +201,7 @@ public class EncodingManagerTest {
 
     @Test
     public void testSharedEncodedValues() {
-        EncodingManager manager = EncodingManager.create("car,foot,bike,motorcycle,mtb");
+        TagParserManager manager = TagParserManager.create("car,foot,bike,motorcycle,mtb");
 
         BooleanEncodedValue roundaboutEnc = manager.getBooleanEncodedValue(Roundabout.KEY);
         for (FlagEncoder tmp : manager.fetchEdgeEncoders()) {

--- a/core/src/test/java/com/graphhopper/routing/util/FootFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/FootFlagEncoderTest.java
@@ -21,9 +21,9 @@ import com.graphhopper.reader.ReaderNode;
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.BooleanEncodedValue;
 import com.graphhopper.routing.ev.DecimalEncodedValue;
+import com.graphhopper.storage.BaseGraph;
 import com.graphhopper.storage.Graph;
 import com.graphhopper.storage.GraphBuilder;
-import com.graphhopper.storage.GraphHopperStorage;
 import com.graphhopper.storage.IntsRef;
 import com.graphhopper.util.*;
 import org.junit.jupiter.api.Test;
@@ -466,7 +466,7 @@ public class FootFlagEncoderTest {
         // be stored. In fact, when we set the speed of an edge to 15 and call the getter afterwards we get a value of 16
         // because of the internal (scaled) integer representation:
         EncodingManager em = EncodingManager.create(encoder);
-        GraphHopperStorage graph = new GraphBuilder(em).create();
+        BaseGraph graph = new BaseGraph.Builder(em).create();
         EdgeIteratorState edge = graph.edge(0, 1).setDistance(100).set(encoder.getAverageSpeedEnc(), 15);
         assertEquals(16, edge.get(encoder.getAverageSpeedEnc()));
 

--- a/core/src/test/java/com/graphhopper/routing/util/FootFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/FootFlagEncoderTest.java
@@ -22,8 +22,6 @@ import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.BooleanEncodedValue;
 import com.graphhopper.routing.ev.DecimalEncodedValue;
 import com.graphhopper.storage.BaseGraph;
-import com.graphhopper.storage.Graph;
-import com.graphhopper.storage.GraphBuilder;
 import com.graphhopper.storage.IntsRef;
 import com.graphhopper.util.*;
 import org.junit.jupiter.api.Test;
@@ -67,7 +65,7 @@ public class FootFlagEncoderTest {
 
     @Test
     public void testCombined() {
-        Graph g = new GraphBuilder(encodingManager).create();
+        BaseGraph g = new BaseGraph.Builder(encodingManager).create();
         EdgeIteratorState edge = g.edge(0, 1);
         edge.set(footAvgSpeedEnc, 10.0).set(footAccessEnc, true, true);
         edge.set(carAvSpeedEnc, 100.0).set(carAccessEnc, true, false);
@@ -89,7 +87,7 @@ public class FootFlagEncoderTest {
 
     @Test
     public void testGraph() {
-        Graph g = new GraphBuilder(encodingManager).create();
+        BaseGraph g = new BaseGraph.Builder(encodingManager).create();
         g.edge(0, 1).setDistance(10).set(footAvgSpeedEnc, 10.0).set(footAccessEnc, true, true);
         g.edge(0, 2).setDistance(10).set(footAvgSpeedEnc, 5.0).set(footAccessEnc, true, true);
         g.edge(1, 3).setDistance(10).set(footAvgSpeedEnc, 10.0).set(footAccessEnc, true, true);

--- a/core/src/test/java/com/graphhopper/routing/util/MotorcycleFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/MotorcycleFlagEncoderTest.java
@@ -20,7 +20,10 @@ package com.graphhopper.routing.util;
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.BooleanEncodedValue;
 import com.graphhopper.routing.ev.DecimalEncodedValue;
-import com.graphhopper.storage.*;
+import com.graphhopper.storage.BaseGraph;
+import com.graphhopper.storage.Graph;
+import com.graphhopper.storage.IntsRef;
+import com.graphhopper.storage.NodeAccess;
 import com.graphhopper.util.*;
 import com.graphhopper.util.shapes.GHPoint;
 import org.junit.jupiter.api.Test;
@@ -39,7 +42,7 @@ public class MotorcycleFlagEncoderTest {
     private final BooleanEncodedValue accessEnc = encoder.getAccessEnc();
 
     private Graph initExampleGraph() {
-        GraphHopperStorage gs = new GraphBuilder(em).set3D(true).create();
+        BaseGraph gs = new BaseGraph.Builder(em).set3D(true).create();
         NodeAccess na = gs.getNodeAccess();
         // 50--(0.0001)-->49--(0.0004)-->55--(0.0005)-->60
         na.setNode(0, 51.1, 12.001, 50);

--- a/core/src/test/java/com/graphhopper/routing/util/NameSimilarityEdgeFilterTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/NameSimilarityEdgeFilterTest.java
@@ -18,8 +18,6 @@
 package com.graphhopper.routing.util;
 
 import com.graphhopper.storage.BaseGraph;
-import com.graphhopper.storage.Graph;
-import com.graphhopper.storage.GraphBuilder;
 import com.graphhopper.storage.NodeAccess;
 import com.graphhopper.util.*;
 import com.graphhopper.util.shapes.GHPoint;
@@ -84,7 +82,7 @@ public class NameSimilarityEdgeFilterTest {
     @Test
     public void testDistanceFiltering() {
         CarFlagEncoder encoder = new CarFlagEncoder();
-        Graph g = new GraphBuilder(EncodingManager.create(encoder)).create();
+        BaseGraph g = new BaseGraph.Builder(EncodingManager.create(encoder)).create();
         NodeAccess na = g.getNodeAccess();
 
         GHPoint pointFarAway = new GHPoint(49.458629, 11.146124);

--- a/core/src/test/java/com/graphhopper/routing/util/RacingBikeFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/RacingBikeFlagEncoderTest.java
@@ -208,7 +208,7 @@ public class RacingBikeFlagEncoderTest extends AbstractBikeFlagEncoderTester {
                 return WAY;
             }
         };
-        EncodingManager encodingManager = EncodingManager.create(encoder);
+        TagParserManager encodingManager = TagParserManager.create(encoder);
         ReaderWay osmWay = new ReaderWay(1);
         osmWay.setTag("highway", "tertiary");
         osmWay.setTag("maxspeed", "50");
@@ -256,7 +256,7 @@ public class RacingBikeFlagEncoderTest extends AbstractBikeFlagEncoderTester {
         assertPriorityAndSpeed(encodingManager, UNCHANGED.getValue(), 4, osmWay);
     }
 
-    private void assertPriorityAndSpeed(EncodingManager encodingManager, int expectedPrio, double expectedSpeed, ReaderWay way) {
+    private void assertPriorityAndSpeed(TagParserManager encodingManager, int expectedPrio, double expectedSpeed, ReaderWay way) {
         IntsRef edgeFlags = encodingManager.handleWayTags(way, encodingManager.createRelationFlags());
         FlagEncoder encoder = encodingManager.fetchEdgeEncoders().iterator().next();
         DecimalEncodedValue enc = encodingManager.getDecimalEncodedValue(EncodingManager.getKey(encoder.toString(), "priority"));

--- a/core/src/test/java/com/graphhopper/routing/util/TagParserManagerTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/TagParserManagerTest.java
@@ -1,0 +1,175 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.graphhopper.routing.util;
+
+import com.graphhopper.reader.ReaderRelation;
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.BooleanEncodedValue;
+import com.graphhopper.routing.ev.Roundabout;
+import com.graphhopper.routing.ev.RouteNetwork;
+import com.graphhopper.storage.IntsRef;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TagParserManagerTest {
+    @Test
+    public void testToDetailsString() {
+        FlagEncoder encoder = new AbstractFlagEncoder(1, 2.0, 0) {
+            @Override
+            public TransportationMode getTransportationMode() {
+                return TransportationMode.BIKE;
+            }
+
+            @Override
+            protected String getPropertiesString() {
+                return "my_properties";
+            }
+
+            @Override
+            public EncodingManager.Access getAccess(ReaderWay way) {
+                return EncodingManager.Access.WAY;
+            }
+
+            @Override
+            public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay way) {
+                return edgeFlags;
+            }
+
+            @Override
+            public String getName() {
+                return "new_encoder";
+            }
+        };
+
+        TagParserManager subject = TagParserManager.create(encoder);
+
+        assertEquals("new_encoder|my_properties", subject.toFlagEncodersAsString());
+    }
+
+    @Test
+    public void testCombineRelations() {
+        ReaderWay osmWay = new ReaderWay(1);
+        osmWay.setTag("highway", "track");
+        ReaderRelation osmRel = new ReaderRelation(1);
+
+        BikeFlagEncoder defaultBike = new BikeFlagEncoder();
+        BikeFlagEncoder lessRelationCodes = new BikeFlagEncoder() {
+            @Override
+            public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay way) {
+                if (bikeRouteEnc.getEnum(false, edgeFlags) != RouteNetwork.MISSING)
+                    priorityEnc.setDecimal(false, edgeFlags, PriorityCode.getFactor(2));
+                return edgeFlags;
+            }
+
+            @Override
+            public String getName() {
+                return "less_relations_bits";
+            }
+        };
+        TagParserManager manager = new TagParserManager.Builder().add(lessRelationCodes).add(defaultBike).build();
+
+        // relation code is PREFER
+        osmRel.setTag("route", "bicycle");
+        osmRel.setTag("network", "lcn");
+        IntsRef relFlags = manager.handleRelationTags(osmRel, manager.createRelationFlags());
+        IntsRef edgeFlags = manager.handleWayTags(osmWay, relFlags);
+
+        assertTrue(defaultBike.priorityEnc.getDecimal(false, edgeFlags)
+                > lessRelationCodes.priorityEnc.getDecimal(false, edgeFlags));
+    }
+
+    @Test
+    public void testMixBikeTypesAndRelationCombination() {
+        ReaderWay osmWay = new ReaderWay(1);
+        osmWay.setTag("highway", "track");
+        osmWay.setTag("tracktype", "grade1");
+
+        ReaderRelation osmRel = new ReaderRelation(1);
+
+        BikeFlagEncoder bikeEncoder = new BikeFlagEncoder();
+        MountainBikeFlagEncoder mtbEncoder = new MountainBikeFlagEncoder();
+        TagParserManager manager = TagParserManager.create(bikeEncoder, mtbEncoder);
+
+        // relation code for network rcn is NICE for bike and PREFER for mountainbike
+        osmRel.setTag("route", "bicycle");
+        osmRel.setTag("network", "rcn");
+        IntsRef relFlags = manager.handleRelationTags(osmRel, manager.createRelationFlags());
+        IntsRef edgeFlags = manager.handleWayTags(osmWay, relFlags);
+
+        // bike: uninfluenced speed for grade but via network => NICE
+        // mtb: uninfluenced speed only PREFER
+        assertTrue(bikeEncoder.priorityEnc.getDecimal(false, edgeFlags)
+                > mtbEncoder.priorityEnc.getDecimal(false, edgeFlags));
+    }
+
+    @Test
+    public void testCompatibilityBug() {
+        TagParserManager manager2 = TagParserManager.create(new DefaultFlagEncoderFactory(), "bike2");
+        ReaderWay osmWay = new ReaderWay(1);
+        osmWay.setTag("highway", "footway");
+        osmWay.setTag("name", "test");
+
+        BikeFlagEncoder singleBikeEnc = (BikeFlagEncoder) manager2.getEncoder("bike2");
+        IntsRef flags = manager2.handleWayTags(osmWay, manager2.createRelationFlags());
+        double singleSpeed = singleBikeEnc.avgSpeedEnc.getDecimal(false, flags);
+        assertEquals(4, singleSpeed, 1e-3);
+        assertEquals(singleSpeed, singleBikeEnc.avgSpeedEnc.getDecimal(true, flags), 1e-3);
+
+        TagParserManager manager = TagParserManager.create(new DefaultFlagEncoderFactory(), "bike2,bike,foot");
+        FootFlagEncoder foot = (FootFlagEncoder) manager.getEncoder("foot");
+        BikeFlagEncoder bike = (BikeFlagEncoder) manager.getEncoder("bike2");
+
+        flags = manager.handleWayTags(osmWay, manager.createRelationFlags());
+        assertEquals(singleSpeed, bike.avgSpeedEnc.getDecimal(false, flags), 1e-2);
+        assertEquals(singleSpeed, bike.avgSpeedEnc.getDecimal(true, flags), 1e-2);
+
+        assertEquals(5, foot.avgSpeedEnc.getDecimal(false, flags), 1e-2);
+        assertEquals(5, foot.avgSpeedEnc.getDecimal(true, flags), 1e-2);
+    }
+
+    @Test
+    public void testSharedEncodedValues() {
+        TagParserManager manager = TagParserManager.create("car,foot,bike,motorcycle,mtb");
+
+        BooleanEncodedValue roundaboutEnc = manager.getBooleanEncodedValue(Roundabout.KEY);
+        for (FlagEncoder tmp : manager.fetchEdgeEncoders()) {
+            BooleanEncodedValue accessEnc = tmp.getAccessEnc();
+
+            ReaderWay way = new ReaderWay(1);
+            way.setTag("highway", "primary");
+            way.setTag("junction", "roundabout");
+            IntsRef edgeFlags = manager.handleWayTags(way, manager.createRelationFlags());
+            assertTrue(accessEnc.getBool(false, edgeFlags));
+            if (!(tmp instanceof FootFlagEncoder))
+                assertFalse(accessEnc.getBool(true, edgeFlags), tmp.toString());
+            assertTrue(roundaboutEnc.getBool(false, edgeFlags), tmp.toString());
+
+            way.clearTags();
+            way.setTag("highway", "tertiary");
+            way.setTag("junction", "circular");
+            edgeFlags = manager.handleWayTags(way, manager.createRelationFlags());
+            assertTrue(accessEnc.getBool(false, edgeFlags));
+            if (!(tmp instanceof FootFlagEncoder))
+                assertFalse(accessEnc.getBool(true, edgeFlags), tmp.toString());
+            assertTrue(roundaboutEnc.getBool(false, edgeFlags), tmp.toString());
+        }
+    }
+
+}

--- a/core/src/test/java/com/graphhopper/routing/util/WheelchairFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/WheelchairFlagEncoderTest.java
@@ -493,7 +493,7 @@ public class WheelchairFlagEncoderTest {
 
     @Test
     public void testApplyWayTags() {
-        GraphHopperStorage graph = new GraphBuilder(encodingManager).set3D(true).create();
+        BaseGraph graph = new BaseGraph.Builder(encodingManager).set3D(true).create();
         NodeAccess na = graph.getNodeAccess();
         // incline of 5% over all
         na.setNode(0, 51.1, 12.0010, 50);

--- a/core/src/test/java/com/graphhopper/routing/util/WheelchairFlagEncoderTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/WheelchairFlagEncoderTest.java
@@ -21,7 +21,9 @@ import com.graphhopper.reader.ReaderNode;
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.BooleanEncodedValue;
 import com.graphhopper.routing.ev.DecimalEncodedValue;
-import com.graphhopper.storage.*;
+import com.graphhopper.storage.BaseGraph;
+import com.graphhopper.storage.IntsRef;
+import com.graphhopper.storage.NodeAccess;
 import com.graphhopper.util.EdgeExplorer;
 import com.graphhopper.util.EdgeIteratorState;
 import com.graphhopper.util.GHUtility;
@@ -55,7 +57,7 @@ public class WheelchairFlagEncoderTest {
 
     @Test
     public void testCombined() {
-        Graph g = new GraphBuilder(encodingManager).create();
+        BaseGraph g = new BaseGraph.Builder(encodingManager).create();
         FlagEncoder carEncoder = encodingManager.getEncoder("car");
         EdgeIteratorState edge = g.edge(0, 1);
         edge.set(wheelchairAvSpeedEnc, 10.0).set(wheelchairAccessEnc, true, true);
@@ -78,7 +80,7 @@ public class WheelchairFlagEncoderTest {
 
     @Test
     public void testGraph() {
-        Graph g = new GraphBuilder(encodingManager).create();
+        BaseGraph g = new BaseGraph.Builder(encodingManager).create();
         g.edge(0, 1).setDistance(10).set(wheelchairAvSpeedEnc, 10.0).set(wheelchairAccessEnc, true, true);
         g.edge(0, 2).setDistance(10).set(wheelchairAvSpeedEnc, 5.0).set(wheelchairAccessEnc, true, true);
         g.edge(1, 3).setDistance(10).set(wheelchairAvSpeedEnc, 10.0).set(wheelchairAccessEnc, true, true);

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMGetOffBikeParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMGetOffBikeParserTest.java
@@ -6,7 +6,7 @@ import com.graphhopper.routing.ev.EnumEncodedValue;
 import com.graphhopper.routing.ev.GetOffBike;
 import com.graphhopper.routing.ev.RoadClass;
 import com.graphhopper.routing.util.BikeFlagEncoder;
-import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.routing.util.TagParserManager;
 import com.graphhopper.storage.IntsRef;
 import org.junit.jupiter.api.Test;
 
@@ -14,7 +14,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class OSMGetOffBikeParserTest {
 
-    private EncodingManager em = EncodingManager.start().add(new BikeFlagEncoder()).build();
+    private TagParserManager em = TagParserManager.start().add(new BikeFlagEncoder()).build();
     private BooleanEncodedValue offBikeEnc = em.getBooleanEncodedValue(GetOffBike.KEY);
     private EnumEncodedValue<RoadClass> roadClassEnc = em.getEnumEncodedValue(RoadClass.KEY, RoadClass.class);
 

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMHazmatParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMHazmatParserTest.java
@@ -3,7 +3,7 @@ package com.graphhopper.routing.util.parsers;
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.EnumEncodedValue;
 import com.graphhopper.routing.ev.Hazmat;
-import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.routing.util.TagParserManager;
 import com.graphhopper.storage.IntsRef;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -12,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class OSMHazmatParserTest {
 
-    private EncodingManager em;
+    private TagParserManager tpm;
     private EnumEncodedValue<Hazmat> hazEnc;
     private OSMHazmatParser parser;
     private IntsRef relFlags;
@@ -20,30 +20,30 @@ public class OSMHazmatParserTest {
     @BeforeEach
     public void setUp() {
         parser = new OSMHazmatParser();
-        em = new EncodingManager.Builder().add(parser).build();
-        relFlags = em.createRelationFlags();
-        hazEnc = em.getEnumEncodedValue(Hazmat.KEY, Hazmat.class);
+        tpm = new TagParserManager.Builder().add(parser).build();
+        relFlags = tpm.createRelationFlags();
+        hazEnc = tpm.getEnumEncodedValue(Hazmat.KEY, Hazmat.class);
     }
 
     @Test
     public void testSimpleTags() {
         ReaderWay readerWay = new ReaderWay(1);
-        IntsRef intsRef = em.createEdgeFlags();
+        IntsRef intsRef = tpm.createEdgeFlags();
         readerWay.setTag("hazmat", "no");
         parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(Hazmat.NO, hazEnc.getEnum(false, intsRef));
 
-        intsRef = em.createEdgeFlags();
+        intsRef = tpm.createEdgeFlags();
         readerWay.setTag("hazmat", "yes");
         parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(Hazmat.YES, hazEnc.getEnum(false, intsRef));
 
-        intsRef = em.createEdgeFlags();
+        intsRef = tpm.createEdgeFlags();
         readerWay.setTag("hazmat", "designated");
         parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(Hazmat.YES, hazEnc.getEnum(false, intsRef));
 
-        intsRef = em.createEdgeFlags();
+        intsRef = tpm.createEdgeFlags();
         readerWay.setTag("hazmat", "designated");
         parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(Hazmat.YES, hazEnc.getEnum(false, intsRef));
@@ -52,7 +52,7 @@ public class OSMHazmatParserTest {
     @Test
     public void testNoNPE() {
         ReaderWay readerWay = new ReaderWay(1);
-        IntsRef intsRef = em.createEdgeFlags();
+        IntsRef intsRef = tpm.createEdgeFlags();
         parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(Hazmat.YES, hazEnc.getEnum(false, intsRef));
     }

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMHazmatTunnelParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMHazmatTunnelParserTest.java
@@ -3,7 +3,7 @@ package com.graphhopper.routing.util.parsers;
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.EnumEncodedValue;
 import com.graphhopper.routing.ev.HazmatTunnel;
-import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.routing.util.TagParserManager;
 import com.graphhopper.storage.IntsRef;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -12,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class OSMHazmatTunnelParserTest {
 
-    private EncodingManager em;
+    private TagParserManager tpm;
     private EnumEncodedValue<HazmatTunnel> hazTunnelEnc;
     private OSMHazmatTunnelParser parser;
     private IntsRef relFlags;
@@ -20,38 +20,38 @@ public class OSMHazmatTunnelParserTest {
     @BeforeEach
     public void setUp() {
         parser = new OSMHazmatTunnelParser();
-        em = new EncodingManager.Builder().add(parser).build();
-        relFlags = em.createRelationFlags();
-        hazTunnelEnc = em.getEnumEncodedValue(HazmatTunnel.KEY, HazmatTunnel.class);
+        tpm = new TagParserManager.Builder().add(parser).build();
+        relFlags = tpm.createRelationFlags();
+        hazTunnelEnc = tpm.getEnumEncodedValue(HazmatTunnel.KEY, HazmatTunnel.class);
     }
 
     @Test
     public void testADRTunnelCat() {
-        IntsRef intsRef = em.createEdgeFlags();
+        IntsRef intsRef = tpm.createEdgeFlags();
         ReaderWay readerWay = new ReaderWay(1);
         readerWay.setTag("hazmat:adr_tunnel_cat", "A");
         parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(HazmatTunnel.A, hazTunnelEnc.getEnum(false, intsRef));
 
-        intsRef = em.createEdgeFlags();
+        intsRef = tpm.createEdgeFlags();
         readerWay = new ReaderWay(1);
         readerWay.setTag("hazmat:adr_tunnel_cat", "B");
         parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(HazmatTunnel.B, hazTunnelEnc.getEnum(false, intsRef));
 
-        intsRef = em.createEdgeFlags();
+        intsRef = tpm.createEdgeFlags();
         readerWay = new ReaderWay(1);
         readerWay.setTag("hazmat:adr_tunnel_cat", "C");
         parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(HazmatTunnel.C, hazTunnelEnc.getEnum(false, intsRef));
 
-        intsRef = em.createEdgeFlags();
+        intsRef = tpm.createEdgeFlags();
         readerWay = new ReaderWay(1);
         readerWay.setTag("hazmat:adr_tunnel_cat", "D");
         parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(HazmatTunnel.D, hazTunnelEnc.getEnum(false, intsRef));
 
-        intsRef = em.createEdgeFlags();
+        intsRef = tpm.createEdgeFlags();
         readerWay = new ReaderWay(1);
         readerWay.setTag("hazmat:adr_tunnel_cat", "E");
         parser.handleWayTags(intsRef, readerWay, relFlags);
@@ -60,31 +60,31 @@ public class OSMHazmatTunnelParserTest {
 
     @Test
     public void testTunnelCat() {
-        IntsRef intsRef = em.createEdgeFlags();
+        IntsRef intsRef = tpm.createEdgeFlags();
         ReaderWay readerWay = new ReaderWay(1);
         readerWay.setTag("hazmat:tunnel_cat", "A");
         parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(HazmatTunnel.A, hazTunnelEnc.getEnum(false, intsRef));
 
-        intsRef = em.createEdgeFlags();
+        intsRef = tpm.createEdgeFlags();
         readerWay = new ReaderWay(1);
         readerWay.setTag("hazmat:tunnel_cat", "B");
         parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(HazmatTunnel.B, hazTunnelEnc.getEnum(false, intsRef));
 
-        intsRef = em.createEdgeFlags();
+        intsRef = tpm.createEdgeFlags();
         readerWay = new ReaderWay(1);
         readerWay.setTag("hazmat:tunnel_cat", "C");
         parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(HazmatTunnel.C, hazTunnelEnc.getEnum(false, intsRef));
 
-        intsRef = em.createEdgeFlags();
+        intsRef = tpm.createEdgeFlags();
         readerWay = new ReaderWay(1);
         readerWay.setTag("hazmat:tunnel_cat", "D");
         parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(HazmatTunnel.D, hazTunnelEnc.getEnum(false, intsRef));
 
-        intsRef = em.createEdgeFlags();
+        intsRef = tpm.createEdgeFlags();
         readerWay = new ReaderWay(1);
         readerWay.setTag("hazmat:tunnel_cat", "E");
         parser.handleWayTags(intsRef, readerWay, relFlags);
@@ -93,35 +93,35 @@ public class OSMHazmatTunnelParserTest {
 
     @Test
     public void testHazmatSubtags() {
-        IntsRef intsRef = em.createEdgeFlags();
+        IntsRef intsRef = tpm.createEdgeFlags();
         ReaderWay readerWay = new ReaderWay(1);
         readerWay.setTag("tunnel", "yes");
         readerWay.setTag("hazmat:A", "no");
         parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(HazmatTunnel.A, hazTunnelEnc.getEnum(false, intsRef));
 
-        intsRef = em.createEdgeFlags();
+        intsRef = tpm.createEdgeFlags();
         readerWay = new ReaderWay(1);
         readerWay.setTag("tunnel", "yes");
         readerWay.setTag("hazmat:B", "no");
         parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(HazmatTunnel.B, hazTunnelEnc.getEnum(false, intsRef));
 
-        intsRef = em.createEdgeFlags();
+        intsRef = tpm.createEdgeFlags();
         readerWay = new ReaderWay(1);
         readerWay.setTag("tunnel", "yes");
         readerWay.setTag("hazmat:C", "no");
         parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(HazmatTunnel.C, hazTunnelEnc.getEnum(false, intsRef));
 
-        intsRef = em.createEdgeFlags();
+        intsRef = tpm.createEdgeFlags();
         readerWay = new ReaderWay(1);
         readerWay.setTag("tunnel", "yes");
         readerWay.setTag("hazmat:D", "no");
         parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(HazmatTunnel.D, hazTunnelEnc.getEnum(false, intsRef));
 
-        intsRef = em.createEdgeFlags();
+        intsRef = tpm.createEdgeFlags();
         readerWay = new ReaderWay(1);
         readerWay.setTag("tunnel", "yes");
         readerWay.setTag("hazmat:E", "no");
@@ -131,7 +131,7 @@ public class OSMHazmatTunnelParserTest {
 
     @Test
     public void testOrder() {
-        IntsRef intsRef = em.createEdgeFlags();
+        IntsRef intsRef = tpm.createEdgeFlags();
         ReaderWay readerWay = new ReaderWay(1);
         readerWay.setTag("tunnel", "yes");
         readerWay.setTag("hazmat:A", "no");
@@ -142,7 +142,7 @@ public class OSMHazmatTunnelParserTest {
         parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(HazmatTunnel.E, hazTunnelEnc.getEnum(false, intsRef));
 
-        intsRef = em.createEdgeFlags();
+        intsRef = tpm.createEdgeFlags();
         readerWay = new ReaderWay(1);
         readerWay.setTag("tunnel", "yes");
         readerWay.setTag("hazmat:A", "no");
@@ -151,7 +151,7 @@ public class OSMHazmatTunnelParserTest {
         parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(HazmatTunnel.C, hazTunnelEnc.getEnum(false, intsRef));
 
-        intsRef = em.createEdgeFlags();
+        intsRef = tpm.createEdgeFlags();
         readerWay = new ReaderWay(1);
         readerWay.setTag("tunnel", "yes");
         readerWay.setTag("hazmat:B", "no");
@@ -162,7 +162,7 @@ public class OSMHazmatTunnelParserTest {
 
     @Test
     public void testIgnoreNonTunnelSubtags() {
-        IntsRef intsRef = em.createEdgeFlags();
+        IntsRef intsRef = tpm.createEdgeFlags();
         ReaderWay readerWay = new ReaderWay(1);
         readerWay.setTag("hazmat:B", "no");
         parser.handleWayTags(intsRef, readerWay, relFlags);
@@ -172,7 +172,7 @@ public class OSMHazmatTunnelParserTest {
     @Test
     public void testNoNPE() {
         ReaderWay readerWay = new ReaderWay(1);
-        IntsRef intsRef = em.createEdgeFlags();
+        IntsRef intsRef = tpm.createEdgeFlags();
         parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(HazmatTunnel.A, hazTunnelEnc.getEnum(false, intsRef));
     }

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMHazmatWaterParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMHazmatWaterParserTest.java
@@ -3,7 +3,7 @@ package com.graphhopper.routing.util.parsers;
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.EnumEncodedValue;
 import com.graphhopper.routing.ev.HazmatWater;
-import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.routing.util.TagParserManager;
 import com.graphhopper.storage.IntsRef;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -12,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class OSMHazmatWaterParserTest {
 
-    private EncodingManager em;
+    private TagParserManager tpm;
     private EnumEncodedValue<HazmatWater> hazWaterEnc;
     private OSMHazmatWaterParser parser;
     private IntsRef relFlags;
@@ -20,25 +20,25 @@ public class OSMHazmatWaterParserTest {
     @BeforeEach
     public void setUp() {
         parser = new OSMHazmatWaterParser();
-        em = new EncodingManager.Builder().add(parser).build();
-        relFlags = em.createRelationFlags();
-        hazWaterEnc = em.getEnumEncodedValue(HazmatWater.KEY, HazmatWater.class);
+        tpm = new TagParserManager.Builder().add(parser).build();
+        relFlags = tpm.createRelationFlags();
+        hazWaterEnc = tpm.getEnumEncodedValue(HazmatWater.KEY, HazmatWater.class);
     }
 
     @Test
     public void testSimpleTags() {
         ReaderWay readerWay = new ReaderWay(1);
-        IntsRef intsRef = em.createEdgeFlags();
+        IntsRef intsRef = tpm.createEdgeFlags();
         readerWay.setTag("hazmat:water", "no");
         parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(HazmatWater.NO, hazWaterEnc.getEnum(false, intsRef));
 
-        intsRef = em.createEdgeFlags();
+        intsRef = tpm.createEdgeFlags();
         readerWay.setTag("hazmat:water", "yes");
         parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(HazmatWater.YES, hazWaterEnc.getEnum(false, intsRef));
 
-        intsRef = em.createEdgeFlags();
+        intsRef = tpm.createEdgeFlags();
         readerWay.setTag("hazmat:water", "permissive");
         parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(HazmatWater.PERMISSIVE, hazWaterEnc.getEnum(false, intsRef));
@@ -47,7 +47,7 @@ public class OSMHazmatWaterParserTest {
     @Test
     public void testNoNPE() {
         ReaderWay readerWay = new ReaderWay(1);
-        IntsRef intsRef = em.createEdgeFlags();
+        IntsRef intsRef = tpm.createEdgeFlags();
         parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(HazmatWater.YES, hazWaterEnc.getEnum(false, intsRef));
     }

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMLanesParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMLanesParserTest.java
@@ -20,7 +20,7 @@ package com.graphhopper.routing.util.parsers;
 
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.Lanes;
-import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.routing.util.TagParserManager;
 import com.graphhopper.storage.IntsRef;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,29 +29,29 @@ import org.junit.jupiter.api.Test;
 class OSMLanesParserTest {
 
     private OSMLanesParser parser;
-    private EncodingManager em;
+    private TagParserManager tpm;
 
     @BeforeEach
     void setup() {
         parser = new OSMLanesParser();
-        em = new EncodingManager.Builder().add(parser).build();
+        tpm = new TagParserManager.Builder().add(parser).build();
     }
 
     @Test
     void basic() {
         ReaderWay readerWay = new ReaderWay(1);
-        IntsRef intsRef = em.createEdgeFlags();
+        IntsRef intsRef = tpm.createEdgeFlags();
         readerWay.setTag("lanes", "4");
-        parser.handleWayTags(intsRef, readerWay, em.createRelationFlags());
-        Assertions.assertEquals(4, em.getIntEncodedValue(Lanes.KEY).getInt(false, intsRef));
+        parser.handleWayTags(intsRef, readerWay, tpm.createRelationFlags());
+        Assertions.assertEquals(4, tpm.getIntEncodedValue(Lanes.KEY).getInt(false, intsRef));
     }
 
     @Test
     void notTagged() {
         ReaderWay readerWay = new ReaderWay(1);
-        IntsRef intsRef = em.createEdgeFlags();
-        parser.handleWayTags(intsRef, readerWay, em.createRelationFlags());
-        Assertions.assertEquals(1, em.getIntEncodedValue(Lanes.KEY).getInt(false, intsRef));
+        IntsRef intsRef = tpm.createEdgeFlags();
+        parser.handleWayTags(intsRef, readerWay, tpm.createRelationFlags());
+        Assertions.assertEquals(1, tpm.getIntEncodedValue(Lanes.KEY).getInt(false, intsRef));
     }
 
 }

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMMaxAxleLoadParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMMaxAxleLoadParserTest.java
@@ -3,7 +3,7 @@ package com.graphhopper.routing.util.parsers;
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.DecimalEncodedValue;
 import com.graphhopper.routing.ev.MaxAxleLoad;
-import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.routing.util.TagParserManager;
 import com.graphhopper.storage.IntsRef;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -12,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class OSMMaxAxleLoadParserTest {
 
-    private EncodingManager em;
+    private TagParserManager tpm;
     private DecimalEncodedValue malEnc;
     private OSMMaxAxleLoadParser parser;
     private IntsRef relFlags;
@@ -20,21 +20,21 @@ public class OSMMaxAxleLoadParserTest {
     @BeforeEach
     public void setUp() {
         parser = new OSMMaxAxleLoadParser();
-        em = new EncodingManager.Builder().add(parser).build();
-        relFlags = em.createRelationFlags();
-        malEnc = em.getDecimalEncodedValue(MaxAxleLoad.KEY);
+        tpm = new TagParserManager.Builder().add(parser).build();
+        relFlags = tpm.createRelationFlags();
+        malEnc = tpm.getDecimalEncodedValue(MaxAxleLoad.KEY);
     }
 
     @Test
     public void testSimpleTags() {
         ReaderWay readerWay = new ReaderWay(1);
-        IntsRef intsRef = em.createEdgeFlags();
+        IntsRef intsRef = tpm.createEdgeFlags();
         readerWay.setTag("maxaxleload", "11.5");
         parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(11.5, malEnc.getDecimal(false, intsRef), .01);
 
         // if value is beyond the maximum then do not use infinity instead fallback to more restrictive maximum
-        intsRef = em.createEdgeFlags();
+        intsRef = tpm.createEdgeFlags();
         readerWay.setTag("maxaxleload", "80");
         parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(malEnc.getMaxDecimal(), malEnc.getDecimal(false, intsRef), .01);
@@ -43,17 +43,17 @@ public class OSMMaxAxleLoadParserTest {
     @Test
     public void testRounding() {
         ReaderWay readerWay = new ReaderWay(1);
-        IntsRef intsRef = em.createEdgeFlags();
+        IntsRef intsRef = tpm.createEdgeFlags();
         readerWay.setTag("maxaxleload", "4.8");
         parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(5.0, malEnc.getDecimal(false, intsRef), .01);
 
-        intsRef = em.createEdgeFlags();
+        intsRef = tpm.createEdgeFlags();
         readerWay.setTag("maxaxleload", "3.6");
         parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(3.5, malEnc.getDecimal(false, intsRef), .01);
 
-        intsRef = em.createEdgeFlags();
+        intsRef = tpm.createEdgeFlags();
         readerWay.setTag("maxaxleload", "2.4");
         parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(2.5, malEnc.getDecimal(false, intsRef), .01);
@@ -62,7 +62,7 @@ public class OSMMaxAxleLoadParserTest {
     @Test
     public void testNoLimit() {
         ReaderWay readerWay = new ReaderWay(1);
-        IntsRef intsRef = em.createEdgeFlags();
+        IntsRef intsRef = tpm.createEdgeFlags();
         parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(Double.POSITIVE_INFINITY, malEnc.getDecimal(false, intsRef), .01);
     }

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMMaxSpeedParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMMaxSpeedParserTest.java
@@ -24,8 +24,7 @@ import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.routing.util.TransportationMode;
 import com.graphhopper.routing.util.countryrules.CountryRule;
-import com.graphhopper.storage.Graph;
-import com.graphhopper.storage.GraphBuilder;
+import com.graphhopper.storage.BaseGraph;
 import com.graphhopper.storage.IntsRef;
 import com.graphhopper.util.EdgeIteratorState;
 import com.graphhopper.util.GHUtility;
@@ -39,7 +38,7 @@ class OSMMaxSpeedParserTest {
     void countryRule() {
         EncodingManager em = EncodingManager.create("car");
         DecimalEncodedValue maxSpeedEnc = em.getDecimalEncodedValue(MaxSpeed.KEY);
-        Graph graph = new GraphBuilder(em).create();
+        BaseGraph graph = new BaseGraph.Builder(em).create();
         FlagEncoder encoder = em.getEncoder("car");
         EdgeIteratorState e1 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(100));
         EdgeIteratorState e2 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(100));

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMMaxWeightParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMMaxWeightParserTest.java
@@ -3,7 +3,7 @@ package com.graphhopper.routing.util.parsers;
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.DecimalEncodedValue;
 import com.graphhopper.routing.ev.MaxWeight;
-import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.routing.util.TagParserManager;
 import com.graphhopper.storage.IntsRef;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -12,30 +12,30 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class OSMMaxWeightParserTest {
 
-    private EncodingManager em;
+    private TagParserManager tpm;
     private DecimalEncodedValue mwEnc;
     private OSMMaxWeightParser parser;
 
     @BeforeEach
     public void setUp() {
         parser = new OSMMaxWeightParser();
-        em = new EncodingManager.Builder().add(parser).build();
-        mwEnc = em.getDecimalEncodedValue(MaxWeight.KEY);
+        tpm = new TagParserManager.Builder().add(parser).build();
+        mwEnc = tpm.getDecimalEncodedValue(MaxWeight.KEY);
     }
 
     @Test
     public void testSimpleTags() {
         ReaderWay readerWay = new ReaderWay(1);
-        IntsRef intsRef = em.createEdgeFlags();
+        IntsRef intsRef = tpm.createEdgeFlags();
         readerWay.setTag("highway", "primary");
         readerWay.setTag("maxweight", "5");
-        parser.handleWayTags(intsRef, readerWay, em.createRelationFlags());
+        parser.handleWayTags(intsRef, readerWay, tpm.createRelationFlags());
         assertEquals(5.0, mwEnc.getDecimal(false, intsRef), .01);
 
         // if value is beyond the maximum then do not use infinity instead fallback to more restrictive maximum
-        intsRef = em.createEdgeFlags();
+        intsRef = tpm.createEdgeFlags();
         readerWay.setTag("maxweight", "50");
-        parser.handleWayTags(intsRef, readerWay, em.createRelationFlags());
+        parser.handleWayTags(intsRef, readerWay, tpm.createRelationFlags());
         assertEquals(mwEnc.getMaxDecimal(), mwEnc.getDecimal(false, intsRef), .01);
     }
 }

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMMtbRatingParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMMtbRatingParserTest.java
@@ -21,7 +21,7 @@ package com.graphhopper.routing.util.parsers;
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.IntEncodedValue;
 import com.graphhopper.routing.ev.MtbRating;
-import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.routing.util.TagParserManager;
 import com.graphhopper.storage.IntsRef;
 import org.junit.jupiter.api.Test;
 
@@ -57,13 +57,13 @@ class OSMMtbRatingParserTest {
 
     private void checkRating(int expectedRating, String scaleString) {
         OSMMtbRatingParser parser = new OSMMtbRatingParser();
-        EncodingManager em = new EncodingManager.Builder().add(parser).build();
-        IntEncodedValue ev = em.getIntEncodedValue(MtbRating.KEY);
-        IntsRef edgeFlags = em.createEdgeFlags();
+        TagParserManager tpm = new TagParserManager.Builder().add(parser).build();
+        IntEncodedValue ev = tpm.getIntEncodedValue(MtbRating.KEY);
+        IntsRef edgeFlags = tpm.createEdgeFlags();
         ReaderWay way = new ReaderWay(0);
         if (scaleString != null)
             way.setTag("mtb:scale", scaleString);
-        parser.handleWayTags(edgeFlags, way, em.createRelationFlags());
+        parser.handleWayTags(edgeFlags, way, tpm.createRelationFlags());
         assertEquals(expectedRating, ev.getInt(false, edgeFlags), "unexpected rating for mtb:scale=" + scaleString);
     }
 

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMRoadAccessParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMRoadAccessParserTest.java
@@ -25,8 +25,7 @@ import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.routing.util.TransportationMode;
 import com.graphhopper.routing.util.countryrules.CountryRule;
-import com.graphhopper.storage.Graph;
-import com.graphhopper.storage.GraphBuilder;
+import com.graphhopper.storage.BaseGraph;
 import com.graphhopper.storage.IntsRef;
 import com.graphhopper.util.EdgeIteratorState;
 import com.graphhopper.util.GHUtility;
@@ -40,7 +39,7 @@ class OSMRoadAccessParserTest {
     void countryRule() {
         EncodingManager em = EncodingManager.create("car");
         EnumEncodedValue<RoadAccess> roadAccessEnc = em.getEnumEncodedValue(RoadAccess.KEY, RoadAccess.class);
-        Graph graph = new GraphBuilder(em).create();
+        BaseGraph graph = new BaseGraph.Builder(em).create();
         FlagEncoder encoder = em.getEncoder("car");
         EdgeIteratorState e1 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(100));
         EdgeIteratorState e2 = GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(100));

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMRoadClassParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMRoadClassParserTest.java
@@ -3,7 +3,7 @@ package com.graphhopper.routing.util.parsers;
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.EnumEncodedValue;
 import com.graphhopper.routing.ev.RoadClass;
-import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.routing.util.TagParserManager;
 import com.graphhopper.storage.IntsRef;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -12,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class OSMRoadClassParserTest {
 
-    private EncodingManager em;
+    private TagParserManager tpm;
     private IntsRef relFlags;
     private EnumEncodedValue<RoadClass> rcEnc;
     private OSMRoadClassParser parser;
@@ -20,25 +20,25 @@ public class OSMRoadClassParserTest {
     @BeforeEach
     public void setUp() {
         parser = new OSMRoadClassParser();
-        em = new EncodingManager.Builder().add(parser).build();
-        relFlags = em.createRelationFlags();
-        rcEnc = em.getEnumEncodedValue(RoadClass.KEY, RoadClass.class);
+        tpm = new TagParserManager.Builder().add(parser).build();
+        relFlags = tpm.createRelationFlags();
+        rcEnc = tpm.getEnumEncodedValue(RoadClass.KEY, RoadClass.class);
     }
 
     @Test
     public void testSimpleTags() {
         ReaderWay readerWay = new ReaderWay(1);
-        IntsRef edgeFlags = em.createEdgeFlags();
+        IntsRef edgeFlags = tpm.createEdgeFlags();
         readerWay.setTag("highway", "primary");
         parser.handleWayTags(edgeFlags, readerWay, relFlags);
         assertEquals(RoadClass.PRIMARY, rcEnc.getEnum(false, edgeFlags));
 
-        edgeFlags = em.createEdgeFlags();
+        edgeFlags = tpm.createEdgeFlags();
         readerWay.setTag("highway", "unknownstuff");
         parser.handleWayTags(edgeFlags, readerWay, relFlags);
         assertEquals(RoadClass.OTHER, rcEnc.getEnum(false, edgeFlags));
 
-        edgeFlags = em.createEdgeFlags();
+        edgeFlags = tpm.createEdgeFlags();
         readerWay.setTag("highway", "motorway_link");
         parser.handleWayTags(edgeFlags, readerWay, relFlags);
         assertEquals(RoadClass.MOTORWAY, rcEnc.getEnum(false, edgeFlags));
@@ -47,7 +47,7 @@ public class OSMRoadClassParserTest {
     @Test
     public void testIgnore() {
         ReaderWay readerWay = new ReaderWay(1);
-        IntsRef edgeFlags = em.createEdgeFlags();
+        IntsRef edgeFlags = tpm.createEdgeFlags();
         readerWay.setTag("route", "ferry");
         parser.handleWayTags(edgeFlags, readerWay, relFlags);
         assertEquals(RoadClass.OTHER, rcEnc.getEnum(false, edgeFlags));
@@ -56,7 +56,7 @@ public class OSMRoadClassParserTest {
     @Test
     public void testNoNPE() {
         ReaderWay readerWay = new ReaderWay(1);
-        IntsRef edgeFlags = em.createEdgeFlags();
+        IntsRef edgeFlags = tpm.createEdgeFlags();
         parser.handleWayTags(edgeFlags, readerWay, relFlags);
         assertEquals(RoadClass.OTHER, rcEnc.getEnum(false, edgeFlags));
     }

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMRoadEnvironmentParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMRoadEnvironmentParserTest.java
@@ -22,7 +22,7 @@ import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.EnumEncodedValue;
 import com.graphhopper.routing.ev.RoadEnvironment;
 import com.graphhopper.routing.util.CarFlagEncoder;
-import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.routing.util.TagParserManager;
 import com.graphhopper.storage.IntsRef;
 import org.junit.jupiter.api.Test;
 
@@ -34,14 +34,14 @@ class OSMRoadEnvironmentParserTest {
     void ferry() {
         OSMRoadEnvironmentParser parser = new OSMRoadEnvironmentParser();
         CarFlagEncoder carEncoder = new CarFlagEncoder();
-        EncodingManager em = new EncodingManager.Builder()
+        TagParserManager tpm = new TagParserManager.Builder()
                 .add(carEncoder)
                 .add(parser).build();
-        EnumEncodedValue<RoadEnvironment> roadEnvironmentEnc = em.getEnumEncodedValue(RoadEnvironment.KEY, RoadEnvironment.class);
-        IntsRef edgeFlags = em.createEdgeFlags();
+        EnumEncodedValue<RoadEnvironment> roadEnvironmentEnc = tpm.getEnumEncodedValue(RoadEnvironment.KEY, RoadEnvironment.class);
+        IntsRef edgeFlags = tpm.createEdgeFlags();
         ReaderWay way = new ReaderWay(0);
         way.setTag("route", "shuttle_train");
-        parser.handleWayTags(edgeFlags, way, em.createRelationFlags());
+        parser.handleWayTags(edgeFlags, way, tpm.createRelationFlags());
         RoadEnvironment roadEnvironment = roadEnvironmentEnc.getEnum(false, edgeFlags);
         assertEquals(RoadEnvironment.FERRY, roadEnvironment);
     }

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMSmoothnessParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMSmoothnessParserTest.java
@@ -3,7 +3,7 @@ package com.graphhopper.routing.util.parsers;
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.EnumEncodedValue;
 import com.graphhopper.routing.ev.Smoothness;
-import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.routing.util.TagParserManager;
 import com.graphhopper.storage.IntsRef;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -12,23 +12,23 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class OSMSmoothnessParserTest {
-    private EncodingManager em;
+    private TagParserManager tpm;
     private EnumEncodedValue<Smoothness> smoothnessEnc;
     private OSMSmoothnessParser parser;
 
     @BeforeEach
     public void setUp() {
         parser = new OSMSmoothnessParser();
-        em = new EncodingManager.Builder().add(parser).build();
-        smoothnessEnc = em.getEnumEncodedValue(Smoothness.KEY, Smoothness.class);
+        tpm = new TagParserManager.Builder().add(parser).build();
+        smoothnessEnc = tpm.getEnumEncodedValue(Smoothness.KEY, Smoothness.class);
     }
 
     @Test
     public void testSimpleTags() {
-        IntsRef relFlags = em.createRelationFlags();
+        IntsRef relFlags = tpm.createRelationFlags();
 
         ReaderWay readerWay = new ReaderWay(1);
-        IntsRef intsRef = em.createEdgeFlags();
+        IntsRef intsRef = tpm.createEdgeFlags();
         readerWay.setTag("highway", "primary");
         parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(Smoothness.MISSING, smoothnessEnc.getEnum(false, intsRef));

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMSurfaceParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMSurfaceParserTest.java
@@ -3,7 +3,7 @@ package com.graphhopper.routing.util.parsers;
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.EnumEncodedValue;
 import com.graphhopper.routing.ev.Surface;
-import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.routing.util.TagParserManager;
 import com.graphhopper.storage.IntsRef;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -12,23 +12,23 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class OSMSurfaceParserTest {
-    private EncodingManager em;
+    private TagParserManager tpm;
     private EnumEncodedValue<Surface> surfaceEnc;
     private OSMSurfaceParser parser;
 
     @BeforeEach
     public void setUp() {
         parser = new OSMSurfaceParser();
-        em = new EncodingManager.Builder().add(parser).build();
-        surfaceEnc = em.getEnumEncodedValue(Surface.KEY, Surface.class);
+        tpm = new TagParserManager.Builder().add(parser).build();
+        surfaceEnc = tpm.getEnumEncodedValue(Surface.KEY, Surface.class);
     }
 
     @Test
     public void testSimpleTags() {
-        IntsRef relFlags = em.createRelationFlags();
+        IntsRef relFlags = tpm.createRelationFlags();
 
         ReaderWay readerWay = new ReaderWay(1);
-        IntsRef intsRef = em.createEdgeFlags();
+        IntsRef intsRef = tpm.createEdgeFlags();
         readerWay.setTag("highway", "primary");
         parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(Surface.MISSING, surfaceEnc.getEnum(false, intsRef));

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMTollParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMTollParserTest.java
@@ -3,7 +3,7 @@ package com.graphhopper.routing.util.parsers;
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.EnumEncodedValue;
 import com.graphhopper.routing.ev.Toll;
-import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.routing.util.TagParserManager;
 import com.graphhopper.storage.IntsRef;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -11,51 +11,51 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class OSMTollParserTest {
-    private EncodingManager em;
+    private TagParserManager tpm;
     private EnumEncodedValue<Toll> tollEnc;
     private OSMTollParser parser;
 
     @BeforeEach
     public void setUp() {
         parser = new OSMTollParser();
-        em = new EncodingManager.Builder().add(parser).build();
-        tollEnc = em.getEnumEncodedValue(Toll.KEY, Toll.class);
+        tpm = new TagParserManager.Builder().add(parser).build();
+        tollEnc = tpm.getEnumEncodedValue(Toll.KEY, Toll.class);
     }
 
     @Test
     public void testSimpleTags() {
         ReaderWay readerWay = new ReaderWay(1);
-        IntsRef relFlags = em.createRelationFlags();
-        IntsRef intsRef = em.createEdgeFlags();
+        IntsRef relFlags = tpm.createRelationFlags();
+        IntsRef intsRef = tpm.createEdgeFlags();
         readerWay.setTag("highway", "primary");
         parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(Toll.MISSING, tollEnc.getEnum(false, intsRef));
 
-        intsRef = em.createEdgeFlags();
+        intsRef = tpm.createEdgeFlags();
         readerWay.setTag("highway", "primary");
         readerWay.setTag("toll:hgv", "yes");
         parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(Toll.HGV, tollEnc.getEnum(false, intsRef));
 
-        intsRef = em.createEdgeFlags();
+        intsRef = tpm.createEdgeFlags();
         readerWay.setTag("highway", "primary");
         readerWay.setTag("toll:N2", "yes");
         parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(Toll.HGV, tollEnc.getEnum(false, intsRef));
 
-        intsRef = em.createEdgeFlags();
+        intsRef = tpm.createEdgeFlags();
         readerWay.setTag("highway", "primary");
         readerWay.setTag("toll:N3", "yes");
         parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(Toll.HGV, tollEnc.getEnum(false, intsRef));
 
-        intsRef = em.createEdgeFlags();
+        intsRef = tpm.createEdgeFlags();
         readerWay.setTag("highway", "primary");
         readerWay.setTag("toll", "yes");
         parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(Toll.ALL, tollEnc.getEnum(false, intsRef));
 
-        intsRef = em.createEdgeFlags();
+        intsRef = tpm.createEdgeFlags();
         readerWay.setTag("highway", "primary");
         readerWay.setTag("toll", "yes");
         readerWay.setTag("toll:hgv", "yes");

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMTrackTypeParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMTrackTypeParserTest.java
@@ -3,7 +3,7 @@ package com.graphhopper.routing.util.parsers;
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.EnumEncodedValue;
 import com.graphhopper.routing.ev.TrackType;
-import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.routing.util.TagParserManager;
 import com.graphhopper.storage.IntsRef;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -12,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class OSMTrackTypeParserTest {
 
-    private EncodingManager em;
+    private TagParserManager tpm;
     private IntsRef relFlags;
     private EnumEncodedValue<TrackType> ttEnc;
     private OSMTrackTypeParser parser;
@@ -20,35 +20,35 @@ public class OSMTrackTypeParserTest {
     @BeforeEach
     public void setUp() {
         parser = new OSMTrackTypeParser();
-        em = new EncodingManager.Builder().add(parser).build();
-        ttEnc = em.getEnumEncodedValue(TrackType.KEY, TrackType.class);
-        relFlags = em.createRelationFlags();
+        tpm = new TagParserManager.Builder().add(parser).build();
+        ttEnc = tpm.getEnumEncodedValue(TrackType.KEY, TrackType.class);
+        relFlags = tpm.createRelationFlags();
     }
 
     @Test
     public void testSimpleTags() {
         ReaderWay readerWay = new ReaderWay(1);
-        IntsRef intsRef = em.createEdgeFlags();
+        IntsRef intsRef = tpm.createEdgeFlags();
         readerWay.setTag("tracktype", "grade1");
         parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(TrackType.GRADE1, ttEnc.getEnum(false, intsRef));
 
-        intsRef = em.createEdgeFlags();
+        intsRef = tpm.createEdgeFlags();
         readerWay.setTag("tracktype", "grade2");
         parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(TrackType.GRADE2, ttEnc.getEnum(false, intsRef));
 
-        intsRef = em.createEdgeFlags();
+        intsRef = tpm.createEdgeFlags();
         readerWay.setTag("tracktype", "grade3");
         parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(TrackType.GRADE3, ttEnc.getEnum(false, intsRef));
 
-        intsRef = em.createEdgeFlags();
+        intsRef = tpm.createEdgeFlags();
         readerWay.setTag("tracktype", "grade4");
         parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(TrackType.GRADE4, ttEnc.getEnum(false, intsRef));
 
-        intsRef = em.createEdgeFlags();
+        intsRef = tpm.createEdgeFlags();
         readerWay.setTag("tracktype", "grade5");
         parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(TrackType.GRADE5, ttEnc.getEnum(false, intsRef));
@@ -57,7 +57,7 @@ public class OSMTrackTypeParserTest {
     @Test
     public void testUnkownValue() {
         ReaderWay readerWay = new ReaderWay(1);
-        IntsRef intsRef = em.createEdgeFlags();
+        IntsRef intsRef = tpm.createEdgeFlags();
         readerWay.setTag("tracktype", "unknownstuff");
         parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(TrackType.MISSING, ttEnc.getEnum(false, intsRef));
@@ -66,7 +66,7 @@ public class OSMTrackTypeParserTest {
     @Test
     public void testNoNPE() {
         ReaderWay readerWay = new ReaderWay(1);
-        IntsRef intsRef = em.createEdgeFlags();
+        IntsRef intsRef = tpm.createEdgeFlags();
         parser.handleWayTags(intsRef, readerWay, relFlags);
         assertEquals(TrackType.MISSING, ttEnc.getEnum(false, intsRef));
     }

--- a/core/src/test/java/com/graphhopper/routing/weighting/FastestWeightingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/FastestWeightingTest.java
@@ -26,7 +26,6 @@ import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.storage.BaseGraph;
 import com.graphhopper.storage.Graph;
-import com.graphhopper.storage.GraphBuilder;
 import com.graphhopper.storage.IntsRef;
 import com.graphhopper.util.*;
 import com.graphhopper.util.Parameters.Routing;
@@ -105,7 +104,7 @@ public class FastestWeightingTest {
 
     @Test
     public void calcWeightAndTime_withTurnCosts() {
-        Graph graph = new GraphBuilder(encodingManager).create();
+        BaseGraph graph = new BaseGraph.Builder(encodingManager).create();
         Weighting weighting = new FastestWeighting(encoder, new DefaultTurnCostProvider(encoder, graph.getTurnCostStorage()));
         GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(100));
         EdgeIteratorState edge = GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(100));
@@ -117,7 +116,7 @@ public class FastestWeightingTest {
 
     @Test
     public void calcWeightAndTime_uTurnCosts() {
-        Graph graph = new GraphBuilder(encodingManager).create();
+        BaseGraph graph = new BaseGraph.Builder(encodingManager).create();
         Weighting weighting = new FastestWeighting(encoder, new DefaultTurnCostProvider(encoder, graph.getTurnCostStorage(), 40));
         EdgeIteratorState edge = GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(100));
         assertEquals(6 + 40, GHUtility.calcWeightWithTurnWeight(weighting, edge, false, 0), 1.e-6);
@@ -126,7 +125,7 @@ public class FastestWeightingTest {
 
     @Test
     public void calcWeightAndTime_withTurnCosts_shortest() {
-        Graph graph = new GraphBuilder(encodingManager).create();
+        BaseGraph graph = new BaseGraph.Builder(encodingManager).create();
         Weighting weighting = new ShortestWeighting(encoder, new DefaultTurnCostProvider(encoder, graph.getTurnCostStorage()));
         GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(100));
         EdgeIteratorState edge = GHUtility.setSpeed(60, true, true, encoder, graph.edge(1, 2).setDistance(100));

--- a/core/src/test/java/com/graphhopper/routing/weighting/FastestWeightingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/FastestWeightingTest.java
@@ -24,9 +24,9 @@ import com.graphhopper.routing.util.Bike2WeightFlagEncoder;
 import com.graphhopper.routing.util.CarFlagEncoder;
 import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.routing.util.FlagEncoder;
+import com.graphhopper.storage.BaseGraph;
 import com.graphhopper.storage.Graph;
 import com.graphhopper.storage.GraphBuilder;
-import com.graphhopper.storage.GraphHopperStorage;
 import com.graphhopper.storage.IntsRef;
 import com.graphhopper.util.*;
 import com.graphhopper.util.Parameters.Routing;
@@ -88,10 +88,11 @@ public class FastestWeightingTest {
     @Test
     public void testTime() {
         FlagEncoder tmpEnc = new Bike2WeightFlagEncoder();
-        GraphHopperStorage g = new GraphBuilder(EncodingManager.create(tmpEnc)).create();
+        EncodingManager em = EncodingManager.create(tmpEnc);
+        BaseGraph g = new BaseGraph.Builder(em).create();
         Weighting w = new FastestWeighting(tmpEnc);
 
-        IntsRef edgeFlags = GHUtility.setSpeed(15, 15, tmpEnc, g.getEncodingManager().createEdgeFlags());
+        IntsRef edgeFlags = GHUtility.setSpeed(15, 15, tmpEnc, em.createEdgeFlags());
         tmpEnc.getAverageSpeedEnc().setDecimal(true, edgeFlags, 10.0);
 
         EdgeIteratorState edge = GHUtility.createMockedEdgeIteratorState(100000, edgeFlags);

--- a/core/src/test/java/com/graphhopper/routing/weighting/custom/CustomModelParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/custom/CustomModelParserTest.java
@@ -22,8 +22,6 @@ import com.graphhopper.routing.ev.*;
 import com.graphhopper.routing.util.CarFlagEncoder;
 import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.storage.BaseGraph;
-import com.graphhopper.storage.Graph;
-import com.graphhopper.storage.GraphBuilder;
 import com.graphhopper.util.CustomModel;
 import com.graphhopper.util.EdgeIteratorState;
 import com.graphhopper.util.JsonFeature;
@@ -44,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class CustomModelParserTest {
 
     CarFlagEncoder encoder;
-    Graph graph;
+    BaseGraph graph;
     EncodingManager encodingManager;
     EnumEncodedValue<RoadClass> roadClassEnc;
     DecimalEncodedValue avgSpeedEnc;
@@ -55,7 +53,7 @@ class CustomModelParserTest {
         encoder = new CarFlagEncoder();
         countryEnc = new StringEncodedValue("country", 10);
         encodingManager = new EncodingManager.Builder().add(encoder).add(countryEnc).add(new EnumEncodedValue<>(Surface.KEY, Surface.class)).build();
-        graph = new GraphBuilder(encodingManager).create();
+        graph = new BaseGraph.Builder(encodingManager).create();
         avgSpeedEnc = encoder.getAverageSpeedEnc();
         roadClassEnc = encodingManager.getEnumEncodedValue(RoadClass.KEY, RoadClass.class);
     }

--- a/core/src/test/java/com/graphhopper/routing/weighting/custom/CustomModelParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/custom/CustomModelParserTest.java
@@ -21,9 +21,9 @@ package com.graphhopper.routing.weighting.custom;
 import com.graphhopper.routing.ev.*;
 import com.graphhopper.routing.util.CarFlagEncoder;
 import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.storage.BaseGraph;
 import com.graphhopper.storage.Graph;
 import com.graphhopper.storage.GraphBuilder;
-import com.graphhopper.storage.GraphHopperStorage;
 import com.graphhopper.util.CustomModel;
 import com.graphhopper.util.EdgeIteratorState;
 import com.graphhopper.util.JsonFeature;
@@ -67,7 +67,7 @@ class CustomModelParserTest {
         CustomWeighting.EdgeToDoubleMapping priorityMapping = CustomModelParser.createWeightingParameters(customModel, encodingManager,
                 avgSpeedEnc, encoder.getMaxSpeed(), null).getEdgeToPriorityMapping();
 
-        GraphHopperStorage graph = new GraphBuilder(encodingManager).create();
+        BaseGraph graph = new BaseGraph.Builder(encodingManager).create();
         EdgeIteratorState edge1 = graph.edge(0, 1).setDistance(100).set(roadClassEnc, RoadClass.PRIMARY);
         EdgeIteratorState edge2 = graph.edge(1, 2).setDistance(100).set(roadClassEnc, RoadClass.SECONDARY);
 

--- a/core/src/test/java/com/graphhopper/routing/weighting/custom/CustomWeightingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/custom/CustomWeightingTest.java
@@ -9,8 +9,7 @@ import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.routing.weighting.FastestWeighting;
 import com.graphhopper.routing.weighting.Weighting;
-import com.graphhopper.storage.GraphBuilder;
-import com.graphhopper.storage.GraphHopperStorage;
+import com.graphhopper.storage.BaseGraph;
 import com.graphhopper.util.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -23,8 +22,7 @@ import static com.graphhopper.routing.weighting.TurnCostProvider.NO_TURN_COST_PR
 import static org.junit.jupiter.api.Assertions.*;
 
 class CustomWeightingTest {
-
-    GraphHopperStorage graph;
+    BaseGraph graph;
     DecimalEncodedValue avSpeedEnc;
     BooleanEncodedValue accessEnc;
     DecimalEncodedValue maxSpeedEnc;
@@ -44,7 +42,7 @@ class CustomWeightingTest {
         accessEnc = carFE.getAccessEnc();
         maxSpeedEnc = encodingManager.getDecimalEncodedValue(MaxSpeed.KEY);
         roadClassEnc = encodingManager.getEnumEncodedValue(KEY, RoadClass.class);
-        graph = new GraphBuilder(encodingManager).create();
+        graph = new BaseGraph.Builder(encodingManager).create();
     }
 
     @Test
@@ -124,7 +122,7 @@ class CustomWeightingTest {
         BooleanEncodedValue specialEnc = new SimpleBooleanEncodedValue("special", true);
         encodingManager = new EncodingManager.Builder().add(carFE).add(specialEnc).build();
         avSpeedEnc = carFE.getAverageSpeedEnc();
-        graph = new GraphBuilder(encodingManager).create();
+        graph = new BaseGraph.Builder(encodingManager).create();
 
         BooleanEncodedValue accessEnc = carFE.getAccessEnc();
         EdgeIteratorState edge = graph.edge(0, 1).set(accessEnc, true).setReverse(accessEnc, true).

--- a/core/src/test/java/com/graphhopper/routing/weighting/custom/CustomWeightingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/custom/CustomWeightingTest.java
@@ -7,9 +7,6 @@ import com.graphhopper.routing.ev.*;
 import com.graphhopper.routing.util.CarFlagEncoder;
 import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.routing.util.FlagEncoder;
-import com.graphhopper.routing.util.parsers.OSMBikeNetworkTagParser;
-import com.graphhopper.routing.util.parsers.OSMHazmatParser;
-import com.graphhopper.routing.util.parsers.OSMTollParser;
 import com.graphhopper.routing.weighting.FastestWeighting;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.GraphBuilder;
@@ -38,7 +35,11 @@ class CustomWeightingTest {
     @BeforeEach
     public void setup() {
         carFE = new CarFlagEncoder(new PMap().putObject("speed_two_directions", true));
-        encodingManager = new EncodingManager.Builder().add(carFE).add(new OSMTollParser()).add(new OSMHazmatParser()).add(new OSMBikeNetworkTagParser()).build();
+        encodingManager = new EncodingManager.Builder().add(carFE)
+                .add(new EnumEncodedValue<>(Toll.KEY, Toll.class))
+                .add(new EnumEncodedValue<>(Hazmat.KEY, Hazmat.class))
+                .add(new EnumEncodedValue<>(BikeNetwork.KEY, RouteNetwork.class))
+                .build();
         avSpeedEnc = carFE.getAverageSpeedEnc();
         accessEnc = carFE.getAccessEnc();
         maxSpeedEnc = encodingManager.getDecimalEncodedValue(MaxSpeed.KEY);

--- a/core/src/test/java/com/graphhopper/routing/weighting/custom/ExpressionVisitorTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/custom/ExpressionVisitorTest.java
@@ -4,7 +4,6 @@ import com.graphhopper.json.Statement;
 import com.graphhopper.routing.ev.EncodedValueLookup;
 import com.graphhopper.routing.ev.StringEncodedValue;
 import com.graphhopper.routing.util.EncodingManager;
-import com.graphhopper.storage.GraphBuilder;
 import com.graphhopper.storage.IntsRef;
 import com.graphhopper.util.Helper;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,7 +24,7 @@ public class ExpressionVisitorTest {
     @BeforeEach
     public void before() {
         StringEncodedValue sev = new StringEncodedValue("country", 10);
-        lookup = new GraphBuilder(new EncodingManager.Builder().add(sev).build()).create().getEncodingManager();
+        lookup = new EncodingManager.Builder().add(sev).build();
         sev.setString(false, new IntsRef(1), "DEU");
     }
 

--- a/core/src/test/java/com/graphhopper/storage/AbstractGraphStorageTester.java
+++ b/core/src/test/java/com/graphhopper/storage/AbstractGraphStorageTester.java
@@ -45,10 +45,10 @@ public abstract class AbstractGraphStorageTester {
     protected int defaultSize = 100;
     protected String defaultGraphLoc = "./target/graphstorage/default";
     protected CarFlagEncoder carEncoder = createCarFlagEncoder();
-    protected EncodingManager encodingManager = new EncodingManager.Builder().add(carEncoder).add(new FootFlagEncoder()).build();
+    protected TagParserManager tagParserManager = new TagParserManager.Builder().add(carEncoder).add(new FootFlagEncoder()).build();
     protected BooleanEncodedValue carAccessEnc = carEncoder.getAccessEnc();
     protected DecimalEncodedValue carAvSpeedEnc = carEncoder.getAverageSpeedEnc();
-    protected FootFlagEncoder footEncoder = (FootFlagEncoder) encodingManager.getEncoder("foot");
+    protected FootFlagEncoder footEncoder = (FootFlagEncoder) tagParserManager.getEncoder("foot");
     protected GraphHopperStorage graph;
     EdgeFilter carOutFilter = AccessFilter.outEdges(carEncoder.getAccessEnc());
     EdgeFilter carInFilter = AccessFilter.inEdges(carEncoder.getAccessEnc());
@@ -664,7 +664,7 @@ public abstract class AbstractGraphStorageTester {
             }
         });
         list.add(new CarFlagEncoder(29, 0.001, 0));
-        EncodingManager manager = EncodingManager.create(list);
+        TagParserManager manager = TagParserManager.create(list);
         graph = new GraphBuilder(manager).create();
 
         EdgeIteratorState edge = graph.edge(0, 1);
@@ -713,7 +713,7 @@ public abstract class AbstractGraphStorageTester {
                 return "car2";
             }
         });
-        manager = EncodingManager.create(list);
+        manager = TagParserManager.create(list);
         graph = new GraphBuilder(manager).create();
         edgeIter = graph.edge(0, 1).set(access0Enc, true, false);
         assertTrue(edgeIter.get(access0Enc));

--- a/core/src/test/java/com/graphhopper/storage/GraphHopperStorageLMTest.java
+++ b/core/src/test/java/com/graphhopper/storage/GraphHopperStorageLMTest.java
@@ -7,7 +7,6 @@ import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.Subnetwork;
 import com.graphhopper.routing.util.CarFlagEncoder;
 import com.graphhopper.routing.util.EncodingManager;
-import com.graphhopper.routing.util.EncodingManager.Access;
 import com.graphhopper.util.GHUtility;
 import com.graphhopper.util.Helper;
 import org.junit.jupiter.api.Test;
@@ -57,7 +56,7 @@ public class GraphHopperStorageLMTest {
         hopper.getLMPreparationHandler().setLMProfiles(new LMProfile("my_profile"));
         // does lm preparation
         hopper.importOrLoad();
-        EncodingManager em = hopper.getEncodingManager();
+        EncodingManager em = hopper.getTagParserManager().getEncodingManager();
         assertNotNull(em);
         assertEquals(1, em.fetchEdgeEncoders().size());
         assertEquals(16, hopper.getLMPreparationHandler().getLandmarks());

--- a/core/src/test/java/com/graphhopper/storage/GraphHopperStorageLMTest.java
+++ b/core/src/test/java/com/graphhopper/storage/GraphHopperStorageLMTest.java
@@ -7,6 +7,7 @@ import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.Subnetwork;
 import com.graphhopper.routing.util.CarFlagEncoder;
 import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.routing.util.TagParserManager;
 import com.graphhopper.util.GHUtility;
 import com.graphhopper.util.Helper;
 import org.junit.jupiter.api.Test;
@@ -23,7 +24,7 @@ public class GraphHopperStorageLMTest {
         String defaultGraphLoc = "./target/ghstorage_lm";
         Helper.removeDir(new File(defaultGraphLoc));
         CarFlagEncoder carFlagEncoder = new CarFlagEncoder();
-        EncodingManager encodingManager = new EncodingManager.Builder().add(carFlagEncoder).add(Subnetwork.create("my_profile")).build();
+        TagParserManager encodingManager = new TagParserManager.Builder().add(carFlagEncoder).add(Subnetwork.create("my_profile")).build();
         GraphHopperStorage graph = GraphBuilder.start(encodingManager).setRAM(defaultGraphLoc, true).create();
 
         // 0-1

--- a/core/src/test/java/com/graphhopper/storage/GraphHopperStorageTest.java
+++ b/core/src/test/java/com/graphhopper/storage/GraphHopperStorageTest.java
@@ -254,7 +254,7 @@ public class GraphHopperStorageTest extends AbstractGraphStorageTester {
 
         hopper = new GraphHopper();
         // load via explicitly configured FlagEncoders then we can define only one profile
-        hopper.getEncodingManagerBuilder().add(createCarFlagEncoder()).add(new BikeFlagEncoder());
+        hopper.getTagParserManagerBuilder().add(createCarFlagEncoder()).add(new BikeFlagEncoder());
         hopper.setProfiles(Collections.singletonList(new Profile("p_car").setVehicle("car").setWeighting("fastest")));
         hopper.setGraphHopperLocation(defaultGraphLoc);
         assertTrue(hopper.load());

--- a/core/src/test/java/com/graphhopper/storage/GraphHopperStorageTest.java
+++ b/core/src/test/java/com/graphhopper/storage/GraphHopperStorageTest.java
@@ -20,7 +20,7 @@ package com.graphhopper.storage;
 import com.graphhopper.GraphHopper;
 import com.graphhopper.config.Profile;
 import com.graphhopper.routing.util.BikeFlagEncoder;
-import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.routing.util.TagParserManager;
 import com.graphhopper.util.*;
 import com.graphhopper.util.shapes.BBox;
 import org.junit.jupiter.api.Test;
@@ -51,7 +51,7 @@ public class GraphHopperStorageTest extends AbstractGraphStorageTester {
     }
 
     protected GraphHopperStorage newGHStorage(Directory dir, boolean enabled3D, int segmentSize) {
-        return GraphBuilder.start(encodingManager).setDir(dir).set3D(enabled3D).setSegmentSize(segmentSize).build();
+        return GraphBuilder.start(tagParserManager).setDir(dir).set3D(enabled3D).setSegmentSize(segmentSize).build();
     }
 
     @Test
@@ -160,7 +160,7 @@ public class GraphHopperStorageTest extends AbstractGraphStorageTester {
 
     @Test
     public void testIdentical() {
-        GraphHopperStorage store = new GraphBuilder(encodingManager).set3D(true).build();
+        GraphHopperStorage store = new GraphBuilder(tagParserManager).set3D(true).build();
         assertEquals(store.getNodes(), store.getBaseGraph().getNodes());
         assertEquals(store.getEdges(), store.getBaseGraph().getEdges());
     }
@@ -206,7 +206,7 @@ public class GraphHopperStorageTest extends AbstractGraphStorageTester {
     public void testDecoupledEdgeIteratorStates() {
         GraphHopperStorage storage = createGHStorage();
         Graph graph = storage.getBaseGraph();
-        IntsRef ref = encodingManager.createEdgeFlags();
+        IntsRef ref = tagParserManager.createEdgeFlags();
         ref.ints[0] = 12;
         GHUtility.setSpeed(60, true, true, carEncoder, graph.edge(1, 2).setDistance(10)).setFlags(ref);
         ref.ints[0] = 13;
@@ -227,7 +227,7 @@ public class GraphHopperStorageTest extends AbstractGraphStorageTester {
     @Test
     public void testLoadGraph_implicitEncodedValues_issue1862() {
         Helper.removeDir(new File(defaultGraphLoc));
-        encodingManager = new EncodingManager.Builder().add(createCarFlagEncoder()).add(new BikeFlagEncoder()).build();
+        tagParserManager = new TagParserManager.Builder().add(createCarFlagEncoder()).add(new BikeFlagEncoder()).build();
         graph = newGHStorage(new RAMDirectory(defaultGraphLoc, true), false).create(defaultSize);
         NodeAccess na = graph.getNodeAccess();
         na.setNode(0, 12, 23);
@@ -268,7 +268,7 @@ public class GraphHopperStorageTest extends AbstractGraphStorageTester {
 
     @Test
     public void testEdgeKey() {
-        GraphHopperStorage g = new GraphBuilder(encodingManager).create();
+        GraphHopperStorage g = new GraphBuilder(tagParserManager).create();
         GHUtility.setSpeed(60, true, true, carEncoder, g.edge(0, 1).setDistance(10));
         // storage direction
         assertEdge(g.getEdgeIteratorState(0, Integer.MIN_VALUE), 0, 1, false, 0, 0);
@@ -282,7 +282,7 @@ public class GraphHopperStorageTest extends AbstractGraphStorageTester {
 
     @Test
     public void testEdgeKey_loop() {
-        GraphHopperStorage g = new GraphBuilder(encodingManager).create();
+        GraphHopperStorage g = new GraphBuilder(tagParserManager).create();
         GHUtility.setSpeed(60, true, true, carEncoder, g.edge(0, 0).setDistance(10));
         // storage direction
         assertEdge(g.getEdgeIteratorState(0, Integer.MIN_VALUE), 0, 0, false, 0, 0);

--- a/core/src/test/java/com/graphhopper/storage/GraphHopperStorageWithTurnCostsTest.java
+++ b/core/src/test/java/com/graphhopper/storage/GraphHopperStorageWithTurnCostsTest.java
@@ -27,7 +27,8 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Random;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Karl Hübner
@@ -45,7 +46,7 @@ public class GraphHopperStorageWithTurnCostsTest extends GraphHopperStorageTest 
 
     @Override
     protected GraphHopperStorage newGHStorage(Directory dir, boolean enabled3D, int segmentSize) {
-        return GraphBuilder.start(encodingManager).setDir(dir).set3D(enabled3D).withTurnCosts(true).setSegmentSize(segmentSize).build();
+        return GraphBuilder.start(tagParserManager).setDir(dir).set3D(enabled3D).withTurnCosts(true).setSegmentSize(segmentSize).build();
     }
 
     @Override
@@ -154,10 +155,10 @@ public class GraphHopperStorageWithTurnCostsTest extends GraphHopperStorageTest 
     }
 
     private double getTurnCost(EdgeIteratorState fromEdge, int viaNode, EdgeIteratorState toEdge) {
-        return graph.getTurnCostStorage().get(((EncodedValueLookup) encodingManager).getDecimalEncodedValue(TurnCost.key("car")), toEdge.getEdge(), viaNode, fromEdge.getEdge());
+        return graph.getTurnCostStorage().get(((EncodedValueLookup) tagParserManager).getDecimalEncodedValue(TurnCost.key("car")), toEdge.getEdge(), viaNode, fromEdge.getEdge());
     }
 
     private void setTurnCost(int fromEdge, int viaNode, int toEdge, int cost) {
-        graph.getTurnCostStorage().set(((EncodedValueLookup) encodingManager).getDecimalEncodedValue(TurnCost.key("car")), fromEdge, viaNode, toEdge, cost);
+        graph.getTurnCostStorage().set(((EncodedValueLookup) tagParserManager).getDecimalEncodedValue(TurnCost.key("car")), fromEdge, viaNode, toEdge, cost);
     }
 }

--- a/core/src/test/java/com/graphhopper/storage/GraphStorageViaMMapTest.java
+++ b/core/src/test/java/com/graphhopper/storage/GraphStorageViaMMapTest.java
@@ -23,7 +23,7 @@ package com.graphhopper.storage;
 public class GraphStorageViaMMapTest extends AbstractGraphStorageTester {
     @Override
     public GraphHopperStorage createGHStorage(String location, boolean is3D) {
-        GraphHopperStorage gs = GraphBuilder.start(encodingManager).set3D(is3D).setMMap(location).setSegmentSize(defaultSize / 2).build();
+        GraphHopperStorage gs = GraphBuilder.start(tagParserManager).set3D(is3D).setMMap(location).setSegmentSize(defaultSize / 2).build();
         gs.create(defaultSize);
         return gs;
     }

--- a/core/src/test/java/com/graphhopper/storage/TurnCostStorageTest.java
+++ b/core/src/test/java/com/graphhopper/storage/TurnCostStorageTest.java
@@ -53,8 +53,8 @@ public class TurnCostStorageTest {
     // 2--3
     // |
     // 4
-    public static void initGraph(GraphHopperStorage g) {
-        GHUtility.setSpeed(60, 60, g.getEncodingManager().getEncoder("car"),
+    public static void initGraph(BaseGraph g, FlagEncoder encoder) {
+        GHUtility.setSpeed(60, 60, encoder,
                 g.edge(0, 1).setDistance(3),
                 g.edge(0, 2).setDistance(1),
                 g.edge(1, 3).setDistance(1),
@@ -67,8 +67,8 @@ public class TurnCostStorageTest {
      */
     @Test
     public void testMultipleTurnCosts() {
-        GraphHopperStorage g = new GraphBuilder(manager).create();
-        initGraph(g);
+        BaseGraph g = new BaseGraph.Builder(manager).create();
+        initGraph(g, manager.getEncoder("car"));
         TurnCostStorage turnCostStorage = g.getTurnCostStorage();
 
         DecimalEncodedValue carEnc = manager.getDecimalEncodedValue(TurnCost.key("car"));
@@ -124,8 +124,8 @@ public class TurnCostStorageTest {
 
     @Test
     public void testMergeFlagsBeforeAdding() {
-        GraphHopperStorage g = new GraphBuilder(manager).create();
-        initGraph(g);
+        BaseGraph g = new BaseGraph.Builder(manager).create();
+        initGraph(g, manager.getEncoder("car"));
         TurnCostStorage turnCostStorage = g.getTurnCostStorage();
 
         DecimalEncodedValue carEnc = manager.getDecimalEncodedValue(TurnCost.key("car"));
@@ -153,8 +153,8 @@ public class TurnCostStorageTest {
 
     @Test
     public void testIterateEmptyStore() {
-        GraphHopperStorage g = new GraphBuilder(manager).create();
-        initGraph(g);
+        BaseGraph g = new BaseGraph.Builder(manager).create();
+        initGraph(g, manager.getEncoder("car"));
         TurnCostStorage turnCostStorage = g.getTurnCostStorage();
 
         TurnCostStorage.TurnRelationIterator iterator = turnCostStorage.getAllTurnRelations();

--- a/core/src/test/java/com/graphhopper/storage/index/LocationIndexTreeTest.java
+++ b/core/src/test/java/com/graphhopper/storage/index/LocationIndexTreeTest.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import java.io.Closeable;
 import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -450,7 +449,7 @@ public class LocationIndexTreeTest {
         assertEquals(3, findClosestEdge(idx, 1.5, 2));
         assertEquals(1, findClosestEdge(idx, -1, -1));
         assertEquals(4, findClosestEdge(idx, 4, 0));
-        Helper.close((Closeable) g);
+        g.close();
     }
 
     @Test
@@ -468,12 +467,12 @@ public class LocationIndexTreeTest {
         assertEquals(4, findClosestEdge(idx, 4, 0));
         assertEquals(6, findClosestNode(idx, 4, -2));
         assertEquals(5, findClosestEdge(idx, 3, 3));
-        Helper.close((Closeable) g);
+        g.close();
     }
 
     @Test
     public void testSinglePoints120() {
-        Graph g = createSampleGraph(EncodingManager.create("car"));
+        BaseGraph g = createSampleGraph(EncodingManager.create("car"));
         LocationIndexTree idx = (LocationIndexTree) createIndexNoPrepare(g, 500000).prepareIndex();
 
         assertEquals(3, findClosestEdge(idx, 1.637, 2.23));
@@ -483,19 +482,19 @@ public class LocationIndexTreeTest {
 
         assertEquals(15, findClosestEdge(idx, 3.8, 0));
         assertEquals(15, findClosestEdge(idx, 3.8466, 0.021));
-        Helper.close((Closeable) g);
+        g.close();
     }
 
     @Test
     public void testSinglePoints32() {
-        Graph g = createSampleGraph(EncodingManager.create("car"));
+        BaseGraph g = createSampleGraph(EncodingManager.create("car"));
         LocationIndexTree idx = (LocationIndexTree) createIndexNoPrepare(g, 500000).prepareIndex();
 
         assertEquals(10, findClosestEdge(idx, 3.649, 1.375));
         assertEquals(15, findClosestEdge(idx, 3.8465748, 0.021762699));
         assertEquals(4, findClosestEdge(idx, 2.485, 1.373));
         assertEquals(0, findClosestEdge(idx, 0.64628404, 0.53006625));
-        Helper.close((Closeable) g);
+        g.close();
     }
 
     @Test
@@ -509,10 +508,10 @@ public class LocationIndexTreeTest {
             na.setNode(i, (float) rand.nextDouble() * 10 + 10, (float) rand.nextDouble() * 10 + 10);
         }
         createIndexNoPrepare(g, 200).prepareIndex();
-        Helper.close((Closeable) g);
+        g.close();
     }
 
-    public Graph createSampleGraph(EncodingManager encodingManager) {
+    public BaseGraph createSampleGraph(EncodingManager encodingManager) {
         BaseGraph graph = new BaseGraph.Builder(encodingManager).create();
         // length does not matter here but lat,lon and outgoing edges do!
 

--- a/core/src/test/java/com/graphhopper/storage/index/LocationIndexTreeTest.java
+++ b/core/src/test/java/com/graphhopper/storage/index/LocationIndexTreeTest.java
@@ -90,7 +90,7 @@ public class LocationIndexTreeTest {
     // 2-------/
     Graph createTestGraph(EncodingManager em) {
         FlagEncoder encoder = em.getEncoder("car");
-        Graph graph = new GraphBuilder(em).create();
+        BaseGraph graph = new BaseGraph.Builder(em).create();
         NodeAccess na = graph.getNodeAccess();
         na.setNode(0, 0.5, -0.5);
         na.setNode(1, -0.5, -0.5);
@@ -150,7 +150,7 @@ public class LocationIndexTreeTest {
     @Test
     public void testMoreReal() {
         FlagEncoder encoder = new CarFlagEncoder();
-        Graph graph = new GraphBuilder(EncodingManager.create(encoder)).create();
+        BaseGraph graph = new BaseGraph.Builder(EncodingManager.create(encoder)).create();
         NodeAccess na = graph.getNodeAccess();
         na.setNode(1, 51.2492152, 9.4317166);
         na.setNode(0, 52, 9);
@@ -174,7 +174,7 @@ public class LocationIndexTreeTest {
     //-1|  2---------/
     //  |
     private Graph createTestGraphWithWayGeometry() {
-        Graph graph = new GraphBuilder(encodingManager).create();
+        BaseGraph graph = new BaseGraph.Builder(encodingManager).create();
         FlagEncoder encoder = encodingManager.getEncoder("car");
         NodeAccess na = graph.getNodeAccess();
         na.setNode(0, 0.5, -0.5);
@@ -205,7 +205,7 @@ public class LocationIndexTreeTest {
 
     @Test
     public void testFindingWayGeometry() {
-        Graph g = new GraphBuilder(encodingManager).create();
+        BaseGraph g = new BaseGraph.Builder(encodingManager).create();
         FlagEncoder encoder = encodingManager.getEncoder("car");
         NodeAccess na = g.getNodeAccess();
         na.setNode(10, 51.2492152, 9.4317166);
@@ -232,7 +232,7 @@ public class LocationIndexTreeTest {
     // see testgraph2.jpg
     Graph createTestGraph2() {
         FlagEncoder encoder = encodingManager.getEncoder("car");
-        Graph graph = new GraphBuilder(encodingManager).create();
+        BaseGraph graph = new BaseGraph.Builder(encodingManager).create();
         NodeAccess na = graph.getNodeAccess();
 
         na.setNode(0, 49.94653, 11.57114);
@@ -341,7 +341,7 @@ public class LocationIndexTreeTest {
         BikeFlagEncoder bikeEncoder = new BikeFlagEncoder();
 
         EncodingManager tmpEM = EncodingManager.create(carEncoder, bikeEncoder);
-        Graph graph = new GraphBuilder(tmpEM).create();
+        BaseGraph graph = new BaseGraph.Builder(tmpEM).create();
         NodeAccess na = graph.getNodeAccess();
 
         // distance from point to point is roughly 1 km
@@ -389,7 +389,7 @@ public class LocationIndexTreeTest {
     @Test
     public void testCrossBoundaryNetwork_issue667() {
         FlagEncoder encoder = encodingManager.getEncoder("car");
-        Graph graph = new GraphBuilder(encodingManager).create();
+        BaseGraph graph = new BaseGraph.Builder(encodingManager).create();
         NodeAccess na = graph.getNodeAccess();
         na.setNode(0, 0.1, 179.5);
         na.setNode(1, 0.1, 179.9);
@@ -442,7 +442,7 @@ public class LocationIndexTreeTest {
     @Test
     public void testSimpleGraph() {
         EncodingManager em = EncodingManager.create("car");
-        Graph g = new GraphBuilder(em).create();
+        BaseGraph g = new BaseGraph.Builder(em).create();
         initSimpleGraph(g, em);
 
         LocationIndexTree idx = (LocationIndexTree) createIndexNoPrepare(g, 500000).prepareIndex();
@@ -456,7 +456,7 @@ public class LocationIndexTreeTest {
     @Test
     public void testSimpleGraph2() {
         EncodingManager em = EncodingManager.create("car");
-        Graph g = new GraphBuilder(em).create();
+        BaseGraph g = new BaseGraph.Builder(em).create();
         initSimpleGraph(g, em);
 
         LocationIndexTree idx = (LocationIndexTree) createIndexNoPrepare(g, 500000).prepareIndex();
@@ -502,7 +502,7 @@ public class LocationIndexTreeTest {
     public void testNoErrorOnEdgeCase_lastIndex() {
         final EncodingManager encodingManager = EncodingManager.create("car");
         int locs = 10000;
-        Graph g = new GraphBuilder(encodingManager).create();
+        BaseGraph g = new BaseGraph.Builder(encodingManager).create();
         NodeAccess na = g.getNodeAccess();
         Random rand = new Random(12);
         for (int i = 0; i < locs; i++) {
@@ -513,7 +513,7 @@ public class LocationIndexTreeTest {
     }
 
     public Graph createSampleGraph(EncodingManager encodingManager) {
-        Graph graph = new GraphBuilder(encodingManager).create();
+        BaseGraph graph = new BaseGraph.Builder(encodingManager).create();
         // length does not matter here but lat,lon and outgoing edges do!
 
 //

--- a/core/src/test/java/com/graphhopper/util/BreadthFirstSearchTest.java
+++ b/core/src/test/java/com/graphhopper/util/BreadthFirstSearchTest.java
@@ -24,8 +24,7 @@ import com.graphhopper.coll.GHTBitSet;
 import com.graphhopper.routing.util.CarFlagEncoder;
 import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.routing.util.FlagEncoder;
-import com.graphhopper.storage.Graph;
-import com.graphhopper.storage.GraphBuilder;
+import com.graphhopper.storage.BaseGraph;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -63,7 +62,7 @@ public class BreadthFirstSearchTest {
         };
 
         FlagEncoder encoder = new CarFlagEncoder();
-        Graph g = new GraphBuilder(EncodingManager.create(encoder)).create();
+        BaseGraph g = new BaseGraph.Builder(EncodingManager.create(encoder)).create();
         GHUtility.setSpeed(60, true, true, encoder, g.edge(0, 1).setDistance(85));
         GHUtility.setSpeed(60, true, true, encoder, g.edge(0, 2).setDistance(217));
         GHUtility.setSpeed(60, true, true, encoder, g.edge(0, 3).setDistance(173));
@@ -103,7 +102,7 @@ public class BreadthFirstSearchTest {
         };
 
         FlagEncoder encoder = new CarFlagEncoder();
-        Graph g = new GraphBuilder(EncodingManager.create(encoder)).create();
+        BaseGraph g = new BaseGraph.Builder(EncodingManager.create(encoder)).create();
         GHUtility.setSpeed(60, true, false, encoder, g.edge(1, 2).setDistance(1));
         GHUtility.setSpeed(60, true, false, encoder, g.edge(2, 3).setDistance(1));
         GHUtility.setSpeed(60, true, false, encoder, g.edge(3, 4).setDistance(1));

--- a/core/src/test/java/com/graphhopper/util/DepthFirstSearchTest.java
+++ b/core/src/test/java/com/graphhopper/util/DepthFirstSearchTest.java
@@ -24,12 +24,12 @@ import com.graphhopper.coll.GHIntHashSet;
 import com.graphhopper.routing.util.AccessFilter;
 import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.routing.util.FlagEncoder;
-import com.graphhopper.storage.Graph;
-import com.graphhopper.storage.GraphBuilder;
+import com.graphhopper.storage.BaseGraph;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author jansoe
@@ -65,7 +65,7 @@ public class DepthFirstSearchTest {
 
         EncodingManager em = EncodingManager.create("car");
         FlagEncoder encoder = em.getEncoder("car");
-        Graph g = new GraphBuilder(em).create();
+        BaseGraph g = new BaseGraph.Builder(em).create();
         GHUtility.setSpeed(60, true, false, encoder, g.edge(1, 2).setDistance(1));
         GHUtility.setSpeed(60, true, false, encoder, g.edge(1, 5).setDistance(1));
         GHUtility.setSpeed(60, true, false, encoder, g.edge(1, 4).setDistance(1));
@@ -100,7 +100,7 @@ public class DepthFirstSearchTest {
 
         EncodingManager em = EncodingManager.create("car");
         FlagEncoder encoder = em.getEncoder("car");
-        Graph g = new GraphBuilder(em).create();
+        BaseGraph g = new BaseGraph.Builder(em).create();
         GHUtility.setSpeed(60, true, false, encoder, g.edge(1, 2).setDistance(1));
         GHUtility.setSpeed(60, true, true, encoder, g.edge(1, 4).setDistance(1));
         GHUtility.setSpeed(60, true, false, encoder, g.edge(1, 3).setDistance(1));

--- a/core/src/test/java/com/graphhopper/util/GHUtilityTest.java
+++ b/core/src/test/java/com/graphhopper/util/GHUtilityTest.java
@@ -22,8 +22,8 @@ import com.graphhopper.routing.util.AllEdgesIterator;
 import com.graphhopper.routing.util.CarFlagEncoder;
 import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.routing.util.FlagEncoder;
+import com.graphhopper.storage.BaseGraph;
 import com.graphhopper.storage.Graph;
-import com.graphhopper.storage.GraphBuilder;
 import com.graphhopper.storage.NodeAccess;
 import org.junit.jupiter.api.Test;
 
@@ -36,8 +36,8 @@ public class GHUtilityTest {
     private final FlagEncoder carEncoder = new CarFlagEncoder();
     private final EncodingManager encodingManager = EncodingManager.create(carEncoder);
 
-    Graph createGraph() {
-        return new GraphBuilder(encodingManager).create();
+    BaseGraph createGraph() {
+        return new BaseGraph.Builder(encodingManager).create();
     }
 
     // 7      8\

--- a/core/src/test/java/com/graphhopper/util/InstructionListTest.java
+++ b/core/src/test/java/com/graphhopper/util/InstructionListTest.java
@@ -31,8 +31,8 @@ import com.graphhopper.routing.weighting.FastestWeighting;
 import com.graphhopper.routing.weighting.TurnCostProvider;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.routing.weighting.custom.CustomModelParser;
+import com.graphhopper.storage.BaseGraph;
 import com.graphhopper.storage.Graph;
-import com.graphhopper.storage.GraphBuilder;
 import com.graphhopper.storage.NodeAccess;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -73,7 +73,7 @@ public class InstructionListTest {
     }
 
     Graph createTestGraph() {
-        Graph g = new GraphBuilder(carManager).create();
+        BaseGraph g = new BaseGraph.Builder(carManager).create();
         // 0-1-2
         // | | |
         // 3-4-5  9-10
@@ -172,7 +172,7 @@ public class InstructionListTest {
 
     @Test
     public void testWayList2() {
-        Graph g = new GraphBuilder(carManager).create();
+        BaseGraph g = new BaseGraph.Builder(carManager).create();
         //   2
         //    \.  5
         //      \/
@@ -211,7 +211,7 @@ public class InstructionListTest {
     // problem: we normally don't want instructions if streetname stays but here it is suboptimal:
     @Test
     public void testNoInstructionIfSameStreet() {
-        Graph g = new GraphBuilder(carManager).create();
+        BaseGraph g = new BaseGraph.Builder(carManager).create();
         //   2
         //    \.  5
         //      \/
@@ -241,7 +241,7 @@ public class InstructionListTest {
 
     @Test
     public void testNoInstructionIfSlightTurnAndAlternativeIsSharp() {
-        Graph g = new GraphBuilder(carManager).create();
+        BaseGraph g = new BaseGraph.Builder(carManager).create();
         // real world example: https://graphhopper.com/maps/?point=51.734514%2C9.225571&point=51.734643%2C9.22541
         // https://github.com/graphhopper/graphhopper/issues/1441
         // From 1 to 3
@@ -270,7 +270,7 @@ public class InstructionListTest {
 
     @Test
     public void testNoInstructionIfSlightTurnAndAlternativeIsSharp2() {
-        Graph g = new GraphBuilder(carManager).create();
+        BaseGraph g = new BaseGraph.Builder(carManager).create();
         // real world example: https://graphhopper.com/maps/?point=48.748493%2C9.322455&point=48.748776%2C9.321889
         // https://github.com/graphhopper/graphhopper/issues/1441
         // From 1 to 3
@@ -302,7 +302,7 @@ public class InstructionListTest {
         BikeFlagEncoder bike = new BikeFlagEncoder();
         EncodingManager tmpEM = new EncodingManager.Builder().add(bike).build();
         EnumEncodedValue<RoadClass> rcEV = tmpEM.getEnumEncodedValue(RoadClass.KEY, RoadClass.class);
-        Graph g = new GraphBuilder(tmpEM).create();
+        BaseGraph g = new BaseGraph.Builder(tmpEM).create();
         // real world example: https://graphhopper.com/maps/?point=48.411549,15.599567&point=48.411663%2C15.600527&profile=bike
         // From 1 to 3
 
@@ -340,7 +340,7 @@ public class InstructionListTest {
         BikeFlagEncoder bike = new BikeFlagEncoder();
         EncodingManager tmpEM = new EncodingManager.Builder().add(bike).build();
         EnumEncodedValue<RoadClass> rcEV = tmpEM.getEnumEncodedValue(RoadClass.KEY, RoadClass.class);
-        Graph g = new GraphBuilder(tmpEM).create();
+        BaseGraph g = new BaseGraph.Builder(tmpEM).create();
         // real world example: https://graphhopper.com/maps/?point=48.412169%2C15.604888&point=48.412251%2C15.60543&profile=bike
         // From 1 to 4
 
@@ -377,7 +377,7 @@ public class InstructionListTest {
     public void testInstructionIfSlightTurnForCustomProfile() {
         FootFlagEncoder foot = new FootFlagEncoder();
         EncodingManager tmpEM = new EncodingManager.Builder().add(foot).build();
-        Graph g = new GraphBuilder(tmpEM).create();
+        BaseGraph g = new BaseGraph.Builder(tmpEM).create();
         // real world example: https://graphhopper.com/maps/?point=43.729379,7.417697&point=43.729798,7.417263&profile=foot
         // From 4 to 3 and 4 to 1
 
@@ -424,7 +424,7 @@ public class InstructionListTest {
         RoadsFlagEncoder roads = new RoadsFlagEncoder();
         EncodingManager tmpEM = EncodingManager.create(roads);
         EnumEncodedValue<RoadClass> rcEV = tmpEM.getEnumEncodedValue(RoadClass.KEY, RoadClass.class);
-        Graph g = new GraphBuilder(tmpEM).create();
+        BaseGraph g = new BaseGraph.Builder(tmpEM).create();
         // real world example: https://graphhopper.com/maps/?point=55.691214%2C12.57065&point=55.689957%2C12.570387
         // From 3 to 4
         //
@@ -457,7 +457,7 @@ public class InstructionListTest {
 
     @Test
     public void testEmptyList() {
-        Graph g = new GraphBuilder(carManager).create();
+        BaseGraph g = new BaseGraph.Builder(carManager).create();
         g.getNodeAccess().setNode(1, 0, 0);
         FastestWeighting weighting = new FastestWeighting(carEncoder);
         Path p = new Dijkstra(g, weighting, tMode).calcPath(0, 1);
@@ -467,7 +467,7 @@ public class InstructionListTest {
 
     @Test
     public void testFind() {
-        Graph g = new GraphBuilder(carManager).create();
+        BaseGraph g = new BaseGraph.Builder(carManager).create();
         //   n-4-5   (n: pillar node)
         //   |
         // 7-3-2-6

--- a/core/src/test/java/com/graphhopper/util/PathSimplificationTest.java
+++ b/core/src/test/java/com/graphhopper/util/PathSimplificationTest.java
@@ -27,8 +27,7 @@ import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.routing.util.TagParserManager;
 import com.graphhopper.routing.util.TraversalMode;
 import com.graphhopper.routing.weighting.ShortestWeighting;
-import com.graphhopper.storage.Graph;
-import com.graphhopper.storage.GraphBuilder;
+import com.graphhopper.storage.BaseGraph;
 import com.graphhopper.storage.IntsRef;
 import com.graphhopper.storage.NodeAccess;
 import com.graphhopper.util.details.PathDetail;
@@ -61,7 +60,7 @@ public class PathSimplificationTest {
 
     @Test
     public void testScenario() {
-        Graph g = new GraphBuilder(carManager.getEncodingManager()).create();
+        BaseGraph g = new BaseGraph.Builder(carManager.getEncodingManager()).create();
         // 0-1-2
         // | | |
         // 3-4-5  9-10

--- a/core/src/test/java/com/graphhopper/util/PathSimplificationTest.java
+++ b/core/src/test/java/com/graphhopper/util/PathSimplificationTest.java
@@ -24,7 +24,7 @@ import com.graphhopper.routing.InstructionsFromEdges;
 import com.graphhopper.routing.Path;
 import com.graphhopper.routing.util.CarFlagEncoder;
 import com.graphhopper.routing.util.EncodingManager;
-import com.graphhopper.routing.util.FlagEncoder;
+import com.graphhopper.routing.util.TagParserManager;
 import com.graphhopper.routing.util.TraversalMode;
 import com.graphhopper.routing.weighting.ShortestWeighting;
 import com.graphhopper.storage.Graph;
@@ -50,18 +50,18 @@ public class PathSimplificationTest {
     private final TranslationMap trMap = TranslationMapTest.SINGLETON;
     private final Translation usTR = trMap.getWithFallBack(Locale.US);
     private final TraversalMode tMode = TraversalMode.NODE_BASED;
-    private EncodingManager carManager;
+    private TagParserManager carManager;
     private CarFlagEncoder carEncoder;
 
     @BeforeEach
     public void setUp() {
         carEncoder = new CarFlagEncoder();
-        carManager = EncodingManager.create(carEncoder);
+        carManager = TagParserManager.create(carEncoder);
     }
 
     @Test
     public void testScenario() {
-        Graph g = new GraphBuilder(carManager).create();
+        Graph g = new GraphBuilder(carManager.getEncodingManager()).create();
         // 0-1-2
         // | | |
         // 3-4-5  9-10

--- a/example/src/main/java/com/graphhopper/example/IsochroneExample.java
+++ b/example/src/main/java/com/graphhopper/example/IsochroneExample.java
@@ -5,7 +5,10 @@ import com.graphhopper.config.Profile;
 import com.graphhopper.isochrone.algorithm.ShortestPathTree;
 import com.graphhopper.routing.ev.Subnetwork;
 import com.graphhopper.routing.querygraph.QueryGraph;
-import com.graphhopper.routing.util.*;
+import com.graphhopper.routing.util.DefaultSnapFilter;
+import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.routing.util.FlagEncoder;
+import com.graphhopper.routing.util.TraversalMode;
 import com.graphhopper.routing.weighting.FastestWeighting;
 import com.graphhopper.storage.index.Snap;
 
@@ -16,7 +19,7 @@ public class IsochroneExample {
         String relDir = args.length == 1 ? args[0] : "";
         GraphHopper hopper = createGraphHopperInstance(relDir + "core/files/andorra.osm.pbf");
         // get encoder from GraphHopper instance
-        EncodingManager encodingManager = hopper.getEncodingManager();
+        EncodingManager encodingManager = hopper.getTagParserManager().getEncodingManager();
         FlagEncoder encoder = encodingManager.getEncoder("car");
 
         // snap some GPS coordinates to the routing graph and build a query graph

--- a/example/src/main/java/com/graphhopper/example/LocationIndexExample.java
+++ b/example/src/main/java/com/graphhopper/example/LocationIndexExample.java
@@ -5,8 +5,7 @@ import com.graphhopper.config.Profile;
 import com.graphhopper.routing.util.CarFlagEncoder;
 import com.graphhopper.routing.util.EdgeFilter;
 import com.graphhopper.routing.util.EncodingManager;
-import com.graphhopper.storage.GraphBuilder;
-import com.graphhopper.storage.GraphHopperStorage;
+import com.graphhopper.storage.BaseGraph;
 import com.graphhopper.storage.index.LocationIndex;
 import com.graphhopper.storage.index.LocationIndexTree;
 import com.graphhopper.storage.index.Snap;
@@ -36,7 +35,7 @@ public class LocationIndexExample {
 
     public static void lowLevelLocationIndex() {
         // If you don't use the GraphHopper class you have to use the low level API:
-        GraphHopperStorage graph = new GraphBuilder(EncodingManager.create(new CarFlagEncoder())).create();
+        BaseGraph graph = new BaseGraph.Builder(EncodingManager.create(new CarFlagEncoder())).create();
         graph.edge(0, 1).setName("test edge");
         graph.getNodeAccess().setNode(0, 12, 42);
         graph.getNodeAccess().setNode(1, 12.01, 42.01);

--- a/example/src/main/java/com/graphhopper/example/LowLevelAPIExample.java
+++ b/example/src/main/java/com/graphhopper/example/LowLevelAPIExample.java
@@ -31,7 +31,7 @@ public class LowLevelAPIExample {
 
     public static void createAndSaveGraph() {
         FlagEncoder encoder = new CarFlagEncoder();
-        EncodingManager em = EncodingManager.create(encoder);
+        TagParserManager em = TagParserManager.create(encoder);
         GraphHopperStorage graph = new GraphBuilder(em).setRAM(graphLocation, true).create();
         // Make a weighted edge between two nodes and set average speed to 50km/h
         EdgeIteratorState edge = graph.edge(0, 1).setDistance(1234).set(encoder.getAverageSpeedEnc(), 50);
@@ -78,8 +78,8 @@ public class LowLevelAPIExample {
         EncodingManager em = EncodingManager.create(encoder);
         Weighting weighting = new FastestWeighting(encoder);
         CHConfig chConfig = CHConfig.nodeBased("my_profile", weighting);
-        GraphHopperStorage graph = new GraphBuilder(em)
-                .setRAM(graphLocation, true)
+        BaseGraph graph = new BaseGraph.Builder(em)
+                .setDir(new RAMDirectory(graphLocation, true))
                 .create();
         graph.flush();
 

--- a/map-matching/src/main/java/com/graphhopper/matching/MapMatching.java
+++ b/map-matching/src/main/java/com/graphhopper/matching/MapMatching.java
@@ -131,7 +131,7 @@ public class MapMatching {
         }
         graph = graphHopper.getGraphHopperStorage().getBaseGraph();
         unwrappedWeighting = graphHopper.createWeighting(profile, hints);
-        inSubnetworkEnc = graphHopper.getEncodingManager().getBooleanEncodedValue(Subnetwork.key(profileStr));
+        inSubnetworkEnc = graphHopper.getTagParserManager().getBooleanEncodedValue(Subnetwork.key(profileStr));
         this.maxVisitedNodes = hints.getInt(Parameters.Routing.MAX_VISITED_NODES, Integer.MAX_VALUE);
     }
 

--- a/reader-gtfs/src/test/java/com/graphhopper/GraphHopperMultimodalIT.java
+++ b/reader-gtfs/src/test/java/com/graphhopper/GraphHopperMultimodalIT.java
@@ -277,7 +277,7 @@ public class GraphHopperMultimodalIT {
     @Test
     public void testSubnetworkRemoval() {
         Profile foot = graphHopperGtfs.getProfile("foot");
-        BooleanEncodedValue footSub = graphHopperGtfs.getEncodingManager().getBooleanEncodedValue(Subnetwork.key(foot.getName()));
+        BooleanEncodedValue footSub = graphHopperGtfs.getTagParserManager().getBooleanEncodedValue(Subnetwork.key(foot.getName()));
 
         // Go through all edges on removed foot subnetworks, and check that we can get to our destination station from there
         List<GHResponse> responses = new ArrayList<>();

--- a/tools/src/main/java/com/graphhopper/tools/Measurement.java
+++ b/tools/src/main/java/com/graphhopper/tools/Measurement.java
@@ -176,7 +176,7 @@ public class Measurement {
         hopper.importOrLoad();
 
         GraphHopperStorage g = hopper.getGraphHopperStorage();
-        EncodingManager encodingManager = hopper.getEncodingManager();
+        EncodingManager encodingManager = hopper.getTagParserManager().getEncodingManager();
         if (encodingManager.fetchEdgeEncoders().size() != 1) {
             throw new IllegalArgumentException("There has to be exactly one encoder for each measurement");
         }
@@ -538,7 +538,7 @@ public class Measurement {
 
         String profileName = querySettings.edgeBased ? "profile_tc" : "profile_no_tc";
         Weighting weighting = hopper.createWeighting(hopper.getProfile(profileName), new PMap());
-        final EdgeFilter edgeFilter = new DefaultSnapFilter(weighting, hopper.getEncodingManager().getBooleanEncodedValue(Subnetwork.key(profileName)));
+        final EdgeFilter edgeFilter = new DefaultSnapFilter(weighting, hopper.getTagParserManager().getBooleanEncodedValue(Subnetwork.key(profileName)));
         final EdgeExplorer edgeExplorer = g.createEdgeExplorer(edgeFilter);
         final AtomicLong visitedNodesSum = new AtomicLong(0);
         final AtomicLong maxVisitedNodes = new AtomicLong(0);

--- a/tools/src/main/java/com/graphhopper/tools/Measurement.java
+++ b/tools/src/main/java/com/graphhopper/tools/Measurement.java
@@ -175,7 +175,7 @@ public class Measurement {
 
         hopper.importOrLoad();
 
-        GraphHopperStorage g = hopper.getGraphHopperStorage();
+        BaseGraph g = hopper.getGraphHopperStorage().getBaseGraph();
         EncodingManager encodingManager = hopper.getTagParserManager().getEncodingManager();
         if (encodingManager.fetchEdgeEncoders().size() != 1) {
             throw new IllegalArgumentException("There has to be exactly one encoder for each measurement");
@@ -410,7 +410,7 @@ public class Measurement {
         }
     }
 
-    private void printGraphDetails(GraphHopperStorage g, String vehicleStr) {
+    private void printGraphDetails(BaseGraph g, String vehicleStr) {
         // graph size (edge, node and storage size)
         put("graph.nodes", g.getNodes());
         put("graph.edges", g.getAllEdges().length());

--- a/tools/src/main/java/com/graphhopper/ui/MiniGraphUI.java
+++ b/tools/src/main/java/com/graphhopper/ui/MiniGraphUI.java
@@ -117,7 +117,7 @@ public class MiniGraphUI {
     public MiniGraphUI(GraphHopper hopper, boolean debug, boolean useCH) {
         this.graph = hopper.getGraphHopperStorage().getBaseGraph();
         this.na = graph.getNodeAccess();
-        encoder = hopper.getEncodingManager().fetchEdgeEncoders().get(0);
+        encoder = hopper.getTagParserManager().fetchEdgeEncoders().get(0);
         avSpeedEnc = encoder.getAverageSpeedEnc();
         accessEnc = encoder.getAccessEnc();
         this.useCH = useCH;

--- a/web-bundle/src/main/java/com/graphhopper/http/GraphHopperBundle.java
+++ b/web-bundle/src/main/java/com/graphhopper/http/GraphHopperBundle.java
@@ -100,7 +100,7 @@ public class GraphHopperBundle implements ConfiguredBundle<GraphHopperBundleConf
 
         @Override
         public EncodingManager provide() {
-            return graphHopper.getEncodingManager();
+            return graphHopper.getTagParserManager().getEncodingManager();
         }
 
         @Override
@@ -132,7 +132,7 @@ public class GraphHopperBundle implements ConfiguredBundle<GraphHopperBundleConf
 
         @Override
         public ProfileResolver provide() {
-            return new ProfileResolver(graphHopper.getEncodingManager(),
+            return new ProfileResolver(graphHopper.getTagParserManager().getEncodingManager(),
                     graphHopper.getProfiles(),
                     graphHopper.getCHPreparationHandler().getCHProfiles(),
                     graphHopper.getLMPreparationHandler().getLMProfiles()

--- a/web-bundle/src/main/java/com/graphhopper/http/GraphHopperManaged.java
+++ b/web-bundle/src/main/java/com/graphhopper/http/GraphHopperManaged.java
@@ -103,8 +103,8 @@ public class GraphHopperManaged implements Managed {
         graphHopper.importOrLoad();
         logger.info("loaded graph at:{}, data_reader_file:{}, encoded values:{}, {} ints for edge flags, {}",
                 graphHopper.getGraphHopperLocation(), graphHopper.getOSMFile(),
-                graphHopper.getEncodingManager().toEncodedValuesAsString(),
-                graphHopper.getEncodingManager().getIntsForFlags(),
+                graphHopper.getTagParserManager().toEncodedValuesAsString(),
+                graphHopper.getTagParserManager().getIntsForFlags(),
                 graphHopper.getGraphHopperStorage().toDetailsString());
     }
 

--- a/web-bundle/src/main/java/com/graphhopper/resources/IsochroneResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/IsochroneResource.java
@@ -97,7 +97,7 @@ public class IsochroneResource {
         LocationIndex locationIndex = graphHopper.getLocationIndex();
         Graph graph = graphHopper.getGraphHopperStorage();
         Weighting weighting = graphHopper.createWeighting(profile, hintsMap);
-        BooleanEncodedValue inSubnetworkEnc = graphHopper.getEncodingManager().getBooleanEncodedValue(Subnetwork.key(profileName));
+        BooleanEncodedValue inSubnetworkEnc = graphHopper.getTagParserManager().getBooleanEncodedValue(Subnetwork.key(profileName));
         if (hintsMap.has(Parameters.Routing.BLOCK_AREA)) {
             GraphEdgeIdFinder.BlockArea blockArea = GraphEdgeIdFinder.createBlockArea(graph, locationIndex,
                     Collections.singletonList(point.get()), hintsMap, new FiniteWeightFilter(weighting));

--- a/web-bundle/src/main/java/com/graphhopper/resources/MapMatchingResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/MapMatchingResource.java
@@ -24,12 +24,12 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.graphhopper.GHResponse;
 import com.graphhopper.GraphHopper;
 import com.graphhopper.ResponsePath;
+import com.graphhopper.gpx.GpxConversions;
+import com.graphhopper.jackson.Gpx;
 import com.graphhopper.jackson.ResponsePathSerializer;
 import com.graphhopper.matching.*;
-import com.graphhopper.jackson.Gpx;
 import com.graphhopper.routing.ProfileResolver;
 import com.graphhopper.util.*;
-import com.graphhopper.gpx.GpxConversions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -137,7 +137,7 @@ public class MapMatchingResource {
                     setDouglasPeucker(peucker).
                     setSimplifyResponse(minPathPrecision > 0);
             ResponsePath responsePath = pathMerger.doWork(PointList.EMPTY, Collections.singletonList(matchResult.getMergedPath()),
-                    graphHopper.getEncodingManager(), tr);
+                    graphHopper.getTagParserManager(), tr);
 
             // GraphHopper thinks an empty path is an invalid path, and further that an invalid path is still a path but
             // marked with a non-empty list of Exception objects. I disagree, so I clear it.

--- a/web-bundle/src/main/java/com/graphhopper/resources/SPTResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/SPTResource.java
@@ -98,7 +98,7 @@ public class SPTResource {
         LocationIndex locationIndex = graphHopper.getLocationIndex();
         Graph graph = graphHopper.getGraphHopperStorage();
         Weighting weighting = graphHopper.createWeighting(profile, hintsMap);
-        BooleanEncodedValue inSubnetworkEnc = graphHopper.getEncodingManager().getBooleanEncodedValue(Subnetwork.key(profileName));
+        BooleanEncodedValue inSubnetworkEnc = graphHopper.getTagParserManager().getBooleanEncodedValue(Subnetwork.key(profileName));
         if (hintsMap.has(Parameters.Routing.BLOCK_AREA)) {
             GraphEdgeIdFinder.BlockArea blockArea = GraphEdgeIdFinder.createBlockArea(graph, locationIndex,
                     Collections.singletonList(point.get()), hintsMap, new FiniteWeightFilter(weighting));

--- a/web-bundle/src/test/java/com/graphhopper/gpx/GpxConversionsTest.java
+++ b/web-bundle/src/test/java/com/graphhopper/gpx/GpxConversionsTest.java
@@ -26,8 +26,7 @@ import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.routing.util.TraversalMode;
 import com.graphhopper.routing.weighting.ShortestWeighting;
-import com.graphhopper.storage.Graph;
-import com.graphhopper.storage.GraphBuilder;
+import com.graphhopper.storage.BaseGraph;
 import com.graphhopper.storage.NodeAccess;
 import com.graphhopper.util.*;
 import org.junit.jupiter.api.BeforeEach;
@@ -62,7 +61,7 @@ public class GpxConversionsTest {
 
     @Test
     public void testInstructionsWithTimeAndPlace() {
-        Graph g = new GraphBuilder(carManager).create();
+        BaseGraph g = new BaseGraph.Builder(carManager).create();
         //   n-4-5   (n: pillar node)
         //   |
         // 7-3-2-6

--- a/web/src/main/java/com/graphhopper/application/cli/MatchCommand.java
+++ b/web/src/main/java/com/graphhopper/application/cli/MatchCommand.java
@@ -130,7 +130,7 @@ public class MatchCommand extends ConfiguredCommand<GraphHopperServerConfigurati
                 System.out.println("\texport results to:" + outFile);
 
                 ResponsePath responsePath = new PathMerger(mr.getGraph(), mr.getWeighting()).
-                        doWork(PointList.EMPTY, Collections.singletonList(mr.getMergedPath()), hopper.getEncodingManager(), tr);
+                        doWork(PointList.EMPTY, Collections.singletonList(mr.getMergedPath()), hopper.getTagParserManager(), tr);
                 if (responsePath.hasErrors()) {
                     System.err.println("Problem with file " + gpxFile + ", " + responsePath.getErrors());
                     continue;


### PR DESCRIPTION
This is based on #2540.

`EncodingManager` does (too) many things. One thing it does is dealing with the different parsers used for the OSM import. However, we use it in very many places where we are not dealing with parsing OSM at all. Here I have created a 1:1 copy of `EncodingManager`, called `TagParserManager` and replaced usages of `EncodingManager` with this new `TagParserManager` class wherever we actually use the parsers. In turn, we can remove the parsing stuff from `EncodingManager`, because it is not needed in all the other places. Now there are around 120 usages of `TagParserManager` und 540 usages of `EncodingManager` which means that we can effectively remove parsing related code in many places. 

The `TagParserManager` is often created via the `GraphHopper` class, just like we created the `EncodingManager` there before. To be able to transition from this higher level code to the lower level API that uses only the `EncodingManager` there is `TagParserManager#getEncodingManager`. 

From here on (not this PR, but soon after) we still need to keep cleaning up `EncodingManager`. Eventually, it should just be a combination of the `encodedValuesMap` and `edge/turnCostConfig`, so we will have to focus on removing the `edgeEncoders` list and the `turnCostParsers` map. One very common usage pattern is this:

```java
CarFlagEncoder encoder = new CarFlagEncoder();
EncodingManager em = EncodingManager.create(encoder);
BaseGraph graph = new BaseGraph.Builder(em.getIntsForFlags()).create(); 
graph.edge(0, 1)
    .set(encoder.getAccessEnc(), true)
    .set(encoder.getAverageSpeedEnc(), 50);
    
// we already have a reference to the car encoder so it looks like we do not need this, 
// but this is what we do at request time: We use the vehicle string to get a certain encoder (see DefaultWeightingFactory)
encoder = em.getEncoder("car"); 
Weighting weighting = new FastestWeighting(encoder);
Dijkstra algo = new Dijkstra(graph, weighting, TraversalMode.NODE_BASED);
```

I think at some point this should (at least in principle) be turned into something like this to get rid of the flag encoders list for example:

```java
String vehicle = "car";
// maybe add some helper code to create these common encoded values, but they are just this: some encoded values
DecimalEncodedValue speedEnc = new DecimalEncodedValueImpl(EncodingManager.getKey(vehicle, "average_speed"), speedBits, speedFactor, speedTwoDirections);
BooleanEncodedValue accessEnc = new SimpleBooleanEncodedValue(EncodingManager.getKey(prefix, "access"), true);
EnumEncodedValue<RoadAccess> roadAccessEnc = new EnumEncodedValue<>(RoadAccess.KEY, RoadAccess.class);
EncodingManager em = new EncodingManager(); // basically this is just an empty encodedValueMap
em.add(speedEnc); // calls ev.init(edgeConfig) internally
em.add(accessEnc);
em.add(roadClassEnc);
graph.edge(0, 1)
     .set(accessEnc, true)
     .set(speedEnc, 50);
     
// at request time we need to get the encoded values from the encoding manager
speedEnc = em.getDecimalEncodedValue(EncodingManager.getKey(vehicle, "average_speed");
accessEnc = em.getBooleanEncodedValue(EncodingManager.getKey(vehicle, "access");     
roadClassEnc = em.getEnumEncodedValue(RoadAccess.KEY, RoadAccess.class);
// we use an empty PMap in this example but it could be used to configure heading/private/destination penalties for example
// by default we could take the max speed from the max possible value for speedEnc here, and set it to a smaller value for production code
Weighting weighting = new FastestWeighting(accessEnc, speedEnc, roadClassEnc, new PMap());
Dijkstra algo = new Dijkstra(graph, weighting, TraversalMode.NODE_BASED);     
```

We will also need to get rid of `Weighting#getFlagEncoder()` for this to work.

One possible shortcut I see that we could use to keep focus on removing FlagEncoders in our import code first, without having to deal with changes to all the `FastestWeighting` usages etc. at the same time, would be something like this:

```java
// this is just a class wrapping the encoded values we saw above. It's an implementation of the FlagEncoder, 
// but it does not extend AbstractFlagEncoder so it has nothing to do with OSM parsing.
RoutingFlagEncoder encoder = RoutingFlagEncoder.forVehicle("car");
EncodingManager em = new EncodingManager(); 
EncodingManager.add(encoder.getEncodedValues());
graph.edge(0, 1)
     .set(encoder.getAccessEnc(), true)
     .set(encoder.getAvgSpeedEnc(), 50);
     
encoder = em.getEncoder("car");     
Weighting weighting = new FastestWeighting(encoder);
Dijkstra algo = new Dijkstra(graph, weighting, TraversalMode.NODE_BASED);     
```

For this the next step would be turning the `List<AbstractFlagEncoder>` in `EncodingManager` into `List<FlagEncoder>`.
