### PR TITLE
Use actual speed maximum rather than flagEncoder#getMaxSpeed() for weighting.getMinWeight()

### DIFF
--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -812,17 +812,18 @@ public class GraphHopper {
         properties.put("datareader.import.date", f.format(new Date()));
         if (reader.getDataDate() != null)
             properties.put("datareader.data.date", f.format(reader.getDataDate()));
+
+        properties.put("graph.em.version", Constants.VERSION_EM);
+        properties.put("graph.em.edge_config", encodingManager.toEdgeConfigAsString());
+        properties.put("graph.em.turn_cost_config", encodingManager.toTurnCostConfigAsString());
+        properties.put("graph.encoded_values", encodingManager.toEncodedValuesAsString());
+        properties.put("graph.flag_encoders", encodingManager.toFlagEncodersAsString());
     }
 
     protected void createBaseGraphAndProperties() {
         baseGraph.getDirectory().create();
         baseGraph.create(100);
         properties.create(100);
-        properties.put("graph.em.version", Constants.VERSION_EM);
-        properties.put("graph.em.edge_config", encodingManager.toEdgeConfigAsString());
-        properties.put("graph.em.turn_cost_config", encodingManager.toTurnCostConfigAsString());
-        properties.put("graph.encoded_values", encodingManager.toEncodedValuesAsString());
-        properties.put("graph.flag_encoders", encodingManager.toFlagEncodersAsString());
     }
 
     private List<CustomArea> readCustomAreas() {

--- a/core/src/main/java/com/graphhopper/routing/ev/DecimalEncodedValue.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/DecimalEncodedValue.java
@@ -40,4 +40,6 @@ public interface DecimalEncodedValue extends EncodedValue {
     double getNextStorableValue(double value);
 
     double getSmallestNonZeroValue();
+
+    double getRealMax();
 }

--- a/core/src/main/java/com/graphhopper/routing/ev/DecimalEncodedValueImpl.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/DecimalEncodedValueImpl.java
@@ -113,7 +113,7 @@ public final class DecimalEncodedValueImpl extends IntEncodedValueImpl implement
         if (Double.isNaN(value))
             throw new IllegalArgumentException("NaN value for " + getName() + " not allowed!");
 
-        realMax = Math.max(realMax, value);
+        realMax = Math.max(realMax, getNextStorableValue(value));
 
         value /= factor;
         if (value > maxValue)

--- a/core/src/main/java/com/graphhopper/routing/ev/DecimalEncodedValueImpl.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/DecimalEncodedValueImpl.java
@@ -29,6 +29,7 @@ public final class DecimalEncodedValueImpl extends IntEncodedValueImpl implement
     private final double factor;
     private final boolean defaultIsInfinity;
     private final boolean useMaximumAsInfinity;
+    private double realMax = -1;
 
     /**
      * @see #DecimalEncodedValueImpl(String, int, double, double, boolean, boolean, boolean, boolean)
@@ -75,6 +76,7 @@ public final class DecimalEncodedValueImpl extends IntEncodedValueImpl implement
                             @JsonProperty("bits") int bits,
                             @JsonProperty("min_value") int minValue,
                             @JsonProperty("max_value") int maxValue,
+                            @JsonProperty("real_max") double realMax,
                             @JsonProperty("negate_reverse_direction") boolean negateReverseDirection,
                             @JsonProperty("store_two_directions") boolean storeTwoDirections,
                             @JsonProperty("fwd_data_index") int fwdDataIndex,
@@ -91,6 +93,7 @@ public final class DecimalEncodedValueImpl extends IntEncodedValueImpl implement
         this.factor = factor;
         this.defaultIsInfinity = defaultIsInfinity;
         this.useMaximumAsInfinity = useMaximumAsInfinity;
+        this.realMax = realMax;
     }
 
     @Override
@@ -109,6 +112,8 @@ public final class DecimalEncodedValueImpl extends IntEncodedValueImpl implement
         }
         if (Double.isNaN(value))
             throw new IllegalArgumentException("NaN value for " + getName() + " not allowed!");
+
+        realMax = Math.max(realMax, value);
 
         value /= factor;
         if (value > maxValue)
@@ -152,5 +157,10 @@ public final class DecimalEncodedValueImpl extends IntEncodedValueImpl implement
     @Override
     public double getMinDecimal() {
         return minValue * factor;
+    }
+
+    @Override
+    public double getRealMax() {
+        return realMax;
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/weighting/CurvatureWeighting.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/CurvatureWeighting.java
@@ -47,7 +47,8 @@ public class CurvatureWeighting extends PriorityWeighting {
         curvatureEnc = flagEncoder.getDecimalEncodedValue(EncodingManager.getKey(flagEncoder, "curvature"));
         avSpeedEnc = flagEncoder.getDecimalEncodedValue(EncodingManager.getKey(flagEncoder, "average_speed"));
         double minBendiness = 1; // see correctErrors
-        minFactor = minBendiness / Math.log(flagEncoder.getMaxSpeed()) / PriorityCode.getValue(BEST.getValue());
+        double maxSpeed = avSpeedEnc.getRealMax() < 0 ? avSpeedEnc.getMaxDecimal() : avSpeedEnc.getRealMax();
+        minFactor = minBendiness / Math.log(maxSpeed) / PriorityCode.getValue(BEST.getValue());
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/weighting/FastestWeighting.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/FastestWeighting.java
@@ -62,7 +62,7 @@ public class FastestWeighting extends AbstractWeighting {
         super(encoder.getAccessEnc(), encoder.getAverageSpeedEnc(), turnCostProvider);
         headingPenalty = map.getDouble(Routing.HEADING_PENALTY, Routing.DEFAULT_HEADING_PENALTY);
         headingPenaltyMillis = Math.round(headingPenalty * 1000);
-        maxSpeed = encoder.getMaxSpeed() / SPEED_CONV;
+        maxSpeed = (speedEnc.getRealMax() < 0 ? speedEnc.getMaxDecimal() : speedEnc.getRealMax()) / SPEED_CONV;
 
         if (!encoder.hasEncodedValue(RoadAccess.KEY))
             throw new IllegalArgumentException("road_access is not available but expected for FastestWeighting");

--- a/core/src/main/java/com/graphhopper/routing/weighting/custom/CustomModelParser.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/custom/CustomModelParser.java
@@ -76,8 +76,9 @@ public class CustomModelParser {
         final String pKey = EncodingManager.getKey(baseFlagEncoder.toString(), "priority");
         DecimalEncodedValue priorityEnc = lookup.hasEncodedValue(pKey) ? lookup.getDecimalEncodedValue(pKey) : null;
 
+        double maxSpeed = avgSpeedEnc.getRealMax() < 0 ? avgSpeedEnc.getMaxDecimal() : avgSpeedEnc.getRealMax();
         CustomWeighting.Parameters parameters = createWeightingParameters(customModel, lookup,
-                avgSpeedEnc, baseFlagEncoder.getMaxSpeed(), priorityEnc);
+                avgSpeedEnc, maxSpeed, priorityEnc);
         return new CustomWeighting(baseFlagEncoder.getAccessEnc(), baseFlagEncoder.getAverageSpeedEnc(), turnCostProvider, parameters);
     }
 

--- a/core/src/test/java/com/graphhopper/GraphHopperTest.java
+++ b/core/src/test/java/com/graphhopper/GraphHopperTest.java
@@ -97,10 +97,10 @@ public class GraphHopperTest {
     @ParameterizedTest
     @CsvSource({
             DIJKSTRA + ",false,511",
-            ASTAR + ",false,444",
+            ASTAR + ",false,256",
             DIJKSTRA_BI + ",false,228",
-            ASTAR_BI + ",false,184",
-            ASTAR_BI + ",true,49",
+            ASTAR_BI + ",false,142",
+            ASTAR_BI + ",true,41",
             DIJKSTRA_BI + ",true,48"
     })
     public void testMonacoDifferentAlgorithms(String algo, boolean withCH, int expectedVisitedNodes) {
@@ -1577,9 +1577,9 @@ public class GraphHopperTest {
         hopper.importOrLoad();
 
         // flex
-        testCrossQueryAssert(profile1, hopper, 528.3, 166, true);
-        testCrossQueryAssert(profile2, hopper, 635.8, 160, true);
-        testCrossQueryAssert(profile3, hopper, 815.2, 158, true);
+        testCrossQueryAssert(profile1, hopper, 528.3, 138, true);
+        testCrossQueryAssert(profile2, hopper, 635.8, 138, true);
+        testCrossQueryAssert(profile3, hopper, 815.2, 140, true);
 
         // LM (should be the same as flex, but with less visited nodes!)
         testCrossQueryAssert(profile1, hopper, 528.3, 74, false);
@@ -1744,7 +1744,7 @@ public class GraphHopperTest {
 
         req.putHint(Landmark.DISABLE, true);
         res = hopper.route(req);
-        assertTrue(res.getHints().getInt("visited_nodes.sum", 0) > 200);
+        assertTrue(res.getHints().getInt("visited_nodes.sum", 0) > 170);
     }
 
     @ParameterizedTest

--- a/core/src/test/java/com/graphhopper/routing/ev/EncodedValueSerializerTest.java
+++ b/core/src/test/java/com/graphhopper/routing/ev/EncodedValueSerializerTest.java
@@ -76,7 +76,7 @@ class EncodedValueSerializerTest {
                 "\"min_value\":0,\"max_value\":7,\"negate_reverse_direction\":false,\"store_two_directions\":false," +
                 "\"fwd_data_index\":0,\"bwd_data_index\":0,\"fwd_shift\":0,\"bwd_shift\":-1,\"fwd_mask\":7,\"bwd_mask\":0}", serialized.get(0));
         assertEquals("{\"className\":\"com.graphhopper.routing.ev.DecimalEncodedValueImpl\",\"name\":\"max_width\",\"bits\":7," +
-                "\"min_value\":0,\"max_value\":127,\"negate_reverse_direction\":false,\"store_two_directions\":false," +
+                "\"min_value\":0,\"max_value\":127,\"real_max\":-1.0,\"negate_reverse_direction\":false,\"store_two_directions\":false," +
                 "\"fwd_data_index\":0,\"bwd_data_index\":0,\"fwd_shift\":3,\"bwd_shift\":-1,\"fwd_mask\":1016,\"bwd_mask\":0," +
                 "\"factor\":0.1,\"default_is_infinity\":true,\"use_maximum_as_infinity\":false}", serialized.get(1));
         assertEquals("{\"className\":\"com.graphhopper.routing.ev.SimpleBooleanEncodedValue\",\"name\":\"get_off_bike\",\"bits\":1," +

--- a/core/src/test/java/com/graphhopper/routing/lm/LMApproximatorTest.java
+++ b/core/src/test/java/com/graphhopper/routing/lm/LMApproximatorTest.java
@@ -29,14 +29,12 @@ import com.graphhopper.storage.RAMDirectory;
 import com.graphhopper.util.EdgeIterator;
 import com.graphhopper.util.GHUtility;
 import com.graphhopper.util.PMap;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.RepeatedTest;
 
 import java.util.Random;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@Disabled("todonow")
 public class LMApproximatorTest {
 
     @RepeatedTest(value = 10)

--- a/core/src/test/java/com/graphhopper/routing/lm/LMApproximatorTest.java
+++ b/core/src/test/java/com/graphhopper/routing/lm/LMApproximatorTest.java
@@ -29,12 +29,14 @@ import com.graphhopper.storage.RAMDirectory;
 import com.graphhopper.util.EdgeIterator;
 import com.graphhopper.util.GHUtility;
 import com.graphhopper.util.PMap;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.RepeatedTest;
 
 import java.util.Random;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@Disabled("todonow")
 public class LMApproximatorTest {
 
     @RepeatedTest(value = 10)

--- a/core/src/test/java/com/graphhopper/routing/lm/PrepareLandmarksTest.java
+++ b/core/src/test/java/com/graphhopper/routing/lm/PrepareLandmarksTest.java
@@ -156,7 +156,7 @@ public class PrepareLandmarksTest {
 
         assertEquals(expectedPath.getWeight(), path.getWeight(), .1);
         assertEquals(expectedPath.calcNodes(), path.calcNodes());
-        assertEquals(expectedAlgo.getVisitedNodes() - 135, oneDirAlgoWithLandmarks.getVisitedNodes());
+        assertEquals(expectedAlgo.getVisitedNodes() - 72, oneDirAlgoWithLandmarks.getVisitedNodes());
 
         // landmarks with bidir A*
         RoutingAlgorithm biDirAlgoWithLandmarks = new LMRoutingAlgorithmFactory(lms).createAlgo(graph, weighting,
@@ -164,7 +164,7 @@ public class PrepareLandmarksTest {
         path = biDirAlgoWithLandmarks.calcPath(41, 183);
         assertEquals(expectedPath.getWeight(), path.getWeight(), .1);
         assertEquals(expectedPath.calcNodes(), path.calcNodes());
-        assertEquals(expectedAlgo.getVisitedNodes() - 162, biDirAlgoWithLandmarks.getVisitedNodes());
+        assertEquals(expectedAlgo.getVisitedNodes() - 99, biDirAlgoWithLandmarks.getVisitedNodes());
 
         // landmarks with A* and a QueryGraph. We expect slightly less optimal as two more cycles needs to be traversed
         // due to the two more virtual nodes but this should not harm in practise
@@ -179,7 +179,7 @@ public class PrepareLandmarksTest {
         expectedPath = expectedAlgo.calcPath(fromSnap.getClosestNode(), toSnap.getClosestNode());
         assertEquals(expectedPath.getWeight(), path.getWeight(), .1);
         assertEquals(expectedPath.calcNodes(), path.calcNodes());
-        assertEquals(expectedAlgo.getVisitedNodes() - 135, qGraphOneDirAlgo.getVisitedNodes());
+        assertEquals(expectedAlgo.getVisitedNodes() - 72, qGraphOneDirAlgo.getVisitedNodes());
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/routing/weighting/FastestWeightingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/FastestWeightingTest.java
@@ -45,8 +45,8 @@ public class FastestWeightingTest {
 
     @Test
     public void testMinWeightHasSameUnitAs_getWeight() {
-        Weighting instance = new FastestWeighting(encoder);
         IntsRef flags = GHUtility.setSpeed(encoder.getMaxSpeed(), 0, encoder.getAccessEnc(), encoder.getAverageSpeedEnc(), encodingManager.createEdgeFlags());
+        Weighting instance = new FastestWeighting(encoder);
         assertEquals(instance.getMinWeight(10), instance.calcEdgeWeight(createMockedEdgeIteratorState(10, flags), false), 1e-8);
     }
 

--- a/core/src/test/java/com/graphhopper/routing/weighting/custom/CustomWeightingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/custom/CustomWeightingTest.java
@@ -248,8 +248,8 @@ class CustomWeightingTest {
                 addToSpeed(If("true", LIMIT, "72")).setDistanceInfluence(0)).getMinWeight(1000));
 
         // ignore too big limit to let custom model compatibility not break when max speed of encoder later decreases
-        assertEquals(1000.0 / 140 * 3.6, createWeighting(new CustomModel().
-                addToSpeed(If("true", LIMIT, "150")).setDistanceInfluence(0)).getMinWeight(1000));
+        assertEquals(1000.0 / 155 * 3.6, createWeighting(new CustomModel().
+                addToSpeed(If("true", LIMIT, "180")).setDistanceInfluence(0)).getMinWeight(1000));
 
         // a speed bigger than the allowed stored speed is fine, see discussion in #2335
         assertEquals(1000.0 / 150 * 3.6, createWeighting(new CustomModel().
@@ -259,27 +259,28 @@ class CustomWeightingTest {
 
     @Test
     public void testMaxPriority() {
-        assertEquals(1000.0 / 140 / 0.5 * 3.6, createWeighting(new CustomModel().
-                addToPriority(If("true", MULTIPLY, "0.5")).setDistanceInfluence(0)).getMinWeight(1000));
+        double maxSpeed = 155;
+        assertEquals(1000.0 / maxSpeed / 0.5 * 3.6, createWeighting(new CustomModel().
+                addToPriority(If("true", MULTIPLY, "0.5")).setDistanceInfluence(0)).getMinWeight(1000), 1.e-6);
 
         // ignore too big limit
-        assertEquals(1000.0 / 140 / 1.0 * 3.6, createWeighting(new CustomModel().
-                addToPriority(If("true", LIMIT, "2.0")).setDistanceInfluence(0)).getMinWeight(1000));
+        assertEquals(1000.0 / maxSpeed / 1.0 * 3.6, createWeighting(new CustomModel().
+                addToPriority(If("true", LIMIT, "2.0")).setDistanceInfluence(0)).getMinWeight(1000), 1.e-6);
 
         // priority bigger 1 is fine (if CustomModel not in query)
-        assertEquals(1000.0 / 140 / 2.0 * 3.6, createWeighting(new CustomModel().
+        assertEquals(1000.0 / maxSpeed / 2.0 * 3.6, createWeighting(new CustomModel().
                 addToPriority(If("true", MULTIPLY, "3.0")).
-                addToPriority(If("true", LIMIT, "2.0")).setDistanceInfluence(0)).getMinWeight(1000));
-        assertEquals(1000.0 / 140 / 1.5 * 3.6, createWeighting(new CustomModel().
-                addToPriority(If("true", MULTIPLY, "1.5")).setDistanceInfluence(0)).getMinWeight(1000));
+                addToPriority(If("true", LIMIT, "2.0")).setDistanceInfluence(0)).getMinWeight(1000), 1.e-6);
+        assertEquals(1000.0 / maxSpeed / 1.5 * 3.6, createWeighting(new CustomModel().
+                addToPriority(If("true", MULTIPLY, "1.5")).setDistanceInfluence(0)).getMinWeight(1000), 1.e-6);
 
         // pick maximum priority from value even if this is for a special case
-        assertEquals(1000.0 / 140 / 3.0 * 3.6, createWeighting(new CustomModel().
-                addToPriority(If("road_class == SERVICE", MULTIPLY, "3.0")).setDistanceInfluence(0)).getMinWeight(1000));
+        assertEquals(1000.0 / maxSpeed / 3.0 * 3.6, createWeighting(new CustomModel().
+                addToPriority(If("road_class == SERVICE", MULTIPLY, "3.0")).setDistanceInfluence(0)).getMinWeight(1000), 1.e-6);
 
         // do NOT pick maximum priority when it is for a special case
-        assertEquals(1000.0 / 140 / 1.0 * 3.6, createWeighting(new CustomModel().
-                addToPriority(If("road_class == SERVICE", MULTIPLY, "0.5")).setDistanceInfluence(0)).getMinWeight(1000));
+        assertEquals(1000.0 / maxSpeed / 1.0 * 3.6, createWeighting(new CustomModel().
+                addToPriority(If("road_class == SERVICE", MULTIPLY, "0.5")).setDistanceInfluence(0)).getMinWeight(1000), 1.e-6);
     }
 
     @Test


### PR DESCRIPTION
Before #2561 we used hard-coded maximum speeds for `FlagEncoder#getMaxSpeed()` and used this for `Weighting#getMinWeight()` (which is needed for the A* beeline heuristic). The maximum speeds were also used to limit the speed during the (OSM) import. Since #2561 the import is separated from the flag encoders so the maximum speed actually appears in two places: the `VehicleTagParser`s for the import and the `FlagEncoder` for the weighting/routing. However, in reality the maximum speed is determined by the import anyway, so we can just store the maximum speed and use it later for the routing.

So the idea is to maintain a 'maxValue' field in each numerical encoded value that gets flushed to disk along with the graph so it can be used later. This allows us to replace `flagEncoder.getMaxSpeed()` with something like `flagEncoder.getAverageSpeedEnc().getMax()` and work towards #2463.