### PR TITLE
Make motor vehicle and hgv properties configurable for roads vehicle EVs

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/DefaultFlagEncoderFactory.java
+++ b/core/src/main/java/com/graphhopper/routing/util/DefaultFlagEncoderFactory.java
@@ -28,7 +28,7 @@ public class DefaultFlagEncoderFactory implements FlagEncoderFactory {
     @Override
     public FlagEncoder createFlagEncoder(String name, PMap configuration) {
         if (name.equals(ROADS))
-            return FlagEncoders.createRoads();
+            return FlagEncoders.createRoads(configuration);
 
         if (name.equals(CAR))
             return FlagEncoders.createCar(configuration);

--- a/core/src/main/java/com/graphhopper/routing/util/FlagEncoders.java
+++ b/core/src/main/java/com/graphhopper/routing/util/FlagEncoders.java
@@ -79,7 +79,7 @@ public class FlagEncoders {
         return VehicleEncodedValues.mountainbike(properties);
     }
 
-    public static FlagEncoder createRoads() {
-        return VehicleEncodedValues.roads();
+    public static FlagEncoder createRoads(PMap properties) {
+        return VehicleEncodedValues.roads(properties);
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/util/VehicleEncodedValues.java
+++ b/core/src/main/java/com/graphhopper/routing/util/VehicleEncodedValues.java
@@ -135,7 +135,7 @@ public class VehicleEncodedValues implements FlagEncoder {
         return new VehicleEncodedValues(name, accessEnc, speedEnc, priorityEnc, curvatureEnc, turnCostEnc, speedEnc.getNextStorableValue(maxSpeed), true, false);
     }
 
-    public static VehicleEncodedValues roads() {
+    public static VehicleEncodedValues roads(PMap properties) {
         String name = "roads";
         int speedBits = 7;
         double speedFactor = 2;
@@ -144,7 +144,9 @@ public class VehicleEncodedValues implements FlagEncoder {
         BooleanEncodedValue accessEnc = new SimpleBooleanEncodedValue(getKey(name, "access"), true);
         DecimalEncodedValue speedEnc = new DecimalEncodedValueImpl(getKey(name, "average_speed"), speedBits, speedFactor, speedTwoDirections);
         DecimalEncodedValue turnCostEnc = maxTurnCosts > 0 ? TurnCost.create(name, maxTurnCosts) : null;
-        return new VehicleEncodedValues(name, accessEnc, speedEnc, null, null, turnCostEnc, speedEnc.getNextStorableValue(ROADS_MAX_SPEED), true, false);
+        boolean isMotorVehicle = properties.getBool("is_motor_vehicle", true);
+        boolean isHGV = properties.getBool("is_hgv", false);
+        return new VehicleEncodedValues(name, accessEnc, speedEnc, null, null, turnCostEnc, speedEnc.getNextStorableValue(ROADS_MAX_SPEED), isMotorVehicle, isHGV);
     }
 
     public VehicleEncodedValues(String name, BooleanEncodedValue accessEnc, DecimalEncodedValue avgSpeedEnc,

--- a/core/src/test/java/com/graphhopper/util/InstructionListTest.java
+++ b/core/src/test/java/com/graphhopper/util/InstructionListTest.java
@@ -424,7 +424,7 @@ public class InstructionListTest {
 
     @Test
     public void testInstructionWithHighlyCustomProfileWithRoadsBase() {
-        FlagEncoder roads = FlagEncoders.createRoads();
+        FlagEncoder roads = FlagEncoders.createRoads(new PMap());
         EncodingManager tmpEM = EncodingManager.create(roads);
         EnumEncodedValue<RoadClass> rcEV = tmpEM.getEnumEncodedValue(RoadClass.KEY, RoadClass.class);
         BaseGraph g = new BaseGraph.Builder(tmpEM).create();


### PR DESCRIPTION
With this PR the default is `roads|is_motor_vehicle=true|is_hgv=false` (as before), but now we can change it.

Note that currently the turn costs are hard-coded for this encoder, i.e. setting `turn_costs=false` would not have an effect.