### PR TITLE
Remove TagParser#createEncodedValues

### DIFF
--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -28,9 +28,7 @@ import com.graphhopper.reader.osm.conditional.DateRangeParser;
 import com.graphhopper.routing.*;
 import com.graphhopper.routing.ch.CHPreparationHandler;
 import com.graphhopper.routing.ch.PrepareContractionHierarchies;
-import com.graphhopper.routing.ev.EnumEncodedValue;
-import com.graphhopper.routing.ev.RoadEnvironment;
-import com.graphhopper.routing.ev.Subnetwork;
+import com.graphhopper.routing.ev.*;
 import com.graphhopper.routing.lm.LMConfig;
 import com.graphhopper.routing.lm.LMPreparationHandler;
 import com.graphhopper.routing.lm.LandmarkStorage;
@@ -119,6 +117,7 @@ public class GraphHopper {
     private String osmFile;
     private ElevationProvider eleProvider = ElevationProvider.NOOP;
     private FlagEncoderFactory flagEncoderFactory = new DefaultFlagEncoderFactory();
+    private EncodedValueFactory encodedValueFactory = new DefaultEncodedValueFactory();
     private TagParserFactory tagParserFactory = new DefaultTagParserFactory();
     private PathDetailsBuilderFactory pathBuilderFactory = new PathDetailsBuilderFactory();
 
@@ -384,6 +383,15 @@ public class GraphHopper {
         return this;
     }
 
+    public EncodedValueFactory getEncodedValueFactory() {
+        return this.encodedValueFactory;
+    }
+
+    public GraphHopper setEncodedValueFactory(EncodedValueFactory factory) {
+        this.encodedValueFactory = factory;
+        return this;
+    }
+
     public TagParserFactory getTagParserFactory() {
         return this.tagParserFactory;
     }
@@ -545,7 +553,7 @@ public class GraphHopper {
         flagEncoderMap.values().forEach(s -> emBuilder.addIfAbsent(flagEncoderFactory, s));
 
         for (String tpStr : encodedValueStr.split(",")) {
-            if (!tpStr.isEmpty()) emBuilder.addIfAbsent(tagParserFactory, tpStr);
+            if (!tpStr.isEmpty()) emBuilder.addIfAbsent(encodedValueFactory, tagParserFactory, tpStr);
         }
 
         return emBuilder.build();

--- a/core/src/main/java/com/graphhopper/routing/ev/DefaultEncodedValueFactory.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/DefaultEncodedValueFactory.java
@@ -1,0 +1,94 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.routing.ev;
+
+import com.graphhopper.util.Helper;
+
+public class DefaultEncodedValueFactory implements EncodedValueFactory {
+    @Override
+    public EncodedValue create(String string) {
+        if (Helper.isEmpty(string))
+            throw new IllegalArgumentException("No string provided to load EncodedValue");
+
+        final EncodedValue enc;
+        String name = string.split("\\|")[0];
+        if (name.isEmpty())
+            throw new IllegalArgumentException("To load EncodedValue a name is required. " + string);
+
+        if (Roundabout.KEY.equals(name)) {
+            enc = Roundabout.create();
+        } else if ("car_access".equals(name)) {
+            enc = new SimpleBooleanEncodedValue("car_access", true);
+        } else if ("bike_access".equals(name)) {
+            enc = new SimpleBooleanEncodedValue("bike_access", true);
+        } else if (GetOffBike.KEY.equals(name)) {
+            enc = GetOffBike.create();
+        } else if (RoadClass.KEY.equals(name)) {
+            enc = new EnumEncodedValue<>(RoadClass.KEY, RoadClass.class);
+        } else if (RoadClassLink.KEY.equals(name)) {
+            enc = new SimpleBooleanEncodedValue(RoadClassLink.KEY);
+        } else if (RoadEnvironment.KEY.equals(name)) {
+            enc = new EnumEncodedValue<>(RoadEnvironment.KEY, RoadEnvironment.class);
+        } else if (RoadAccess.KEY.equals(name)) {
+            enc = new EnumEncodedValue<>(RoadAccess.KEY, RoadAccess.class);
+        } else if (MaxSpeed.KEY.equals(name)) {
+            enc = MaxSpeed.create();
+        } else if (MaxWeight.KEY.equals(name)) {
+            enc = MaxWeight.create();
+        } else if (MaxHeight.KEY.equals(name)) {
+            enc = MaxHeight.create();
+        } else if (MaxWidth.KEY.equals(name)) {
+            enc = MaxWidth.create();
+        } else if (MaxAxleLoad.KEY.equals(name)) {
+            enc = MaxAxleLoad.create();
+        } else if (MaxLength.KEY.equals(name)) {
+            enc = MaxLength.create();
+        } else if (Surface.KEY.equals(name)) {
+            enc = new EnumEncodedValue<>(Surface.KEY, Surface.class);
+        } else if (Smoothness.KEY.equals(name)) {
+            enc = new EnumEncodedValue<>(Smoothness.KEY, Smoothness.class);
+        } else if (Toll.KEY.equals(name)) {
+            enc = new EnumEncodedValue<>(Toll.KEY, Toll.class);
+        } else if (TrackType.KEY.equals(name)) {
+            enc = new EnumEncodedValue<>(TrackType.KEY, TrackType.class);
+        } else if (BikeNetwork.KEY.equals(name) || FootNetwork.KEY.equals(name)) {
+            enc = new EnumEncodedValue<>(name, RouteNetwork.class);
+        } else if (Hazmat.KEY.equals(name)) {
+            enc = new EnumEncodedValue<>(Hazmat.KEY, Hazmat.class);
+        } else if (HazmatTunnel.KEY.equals(name)) {
+            enc = new EnumEncodedValue<>(HazmatTunnel.KEY, HazmatTunnel.class);
+        } else if (HazmatWater.KEY.equals(name)) {
+            enc = new EnumEncodedValue<>(HazmatWater.KEY, HazmatWater.class);
+        } else if (Lanes.KEY.equals(name)) {
+            enc = Lanes.create();
+        } else if (MtbRating.KEY.equals(name)) {
+            enc = MtbRating.create();
+        } else if (HikeRating.KEY.equals(name)) {
+            enc = HikeRating.create();
+        } else if (HorseRating.KEY.equals(name)) {
+            enc = HorseRating.create();
+        } else if (Country.KEY.equals(name)) {
+            enc = Country.create();
+        } else if (name.endsWith(Subnetwork.key(""))) {
+            enc = new SimpleBooleanEncodedValue(name);
+        } else {
+            throw new IllegalArgumentException("DefaultEncodedValueFactory cannot find EncodedValue " + name);
+        }
+        return enc;
+    }
+}

--- a/core/src/main/java/com/graphhopper/routing/ev/EncodedValueFactory.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/EncodedValueFactory.java
@@ -1,0 +1,26 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.routing.ev;
+
+public interface EncodedValueFactory {
+    /**
+     * This method assumes a string value with the key of an EncodedValue like "road_class" and returns an instance
+     * of it.
+     */
+    EncodedValue create(String encodedValueString);
+}

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/CountryParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/CountryParser.java
@@ -19,23 +19,14 @@ package com.graphhopper.routing.util.parsers;
 
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.Country;
-import com.graphhopper.routing.ev.EncodedValue;
-import com.graphhopper.routing.ev.EncodedValueLookup;
 import com.graphhopper.routing.ev.EnumEncodedValue;
 import com.graphhopper.storage.IntsRef;
-
-import java.util.List;
 
 public class CountryParser implements TagParser {
     private final EnumEncodedValue<Country> countryEnc;
 
-    public CountryParser() {
-        this.countryEnc = Country.create();
-    }
-
-    @Override
-    public void createEncodedValues(EncodedValueLookup lookup, List<EncodedValue> registerNewEncodedValue) {
-        registerNewEncodedValue.add(countryEnc);
+    public CountryParser(EnumEncodedValue<Country> countryEnc) {
+        this.countryEnc = countryEnc;
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/DefaultTagParserFactory.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/DefaultTagParserFactory.java
@@ -24,61 +24,61 @@ import static com.graphhopper.util.Helper.toLowerCase;
 
 public class DefaultTagParserFactory implements TagParserFactory {
     @Override
-    public TagParser create(String name) {
+    public TagParser create(EncodedValueLookup lookup, String name) {
         name = name.trim();
         if (!name.equals(toLowerCase(name)))
             throw new IllegalArgumentException("Use lower case for TagParsers: " + name);
 
         if (Roundabout.KEY.equals(name))
-            return new OSMRoundaboutParser();
+            return new OSMRoundaboutParser(lookup.getBooleanEncodedValue(Roundabout.KEY));
         else if (name.equals(RoadClass.KEY))
-            return new OSMRoadClassParser();
+            return new OSMRoadClassParser(lookup.getEnumEncodedValue(RoadClass.KEY, RoadClass.class));
         else if (name.equals(RoadClassLink.KEY))
-            return new OSMRoadClassLinkParser();
+            return new OSMRoadClassLinkParser(lookup.getBooleanEncodedValue(RoadClassLink.KEY));
         else if (name.equals(RoadEnvironment.KEY))
-            return new OSMRoadEnvironmentParser();
+            return new OSMRoadEnvironmentParser(lookup.getEnumEncodedValue(RoadEnvironment.KEY, RoadEnvironment.class));
         else if (name.equals(RoadAccess.KEY))
-            return new OSMRoadAccessParser();
+            return new OSMRoadAccessParser(lookup.getEnumEncodedValue(RoadAccess.KEY, RoadAccess.class), OSMRoadAccessParser.toOSMRestrictions(TransportationMode.CAR));
         else if (name.equals("car_access"))
-            return new OSMAccessParser("car_access", OSMRoadAccessParser.toOSMRestrictions(TransportationMode.CAR), TransportationMode.CAR);
+            return new OSMAccessParser(lookup.getBooleanEncodedValue("car_access"), lookup.getBooleanEncodedValue(Roundabout.KEY), OSMRoadAccessParser.toOSMRestrictions(TransportationMode.CAR), TransportationMode.CAR);
         else if (name.equals("bike_access"))
-            return new OSMAccessParser("bike_access", OSMRoadAccessParser.toOSMRestrictions(TransportationMode.BIKE), TransportationMode.BIKE);
+            return new OSMAccessParser(lookup.getBooleanEncodedValue("bike_access"), lookup.getBooleanEncodedValue(Roundabout.KEY), OSMRoadAccessParser.toOSMRestrictions(TransportationMode.BIKE), TransportationMode.BIKE);
         else if (name.equals(MaxSpeed.KEY))
-            return new OSMMaxSpeedParser();
+            return new OSMMaxSpeedParser(lookup.getDecimalEncodedValue(MaxSpeed.KEY));
         else if (name.equals(MaxWeight.KEY))
-            return new OSMMaxWeightParser();
+            return new OSMMaxWeightParser(lookup.getDecimalEncodedValue(MaxWeight.KEY));
         else if (name.equals(MaxHeight.KEY))
-            return new OSMMaxHeightParser();
+            return new OSMMaxHeightParser(lookup.getDecimalEncodedValue(MaxHeight.KEY));
         else if (name.equals(MaxWidth.KEY))
-            return new OSMMaxWidthParser();
+            return new OSMMaxWidthParser(lookup.getDecimalEncodedValue(MaxWidth.KEY));
         else if (name.equals(MaxAxleLoad.KEY))
-            return new OSMMaxAxleLoadParser();
+            return new OSMMaxAxleLoadParser(lookup.getDecimalEncodedValue(MaxAxleLoad.KEY));
         else if (name.equals(MaxLength.KEY))
-            return new OSMMaxLengthParser();
+            return new OSMMaxLengthParser(lookup.getDecimalEncodedValue(MaxLength.KEY));
         else if (name.equals(Surface.KEY))
-            return new OSMSurfaceParser();
+            return new OSMSurfaceParser(lookup.getEnumEncodedValue(Surface.KEY, Surface.class));
         else if (name.equals(Smoothness.KEY))
-            return new OSMSmoothnessParser();
+            return new OSMSmoothnessParser(lookup.getEnumEncodedValue(Smoothness.KEY, Smoothness.class));
         else if (name.equals(Toll.KEY))
-            return new OSMTollParser();
+            return new OSMTollParser(lookup.getEnumEncodedValue(Toll.KEY, Toll.class));
         else if (name.equals(TrackType.KEY))
-            return new OSMTrackTypeParser();
+            return new OSMTrackTypeParser(lookup.getEnumEncodedValue(TrackType.KEY, TrackType.class));
         else if (name.equals(Hazmat.KEY))
-            return new OSMHazmatParser();
+            return new OSMHazmatParser(lookup.getEnumEncodedValue(Hazmat.KEY, Hazmat.class));
         else if (name.equals(HazmatTunnel.KEY))
-            return new OSMHazmatTunnelParser();
+            return new OSMHazmatTunnelParser(lookup.getEnumEncodedValue(HazmatTunnel.KEY, HazmatTunnel.class));
         else if (name.equals(HazmatWater.KEY))
-            return new OSMHazmatWaterParser();
+            return new OSMHazmatWaterParser(lookup.getEnumEncodedValue(HazmatWater.KEY, HazmatWater.class));
         else if (name.equals(Lanes.KEY))
-            return new OSMLanesParser();
+            return new OSMLanesParser(lookup.getIntEncodedValue(Lanes.KEY));
         else if (name.equals(MtbRating.KEY))
-            return new OSMMtbRatingParser();
+            return new OSMMtbRatingParser(lookup.getIntEncodedValue(MtbRating.KEY));
         else if (name.equals(HikeRating.KEY))
-            return new OSMHikeRatingParser();
+            return new OSMHikeRatingParser(lookup.getIntEncodedValue(HikeRating.KEY));
         else if (name.equals(HorseRating.KEY))
-            return new OSMHorseRatingParser();
+            return new OSMHorseRatingParser(lookup.getIntEncodedValue(HorseRating.KEY));
         else if (name.equals(Country.KEY))
-            return new CountryParser();
+            return new CountryParser(lookup.getEnumEncodedValue(Country.KEY, Country.class));
 
         throw new IllegalArgumentException("DefaultTagParserFactory cannot find: " + name);
     }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMAccessParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMAccessParser.java
@@ -18,7 +18,8 @@
 package com.graphhopper.routing.util.parsers;
 
 import com.graphhopper.reader.ReaderWay;
-import com.graphhopper.routing.ev.*;
+import com.graphhopper.routing.ev.BooleanEncodedValue;
+import com.graphhopper.routing.ev.RoadAccess;
 import com.graphhopper.routing.util.TransportationMode;
 import com.graphhopper.routing.util.countryrules.CountryRule;
 import com.graphhopper.storage.IntsRef;
@@ -40,12 +41,13 @@ public class OSMAccessParser implements TagParser {
     private final Set<String> restrictedValues = new HashSet<>(10);
     private final Set<String> oneways = new HashSet<>(5);
     private final HashSet<String> oppositeLanes = new HashSet<>();
-    private BooleanEncodedValue roundaboutEnc;
+    private final BooleanEncodedValue roundaboutEnc;
 
-    private Set<String> intendedValues = new HashSet<>(5);
+    private final Set<String> intendedValues = new HashSet<>(5);
 
-    public OSMAccessParser(String name, List<String> restrictions, TransportationMode transportationMode) {
-        this.accessEnc = new SimpleBooleanEncodedValue(name, true);
+    public OSMAccessParser(BooleanEncodedValue accessEnc, BooleanEncodedValue roundaboutEnc, List<String> restrictions, TransportationMode transportationMode) {
+        this.roundaboutEnc = roundaboutEnc;
+        this.accessEnc = accessEnc;
         this.restrictions = restrictions;
         this.transportationMode = transportationMode;
 
@@ -71,12 +73,6 @@ public class OSMAccessParser implements TagParser {
         oppositeLanes.add("opposite");
         oppositeLanes.add("opposite_lane");
         oppositeLanes.add("opposite_track");
-    }
-
-    @Override
-    public void createEncodedValues(EncodedValueLookup lookup, List<EncodedValue> list) {
-        list.add(accessEnc);
-        roundaboutEnc = lookup.getBooleanEncodedValue(Roundabout.KEY);
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMBikeNetworkTagParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMBikeNetworkTagParser.java
@@ -19,22 +19,22 @@ package com.graphhopper.routing.util.parsers;
 
 import com.graphhopper.reader.ReaderRelation;
 import com.graphhopper.reader.ReaderWay;
-import com.graphhopper.routing.ev.*;
+import com.graphhopper.routing.ev.EncodedValue;
+import com.graphhopper.routing.ev.EnumEncodedValue;
+import com.graphhopper.routing.ev.RouteNetwork;
 import com.graphhopper.storage.IntsRef;
 import com.graphhopper.util.Helper;
-
-import java.util.List;
 
 import static com.graphhopper.routing.util.EncodingManager.getKey;
 
 public class OSMBikeNetworkTagParser implements RelationTagParser {
-    private EnumEncodedValue<RouteNetwork> bikeRouteEnc;
+    private final EnumEncodedValue<RouteNetwork> bikeRouteEnc;
     // used only for internal transformation from relations into edge flags
-    private EnumEncodedValue<RouteNetwork> transformerRouteRelEnc;
+    private final EnumEncodedValue<RouteNetwork> transformerRouteRelEnc = new EnumEncodedValue<>(getKey("bike", "route_relation"), RouteNetwork.class);
 
-    @Override
-    public void createRelationEncodedValues(EncodedValueLookup lookup, List<EncodedValue> registerNewEncodedValue) {
-        registerNewEncodedValue.add(transformerRouteRelEnc = new EnumEncodedValue<>(getKey("bike", "route_relation"), RouteNetwork.class));
+    public OSMBikeNetworkTagParser(EnumEncodedValue<RouteNetwork> bikeRouteEnc, EncodedValue.InitializerConfig relConfig) {
+        this.bikeRouteEnc = bikeRouteEnc;
+        this.transformerRouteRelEnc.init(relConfig);
     }
 
     @Override
@@ -57,11 +57,6 @@ public class OSMBikeNetworkTagParser implements RelationTagParser {
         }
 
         return relFlags;
-    }
-
-    @Override
-    public void createEncodedValues(EncodedValueLookup lookup, List<EncodedValue> registerNewEncodedValue) {
-        registerNewEncodedValue.add(bikeRouteEnc = new EnumEncodedValue<>(BikeNetwork.KEY, RouteNetwork.class));
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMFootNetworkTagParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMFootNetworkTagParser.java
@@ -19,22 +19,22 @@ package com.graphhopper.routing.util.parsers;
 
 import com.graphhopper.reader.ReaderRelation;
 import com.graphhopper.reader.ReaderWay;
-import com.graphhopper.routing.ev.*;
+import com.graphhopper.routing.ev.EncodedValue;
+import com.graphhopper.routing.ev.EnumEncodedValue;
+import com.graphhopper.routing.ev.RouteNetwork;
 import com.graphhopper.storage.IntsRef;
 import com.graphhopper.util.Helper;
-
-import java.util.List;
 
 import static com.graphhopper.routing.util.EncodingManager.getKey;
 
 public class OSMFootNetworkTagParser implements RelationTagParser {
-    private EnumEncodedValue<RouteNetwork> footRouteEnc;
+    private final EnumEncodedValue<RouteNetwork> footRouteEnc;
     // used for internal transformation from relations into footRouteEnc
-    private EnumEncodedValue<RouteNetwork> transformerRouteRelEnc;
+    private final EnumEncodedValue<RouteNetwork> transformerRouteRelEnc = new EnumEncodedValue<>(getKey("foot", "route_relation"), RouteNetwork.class);
 
-    @Override
-    public void createRelationEncodedValues(EncodedValueLookup lookup, List<EncodedValue> registerNewEncodedValue) {
-        registerNewEncodedValue.add(transformerRouteRelEnc = new EnumEncodedValue<>(getKey("foot", "route_relation"), RouteNetwork.class));
+    public OSMFootNetworkTagParser(EnumEncodedValue<RouteNetwork> footRouteEnc, EncodedValue.InitializerConfig relConfig) {
+        this.footRouteEnc = footRouteEnc;
+        this.transformerRouteRelEnc.init(relConfig);
     }
 
     @Override
@@ -57,11 +57,6 @@ public class OSMFootNetworkTagParser implements RelationTagParser {
         }
 
         return relFlags;
-    }
-
-    @Override
-    public void createEncodedValues(EncodedValueLookup lookup, List<EncodedValue> registerNewEncodedValue) {
-        registerNewEncodedValue.add(footRouteEnc = new EnumEncodedValue<>(FootNetwork.KEY, RouteNetwork.class));
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMGetOffBikeParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMGetOffBikeParser.java
@@ -2,9 +2,6 @@ package com.graphhopper.routing.util.parsers;
 
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.BooleanEncodedValue;
-import com.graphhopper.routing.ev.EncodedValue;
-import com.graphhopper.routing.ev.EncodedValueLookup;
-import com.graphhopper.routing.ev.GetOffBike;
 import com.graphhopper.storage.IntsRef;
 
 import java.util.Arrays;
@@ -19,10 +16,6 @@ public class OSMGetOffBikeParser implements TagParser {
     private final List<String> accepted = Arrays.asList("designated", "yes", "official", "permissive");
     private final BooleanEncodedValue offBikeEnc;
 
-    public OSMGetOffBikeParser() {
-        this(GetOffBike.create());
-    }
-
     public OSMGetOffBikeParser(BooleanEncodedValue getOffBikeEnc) {
         // steps -> special handling
         this(getOffBikeEnc, Arrays.asList("path", "footway", "pedestrian", "platform"));
@@ -31,11 +24,6 @@ public class OSMGetOffBikeParser implements TagParser {
     public OSMGetOffBikeParser(BooleanEncodedValue getOffBikeEnc, List<String> pushBikeTags) {
         offBikeEnc = getOffBikeEnc;
         pushBikeHighwayTags.addAll(pushBikeTags);
-    }
-
-    @Override
-    public void createEncodedValues(EncodedValueLookup lookup, List<EncodedValue> registerNewEncodedValue) {
-        registerNewEncodedValue.add(offBikeEnc);
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMHazmatParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMHazmatParser.java
@@ -1,29 +1,16 @@
 package com.graphhopper.routing.util.parsers;
 
 import com.graphhopper.reader.ReaderWay;
-import com.graphhopper.routing.ev.EncodedValue;
-import com.graphhopper.routing.ev.EncodedValueLookup;
 import com.graphhopper.routing.ev.EnumEncodedValue;
 import com.graphhopper.routing.ev.Hazmat;
 import com.graphhopper.storage.IntsRef;
-
-import java.util.List;
 
 public class OSMHazmatParser implements TagParser {
 
     private final EnumEncodedValue<Hazmat> hazEnc;
 
-    public OSMHazmatParser() {
-        this(new EnumEncodedValue<>(Hazmat.KEY, Hazmat.class));
-    }
-
     public OSMHazmatParser(EnumEncodedValue<Hazmat> hazEnc) {
         this.hazEnc = hazEnc;
-    }
-
-    @Override
-    public void createEncodedValues(EncodedValueLookup lookup, List<EncodedValue> registerNewEncodedValue) {
-        registerNewEncodedValue.add(hazEnc);
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMHazmatTunnelParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMHazmatTunnelParser.java
@@ -1,13 +1,9 @@
 package com.graphhopper.routing.util.parsers;
 
 import com.graphhopper.reader.ReaderWay;
-import com.graphhopper.routing.ev.EncodedValue;
-import com.graphhopper.routing.ev.EncodedValueLookup;
 import com.graphhopper.routing.ev.EnumEncodedValue;
 import com.graphhopper.routing.ev.HazmatTunnel;
 import com.graphhopper.storage.IntsRef;
-
-import java.util.List;
 
 public class OSMHazmatTunnelParser implements TagParser {
 
@@ -23,18 +19,8 @@ public class OSMHazmatTunnelParser implements TagParser {
 
     private final EnumEncodedValue<HazmatTunnel> hazTunnelEnc;
 
-    public OSMHazmatTunnelParser() {
-        this(new EnumEncodedValue<>(HazmatTunnel.KEY, HazmatTunnel.class));
-    }
-
     public OSMHazmatTunnelParser(EnumEncodedValue<HazmatTunnel> hazTunnelEnc) {
         this.hazTunnelEnc = hazTunnelEnc;
-    }
-
-
-    @Override
-    public void createEncodedValues(EncodedValueLookup lookup, List<EncodedValue> registerNewEncodedValue) {
-        registerNewEncodedValue.add(hazTunnelEnc);
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMHazmatWaterParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMHazmatWaterParser.java
@@ -1,30 +1,17 @@
 package com.graphhopper.routing.util.parsers;
 
 import com.graphhopper.reader.ReaderWay;
-import com.graphhopper.routing.ev.EncodedValue;
-import com.graphhopper.routing.ev.EncodedValueLookup;
 import com.graphhopper.routing.ev.EnumEncodedValue;
 import com.graphhopper.routing.ev.HazmatWater;
 import com.graphhopper.storage.IntsRef;
-
-import java.util.List;
 
 
 public class OSMHazmatWaterParser implements TagParser {
 
     private final EnumEncodedValue<HazmatWater> hazWaterEnc;
 
-    public OSMHazmatWaterParser() {
-        this(new EnumEncodedValue<>(HazmatWater.KEY, HazmatWater.class));
-    }
-
     public OSMHazmatWaterParser(EnumEncodedValue<HazmatWater> hazWaterEnc) {
         this.hazWaterEnc = hazWaterEnc;
-    }
-
-    @Override
-    public void createEncodedValues(EncodedValueLookup lookup, List<EncodedValue> registerNewEncodedValue) {
-        registerNewEncodedValue.add(hazWaterEnc);
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMHikeRatingParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMHikeRatingParser.java
@@ -18,13 +18,8 @@
 package com.graphhopper.routing.util.parsers;
 
 import com.graphhopper.reader.ReaderWay;
-import com.graphhopper.routing.ev.EncodedValue;
-import com.graphhopper.routing.ev.EncodedValueLookup;
-import com.graphhopper.routing.ev.HikeRating;
 import com.graphhopper.routing.ev.IntEncodedValue;
 import com.graphhopper.storage.IntsRef;
-
-import java.util.List;
 
 /**
  * Parses the hiking difficulty. Where hiking corresponds to 1, mountain_hiking to 2 until 6.
@@ -35,13 +30,8 @@ public class OSMHikeRatingParser implements TagParser {
 
     private final IntEncodedValue sacScaleEnc;
 
-    public OSMHikeRatingParser() {
-        this.sacScaleEnc = HikeRating.create();
-    }
-
-    @Override
-    public void createEncodedValues(EncodedValueLookup lookup, List<EncodedValue> link) {
-        link.add(sacScaleEnc);
+    public OSMHikeRatingParser(IntEncodedValue sacScaleEnc) {
+        this.sacScaleEnc = sacScaleEnc;
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMHorseRatingParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMHorseRatingParser.java
@@ -18,13 +18,8 @@
 package com.graphhopper.routing.util.parsers;
 
 import com.graphhopper.reader.ReaderWay;
-import com.graphhopper.routing.ev.EncodedValue;
-import com.graphhopper.routing.ev.EncodedValueLookup;
-import com.graphhopper.routing.ev.HorseRating;
 import com.graphhopper.routing.ev.IntEncodedValue;
 import com.graphhopper.storage.IntsRef;
-
-import java.util.List;
 
 /**
  * Parses the horseback riding difficulty. Where common is mapped to 1, demanding to 2 until 6
@@ -35,13 +30,8 @@ public class OSMHorseRatingParser implements TagParser {
 
     private final IntEncodedValue horseScale;
 
-    public OSMHorseRatingParser() {
-        this.horseScale = HorseRating.create();
-    }
-
-    @Override
-    public void createEncodedValues(EncodedValueLookup lookup, List<EncodedValue> link) {
-        link.add(horseScale);
+    public OSMHorseRatingParser(IntEncodedValue horseScale) {
+        this.horseScale = horseScale;
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMLanesParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMLanesParser.java
@@ -19,13 +19,8 @@
 package com.graphhopper.routing.util.parsers;
 
 import com.graphhopper.reader.ReaderWay;
-import com.graphhopper.routing.ev.EncodedValue;
-import com.graphhopper.routing.ev.EncodedValueLookup;
 import com.graphhopper.routing.ev.IntEncodedValue;
-import com.graphhopper.routing.ev.Lanes;
 import com.graphhopper.storage.IntsRef;
-
-import java.util.List;
 
 /**
  * https://wiki.openstreetmap.org/wiki/Key:lanes
@@ -33,17 +28,8 @@ import java.util.List;
 public class OSMLanesParser implements TagParser {
     private final IntEncodedValue lanesEnc;
 
-    public OSMLanesParser() {
-        this(Lanes.create());
-    }
-
     public OSMLanesParser(IntEncodedValue lanesEnc) {
         this.lanesEnc = lanesEnc;
-    }
-
-    @Override
-    public void createEncodedValues(EncodedValueLookup lookup, List<EncodedValue> registerNewEncodedValue) {
-        registerNewEncodedValue.add(lanesEnc);
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMMaxAxleLoadParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMMaxAxleLoadParser.java
@@ -19,30 +19,17 @@ package com.graphhopper.routing.util.parsers;
 
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.DecimalEncodedValue;
-import com.graphhopper.routing.ev.EncodedValue;
-import com.graphhopper.routing.ev.EncodedValueLookup;
-import com.graphhopper.routing.ev.MaxAxleLoad;
 import com.graphhopper.routing.util.parsers.helpers.OSMValueExtractor;
 import com.graphhopper.storage.IntsRef;
 
 import java.util.Collections;
-import java.util.List;
 
 public class OSMMaxAxleLoadParser implements TagParser {
 
     private final DecimalEncodedValue maxAxleLoadEncoder;
 
-    public OSMMaxAxleLoadParser() {
-        this(MaxAxleLoad.create());
-    }
-
     public OSMMaxAxleLoadParser(DecimalEncodedValue maxAxleLoadEncoder) {
         this.maxAxleLoadEncoder = maxAxleLoadEncoder;
-    }
-
-    @Override
-    public void createEncodedValues(EncodedValueLookup lookup, List<EncodedValue> registerNewEncodedValue) {
-        registerNewEncodedValue.add(maxAxleLoadEncoder);
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMMaxHeightParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMMaxHeightParser.java
@@ -19,9 +19,6 @@ package com.graphhopper.routing.util.parsers;
 
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.DecimalEncodedValue;
-import com.graphhopper.routing.ev.EncodedValue;
-import com.graphhopper.routing.ev.EncodedValueLookup;
-import com.graphhopper.routing.ev.MaxHeight;
 import com.graphhopper.routing.util.parsers.helpers.OSMValueExtractor;
 import com.graphhopper.storage.IntsRef;
 
@@ -32,17 +29,8 @@ public class OSMMaxHeightParser implements TagParser {
 
     private final DecimalEncodedValue heightEncoder;
 
-    public OSMMaxHeightParser() {
-        this(MaxHeight.create());
-    }
-
     public OSMMaxHeightParser(DecimalEncodedValue heightEncoder) {
         this.heightEncoder = heightEncoder;
-    }
-
-    @Override
-    public void createEncodedValues(EncodedValueLookup lookup, List<EncodedValue> registerNewEncodedValue) {
-        registerNewEncodedValue.add(heightEncoder);
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMMaxLengthParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMMaxLengthParser.java
@@ -19,30 +19,17 @@ package com.graphhopper.routing.util.parsers;
 
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.DecimalEncodedValue;
-import com.graphhopper.routing.ev.EncodedValue;
-import com.graphhopper.routing.ev.EncodedValueLookup;
-import com.graphhopper.routing.ev.MaxLength;
 import com.graphhopper.routing.util.parsers.helpers.OSMValueExtractor;
 import com.graphhopper.storage.IntsRef;
 
 import java.util.Collections;
-import java.util.List;
 
 public class OSMMaxLengthParser implements TagParser {
 
     private final DecimalEncodedValue lengthEncoder;
 
-    public OSMMaxLengthParser() {
-        this(MaxLength.create());
-    }
-
     public OSMMaxLengthParser(DecimalEncodedValue lengthEncoder) {
         this.lengthEncoder = lengthEncoder;
-    }
-
-    @Override
-    public void createEncodedValues(EncodedValueLookup lookup, List<EncodedValue> registerNewEncodedValue) {
-        registerNewEncodedValue.add(lengthEncoder);
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMMaxSpeedParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMMaxSpeedParser.java
@@ -19,15 +19,11 @@ package com.graphhopper.routing.util.parsers;
 
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.DecimalEncodedValue;
-import com.graphhopper.routing.ev.EncodedValue;
-import com.graphhopper.routing.ev.EncodedValueLookup;
 import com.graphhopper.routing.ev.MaxSpeed;
 import com.graphhopper.routing.util.TransportationMode;
 import com.graphhopper.routing.util.countryrules.CountryRule;
 import com.graphhopper.routing.util.parsers.helpers.OSMValueExtractor;
 import com.graphhopper.storage.IntsRef;
-
-import java.util.List;
 
 import static com.graphhopper.routing.ev.MaxSpeed.UNSET_SPEED;
 
@@ -35,20 +31,11 @@ public class OSMMaxSpeedParser implements TagParser {
 
     protected final DecimalEncodedValue carMaxSpeedEnc;
 
-    public OSMMaxSpeedParser() {
-        this(MaxSpeed.create());
-    }
-
     public OSMMaxSpeedParser(DecimalEncodedValue carMaxSpeedEnc) {
         if (!carMaxSpeedEnc.isStoreTwoDirections())
             throw new IllegalArgumentException("EncodedValue for maxSpeed must be able to store two directions");
 
         this.carMaxSpeedEnc = carMaxSpeedEnc;
-    }
-
-    @Override
-    public void createEncodedValues(EncodedValueLookup lookup, List<EncodedValue> list) {
-        list.add(carMaxSpeedEnc);
     }
 
     @Override
@@ -81,7 +68,7 @@ public class OSMMaxSpeedParser implements TagParser {
         carMaxSpeedEnc.setDecimal(true, edgeFlags, bwdSpeed);
         return edgeFlags;
     }
-    
+
     /**
      * @return <i>true</i> if the given speed is not {@link Double#NaN}
      */

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMMaxWeightParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMMaxWeightParser.java
@@ -19,9 +19,6 @@ package com.graphhopper.routing.util.parsers;
 
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.DecimalEncodedValue;
-import com.graphhopper.routing.ev.EncodedValue;
-import com.graphhopper.routing.ev.EncodedValueLookup;
-import com.graphhopper.routing.ev.MaxWeight;
 import com.graphhopper.routing.util.parsers.helpers.OSMValueExtractor;
 import com.graphhopper.storage.IntsRef;
 
@@ -32,17 +29,8 @@ public class OSMMaxWeightParser implements TagParser {
 
     private final DecimalEncodedValue weightEncoder;
 
-    public OSMMaxWeightParser() {
-        this(MaxWeight.create());
-    }
-
     public OSMMaxWeightParser(DecimalEncodedValue weightEncoder) {
         this.weightEncoder = weightEncoder;
-    }
-
-    @Override
-    public void createEncodedValues(EncodedValueLookup lookup, List<EncodedValue> registerNewEncodedValue) {
-        registerNewEncodedValue.add(weightEncoder);
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMMaxWidthParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMMaxWidthParser.java
@@ -19,9 +19,6 @@ package com.graphhopper.routing.util.parsers;
 
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.DecimalEncodedValue;
-import com.graphhopper.routing.ev.EncodedValue;
-import com.graphhopper.routing.ev.EncodedValueLookup;
-import com.graphhopper.routing.ev.MaxWidth;
 import com.graphhopper.routing.util.parsers.helpers.OSMValueExtractor;
 import com.graphhopper.storage.IntsRef;
 
@@ -32,17 +29,8 @@ public class OSMMaxWidthParser implements TagParser {
 
     private final DecimalEncodedValue widthEncoder;
 
-    public OSMMaxWidthParser() {
-        this(MaxWidth.create());
-    }
-
     public OSMMaxWidthParser(DecimalEncodedValue widthEncoder) {
         this.widthEncoder = widthEncoder;
-    }
-
-    @Override
-    public void createEncodedValues(EncodedValueLookup lookup, List<EncodedValue> registerNewEncodedValue) {
-        registerNewEncodedValue.add(widthEncoder);
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMMtbRatingParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMMtbRatingParser.java
@@ -18,13 +18,8 @@
 package com.graphhopper.routing.util.parsers;
 
 import com.graphhopper.reader.ReaderWay;
-import com.graphhopper.routing.ev.EncodedValue;
-import com.graphhopper.routing.ev.EncodedValueLookup;
 import com.graphhopper.routing.ev.IntEncodedValue;
-import com.graphhopper.routing.ev.MtbRating;
 import com.graphhopper.storage.IntsRef;
-
-import java.util.List;
 
 /**
  * Parses the mountain biking difficulty.
@@ -36,17 +31,8 @@ import java.util.List;
 public class OSMMtbRatingParser implements TagParser {
     private final IntEncodedValue mtbRatingEnc;
 
-    public OSMMtbRatingParser() {
-        this(MtbRating.create());
-    }
-
     public OSMMtbRatingParser(IntEncodedValue mtbRatingEnc) {
         this.mtbRatingEnc = mtbRatingEnc;
-    }
-
-    @Override
-    public void createEncodedValues(EncodedValueLookup lookup, List<EncodedValue> link) {
-        link.add(mtbRatingEnc);
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMRoadAccessParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMRoadAccessParser.java
@@ -18,8 +18,6 @@
 package com.graphhopper.routing.util.parsers;
 
 import com.graphhopper.reader.ReaderWay;
-import com.graphhopper.routing.ev.EncodedValue;
-import com.graphhopper.routing.ev.EncodedValueLookup;
 import com.graphhopper.routing.ev.EnumEncodedValue;
 import com.graphhopper.routing.ev.RoadAccess;
 import com.graphhopper.routing.util.TransportationMode;
@@ -35,18 +33,9 @@ public class OSMRoadAccessParser implements TagParser {
     protected final EnumEncodedValue<RoadAccess> roadAccessEnc;
     private final List<String> restrictions;
 
-    public OSMRoadAccessParser() {
-        this(new EnumEncodedValue<>(RoadAccess.KEY, RoadAccess.class), toOSMRestrictions(TransportationMode.CAR));
-    }
-
     public OSMRoadAccessParser(EnumEncodedValue<RoadAccess> roadAccessEnc, List<String> restrictions) {
         this.roadAccessEnc = roadAccessEnc;
         this.restrictions = restrictions;
-    }
-
-    @Override
-    public void createEncodedValues(EncodedValueLookup lookup, List<EncodedValue> list) {
-        list.add(roadAccessEnc);
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMRoadClassLinkParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMRoadClassLinkParser.java
@@ -18,22 +18,15 @@
 package com.graphhopper.routing.util.parsers;
 
 import com.graphhopper.reader.ReaderWay;
-import com.graphhopper.routing.ev.*;
+import com.graphhopper.routing.ev.BooleanEncodedValue;
 import com.graphhopper.storage.IntsRef;
 import com.graphhopper.util.Helper;
-
-import java.util.List;
 
 public class OSMRoadClassLinkParser implements TagParser {
     private final BooleanEncodedValue linkEnc;
 
-    public OSMRoadClassLinkParser() {
-        this.linkEnc = new SimpleBooleanEncodedValue(RoadClassLink.KEY);
-    }
-
-    @Override
-    public void createEncodedValues(EncodedValueLookup lookup, List<EncodedValue> list) {
-        list.add(linkEnc);
+    public OSMRoadClassLinkParser(BooleanEncodedValue linkEnc) {
+        this.linkEnc = linkEnc;
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMRoadClassParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMRoadClassParser.java
@@ -18,31 +18,18 @@
 package com.graphhopper.routing.util.parsers;
 
 import com.graphhopper.reader.ReaderWay;
-import com.graphhopper.routing.ev.EncodedValue;
-import com.graphhopper.routing.ev.EncodedValueLookup;
 import com.graphhopper.routing.ev.EnumEncodedValue;
 import com.graphhopper.routing.ev.RoadClass;
 import com.graphhopper.storage.IntsRef;
-
-import java.util.List;
 
 import static com.graphhopper.routing.ev.RoadClass.OTHER;
 
 public class OSMRoadClassParser implements TagParser {
 
-    private final EnumEncodedValue<RoadClass> roadClassEnc;
-
-    public OSMRoadClassParser() {
-        this(new EnumEncodedValue<>(RoadClass.KEY, RoadClass.class));
-    }
+    protected final EnumEncodedValue<RoadClass> roadClassEnc;
 
     public OSMRoadClassParser(EnumEncodedValue<RoadClass> roadClassEnc) {
         this.roadClassEnc = roadClassEnc;
-    }
-
-    @Override
-    public void createEncodedValues(EncodedValueLookup lookup, List<EncodedValue> link) {
-        link.add(roadClassEnc);
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMRoadEnvironmentParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMRoadEnvironmentParser.java
@@ -18,13 +18,9 @@
 package com.graphhopper.routing.util.parsers;
 
 import com.graphhopper.reader.ReaderWay;
-import com.graphhopper.routing.ev.EncodedValue;
-import com.graphhopper.routing.ev.EncodedValueLookup;
 import com.graphhopper.routing.ev.EnumEncodedValue;
 import com.graphhopper.routing.ev.RoadEnvironment;
 import com.graphhopper.storage.IntsRef;
-
-import java.util.List;
 
 import static com.graphhopper.routing.ev.RoadEnvironment.*;
 
@@ -32,17 +28,8 @@ public class OSMRoadEnvironmentParser implements TagParser {
 
     private final EnumEncodedValue<RoadEnvironment> roadEnvEnc;
 
-    public OSMRoadEnvironmentParser() {
-        this(new EnumEncodedValue<>(RoadEnvironment.KEY, RoadEnvironment.class));
-    }
-
     public OSMRoadEnvironmentParser(EnumEncodedValue<RoadEnvironment> roadEnvEnc) {
         this.roadEnvEnc = roadEnvEnc;
-    }
-
-    @Override
-    public void createEncodedValues(EncodedValueLookup lookup, List<EncodedValue> list) {
-        list.add(roadEnvEnc);
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMRoundaboutParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMRoundaboutParser.java
@@ -19,28 +19,14 @@ package com.graphhopper.routing.util.parsers;
 
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.BooleanEncodedValue;
-import com.graphhopper.routing.ev.EncodedValue;
-import com.graphhopper.routing.ev.EncodedValueLookup;
-import com.graphhopper.routing.ev.Roundabout;
 import com.graphhopper.storage.IntsRef;
-
-import java.util.List;
 
 public class OSMRoundaboutParser implements TagParser {
 
     private final BooleanEncodedValue roundaboutEnc;
 
-    public OSMRoundaboutParser() {
-        this(Roundabout.create());
-    }
-
     public OSMRoundaboutParser(BooleanEncodedValue roundaboutEnc) {
         this.roundaboutEnc = roundaboutEnc;
-    }
-
-    @Override
-    public void createEncodedValues(EncodedValueLookup lookup, List<EncodedValue> list) {
-        list.add(roundaboutEnc);
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMSmoothnessParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMSmoothnessParser.java
@@ -18,32 +18,18 @@
 package com.graphhopper.routing.util.parsers;
 
 import com.graphhopper.reader.ReaderWay;
-import com.graphhopper.routing.ev.EncodedValue;
-import com.graphhopper.routing.ev.EncodedValueLookup;
 import com.graphhopper.routing.ev.EnumEncodedValue;
 import com.graphhopper.routing.ev.Smoothness;
 import com.graphhopper.storage.IntsRef;
 
-import java.util.List;
-
-import static com.graphhopper.routing.ev.Smoothness.KEY;
 import static com.graphhopper.routing.ev.Smoothness.MISSING;
 
 public class OSMSmoothnessParser implements TagParser {
 
     private final EnumEncodedValue<Smoothness> smoothnessEnc;
 
-    public OSMSmoothnessParser() {
-        this(new EnumEncodedValue<>(KEY, Smoothness.class));
-    }
-
     public OSMSmoothnessParser(EnumEncodedValue<Smoothness> smoothnessEnc) {
         this.smoothnessEnc = smoothnessEnc;
-    }
-
-    @Override
-    public void createEncodedValues(EncodedValueLookup lookup, List<EncodedValue> list) {
-        list.add(smoothnessEnc);
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMSurfaceParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMSurfaceParser.java
@@ -18,13 +18,9 @@
 package com.graphhopper.routing.util.parsers;
 
 import com.graphhopper.reader.ReaderWay;
-import com.graphhopper.routing.ev.EncodedValue;
-import com.graphhopper.routing.ev.EncodedValueLookup;
 import com.graphhopper.routing.ev.EnumEncodedValue;
 import com.graphhopper.routing.ev.Surface;
 import com.graphhopper.storage.IntsRef;
-
-import java.util.List;
 
 import static com.graphhopper.routing.ev.Surface.*;
 
@@ -32,17 +28,8 @@ public class OSMSurfaceParser implements TagParser {
 
     private final EnumEncodedValue<Surface> surfaceEnc;
 
-    public OSMSurfaceParser() {
-        this(new EnumEncodedValue<>(KEY, Surface.class));
-    }
-
     public OSMSurfaceParser(EnumEncodedValue<Surface> surfaceEnc) {
         this.surfaceEnc = surfaceEnc;
-    }
-
-    @Override
-    public void createEncodedValues(EncodedValueLookup lookup, List<EncodedValue> list) {
-        list.add(surfaceEnc);
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMTollParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMTollParser.java
@@ -18,8 +18,6 @@
 package com.graphhopper.routing.util.parsers;
 
 import com.graphhopper.reader.ReaderWay;
-import com.graphhopper.routing.ev.EncodedValue;
-import com.graphhopper.routing.ev.EncodedValueLookup;
 import com.graphhopper.routing.ev.EnumEncodedValue;
 import com.graphhopper.routing.ev.Toll;
 import com.graphhopper.routing.util.TransportationMode;
@@ -35,17 +33,8 @@ public class OSMTollParser implements TagParser {
     private static final List<String> HGV_TAGS = Collections.unmodifiableList(Arrays.asList("toll:hgv", "toll:N2", "toll:N3"));
     private final EnumEncodedValue<Toll> tollEnc;
 
-    public OSMTollParser() {
-        this(new EnumEncodedValue<>(Toll.KEY, Toll.class));
-    }
-
     public OSMTollParser(EnumEncodedValue<Toll> tollEnc) {
         this.tollEnc = tollEnc;
-    }
-
-    @Override
-    public void createEncodedValues(EncodedValueLookup lookup, List<EncodedValue> list) {
-        list.add(tollEnc);
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMTrackTypeParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMTrackTypeParser.java
@@ -18,13 +18,9 @@
 package com.graphhopper.routing.util.parsers;
 
 import com.graphhopper.reader.ReaderWay;
-import com.graphhopper.routing.ev.EncodedValue;
-import com.graphhopper.routing.ev.EncodedValueLookup;
 import com.graphhopper.routing.ev.EnumEncodedValue;
 import com.graphhopper.routing.ev.TrackType;
 import com.graphhopper.storage.IntsRef;
-
-import java.util.List;
 
 import static com.graphhopper.routing.ev.TrackType.MISSING;
 
@@ -32,17 +28,8 @@ public class OSMTrackTypeParser implements TagParser {
 
     private final EnumEncodedValue<TrackType> trackTypeEnc;
 
-    public OSMTrackTypeParser() {
-        this(new EnumEncodedValue<>(TrackType.KEY, TrackType.class));
-    }
-
     public OSMTrackTypeParser(EnumEncodedValue<TrackType> trackTypeEnc) {
         this.trackTypeEnc = trackTypeEnc;
-    }
-
-    @Override
-    public void createEncodedValues(EncodedValueLookup lookup, List<EncodedValue> link) {
-        link.add(trackTypeEnc);
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/RelationTagParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/RelationTagParser.java
@@ -18,11 +18,7 @@
 package com.graphhopper.routing.util.parsers;
 
 import com.graphhopper.reader.ReaderRelation;
-import com.graphhopper.routing.ev.EncodedValue;
-import com.graphhopper.routing.ev.EncodedValueLookup;
 import com.graphhopper.storage.IntsRef;
-
-import java.util.List;
 
 /**
  * This interface serves the purpose of creating relation flags (max. 64 bits) from ReaderRelation in handleRelationTags
@@ -30,8 +26,6 @@ import java.util.List;
  * flags is not yet possible yet due to storage limitation of the 'supervisor' OSMReader. See #1775.
  */
 public interface RelationTagParser extends TagParser {
-
-    void createRelationEncodedValues(EncodedValueLookup lookup, List<EncodedValue> registerNewEncodedValue);
 
     /**
      * Analyze the tags of a relation and create the routing flags for the second read step.

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/TagParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/TagParser.java
@@ -18,19 +18,13 @@
 package com.graphhopper.routing.util.parsers;
 
 import com.graphhopper.reader.ReaderWay;
-import com.graphhopper.routing.ev.EncodedValue;
-import com.graphhopper.routing.ev.EncodedValueLookup;
 import com.graphhopper.storage.IntsRef;
-
-import java.util.List;
 
 /**
  * This interface defines how parts of the information from 'way' is converted into IntsRef. A TagParser usually
  * has one corresponding EncodedValue but more are possible too.
  */
 public interface TagParser {
-
-    void createEncodedValues(EncodedValueLookup lookup, List<EncodedValue> registerNewEncodedValue);
 
     IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay way, IntsRef relationFlags);
 }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/TagParserFactory.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/TagParserFactory.java
@@ -1,5 +1,7 @@
 package com.graphhopper.routing.util.parsers;
 
+import com.graphhopper.routing.ev.EncodedValueLookup;
+
 public interface TagParserFactory {
-    TagParser create(String name);
+    TagParser create(EncodedValueLookup lookup, String name);
 }

--- a/core/src/test/java/com/graphhopper/GraphHopperTest.java
+++ b/core/src/test/java/com/graphhopper/GraphHopperTest.java
@@ -24,6 +24,8 @@ import com.graphhopper.json.Statement;
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.reader.dem.SRTMProvider;
 import com.graphhopper.reader.dem.SkadiProvider;
+import com.graphhopper.routing.ev.EncodedValueLookup;
+import com.graphhopper.routing.ev.RoadEnvironment;
 import com.graphhopper.routing.ev.Subnetwork;
 import com.graphhopper.routing.util.AllEdgesIterator;
 import com.graphhopper.routing.util.DefaultSnapFilter;
@@ -1053,10 +1055,10 @@ public class GraphHopperTest {
         if (!withTunnelInterpolation) {
             hopper.setTagParserFactory(new DefaultTagParserFactory() {
                 @Override
-                public TagParser create(String name) {
-                    TagParser parser = super.create(name);
+                public TagParser create(EncodedValueLookup lookup, String name) {
+                    TagParser parser = super.create(lookup, name);
                     if (name.equals("road_environment"))
-                        parser = new OSMRoadEnvironmentParser() {
+                        parser = new OSMRoadEnvironmentParser(lookup.getEnumEncodedValue(RoadEnvironment.KEY, RoadEnvironment.class)) {
                             @Override
                             public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay readerWay, IntsRef relationFlags) {
                                 // do not change RoadEnvironment to avoid triggering tunnel interpolation

--- a/core/src/test/java/com/graphhopper/reader/osm/OSMReaderTest.java
+++ b/core/src/test/java/com/graphhopper/reader/osm/OSMReaderTest.java
@@ -933,11 +933,12 @@ public class OSMReaderTest {
     @Test
     public void testCurvedWayAlongBorder() throws IOException {
         // see https://discuss.graphhopper.com/t/country-of-way-is-wrong-on-road-near-border-with-curvature/6908/2
+        EnumEncodedValue<Country> countryEnc = new EnumEncodedValue<>(Country.KEY, Country.class);
         TagParserManager em = TagParserManager.start()
                 .add(FlagEncoders.createCar())
-                .add(new CountryParser())
+                .add(countryEnc)
+                .add(new CountryParser(countryEnc))
                 .build();
-        EnumEncodedValue<Country> countryEnc = em.getEnumEncodedValue(Country.KEY, Country.class);
         BaseGraph graph = new BaseGraph.Builder(em.getEncodingManager()).create();
         OSMReader reader = new OSMReader(graph, em, new OSMReaderConfig());
         reader.setCountryRuleFactory(new CountryRuleFactory());


### PR DESCRIPTION
With this PR encoded values are no longer created inside tag parsers. The tag parsers receive the encoded values they are working with via their constructors instead. The GraphHopper class now creates encoded values via the `EncodedValueFactory` (in every case, not just when calling load() without init()...). Next thing to do will be removing `AbstractFlagEncoder#createEncodedValues` as well.

Related: #2463,#2551