### PR TITLE
Replace deprecated dropwizard parameter types

### DIFF
--- a/web/src/test/java/com/graphhopper/application/resources/IsochroneResourceTest.java
+++ b/web/src/test/java/com/graphhopper/application/resources/IsochroneResourceTest.java
@@ -274,6 +274,7 @@ public class IsochroneResourceTest {
         Response response = clientTarget(app, "/isochrone?profile=fast_car&point=42.531073,1.573792&time_limit=wurst")
                 .request().buildGet().invoke();
 
+        assertEquals(400, response.getStatus());
         JsonNode json = response.readEntity(JsonNode.class);
         String message = json.path("message").asText();
 


### PR DESCRIPTION
Replaces both deprecated parameter classes with their java.util counterparts.

see https://github.com/dropwizard/dropwizard/blob/4fb8906bb761886c85891d4bbf6dcf0a15ca4e9c/dropwizard-jersey/src/main/java/io/dropwizard/jersey/params/LongParam.java#L9-L12