### PR TITLE
Provide all intersections with additional information along a route via PathDetails

### DIFF
--- a/core/src/main/java/com/graphhopper/util/PathMerger.java
+++ b/core/src/main/java/com/graphhopper/util/PathMerger.java
@@ -135,7 +135,7 @@ public class PathMerger {
                 }
 
                 fullPoints.add(tmpPoints);
-                responsePath.addPathDetails(PathDetailsFromEdges.calcDetails(path, evLookup, weighting, requestedPathDetails, pathBuilderFactory, origPoints));
+                responsePath.addPathDetails(PathDetailsFromEdges.calcDetails(path, evLookup, weighting, requestedPathDetails, pathBuilderFactory, origPoints, graph));
                 origPoints = fullPoints.size();
             }
 

--- a/core/src/main/java/com/graphhopper/util/details/AverageSpeedDetails.java
+++ b/core/src/main/java/com/graphhopper/util/details/AverageSpeedDetails.java
@@ -1,3 +1,20 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package com.graphhopper.util.details;
 
 import com.graphhopper.routing.weighting.Weighting;

--- a/core/src/main/java/com/graphhopper/util/details/IntersectionDetails.java
+++ b/core/src/main/java/com/graphhopper/util/details/IntersectionDetails.java
@@ -1,3 +1,20 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package com.graphhopper.util.details;
 
 import com.graphhopper.routing.querygraph.VirtualEdgeIteratorState;

