### PR TITLE
Stop removing elements from the priority queue, speeds up flexible algorithms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 6.0 [not yet released]
-- don't allow cars or motorcycles to use ways tagged with service=emergency_access (#2484) 
+- don't allow cars or motorcycles to use ways tagged with service=emergency_access (#2484)
+- faster flexible routing, especially in conjunction with turn costs
 
 ### 5.0 [23 Mar 2022]
 

--- a/core/src/main/java/com/graphhopper/routing/AStarBidirection.java
+++ b/core/src/main/java/com/graphhopper/routing/AStarBidirection.java
@@ -95,14 +95,6 @@ public class AStarBidirection extends AbstractNonCHBidirAlgo {
     }
 
     @Override
-    protected void updateEntry(SPTEntry entry, EdgeIteratorState edge, double weight, SPTEntry parent, boolean reverse) {
-        entry.edge = edge.getEdge();
-        entry.weight = weight + weightApprox.approximate(edge.getAdjNode(), reverse);
-        ((AStarEntry) entry).weightOfVisitedPath = weight;
-        entry.parent = parent;
-    }
-
-    @Override
     protected double calcWeight(EdgeIteratorState iter, SPTEntry currEdge, boolean reverse) {
         // TODO performance: check if the node is already existent in the opposite direction
         // then we could avoid the approximation as we already know the exact complete path!

--- a/core/src/main/java/com/graphhopper/routing/AbstractBidirCHAlgo.java
+++ b/core/src/main/java/com/graphhopper/routing/AbstractBidirCHAlgo.java
@@ -133,17 +133,13 @@ public abstract class AbstractBidirCHAlgo extends AbstractBidirAlgo implements B
 
     @Override
     boolean fillEdgesFrom() {
-        if (pqOpenSetFrom.isEmpty()) {
-            return false;
-        }
-        while (!pqOpenSetFrom.isEmpty()) {
+        while (true) {
+            if (pqOpenSetFrom.isEmpty())
+                return false;
             currFrom = pqOpenSetFrom.poll();
-            if (currFrom.adjNode < 0)
-                continue;
-            break;
+            if (!currFrom.isDeleted())
+                break;
         }
-        if (currFrom.adjNode < 0)
-            return false;
         visitedCountFrom++;
         if (fromEntryCanBeSkipped()) {
             return true;
@@ -158,17 +154,13 @@ public abstract class AbstractBidirCHAlgo extends AbstractBidirAlgo implements B
 
     @Override
     boolean fillEdgesTo() {
-        if (pqOpenSetTo.isEmpty()) {
-            return false;
-        }
-        while (!pqOpenSetTo.isEmpty()) {
+        while (true) {
+            if (pqOpenSetTo.isEmpty())
+                return false;
             currTo = pqOpenSetTo.poll();
-            if (currTo.adjNode < 0)
-                continue;
-            break;
+            if (!currTo.isDeleted())
+                break;
         }
-        if (currTo.adjNode < 0)
-            return false;
         visitedCountTo++;
         if (toEntryCanBeSkipped()) {
             return true;
@@ -201,17 +193,19 @@ public abstract class AbstractBidirCHAlgo extends AbstractBidirAlgo implements B
                 prioQueue.add(entry);
             } else if (entry.getWeightOfVisitedPath() > weight) {
                 // flagging this entry, so it will be ignored when it is polled the next time
-                boolean best = reverse ? (entry == bestBwdEntry) : (entry == bestFwdEntry);
-                entry.adjNode = -1;
+                // this is faster than removing the entry from the queue and adding again, but for CH it does not really
+                // make a difference overall.
+                entry.setDeleted();
+                boolean isBestEntry = reverse ? (entry == bestBwdEntry) : (entry == bestFwdEntry);
                 entry = createEntry(iter.getEdge(), iter.getAdjNode(), origEdgeId, weight, currEdge, reverse);
                 bestWeightMap.put(traversalId, entry);
                 prioQueue.add(entry);
-                if (best) {
+                // if this is the best entry we need to update the best reference as well. somehow this is only needed for CH?
+                if (isBestEntry)
                     if (reverse)
                         bestBwdEntry = entry;
                     else
                         bestFwdEntry = entry;
-                }
             } else
                 continue;
 

--- a/core/src/main/java/com/graphhopper/routing/AbstractBidirCHAlgo.java
+++ b/core/src/main/java/com/graphhopper/routing/AbstractBidirCHAlgo.java
@@ -136,7 +136,14 @@ public abstract class AbstractBidirCHAlgo extends AbstractBidirAlgo implements B
         if (pqOpenSetFrom.isEmpty()) {
             return false;
         }
-        currFrom = pqOpenSetFrom.poll();
+        while (!pqOpenSetFrom.isEmpty()) {
+            currFrom = pqOpenSetFrom.poll();
+            if (currFrom.adjNode < 0)
+                continue;
+            break;
+        }
+        if (currFrom.adjNode < 0)
+            return false;
         visitedCountFrom++;
         if (fromEntryCanBeSkipped()) {
             return true;
@@ -154,7 +161,14 @@ public abstract class AbstractBidirCHAlgo extends AbstractBidirAlgo implements B
         if (pqOpenSetTo.isEmpty()) {
             return false;
         }
-        currTo = pqOpenSetTo.poll();
+        while (!pqOpenSetTo.isEmpty()) {
+            currTo = pqOpenSetTo.poll();
+            if (currTo.adjNode < 0)
+                continue;
+            break;
+        }
+        if (currTo.adjNode < 0)
+            return false;
         visitedCountTo++;
         if (toEntryCanBeSkipped()) {
             return true;
@@ -186,9 +200,18 @@ public abstract class AbstractBidirCHAlgo extends AbstractBidirAlgo implements B
                 bestWeightMap.put(traversalId, entry);
                 prioQueue.add(entry);
             } else if (entry.getWeightOfVisitedPath() > weight) {
-                prioQueue.remove(entry);
-                updateEntry(entry, iter.getEdge(), iter.getAdjNode(), origEdgeId, weight, currEdge, reverse);
+                // flagging this entry, so it will be ignored when it is polled the next time
+                boolean best = reverse ? (entry == bestBwdEntry) : (entry == bestFwdEntry);
+                entry.adjNode = -1;
+                entry = createEntry(iter.getEdge(), iter.getAdjNode(), origEdgeId, weight, currEdge, reverse);
+                bestWeightMap.put(traversalId, entry);
                 prioQueue.add(entry);
+                if (best) {
+                    if (reverse)
+                        bestBwdEntry = entry;
+                    else
+                        bestFwdEntry = entry;
+                }
             } else
                 continue;
 

--- a/core/src/main/java/com/graphhopper/routing/AbstractNonCHBidirAlgo.java
+++ b/core/src/main/java/com/graphhopper/routing/AbstractNonCHBidirAlgo.java
@@ -109,17 +109,13 @@ public abstract class AbstractNonCHBidirAlgo extends AbstractBidirAlgo implement
 
     @Override
     boolean fillEdgesFrom() {
-        if (pqOpenSetFrom.isEmpty()) {
-            return false;
-        }
-        while (!pqOpenSetFrom.isEmpty()) {
+        while (true) {
+            if (pqOpenSetFrom.isEmpty())
+                return false;
             currFrom = pqOpenSetFrom.poll();
-            if (currFrom.adjNode < 0)
-                continue;
-            break;
+            if (!currFrom.isDeleted())
+                break;
         }
-        if (currFrom.adjNode < 0)
-            return false;
         visitedCountFrom++;
         if (fromEntryCanBeSkipped()) {
             return true;
@@ -134,17 +130,13 @@ public abstract class AbstractNonCHBidirAlgo extends AbstractBidirAlgo implement
 
     @Override
     boolean fillEdgesTo() {
-        if (pqOpenSetTo.isEmpty()) {
-            return false;
-        }
-        while (!pqOpenSetTo.isEmpty()) {
+        while (true) {
+            if (pqOpenSetTo.isEmpty())
+                return false;
             currTo = pqOpenSetTo.poll();
-            if (currTo.adjNode < 0)
-                continue;
-            break;
+            if (!currTo.isDeleted())
+                break;
         }
-        if (currTo.adjNode < 0)
-            return false;
         visitedCountTo++;
         if (toEntryCanBeSkipped()) {
             return true;
@@ -175,7 +167,7 @@ public abstract class AbstractNonCHBidirAlgo extends AbstractBidirAlgo implement
                 prioQueue.add(entry);
             } else if (entry.getWeightOfVisitedPath() > weight) {
                 // flagging this entry, so it will be ignored when it is polled the next time
-                entry.adjNode = -1;
+                entry.setDeleted();
                 entry = createEntry(iter, weight, currEdge, reverse);
                 bestWeightMap.put(traversalId, entry);
                 prioQueue.add(entry);

--- a/core/src/main/java/com/graphhopper/routing/AbstractNonCHBidirAlgo.java
+++ b/core/src/main/java/com/graphhopper/routing/AbstractNonCHBidirAlgo.java
@@ -184,12 +184,6 @@ public abstract class AbstractNonCHBidirAlgo extends AbstractBidirAlgo implement
         }
     }
 
-    protected void updateEntry(SPTEntry entry, EdgeIteratorState edge, double weight, SPTEntry parent, boolean reverse) {
-        entry.edge = edge.getEdge();
-        entry.weight = weight;
-        entry.parent = parent;
-    }
-
     protected double calcWeight(EdgeIteratorState iter, SPTEntry currEdge, boolean reverse) {
         // note that for node-based routing the weights will be wrong in case the weighting is returning non-zero
         // turn weights, see discussion in #1960

--- a/core/src/main/java/com/graphhopper/routing/AbstractNonCHBidirAlgo.java
+++ b/core/src/main/java/com/graphhopper/routing/AbstractNonCHBidirAlgo.java
@@ -112,7 +112,14 @@ public abstract class AbstractNonCHBidirAlgo extends AbstractBidirAlgo implement
         if (pqOpenSetFrom.isEmpty()) {
             return false;
         }
-        currFrom = pqOpenSetFrom.poll();
+        while (!pqOpenSetFrom.isEmpty()) {
+            currFrom = pqOpenSetFrom.poll();
+            if (currFrom.adjNode < 0)
+                continue;
+            break;
+        }
+        if (currFrom.adjNode < 0)
+            return false;
         visitedCountFrom++;
         if (fromEntryCanBeSkipped()) {
             return true;
@@ -130,7 +137,14 @@ public abstract class AbstractNonCHBidirAlgo extends AbstractBidirAlgo implement
         if (pqOpenSetTo.isEmpty()) {
             return false;
         }
-        currTo = pqOpenSetTo.poll();
+        while (!pqOpenSetTo.isEmpty()) {
+            currTo = pqOpenSetTo.poll();
+            if (currTo.adjNode < 0)
+                continue;
+            break;
+        }
+        if (currTo.adjNode < 0)
+            return false;
         visitedCountTo++;
         if (toEntryCanBeSkipped()) {
             return true;
@@ -160,8 +174,10 @@ public abstract class AbstractNonCHBidirAlgo extends AbstractBidirAlgo implement
                 bestWeightMap.put(traversalId, entry);
                 prioQueue.add(entry);
             } else if (entry.getWeightOfVisitedPath() > weight) {
-                prioQueue.remove(entry);
-                updateEntry(entry, iter, weight, currEdge, reverse);
+                // flagging this entry, so it will be ignored when it is polled the next time
+                entry.adjNode = -1;
+                entry = createEntry(iter, weight, currEdge, reverse);
+                bestWeightMap.put(traversalId, entry);
                 prioQueue.add(entry);
             } else
                 continue;

--- a/core/src/main/java/com/graphhopper/routing/Dijkstra.java
+++ b/core/src/main/java/com/graphhopper/routing/Dijkstra.java
@@ -58,16 +58,19 @@ public class Dijkstra extends AbstractRoutingAlgorithm {
     public Path calcPath(int from, int to) {
         checkAlreadyRun();
         this.to = to;
-        currEdge = new SPTEntry(from, 0);
-        if (!traversalMode.isEdgeBased()) {
+        SPTEntry startEntry = new SPTEntry(from, 0);
+        fromHeap.add(startEntry);
+        if (!traversalMode.isEdgeBased())
             fromMap.put(from, currEdge);
-        }
         runAlgo();
         return extractPath();
     }
 
     protected void runAlgo() {
-        while (true) {
+        while (!fromHeap.isEmpty()) {
+            currEdge = fromHeap.poll();
+            if (currEdge.isDeleted())
+                continue;
             visitedNodes++;
             if (isMaxVisitedNodesExceeded() || finished())
                 break;
@@ -90,23 +93,15 @@ public class Dijkstra extends AbstractRoutingAlgorithm {
                     fromMap.put(traversalId, nEdge);
                     fromHeap.add(nEdge);
                 } else if (nEdge.weight > tmpWeight) {
-                    fromHeap.remove(nEdge);
-                    nEdge.edge = iter.getEdge();
-                    nEdge.weight = tmpWeight;
-                    nEdge.parent = currEdge;
+                    nEdge.setDeleted();
+                    nEdge = new SPTEntry(iter.getEdge(), iter.getAdjNode(), tmpWeight, currEdge);
+                    fromMap.put(traversalId, nEdge);
                     fromHeap.add(nEdge);
                 } else
                     continue;
 
                 updateBestPath(iter, nEdge, traversalId);
             }
-
-            if (fromHeap.isEmpty())
-                break;
-
-            currEdge = fromHeap.poll();
-            if (currEdge == null)
-                throw new AssertionError("Empty edge cannot happen");
         }
     }
 

--- a/core/src/main/java/com/graphhopper/routing/SPTEntry.java
+++ b/core/src/main/java/com/graphhopper/routing/SPTEntry.java
@@ -42,6 +42,14 @@ public class SPTEntry implements Comparable<SPTEntry> {
         this.parent = parent;
     }
 
+    public void setDeleted() {
+        adjNode = Integer.MIN_VALUE;
+    }
+
+    public boolean isDeleted() {
+        return adjNode == Integer.MIN_VALUE;
+    }
+
     /**
      * This method returns the weight to the origin e.g. to the start for the forward SPT and to the
      * destination for the backward SPT. Where the variable 'weight' is used to let heap select

--- a/core/src/test/java/com/graphhopper/routing/ch/CHTurnCostTest.java
+++ b/core/src/test/java/com/graphhopper/routing/ch/CHTurnCostTest.java
@@ -1131,6 +1131,21 @@ public class CHTurnCostTest {
         compareCHQueryWithDijkstra(0, 5);
     }
 
+    @Test
+    void testBestFwdBwdEntryUpdate() {
+        // 2-3
+        // | |
+        // 0-4-1
+        GHUtility.setSpeed(60, 60, encoder, graph.edge(2, 0).setDistance(800.22));
+        GHUtility.setSpeed(60, 60, encoder, graph.edge(3, 4).setDistance(478.84));
+        GHUtility.setSpeed(60, 60, encoder, graph.edge(0, 4).setDistance(547.08));
+        GHUtility.setSpeed(60, 60, encoder, graph.edge(4, 1).setDistance(288.95));
+        GHUtility.setSpeed(60, 60, encoder, graph.edge(2, 3).setDistance(90));
+        graph.freeze();
+        prepareCH(1, 3, 0, 2, 4);
+        compareCHQueryWithDijkstra(1, 2);
+    }
+
     /**
      * This test runs on a random graph with random turn costs and a predefined (but random) contraction order.
      * It often produces exotic conditions that are hard to anticipate beforehand.


### PR DESCRIPTION
`PriorityQueue#remove` is an expensive operation, especially for large queues as it has O(N) complexity. We use it for Dijkstra and related algorithms, because there is no efficient update operation: We simply remove the old entry and add the updated entry. An alternative approach is to flag the old entry, add a new one and ignore the flagged ones when polling from the queue. @michaz already did this for isochrones some time ago: #2092

We tried this for the other algorithms already in the past, but without success so far: #489, https://github.com/graphhopper/graphhopper/pull/2107, https://github.com/graphhopper/graphhopper/issues/2408

Trying this again I think this change clearly speeds up the flexible (non-CH) algorithms, especially for the edge-based traversal mode. In our measurements edge-based AStar was more than 30% faster and also the alternative algorithms. For LM the queries are ~25% faster and even the LM preparation is ~15% faster now.

Here are the results:

```
# Bavaria before
routing: sum:27.953s, time/call:0.112s, dummy: 614737
routing_alt: sum:12.457s, time/call:2.491s, dummy: 12939
routing_edge: sum:149.028s, time/call:0.596s, dummy: 615013
routing_edge_alt: sum:165.167s, time/call:33.033s, dummy: 12946

# Bavaria now
routing: sum:26.518s, time/call:0.106s, dummy: 614737
routing_alt: sum:10.845s, time/call:2.169s, dummy: 12939
routing_edge: sum:98.296s, time/call:0.393s, dummy: 615013
routing_edge_alt: sum:130.904s, time/call:26.181s, dummy: 12946

# Germany before
Calculated landmarks for 1 subnetworks, took:311s
routingLM4: sum:14.978s, time/call:0.06s, dummy: 1038316
routingLM4_alt: sum:25.455s, time/call:5.091s, dummy: 17288
routingLM4_edge: sum:78.8s, time/call:0.315s, dummy: 1038820
routingLM4_alt_edge: sum:482.417s, time/call:96.483s, dummy: 17839
routingLM8: sum:14.408s, time/call:0.058s, dummy: 1038316
routingLM8_alt: sum:25.885s, time/call:5.177s, dummy: 17288
routingLM8_edge: sum:61.402s, time/call:0.246s, dummy: 1038820
routingLM8_alt_edge: sum:456.623s, time/call:91.325s, dummy: 17839
routingLM12: sum:15.463s, time/call:0.062s, dummy: 1038316
routingLM12_alt: sum:27.118s, time/call:5.424s, dummy: 17288
routingLM12_edge: sum:64.217s, time/call:0.257s, dummy: 1038820
routingLM12_alt_edge: sum:493.755s, time/call:98.751s, dummy: 17839
routingLM16: sum:16.573s, time/call:0.066s, dummy: 1038316
routingLM16_alt: sum:28.179s, time/call:5.636s, dummy: 17288
routingLM16_edge: sum:66.663s, time/call:0.267s, dummy: 1038820
routingLM16_alt_edge: sum:504.28s, time/call:100.856s, dummy: 17839
routingLM8_block_area: sum:23.476s, time/call:0.094s, dummy: 1049107

# Germany now
Calculated landmarks for 1 subnetworks, took:258s
routingLM4: sum:14.042s, time/call:0.056s, dummy: 1038316
routingLM4_alt: sum:20.834s, time/call:4.167s, dummy: 17288
routingLM4_edge: sum:45.134s, time/call:0.181s, dummy: 1038820
routingLM4_alt_edge: sum:362.848s, time/call:72.57s, dummy: 17839
routingLM8: sum:13.902s, time/call:0.056s, dummy: 1038316
routingLM8_alt: sum:21.381s, time/call:4.276s, dummy: 17288
routingLM8_edge: sum:43.512s, time/call:0.174s, dummy: 1038820
routingLM8_alt_edge: sum:359.046s, time/call:71.809s, dummy: 17839
routingLM12: sum:14.877s, time/call:0.06s, dummy: 1038316
routingLM12_alt: sum:21.979s, time/call:4.396s, dummy: 17288
routingLM12_edge: sum:45.994s, time/call:0.184s, dummy: 1038820
routingLM12_alt_edge: sum:405.193s, time/call:81.039s, dummy: 17839
routingLM16: sum:16.06s, time/call:0.064s, dummy: 1038316
routingLM16_alt: sum:23.153s, time/call:4.631s, dummy: 17288
routingLM16_edge: sum:48.906s, time/call:0.196s, dummy: 1038820
routingLM16_alt_edge: sum:402.926s, time/call:80.585s, dummy: 17839
routingLM8_block_area: sum:22.274s, time/call:0.089s, dummy: 104910
```