### PR TITLE
Maps: Add slope detail to elevation diagram

### DIFF
--- a/web-bundle/src/main/resources/com/graphhopper/maps/js/map.js
+++ b/web-bundle/src/main/resources/com/graphhopper/maps/js/map.js
@@ -304,7 +304,6 @@ module.exports.addElevation = function (geoJsonFeature, details, selectedDetail,
             selectedDetailIdx = detailIdx;
         GHFeatureCollection.push(sliceFeatureCollection(details[detailKey], detailKey, geoJsonFeature));
         options.mappings[detailKey] = getColorMapping(details[detailKey]);
-
     }
 
     // always show elevation and slope
@@ -324,13 +323,13 @@ module.exports.addElevation = function (geoJsonFeature, details, selectedDetail,
             selectedDetailIdx = detailIdx;
         GHFeatureCollection.push(elevationCollection);
         // Use a fixed color for elevation
-        options.mappings = {Elevation: {'elevation': {text: 'Elevation [m]', color: '#27ce49'}}};
+        options.mappings['Elevation'] = {'elevation': {text: 'Elevation [m]', color: '#27ce49'}};
 
         var slopeFeatures = [];
         for (var i = 0; i < geoJsonFeature.geometry.coordinates.length - 1; i++) {
             var from = geoJsonFeature.geometry.coordinates[i];
             var to = geoJsonFeature.geometry.coordinates[i + 1];
-            var distance = L.latLng(from[1], from[0]).distanceTo(L.latLng(to[1], to[0]));
+            var distance = getDist(from, to);
             var slope = 100.0 * (to[2] - from[2]) / distance;
             slopeFeatures.push({
                 "type": "Feature",
@@ -355,20 +354,58 @@ module.exports.addElevation = function (geoJsonFeature, details, selectedDetail,
         if (selectedDetail === 'Slope')
             selectedDetailIdx = detailIdx;
         GHFeatureCollection.push(slopeCollection);
-        options.mappings["Slope"] = slope => {
-            var colorMin = [0, 153, 247];
-            var colorMax = [241, 23, 18];
-            var absSlope = Math.abs(slope);
-            absSlope = Math.min(25, absSlope);
-            var factor = absSlope / 25;
-            var color = [];
-            for (var i = 0; i < 3; i++)
-                color.push(colorMin[i] + factor * (colorMax[i] - colorMin[i]));
-            return {
-                text: slope.toFixed(2),
-                color: 'rgb(' + color[0] + ', ' + color[1] + ', ' + color[2] + ')'
+        options.mappings["Slope"] = slope2color;
+
+        // tower slope: slope between tower nodes: use edge_id detail to find tower nodes
+        if (details['edge_id']) {
+            var detail = details['edge_id'];
+            var towerSlopeFeatures = [];
+            var points = geoJsonFeature.geometry.coordinates;
+            for (var i = 0; i < detail.length; i++) {
+                var featurePoints = points.slice(detail[i][0], detail[i][1] + 1);
+                var from = featurePoints[0];
+                var to = featurePoints[featurePoints.length - 1];
+                var distance = getDist(from, to);
+                var slope = 100.0 * (to[2] - from[2]) / distance;
+                // for the elevations in tower slope diagram we do linear interpolation between the tower nodes. note that
+                // we cannot simply leave out the pillar nodes, because otherwise the total distance would change
+                var tmpDistance = 0;
+                for (var j = 0; j < featurePoints.length; j++) {
+                    var factor = tmpDistance / distance;
+                    var ele = from[2] + factor * (to[2] - from[2]);
+                    if (j === featurePoints.length - 1)
+                        // there seem to be some small rounding errors which lead to ugly little spikes in the diagram,
+                        // so for the last point use the elevation of the to point directly
+                        ele = to[2];
+                    featurePoints[j] = [featurePoints[j][0], featurePoints[j][1], ele];
+                    if (j < featurePoints.length - 1)
+                        tmpDistance += getDist(featurePoints[j], featurePoints[j + 1]);
+                }
+                towerSlopeFeatures.push({
+                    "type": "Feature",
+                    "geometry": {
+                        "type": "LineString",
+                        "coordinates": featurePoints
+                    },
+                    "properties": {
+                        "attributeType": slope
+                    }
+                });
             }
-        };
+            var towerSlopeCollection = {
+                "type": "FeatureCollection",
+                "features": towerSlopeFeatures,
+                "properties": {
+                    "records": towerSlopeFeatures.length,
+                    "summary": "Towerslope"
+                }
+            };
+            detailIdx++;
+            if (selectedDetail === 'Towerslope')
+                selectedDetailIdx = detailIdx;
+            GHFeatureCollection.push(towerSlopeCollection);
+            options.mappings["Towerslope"] = slope2color;
+        }
     }
 
     if (selectedDetailIdx >= 0)
@@ -381,6 +418,25 @@ module.exports.addElevation = function (geoJsonFeature, details, selectedDetail,
 
     elevationControl.addData(GHFeatureCollection);
 };
+
+function getDist(p, q) {
+    return L.latLng(p[1], p[0]).distanceTo(L.latLng(q[1], q[0]));
+}
+
+function slope2color(slope) {
+    var colorMin = [0, 153, 247];
+    var colorMax = [241, 23, 18];
+    var absSlope = Math.abs(slope);
+    absSlope = Math.min(25, absSlope);
+    var factor = absSlope / 25;
+    var color = [];
+    for (var i = 0; i < 3; i++)
+        color.push(colorMin[i] + factor * (colorMax[i] - colorMin[i]));
+    return {
+        text: slope.toFixed(2),
+        color: 'rgb(' + color[0] + ', ' + color[1] + ', ' + color[2] + ')'
+    }
+}
 
 function getColorMapping(detail) {
     var detailInfo = analyzeDetail(detail);


### PR DESCRIPTION
I added two elevation diagram details: 'Slope' shows the slope of every path segment (between pillar nodes) and 'Towerslope' shows the slope between tower nodes only. Both are calculated on the client-side from the point list. 'Slope' is always shown and 'Towerslope' is only shown when the `edge_id` detail is enabled (because this is needed to calculate 'Towerslope' and both can be considered debug features). For 'Towerslope' I also adjusted the elevations (skipped those of the tower nodes so the diagram matches the slope values):

![image](https://user-images.githubusercontent.com/17603532/187022405-1fdf0664-ee74-4cb0-893f-5818596c59d1.png)
![image](https://user-images.githubusercontent.com/17603532/187022443-5946a39d-55bd-4b1a-9ffc-086b14caf501.png)

The colors indicate the absolute slope value (e.g. -5 is the same color as +5) and the spectrum ranges from 0 (blue) to 25 (red).