--- a/core/src/main/java/com/graphhopper/util/details/IntersectionDetails.java
+++ b/core/src/main/java/com/graphhopper/util/details/IntersectionDetails.java
@@ -1,0 +1,153 @@
+package com.graphhopper.util.details;
+
+import com.graphhopper.routing.querygraph.VirtualEdgeIteratorState;
+import com.graphhopper.routing.weighting.Weighting;
+import com.graphhopper.storage.Graph;
+import com.graphhopper.storage.NodeAccess;
+import com.graphhopper.util.*;
+import com.graphhopper.util.shapes.GHPoint;
+
+import java.util.*;
+
+import static com.graphhopper.util.Parameters.Details.INTERSECTION;
+
+/**
+ * Calculate the intersections for a route. Every change of the edge id is considered an intersection.
+ * <p>
+ * The format is inspired by the format that is consumed by Maplibre Navigation SDK.
+ * <p>
+ * Explanation of the format:
+ * - <code>entry</code> contain an array of the edges at that intersection. They are sorted by bearing, starting from 0 (which is 0° north) to 359. Every edge that we can turn onto is marked with “true” in the array.
+ * - <code>bearings</code> contain an array of the edges at that intersection. They are sorted by bearing, starting from 0 (which is 0° north) to 359.  The array contains the bearings of each edge at that intersection.
+ * - <code>in</code> marks the index in the “bearings” edge we are coming from.
+ * - <code>out</code> the index we are going to.
+ * - <code>location</code> is the coordinate of the intersection.
+ *
+ * @author Robin Boldt
+ */
+public class IntersectionDetails extends AbstractPathDetailsBuilder {
+
+    private int fromEdge = -1;
+
+    private Map<String, Object> intersectionMap = new HashMap<>();
+
+    private final EdgeExplorer crossingExplorer;
+    private final NodeAccess nodeAccess;
+    private final Weighting weighting;
+
+    public IntersectionDetails(Graph graph, Weighting weighting) {
+        super(INTERSECTION);
+
+        crossingExplorer = graph.createEdgeExplorer();
+        nodeAccess = graph.getNodeAccess();
+        this.weighting = weighting;
+    }
+
+    @Override
+    public boolean isEdgeDifferentToLastEdge(EdgeIteratorState edge) {
+        int toEdge = edgeId(edge);
+        if (toEdge != fromEdge) {
+            // Important to create a new map and not to clean the old map!
+            intersectionMap = new HashMap<>();
+
+            List<IntersectionValues> intersections = new ArrayList<>();
+
+            int baseNode = edge.getBaseNode();
+            EdgeIteratorState tmpEdge;
+
+            double startLat = nodeAccess.getLat(baseNode);
+            double startLon = nodeAccess.getLon(baseNode);
+
+
+            EdgeIterator edgeIter = crossingExplorer.setBaseNode(baseNode);
+            while (edgeIter.next()) {
+                tmpEdge = edgeIter.detach(false);
+
+                // Special case for the first intersection. Mapbox expects only the start edge to be present, so we skip
+                // every edge that is not our edge (same base&adj node)
+                if (fromEdge == -1 && tmpEdge.getAdjNode() != edge.getAdjNode()) {
+                    continue;
+                }
+
+                IntersectionValues intersectionValues = new IntersectionValues();
+                intersectionValues.location = new GHPoint(startLat, startLon);
+                intersectionValues.bearing = calculateBearing(startLat, startLon, tmpEdge);
+                intersectionValues.in = edgeId(tmpEdge) == fromEdge;
+                intersectionValues.out = edgeId(tmpEdge) == edgeId(edge);
+                // The in edge is always false, this means that u-turns are not considered as possible turning option
+                intersectionValues.entry = !intersectionValues.in && Double.isFinite(weighting.calcEdgeWeightWithAccess(tmpEdge, false));
+
+                intersections.add(intersectionValues);
+            }
+
+            intersections.sort(null);
+
+            List<Integer> bearings = new ArrayList<>(intersections.size());
+            List<Boolean> entry = new ArrayList<>(intersections.size());
+
+            for (int i = 0; i < intersections.size(); i++) {
+                IntersectionValues intersectionValues = intersections.get(i);
+                intersectionMap.put("location", Arrays.asList(intersectionValues.location.lon, intersectionValues.location.lat));
+                bearings.add(intersectionValues.bearing);
+                entry.add(intersectionValues.entry);
+                if (intersectionValues.in) {
+                    intersectionMap.put("in", i);
+                }
+                if (intersectionValues.out) {
+                    intersectionMap.put("out", i);
+                }
+            }
+
+            intersectionMap.put("bearings", bearings);
+            intersectionMap.put("entry", entry);
+
+            fromEdge = toEdge;
+            return true;
+        }
+        return false;
+    }
+
+    private int calculateBearing(double startLat, double startLon, EdgeIteratorState tmpEdge) {
+        double latitude;
+        double longitude;
+        PointList wayGeo = tmpEdge.fetchWayGeometry(FetchMode.ALL);
+        if (wayGeo.size() <= 3) {
+            latitude = nodeAccess.getLat(tmpEdge.getAdjNode());
+            longitude = nodeAccess.getLon(tmpEdge.getAdjNode());
+        } else {
+            latitude = wayGeo.getLat(1);
+            longitude = wayGeo.getLon(1);
+        }
+        return (int) Math.round(AngleCalc.ANGLE_CALC.calcAzimuth(startLat, startLon, latitude, longitude));
+    }
+
+    private int edgeId(EdgeIteratorState edge) {
+        if (edge instanceof VirtualEdgeIteratorState) {
+            return GHUtility.getEdgeFromEdgeKey(((VirtualEdgeIteratorState) edge).getOriginalEdgeKey());
+        } else {
+            return edge.getEdge();
+        }
+    }
+
+    @Override
+    public Object getCurrentValue() {
+        return this.intersectionMap;
+    }
+
+    private class IntersectionValues implements Comparable {
+
+        public GHPoint location;
+        public int bearing;
+        public boolean entry;
+        public boolean in;
+        public boolean out;
+
+        @Override
+        public int compareTo(Object o) {
+            if (o instanceof IntersectionValues) {
+                return Integer.compare(this.bearing, ((IntersectionValues) o).bearing);
+            }
+            return 0;
+        }
+    }
+}

--- a/core/src/main/java/com/graphhopper/util/details/PathDetailsBuilderFactory.java
+++ b/core/src/main/java/com/graphhopper/util/details/PathDetailsBuilderFactory.java
@@ -19,6 +19,7 @@ package com.graphhopper.util.details;
 
 import com.graphhopper.routing.ev.*;
 import com.graphhopper.routing.weighting.Weighting;
