### PR TITLE
Increase maximum edge-based CH key for preparation to 2^30 again

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/ch/CHPreparationGraph.java
+++ b/core/src/main/java/com/graphhopper/routing/ch/CHPreparationGraph.java
@@ -166,31 +166,6 @@ public class CHPreparationGraph {
         };
     }
 
-    static int getKeyWithFlags(int key, boolean fwd, boolean bwd) {
-        // we use only 30 bits for the key and store two access flags along with the same int
-        if (key > Integer.MAX_VALUE >> 1)
-            throw new IllegalArgumentException("Maximum edge key exceeded: " + key);
-        key <<= 1;
-        if (fwd)
-            key++;
-        key <<= 1;
-        if (bwd)
-            key++;
-        return key;
-    }
-
-    static int getKeyFromKeyWithFlags(int k) {
-        return k >>> 2;
-    }
-
-    static boolean getFwdAccessFromKeyWithFlags(int k) {
-        return (k & 0b10) == 0b10;
-    }
-
-    static boolean getBwdAccessFromKeyWithFlags(int k) {
-        return (k & 0b01) == 0b01;
-    }
-
     public int getNodes() {
         return nodes;
     }
@@ -928,6 +903,19 @@ public class CHPreparationGraph {
                 return new OrigGraph(buildFirstEdgesByNode(), toNodes, keysAndFlags);
             }
 
