### PR TITLE
Update custom model editor: validation + auto-complete for rhs expressions

### DIFF
--- a/web-bundle/package.json
+++ b/web-bundle/package.json
@@ -25,7 +25,7 @@
     }
   },
   "dependencies": {
-    "custom-model-editor": "github:graphhopper/custom-model-editor#804566f0b11add4688692499fee95d1f1ac3a02d",
+    "custom-model-editor": "github:graphhopper/custom-model-editor#a8c97e4ef8e76c963be375984a3c08ff3c1e8288",
     "flatpickr": "4.4.6",
     "jquery": "3.5.0",
     "leaflet": "1.5.1",


### PR DESCRIPTION
This adds support for the new right-hand side expressions for the `limit_to` and `multiply_by` operators in custom models that we introduced in #2568.
The auto-complete suggestions include all numeric encoded values and simple arithmetic expressions like `50 + car_average_speed * 0.9` are allowed. Only `+`,`-` and `*` and only one encoded value per expression is allowed.

![image](https://user-images.githubusercontent.com/17603532/176416950-c73cf7bc-6864-4af5-a773-cb7230df77d6.png)

@karussell can you try this?