### PR TITLE
Fix bias in map-matching

### DIFF
--- a/map-matching/src/main/java/com/graphhopper/matching/MapMatching.java
+++ b/map-matching/src/main/java/com/graphhopper/matching/MapMatching.java
@@ -187,7 +187,7 @@ public class MapMatching {
      * Filters observations to only those which will be used for map matching (i.e. those which
      * are separated by at least 2 * measurementErrorSigman
      */
-    private List<Observation> filterObservations(List<Observation> observations) {
+    public List<Observation> filterObservations(List<Observation> observations) {
         List<Observation> filtered = new ArrayList<>();
         Observation prevEntry = null;
         double acc = 0.0;
@@ -206,6 +206,10 @@ public class MapMatching {
                             prevEntry.getPoint().getLat(), prevEntry.getPoint().getLon(),
                             observation.getPoint().getLat(), observation.getPoint().getLon());
                 }
+                // Here we store the meters of distance that we are missing because of the filtering,
+                // so that when we add these terms to the distances between the filtered points,
+                // the original total distance between the unfiltered points is conserved.
+                // (See test for kind of a specification.)
                 observation.setAccumulatedLinearDistanceToPrevious(acc);
                 filtered.add(observation);
                 prevEntry = observation;
@@ -215,7 +219,6 @@ public class MapMatching {
                 acc += distanceCalc.calcDist(
                         prevObservation.getPoint().getLat(), prevObservation.getPoint().getLon(),
                         observation.getPoint().getLat(), observation.getPoint().getLon());
-                logger.debug("Filter out observation: {}", i + 1);
             }
         }
         return filtered;

--- a/map-matching/src/main/java/com/graphhopper/matching/Observation.java
+++ b/map-matching/src/main/java/com/graphhopper/matching/Observation.java
@@ -23,6 +23,7 @@ import java.util.Objects;
 
 public class Observation {
     private GHPoint point;
+    private double accumulatedLinearDistanceToPrevious;
 
     public Observation(GHPoint p) {
         this.point = p;
@@ -30,6 +31,14 @@ public class Observation {
 
     public GHPoint getPoint() {
         return point;
+    }
+
+    public double getAccumulatedLinearDistanceToPrevious() {
+        return accumulatedLinearDistanceToPrevious;
+    }
+
+    public void setAccumulatedLinearDistanceToPrevious(double accumulatedLinearDistanceToPrevious) {
+        this.accumulatedLinearDistanceToPrevious = accumulatedLinearDistanceToPrevious;
     }
 
     @Override


### PR DESCRIPTION
Map-matching has a very old think-bug made when the "filtering" of the input points was added: The original linear distance between the input points would not be preserved, so the entire estimator is biased towards shorter routes, which makes it cut corners like this for even the default value of `measurementErrorSigma`:

![Screenshot 2022-04-15 at 11 37 07](https://user-images.githubusercontent.com/520916/163555040-90a1c6ba-e621-4adb-b5c3-ad4d9bfd84aa.png)

Not anymore.

(The entire feature was, of course, a Performance Optimization. I hope to remove it next time I comb through map matching, since I have an idea to make it faster.)