### PR TITLE
WIP: Replace flag encoders in tests

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/weighting/DefaultTurnCostProvider.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/DefaultTurnCostProvider.java
@@ -36,11 +36,20 @@ public class DefaultTurnCostProvider implements TurnCostProvider {
         this(encoder, turnCostStorage, Weighting.INFINITE_U_TURN_COSTS);
     }
 
+    public DefaultTurnCostProvider(DecimalEncodedValue turnCostEnc, TurnCostStorage turnCostStorage) {
+        this(turnCostEnc, turnCostStorage, INFINITE_U_TURN_COSTS);
+    }
+
+    public DefaultTurnCostProvider(FlagEncoder encoder, TurnCostStorage turnCostStorage, int uTurnCosts) {
+        this(encoder.hasEncodedValue(TurnCost.key(encoder.toString())) ? encoder.getDecimalEncodedValue(TurnCost.key(encoder.toString())) : null,
+                turnCostStorage, uTurnCosts);
+    }
+
     /**
      * @param uTurnCosts the costs of a u-turn in seconds, for {@link Weighting#INFINITE_U_TURN_COSTS} the u-turn costs
      *                   will be infinite
      */
-    public DefaultTurnCostProvider(FlagEncoder encoder, TurnCostStorage turnCostStorage, int uTurnCosts) {
+    public DefaultTurnCostProvider(DecimalEncodedValue turnCostEnc, TurnCostStorage turnCostStorage, int uTurnCosts) {
         if (uTurnCosts < 0 && uTurnCosts != INFINITE_U_TURN_COSTS) {
             throw new IllegalArgumentException("u-turn costs must be positive, or equal to " + INFINITE_U_TURN_COSTS + " (=infinite costs)");
         }
@@ -49,9 +58,9 @@ public class DefaultTurnCostProvider implements TurnCostProvider {
         if (turnCostStorage == null) {
             throw new IllegalArgumentException("No storage set to calculate turn weight");
         }
-        String key = TurnCost.key(encoder.toString());
+
         // if null the TurnCostProvider can be still useful for edge-based routing
-        this.turnCostEnc = encoder.hasEncodedValue(key) ? encoder.getDecimalEncodedValue(key) : null;
+        this.turnCostEnc = turnCostEnc;
         this.turnCostStorage = turnCostStorage;
     }
 

--- a/core/src/main/java/com/graphhopper/routing/weighting/TestWeighting.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/TestWeighting.java
@@ -1,0 +1,77 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.graphhopper.routing.weighting;
+
+import com.graphhopper.routing.ev.BooleanEncodedValue;
+import com.graphhopper.routing.util.FlagEncoder;
+import com.graphhopper.util.EdgeIteratorState;
+
+public class TestWeighting implements Weighting {
+    private final BooleanEncodedValue accessEnc;
+    private final TurnCostProvider turnCostProvider;
+    private final double speed = 60 / 3.6;
+
+    public TestWeighting(BooleanEncodedValue accessEnc, TurnCostProvider turnCostProvider) {
+        this.accessEnc = accessEnc;
+        this.turnCostProvider = turnCostProvider;
+    }
+
+    @Override
+    public double getMinWeight(double distance) {
+        return 1000 * distance / speed;
+    }
+
+    @Override
+    public double calcEdgeWeight(EdgeIteratorState edgeState, boolean reverse) {
+        boolean access = reverse ? edgeState.getReverse(accessEnc) : edgeState.get(accessEnc);
+        if (!access)
+            return Double.POSITIVE_INFINITY;
+        return calcEdgeMillis(edgeState, reverse);
+    }
+
+    @Override
+    public long calcEdgeMillis(EdgeIteratorState edgeState, boolean reverse) {
+        return 1000 * Math.round(edgeState.getDistance() / speed);
+    }
+
+    @Override
+    public double calcTurnWeight(int inEdge, int viaNode, int outEdge) {
+        return turnCostProvider.calcTurnWeight(inEdge, viaNode, outEdge);
+    }
+
+    @Override
+    public long calcTurnMillis(int inEdge, int viaNode, int outEdge) {
+        return turnCostProvider.calcTurnMillis(inEdge, viaNode, outEdge);
+    }
+
+    @Override
+    public boolean hasTurnCosts() {
+        return turnCostProvider != TurnCostProvider.NO_TURN_COST_PROVIDER;
+    }
+
+    @Override
+    public FlagEncoder getFlagEncoder() {
+        throw new UnsupportedOperationException("This method should be removed");
+    }
+
+    @Override
+    public String getName() {
+        throw new UnsupportedOperationException("This method should be removed");
+    }
+}

--- a/core/src/main/java/com/graphhopper/util/GHUtility.java
+++ b/core/src/main/java/com/graphhopper/util/GHUtility.java
@@ -654,6 +654,17 @@ public class GHUtility {
         return edge;
     }
 
+    public static void setAccess(boolean fwd, boolean bwd, BooleanEncodedValue accessEnc, EdgeIteratorState... edges) {
+        setAccess(fwd, bwd, accessEnc, Arrays.asList(edges));
+    }
+
+    public static void setAccess(boolean fwd, boolean bwd, BooleanEncodedValue accessEnc, Collection<EdgeIteratorState> edges) {
+        for (EdgeIteratorState edge : edges) {
+            edge.set(accessEnc, fwd);
+            edge.setReverse(accessEnc, bwd);
+        }
+    }
+
     public static void updateDistancesFor(Graph g, int node, double lat, double lon) {
         NodeAccess na = g.getNodeAccess();
         na.setNode(node, lat, lon);


### PR DESCRIPTION
There are lots of tests that use FlagEncoder, even though all that is actually needed is *some* speed per edge. Usually these speeds aren't related to 'vehicles' at all and in many cases the speed is always the same (set to 60 using `GHUtility#setSpeed`). Replacing these usages will be necessary for #2463.

todo:

* [ ] #2548 
* [ ] allow adding turn cost encoded values to EncodingManager without FlagEncoder