+            private static int getKeyWithFlags(int key, boolean fwd, boolean bwd) {
+                // we use only 30 bits for the key and store two access flags along with the same int
+                if (key > Integer.MAX_VALUE >> 1)
+                    throw new IllegalArgumentException("Maximum edge key exceeded: " + key + ", max: " + (Integer.MAX_VALUE >> 1));
+                key <<= 1;
+                if (fwd)
+                    key++;
+                key <<= 1;
+                if (bwd)
+                    key++;
+                return key;
+            }
+
             private IntArrayList buildFirstEdgesByNode() {
                 // it is assumed the edges have been sorted already
                 final int numFroms = maxFrom + 1;
@@ -995,7 +983,7 @@ public class CHPreparationGraph {
 
         @Override
         public int getOrigEdgeKeyFirst() {
-            return getKeyFromKeyWithFlags(graph.keysAndFlags.get(index));
+            return graph.keysAndFlags.get(index) >>> 2;
         }
 
         @Override
@@ -1006,9 +994,9 @@ public class CHPreparationGraph {
         private boolean hasAccess() {
             int e = graph.keysAndFlags.get(index);
             if (reverse)
-                return getBwdAccessFromKeyWithFlags(e);
+                return (e & 0b01) == 0b01;
             else
-                return getFwdAccessFromKeyWithFlags(e);
+                return (e & 0b10) == 0b10;
         }
 
         @Override

--- a/core/src/main/java/com/graphhopper/routing/ch/CHPreparationGraph.java
+++ b/core/src/main/java/com/graphhopper/routing/ch/CHPreparationGraph.java
@@ -168,7 +168,7 @@ public class CHPreparationGraph {
 
     static int getKeyWithFlags(int key, boolean fwd, boolean bwd) {
         // we use only 30 bits for the key and store two access flags along with the same int
-        if (key >= Integer.MAX_VALUE >> 1)
+        if (key > Integer.MAX_VALUE >> 1)
             throw new IllegalArgumentException("Maximum edge key exceeded: " + key);
         key <<= 1;
         if (fwd)
@@ -180,7 +180,7 @@ public class CHPreparationGraph {
     }
 
     static int getKeyFromKeyWithFlags(int k) {
-        return k >> 2;
+        return k >>> 2;
     }
 
     static boolean getFwdAccessFromKeyWithFlags(int k) {

--- a/core/src/main/java/com/graphhopper/routing/ch/CHPreparationGraph.java
+++ b/core/src/main/java/com/graphhopper/routing/ch/CHPreparationGraph.java
@@ -905,6 +905,9 @@ public class CHPreparationGraph {
 
             private static int getKeyWithFlags(int key, boolean fwd, boolean bwd) {
                 // we use only 30 bits for the key and store two access flags along with the same int
+                // this allows for a maximum of 536mio edges in base graph which is still enough for planet-wide OSM,
+                // but if we exceed this limit we should probably move one of the fwd/bwd bits to the nodes field or
+                // store the edge instead of the key as we did before #2567 (only here)
                 if (key > Integer.MAX_VALUE >> 1)
                     throw new IllegalArgumentException("Maximum edge key exceeded: " + key + ", max: " + (Integer.MAX_VALUE >> 1));
                 key <<= 1;

--- a/core/src/main/java/com/graphhopper/routing/ch/CHPreparationGraph.java
+++ b/core/src/main/java/com/graphhopper/routing/ch/CHPreparationGraph.java
@@ -166,6 +166,31 @@ public class CHPreparationGraph {
         };
     }
 
+    static int getKeyWithFlags(int key, boolean fwd, boolean bwd) {
+        // we use only 30 bits for the key and store two access flags along with the same int
+        if (key >= Integer.MAX_VALUE >> 1)
+            throw new IllegalArgumentException("Maximum edge key exceeded: " + key);
+        key <<= 1;
+        if (fwd)
+            key++;
+        key <<= 1;
+        if (bwd)
+            key++;
+        return key;
+    }
+
+    static int getKeyFromKeyWithFlags(int k) {
+        return k >> 2;
+    }
+
+    static boolean getFwdAccessFromKeyWithFlags(int k) {
+        return (k & 0b10) == 0b10;
+    }
+
+    static boolean getBwdAccessFromKeyWithFlags(int k) {
+        return (k & 0b01) == 0b01;
+    }
+
     public int getNodes() {
         return nodes;
     }
@@ -903,19 +928,6 @@ public class CHPreparationGraph {
                 return new OrigGraph(buildFirstEdgesByNode(), toNodes, keysAndFlags);
             }
 
-            private int getKeyWithFlags(int key, boolean fwd, boolean bwd) {
-                // we use only 30 bits for the key and store two access flags along with the same int
-                if (key >= Integer.MAX_VALUE >> 1)
-                    throw new IllegalArgumentException("Maximum edge key exceeded: " + key);
-                key <<= 1;
-                if (fwd)
-                    key++;
-                key <<= 1;
-                if (bwd)
-                    key++;
-                return key;
-            }
-
             private IntArrayList buildFirstEdgesByNode() {
                 // it is assumed the edges have been sorted already
                 final int numFroms = maxFrom + 1;
@@ -983,7 +995,7 @@ public class CHPreparationGraph {
 
         @Override
         public int getOrigEdgeKeyFirst() {
-            return graph.keysAndFlags.get(index) >> 2;
+            return getKeyFromKeyWithFlags(graph.keysAndFlags.get(index));
         }
 
         @Override
@@ -993,11 +1005,10 @@ public class CHPreparationGraph {
 
         private boolean hasAccess() {
             int e = graph.keysAndFlags.get(index);
-            if (reverse) {
-                return (e & 0b01) == 0b01;
-            } else {
-                return (e & 0b10) == 0b10;
-            }
+            if (reverse)
+                return getBwdAccessFromKeyWithFlags(e);
+            else
+                return getFwdAccessFromKeyWithFlags(e);
         }
 
         @Override

--- a/core/src/test/java/com/graphhopper/routing/ch/CHPreparationGraphTest.java
+++ b/core/src/test/java/com/graphhopper/routing/ch/CHPreparationGraphTest.java
@@ -53,4 +53,24 @@ class CHPreparationGraphTest {
         }
         assertEquals("3-4 16.0,", res.toString());
     }
+
+    @Test
+    void convertKeyWithFlags() {
+        int max = Integer.MAX_VALUE >> 1;
+        for (int key = 0; key <= max; key++) {
+            for (int ifwd = 0; ifwd < 2; ifwd++) {
+                for (int ibwd = 0; ibwd < 2; ibwd++) {
+                    boolean fwd = ifwd > 0;
+                    boolean bwd = ibwd > 0;
+                    int keyWithFlags = CHPreparationGraph.getKeyWithFlags(key, fwd, bwd);
+                    int keyAfter = CHPreparationGraph.getKeyFromKeyWithFlags(keyWithFlags);
+                    boolean fwdAfter = CHPreparationGraph.getFwdAccessFromKeyWithFlags(keyWithFlags);
+                    boolean bwdAfter = CHPreparationGraph.getBwdAccessFromKeyWithFlags(keyWithFlags);
+                    assertEquals(key, keyAfter);
+                    assertEquals(fwd, fwdAfter);
+                    assertEquals(bwd, bwdAfter);
+                }
+            }
+        }
+    }
 }

--- a/core/src/test/java/com/graphhopper/routing/ch/CHPreparationGraphTest.java
+++ b/core/src/test/java/com/graphhopper/routing/ch/CHPreparationGraphTest.java
@@ -53,24 +53,4 @@ class CHPreparationGraphTest {
         }
         assertEquals("3-4 16.0,", res.toString());
     }
-
-    @Test
-    void convertKeyWithFlags() {
-        int max = Integer.MAX_VALUE >> 1;
-        for (int key = 0; key <= max; key++) {
-            for (int ifwd = 0; ifwd < 2; ifwd++) {
-                for (int ibwd = 0; ibwd < 2; ibwd++) {
-                    boolean fwd = ifwd > 0;
-                    boolean bwd = ibwd > 0;
-                    int keyWithFlags = CHPreparationGraph.getKeyWithFlags(key, fwd, bwd);
-                    int keyAfter = CHPreparationGraph.getKeyFromKeyWithFlags(keyWithFlags);
-                    boolean fwdAfter = CHPreparationGraph.getFwdAccessFromKeyWithFlags(keyWithFlags);
-                    boolean bwdAfter = CHPreparationGraph.getBwdAccessFromKeyWithFlags(keyWithFlags);
-                    assertEquals(key, keyAfter);
-                    assertEquals(fwd, fwdAfter);
-                    assertEquals(bwd, bwdAfter);
-                }
-            }
-        }
-    }
 }


### PR DESCRIPTION
Since #2567 we store the edge key instead of the edge ID in CHPreparationGraph#OrigGraph, which is used (only) for edge-based CH preparation. Before this the maximum possible edge ID was around 536mio (`Integer.MAX_VALUE >> 2`), but due to the change now the maximum possible edge **key** is around 536mio, which means that the import will fail if the base graph has more than around 268mio edges! 
However, we did not use the unsigned bitshift operator so far which means we were applying a limit that was below the physical limit implied by the 30bits we reserve for the edge ID/key. Using the unsigned shift the maximum is around 1 billion (`Integer.MAX_VALUE >> 1`) and since we are now storing edge keys this means the maximum number of edges is around `536mio` when we use the unsigned shift.

@karussell already fixed this here: 7bb8ff7d4581e8f34baf574fb470816f3adfcc64 (thanks!), but reverted to the signed shift here again: 47c57118423b57f302ab1a021b00b913f80e527a, which I think is wrong.

Here I first extracted the methods doing the bit operations and added a test that shows that with the unsigned shift the conversion goes wrong above 536mio: c4f5e923ab7010cf704256ccd95d9e4c748b3f57. Then I used the signed shift which fixes the failing test up to 1 billion: c34fc355de81ae2802bcf1302e61e9f398395ab2, and finally I inlined everything again and removed the test (or should we keep this?) for this PR.