+import com.graphhopper.storage.Graph;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -34,7 +35,7 @@ import static com.graphhopper.util.Parameters.Details.*;
  */
 public class PathDetailsBuilderFactory {
 
-    public List<PathDetailsBuilder> createPathDetailsBuilders(List<String> requestedPathDetails, EncodedValueLookup evl, Weighting weighting) {
+    public List<PathDetailsBuilder> createPathDetailsBuilders(List<String> requestedPathDetails, EncodedValueLookup evl, Weighting weighting, Graph graph) {
         List<PathDetailsBuilder> builders = new ArrayList<>();
 
         if (requestedPathDetails.contains(AVERAGE_SPEED))
@@ -57,6 +58,9 @@ public class PathDetailsBuilderFactory {
 
         if (requestedPathDetails.contains(DISTANCE))
             builders.add(new DistanceDetails());
+
+        if (requestedPathDetails.contains(INTERSECTION))
+            builders.add(new IntersectionDetails(graph, weighting));
 
         for (String checkSuffix : requestedPathDetails) {
             if (checkSuffix.endsWith(getKey("", "priority")) && evl.hasEncodedValue(checkSuffix))

--- a/core/src/main/java/com/graphhopper/util/details/PathDetailsFromEdges.java
+++ b/core/src/main/java/com/graphhopper/util/details/PathDetailsFromEdges.java
@@ -20,6 +20,7 @@ package com.graphhopper.util.details;
 import com.graphhopper.routing.Path;
 import com.graphhopper.routing.ev.EncodedValueLookup;
 import com.graphhopper.routing.weighting.Weighting;
+import com.graphhopper.storage.Graph;
 import com.graphhopper.util.EdgeIteratorState;
 import com.graphhopper.util.FetchMode;
 
@@ -57,10 +58,11 @@ public class PathDetailsFromEdges implements Path.EdgeVisitor {
      * @return List of PathDetails for this Path
      */
     public static Map<String, List<PathDetail>> calcDetails(Path path, EncodedValueLookup evLookup, Weighting weighting,
-                                                            List<String> requestedPathDetails, PathDetailsBuilderFactory pathBuilderFactory, int previousIndex) {
+                                                            List<String> requestedPathDetails, PathDetailsBuilderFactory pathBuilderFactory,
+                                                            int previousIndex, Graph graph) {
         if (!path.isFound() || requestedPathDetails.isEmpty())
             return Collections.emptyMap();
-        List<PathDetailsBuilder> pathBuilders = pathBuilderFactory.createPathDetailsBuilders(requestedPathDetails, evLookup, weighting);
+        List<PathDetailsBuilder> pathBuilders = pathBuilderFactory.createPathDetailsBuilders(requestedPathDetails, evLookup, weighting, graph);
         if (pathBuilders.isEmpty())
             return Collections.emptyMap();
 

--- a/core/src/test/java/com/graphhopper/routing/PathTest.java
+++ b/core/src/test/java/com/graphhopper/routing/PathTest.java
@@ -278,7 +278,7 @@ public class PathTest {
         assertTrue(p.isFound());
 
         Map<String, List<PathDetail>> details = PathDetailsFromEdges.calcDetails(p, carManager, weighting,
-                Arrays.asList(AVERAGE_SPEED), new PathDetailsBuilderFactory(), 0);
+                Arrays.asList(AVERAGE_SPEED), new PathDetailsBuilderFactory(), 0, pathDetailGraph);
         assertTrue(details.size() == 1);
 
         List<PathDetail> averageSpeedDetails = details.get(AVERAGE_SPEED);
@@ -301,7 +301,7 @@ public class PathTest {
         Path p = new Dijkstra(pathDetailGraph, weighting, TraversalMode.NODE_BASED).calcPath(1, 6);
         assertTrue(p.isFound());
         Map<String, List<PathDetail>> details = PathDetailsFromEdges.calcDetails(p, carManager, weighting,
-                Arrays.asList(AVERAGE_SPEED), new PathDetailsBuilderFactory(), 0);
+                Arrays.asList(AVERAGE_SPEED), new PathDetailsBuilderFactory(), 0, pathDetailGraph);
         assertTrue(details.size() == 1);
         List<PathDetail> averageSpeedDetails = details.get(AVERAGE_SPEED);
         assertEquals(4, averageSpeedDetails.size());
@@ -310,7 +310,7 @@ public class PathTest {
         p = new Dijkstra(pathDetailGraph, weighting, TraversalMode.NODE_BASED).calcPath(6, 1);
         assertTrue(p.isFound());
         details = PathDetailsFromEdges.calcDetails(p, carManager, weighting,
-                Arrays.asList(AVERAGE_SPEED), new PathDetailsBuilderFactory(), 0);
+                Arrays.asList(AVERAGE_SPEED), new PathDetailsBuilderFactory(), 0, pathDetailGraph);
         assertTrue(details.size() == 1);
         averageSpeedDetails = details.get(AVERAGE_SPEED);
         assertEquals(5, averageSpeedDetails.size());
@@ -324,7 +324,7 @@ public class PathTest {
         assertTrue(p.isFound());
 
         Map<String, List<PathDetail>> details = PathDetailsFromEdges.calcDetails(p, carManager, weighting,
-                Arrays.asList(STREET_NAME), new PathDetailsBuilderFactory(), 0);
+                Arrays.asList(STREET_NAME), new PathDetailsBuilderFactory(), 0, pathDetailGraph);
         assertTrue(details.size() == 1);
 
         List<PathDetail> streetNameDetails = details.get(STREET_NAME);
@@ -350,7 +350,7 @@ public class PathTest {
         assertTrue(p.isFound());
 
         Map<String, List<PathDetail>> details = PathDetailsFromEdges.calcDetails(p, carManager, weighting,
-                Arrays.asList(EDGE_ID), new PathDetailsBuilderFactory(), 0);
+                Arrays.asList(EDGE_ID), new PathDetailsBuilderFactory(), 0, pathDetailGraph);
         assertTrue(details.size() == 1);
 
         List<PathDetail> edgeIdDetails = details.get(EDGE_ID);
@@ -375,7 +375,7 @@ public class PathTest {
         assertTrue(p.isFound());
 
         Map<String, List<PathDetail>> details = PathDetailsFromEdges.calcDetails(p, carManager, weighting,
-                Arrays.asList(EDGE_KEY), new PathDetailsBuilderFactory(), 0);
+                Arrays.asList(EDGE_KEY), new PathDetailsBuilderFactory(), 0, pathDetailGraph);
         List<PathDetail> edgeKeyDetails = details.get(EDGE_KEY);
 
         assertEquals(4, edgeKeyDetails.size());
@@ -392,7 +392,7 @@ public class PathTest {
         assertTrue(p.isFound());
 
         Map<String, List<PathDetail>> details = PathDetailsFromEdges.calcDetails(p, carManager, weighting,
-                Arrays.asList(EDGE_KEY), new PathDetailsBuilderFactory(), 0);
+                Arrays.asList(EDGE_KEY), new PathDetailsBuilderFactory(), 0, pathDetailGraph);
         List<PathDetail> edgeKeyDetails = details.get(EDGE_KEY);
 
         assertEquals(4, edgeKeyDetails.size());
@@ -409,7 +409,7 @@ public class PathTest {
         assertTrue(p.isFound());
 
         Map<String, List<PathDetail>> details = PathDetailsFromEdges.calcDetails(p, carManager, weighting,
-                Arrays.asList(TIME), new PathDetailsBuilderFactory(), 0);
+                Arrays.asList(TIME), new PathDetailsBuilderFactory(), 0, pathDetailGraph);
         assertTrue(details.size() == 1);
 
         List<PathDetail> timeDetails = details.get(TIME);
@@ -433,7 +433,7 @@ public class PathTest {
         assertTrue(p.isFound());
 
         Map<String, List<PathDetail>> details = PathDetailsFromEdges.calcDetails(p, carManager, weighting,
-                Arrays.asList(DISTANCE), new PathDetailsBuilderFactory(), 0);
+                Arrays.asList(DISTANCE), new PathDetailsBuilderFactory(), 0, pathDetailGraph);
         assertTrue(details.size() == 1);
 
         List<PathDetail> distanceDetails = details.get(DISTANCE);
@@ -441,6 +441,37 @@ public class PathTest {
         assertEquals(5D, distanceDetails.get(1).getValue());
         assertEquals(10D, distanceDetails.get(2).getValue());
         assertEquals(5D, distanceDetails.get(3).getValue());
+    }
+
+    @Test
+    public void testCalcIntersectionDetails() {
+        ShortestWeighting weighting = new ShortestWeighting(encoder);
+        Path p = new Dijkstra(pathDetailGraph, weighting, TraversalMode.NODE_BASED).calcPath(1, 5);
+        assertTrue(p.isFound());
+
+        Map<String, List<PathDetail>> details = PathDetailsFromEdges.calcDetails(p, carManager, weighting,
+                Arrays.asList(INTERSECTION), new PathDetailsBuilderFactory(), 0, pathDetailGraph);
+        assertTrue(details.size() == 1);
+
+        List<PathDetail> intersectionDetails = details.get(INTERSECTION);
+        assertEquals(4, intersectionDetails.size());
+
+        Map<String, Object> intersectionMap = new HashMap<>();
+        intersectionMap.put("out", 0);
+        intersectionMap.put("entry", Arrays.asList(true));
+        intersectionMap.put("bearings", Arrays.asList(90));
+        intersectionMap.put("location", Arrays.asList(13.348, 52.514));
+
+        assertEquals(intersectionMap, intersectionDetails.get(0).getValue());
+
+        intersectionMap.clear();
+        intersectionMap.put("out", 0);
+        intersectionMap.put("in", 1);
+        intersectionMap.put("entry", Arrays.asList(true, false));
+        intersectionMap.put("bearings", Arrays.asList(90, 270));
+        intersectionMap.put("location", Arrays.asList(13.349, 52.514));
+
+        assertEquals(intersectionMap, intersectionDetails.get(1).getValue());
     }
 
     /**

--- a/core/src/test/java/com/graphhopper/util/PathSimplificationTest.java
+++ b/core/src/test/java/com/graphhopper/util/PathSimplificationTest.java
@@ -107,7 +107,7 @@ public class PathSimplificationTest {
         Path p = new Dijkstra(g, weighting, tMode).calcPath(0, 10);
         InstructionList wayList = InstructionsFromEdges.calcInstructions(p, g, weighting, carManager, usTR);
         Map<String, List<PathDetail>> details = PathDetailsFromEdges.calcDetails(p, carManager, weighting,
-                Arrays.asList(AVERAGE_SPEED), new PathDetailsBuilderFactory(), 0);
+                Arrays.asList(AVERAGE_SPEED), new PathDetailsBuilderFactory(), 0, g);
 
         ResponsePath responsePath = new ResponsePath();
         responsePath.setInstructions(wayList);

--- a/navigation/src/main/java/com/graphhopper/navigation/NavigateResource.java
+++ b/navigation/src/main/java/com/graphhopper/navigation/NavigateResource.java
@@ -39,6 +39,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 import java.util.*;
 
+import static com.graphhopper.util.Parameters.Details.INTERSECTION;
 import static com.graphhopper.util.Parameters.Routing.*;
 
 /**
@@ -169,6 +170,8 @@ public class NavigateResource {
 
         request.setProfile(profileStr).
                 setLocale(localeStr).
+                // We force the intersection details here as we cannot easily add this to the URL
+                setPathDetails(Arrays.asList(INTERSECTION)).
                 putHint(CALC_POINTS, true).
                 putHint(INSTRUCTIONS, enableInstructions).
                 putHint(WAY_POINT_MAX_DISTANCE, minPathPrecision).

--- a/navigation/src/main/java/com/graphhopper/navigation/NavigateResponseConverter.java
+++ b/navigation/src/main/java/com/graphhopper/navigation/NavigateResponseConverter.java
@@ -24,10 +24,11 @@ import com.graphhopper.GHResponse;
 import com.graphhopper.ResponsePath;
 import com.graphhopper.jackson.ResponsePathSerializer;
 import com.graphhopper.util.*;
+import com.graphhopper.util.details.PathDetail;
 
-import java.util.List;
-import java.util.Locale;
-import java.util.UUID;
+import java.util.*;
+
+import static com.graphhopper.util.Parameters.Details.INTERSECTION;
 
 public class NavigateResponseConverter {
 
@@ -82,11 +83,20 @@ public class NavigateResponseConverter {
         long time = 0;
         double distance = 0;
         boolean isFirstInstructionOfLeg = true;
+        int pointIndexFrom = 0;
+
+        Map<String, List<PathDetail>> pathDetails = path.getPathDetails();
+        List<PathDetail> intersectionDetails = pathDetails.getOrDefault(INTERSECTION, Collections.emptyList());
 
         for (int i = 0; i < instructions.size(); i++) {
             ObjectNode instructionJson = steps.addObject();
-            putInstruction(instructions, i, locale, translationMap, instructionJson, isFirstInstructionOfLeg, distanceConfig);
             Instruction instruction = instructions.get(i);
+            int pointIndexTo = pointIndexFrom;
+            if (instruction.getSign() != Instruction.REACHED_VIA && instruction.getSign() != Instruction.FINISH) {
+                pointIndexTo += instructions.get(i).getPoints().size();
+            }
+            putInstruction(instructions, i, locale, translationMap, instructionJson, isFirstInstructionOfLeg, distanceConfig, intersectionDetails, pointIndexFrom, pointIndexTo);
+            pointIndexFrom = pointIndexTo;
             time += instruction.getTime();
             distance += instruction.getDistance();
             isFirstInstructionOfLeg = false;
@@ -126,26 +136,68 @@ public class NavigateResponseConverter {
         legJson.put("distance", Helper.round(distance, 1));
     }
 
-    private static ObjectNode putInstruction(InstructionList instructions, int index, Locale locale, TranslationMap translationMap,
-                                             ObjectNode instructionJson, boolean isFirstInstructionOfLeg, DistanceConfig distanceConfig) {
-        Instruction instruction = instructions.get(index);
+    private static ObjectNode putInstruction(InstructionList instructions, int instructionIndex, Locale locale, TranslationMap translationMap,
+                                             ObjectNode instructionJson, boolean isFirstInstructionOfLeg, DistanceConfig distanceConfig,
+                                             List<PathDetail> intersectionDetails, int pointIndexFrom, int pointIndexTo) {
+        Instruction instruction = instructions.get(instructionIndex);
         ArrayNode intersections = instructionJson.putArray("intersections");
-        ObjectNode intersection = intersections.addObject();
-        intersection.putArray("entry");
-        intersection.putArray("bearings");
+
+        for (PathDetail intersectionDetail : intersectionDetails) {
+            if (intersectionDetail.getFirst() >= pointIndexTo) {
+                break;
+            }
+            if (intersectionDetail.getFirst() >= pointIndexFrom) {
+                ObjectNode intersection = intersections.addObject();
+                Map<String, Object> intersectionValue = (Map<String, Object>) intersectionDetail.getValue();
+                // Location
+                List<Double> locationList = (List<Double>) intersectionValue.getOrDefault("location", Collections.emptyList());
+                ArrayNode locationArray = intersection.putArray("location");
+                for (Double location : locationList) {
+                    locationArray.add(Helper.round6(location));
+                }
+                // Entry
+                List<Boolean> entryList = (List<Boolean>) intersectionValue.getOrDefault("entry", Collections.emptyList());
+                ArrayNode entryArray = intersection.putArray("entry");
+                for (Boolean entry : entryList) {
+                    entryArray.add(entry);
+                }
+                // Bearings
+                List<Integer> bearingsList = (List<Integer>) intersectionValue.getOrDefault("bearings", Collections.emptyList());
+                ArrayNode bearingsrray = intersection.putArray("bearings");
+                for (Integer bearing : bearingsList) {
+                    bearingsrray.add(bearing);
+                }
+                // in
+                if (intersectionValue.containsKey("in")) {
+                    intersection.put("in", (int) intersectionValue.get("in"));
+                }
+                // out
+                if (intersectionValue.containsKey("out")) {
+                    intersection.put("out", (int) intersectionValue.get("out"));
+                }
+            }
+        }
+
         //Make pointList mutable
         PointList pointList = instruction.getPoints().clone(false);
 
-        if (index + 2 < instructions.size()) {
+        if (instructionIndex + 2 < instructions.size()) {
             // Add the first point of the next instruction
-            PointList nextPoints = instructions.get(index + 1).getPoints();
+            PointList nextPoints = instructions.get(instructionIndex + 1).getPoints();
             pointList.add(nextPoints.getLat(0), nextPoints.getLon(0), nextPoints.getEle(0));
         } else if (pointList.size() == 1) {
             // Duplicate the last point in the arrive instruction, if the size is 1
             pointList.add(pointList.getLat(0), pointList.getLon(0), pointList.getEle(0));
         }
 
-        putLocation(pointList.getLat(0), pointList.getLon(0), intersection);
+        if (intersections.size() == 0) {
+            // this is the fallback if we don't have any intersections.
+            // this can happen for via points or finish instructions or when no intersection details have been requested
+            ObjectNode intersection = intersections.addObject();
+            intersection.putArray("entry");
+            intersection.putArray("bearings");
+            putLocation(pointList.getLat(0), pointList.getLon(0), intersection);
+        }
 
         instructionJson.put("driving_side", "right");
 
@@ -168,9 +220,9 @@ public class NavigateResponseConverter {
         ArrayNode bannerInstructions = instructionJson.putArray("bannerInstructions");
 
         // Voice and banner instructions are empty for the last element
-        if (index + 1 < instructions.size()) {
-            putVoiceInstructions(instructions, distance, index, locale, translationMap, voiceInstructions, distanceConfig);
-            putBannerInstructions(instructions, distance, index, locale, translationMap, bannerInstructions);
+        if (instructionIndex + 1 < instructions.size()) {
+            putVoiceInstructions(instructions, distance, instructionIndex, locale, translationMap, voiceInstructions, distanceConfig);
+            putBannerInstructions(instructions, distance, instructionIndex, locale, translationMap, bannerInstructions);
         }
 
         return instructionJson;

--- a/navigation/src/test/java/com/graphhopper/navigation/NavigateResponseConverterTest.java
+++ b/navigation/src/test/java/com/graphhopper/navigation/NavigateResponseConverterTest.java
@@ -16,10 +16,10 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
+import java.util.Collections;
 import java.util.Locale;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class NavigateResponseConverterTest {
 
@@ -248,6 +248,36 @@ public class NavigateResponseConverterTest {
         assertEquals("right", primary.get("modifier").asText());
         assertEquals(222, primary.get("degrees").asDouble(), 1);
 
+    }
+
+    @Test
+    public void intersectionTest() {
+        GHResponse rsp = hopper.route(new GHRequest(42.554851, 1.536198, 42.510071, 1.548128).
+                setProfile(profile).setPathDetails(Collections.singletonList("intersection")));
+
+        ObjectNode json = NavigateResponseConverter.convertFromGHResponse(rsp, trMap, Locale.ENGLISH, distanceConfig);
+
+        JsonNode steps = json.get("routes").get(0).get("legs").get(0).get("steps");
+
+        JsonNode step = steps.get(0);
+
+        JsonNode intersection = step.get("intersections").get(0);
+
+        assertFalse(intersection.has("in"));
+        assertEquals(0, intersection.get("out").asInt());
+
+        JsonNode location = intersection.get("location");
+        // The first intersection to be equal to the first snapped waypoint
+        assertEquals(rsp.getBest().getWaypoints().get(0).lon, location.get(0).asDouble(), .000001);
+        assertEquals(rsp.getBest().getWaypoints().get(0).lat, location.get(1).asDouble(), .000001);
+
+        step = steps.get(4);
+        intersection = step.get("intersections").get(3);
+        assertEquals(1, intersection.get("in").asInt());
+        assertEquals(0, intersection.get("out").asInt());
+        location = intersection.get("location");
+        assertEquals(1.534679, location.get(0).asDouble(), .000001);
+        assertEquals(42.556444, location.get(1).asDouble(), .000001);
     }
 
     @Test

--- a/reader-gtfs/src/main/java/com/graphhopper/gtfs/TripFromLabel.java
+++ b/reader-gtfs/src/main/java/com/graphhopper/gtfs/TripFromLabel.java
@@ -401,7 +401,7 @@ class TripFromLabel {
             pathh.setFromNode(path.get(0).label.node.streetNode);
             pathh.setEndNode(path.get(path.size() - 1).label.node.streetNode);
             pathh.setFound(true);
-            Map<String, List<PathDetail>> pathDetails = PathDetailsFromEdges.calcDetails(pathh, encodedValueLookup, weighting, requestedPathDetails, pathDetailsBuilderFactory, 0);
+            Map<String, List<PathDetail>> pathDetails = PathDetailsFromEdges.calcDetails(pathh, encodedValueLookup, weighting, requestedPathDetails, pathDetailsBuilderFactory, 0, graph);
 
             final Instant departureTime = Instant.ofEpochMilli(path.get(0).label.currentTime);
             final Instant arrivalTime = Instant.ofEpochMilli(path.get(path.size() - 1).label.currentTime);

--- a/web-api/src/main/java/com/graphhopper/jackson/PathDetailSerializer.java
+++ b/web-api/src/main/java/com/graphhopper/jackson/PathDetailSerializer.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 import com.graphhopper.util.details.PathDetail;
 
 import java.io.IOException;
+import java.util.Map;
 
 public class PathDetailSerializer extends JsonSerializer<PathDetail> {
 
@@ -44,6 +45,8 @@ public class PathDetailSerializer extends JsonSerializer<PathDetail> {
             gen.writeBoolean((Boolean) value.getValue());
         else if (value.getValue() instanceof String)
             gen.writeString((String) value.getValue());
+        else if (value.getValue() instanceof Map)
+            gen.writeObject(value.getValue());
         else if (value.getValue() == null)
             gen.writeNull();
         else

--- a/web-api/src/main/java/com/graphhopper/util/Parameters.java
+++ b/web-api/src/main/java/com/graphhopper/util/Parameters.java
@@ -204,6 +204,7 @@ public class Parameters {
         public static final String TIME = "time";
         public static final String WEIGHT = "weight";
         public static final String DISTANCE = "distance";
+        public static final String INTERSECTION = "intersection";
     }
 
 }


### PR DESCRIPTION
Fixes #1415. This PR adds the ability to calculate the intersections for a route. This feature can be especially helpful for navigation clients to improve recognising off route cases. Navigation clients could do this because they know where an intersection is and at what angles users can turn onto a different road. This means that if a user is not close to an intersection, being away from the route is probably due to poor GPS or inaccurate road data. When leaving the route at an intersection with the provided bearing, the navigation client could recognise this case and calculate a new route.

We calculate the bearings similarly to how we do it for the instructions. The calculation requires to use the `atan` function which is rather performance intensive, so there is a slowdown when you use this feature with CH. Since we calculate bearings for every edge change, the performance impact is larger than the performance impact of instructions.  As this feature is optional there should be no influence for the regular routing, but it is forced for the NavigateResource. We have to force it for the NavigateResource as the Maplibre Navigation client can't change the request parameters easily, so that the client could opt in to get this information.

In order to calculate the the bearings we need an EdgeExplorer and NodeAccess so I added the Graph to the `PathDetailsBuilderFactory`.

The format of the IntersectionDetails follows the format that we need in the NavigateResource.