### PR TITLE
Support ";" access delimiter for car access.

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/CarTagParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/CarTagParser.java
@@ -195,10 +195,14 @@ public class CarTagParser extends VehicleTagParser {
 
         // multiple restrictions needs special handling compared to foot and bike, see also motorcycle
         if (!firstValue.isEmpty()) {
-            if (restrictedValues.contains(firstValue) && !getConditionalTagInspector().isRestrictedWayConditionallyPermitted(way))
-                return WayAccess.CAN_SKIP;
-            if (intendedValues.contains(firstValue))
-                return WayAccess.WAY;
+            String[] restrict = firstValue.split(";");
+            boolean notConditionalyPermitted = !getConditionalTagInspector().isRestrictedWayConditionallyPermitted(way);
+            for (String value: restrict) {
+                if (restrictedValues.contains(value) && notConditionalyPermitted)
+                    return WayAccess.CAN_SKIP;
+                if (intendedValues.contains(value))
+                    return WayAccess.WAY;
+            }
         }
 
         // do not drive street cars into fords

--- a/core/src/test/java/com/graphhopper/routing/util/CarTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/CarTagParserTest.java
@@ -112,6 +112,19 @@ public class CarTagParserTest {
         assertTrue(parser.getAccess(way).canSkip());
 
         way.clearTags();
+        way.setTag("highway", "track");
+        way.setTag("motor_vehicle", "agricultural");
+        assertTrue(parser.getAccess(way).canSkip());
+        way.setTag("motor_vehicle", "agricultural;forestry");
+        assertTrue(parser.getAccess(way).canSkip());
+        way.setTag("motor_vehicle", "forestry;agricultural");
+        assertTrue(parser.getAccess(way).canSkip());
+        way.setTag("motor_vehicle", "forestry;agricultural;unknown");
+        assertTrue(parser.getAccess(way).canSkip());
+        way.setTag("motor_vehicle", "yes;forestry;agricultural");
+        assertTrue(parser.getAccess(way).isWay());
+
+        way.clearTags();
         way.setTag("highway", "service");
         way.setTag("access", "no");
         way.setTag("motorcar", "yes");


### PR DESCRIPTION
One example is motor_vehicle = agricultural;forestry

Triggered by discussion in https://forum.openstreetmap.org/viewtopic.php?id=74612