### PR TITLE
Remove VehicleTagParser#applyWayTags

### DIFF
--- a/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
+++ b/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
@@ -341,7 +341,6 @@ public class OSMReader {
         IntsRef relationFlags = getRelFlagsMap(way.getId());
         IntsRef edgeFlags = encodingManager.createEdgeFlags();
         edgeFlags = osmParsers.handleWayTags(edgeFlags, way, relationFlags);
-        osmParsers.applyWayTags(way, edgeFlags, way.getTag("point_list", null), way.getTag("edge_distance", 0d));
         if (edgeFlags.isEmpty())
             return;
 

--- a/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
+++ b/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
@@ -357,7 +357,9 @@ public class OSMReader {
             checkCoordinates(toIndex, pointList.get(pointList.size() - 1));
             edge.setWayGeometry(pointList.shallowCopy(1, pointList.size() - 1, false));
         }
-        osmParsers.applyWayTags(way, edge);
+        edgeFlags = edge.getFlags();
+        osmParsers.applyWayTags(way, edgeFlags, edge.fetchWayGeometry(FetchMode.ALL), edge.getDistance());
+        edge.setFlags(edgeFlags);
 
         checkDistance(edge);
         if (osmWayIdSet.contains(way.getId())) {

--- a/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
+++ b/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
@@ -341,6 +341,7 @@ public class OSMReader {
         IntsRef relationFlags = getRelFlagsMap(way.getId());
         IntsRef edgeFlags = encodingManager.createEdgeFlags();
         edgeFlags = osmParsers.handleWayTags(edgeFlags, way, relationFlags);
+        osmParsers.applyWayTags(way, edgeFlags, way.getTag("point_list", null), way.getTag("edge_distance", 0d));
         if (edgeFlags.isEmpty())
             return;
 
@@ -357,9 +358,6 @@ public class OSMReader {
             checkCoordinates(toIndex, pointList.get(pointList.size() - 1));
             edge.setWayGeometry(pointList.shallowCopy(1, pointList.size() - 1, false));
         }
-        edgeFlags = edge.getFlags();
-        osmParsers.applyWayTags(way, edgeFlags, edge.fetchWayGeometry(FetchMode.ALL), edge.getDistance());
-        edge.setFlags(edgeFlags);
 
         checkDistance(edge);
         if (osmWayIdSet.contains(way.getId())) {

--- a/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
+++ b/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
@@ -43,7 +43,6 @@ import com.graphhopper.storage.TurnCostStorage;
 import com.graphhopper.util.*;
 import com.graphhopper.util.shapes.GHPoint;
 import com.graphhopper.util.shapes.GHPoint3D;
-import org.locationtech.jts.geom.Polygon;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/core/src/main/java/com/graphhopper/routing/util/Bike2WeightTagParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/Bike2WeightTagParser.java
@@ -60,10 +60,13 @@ public class Bike2WeightTagParser extends BikeTagParser {
     @Override
     public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay way) {
         edgeFlags = super.handleWayTags(edgeFlags, way);
-        return applyWayTags(way, edgeFlags, way.getTag("point_list", null), way.getTag("edge_distance", 0d));
+        return applyWayTags(way, edgeFlags);
     }
 
-    public IntsRef applyWayTags(ReaderWay way, IntsRef intsRef, PointList pl, double distance) {
+    public IntsRef applyWayTags(ReaderWay way, IntsRef intsRef) {
+        PointList pl = way.getTag("point_list", null);
+        if (pl == null)
+            throw new IllegalArgumentException("The artificial point_list tag is missing");
         if (!pl.is3D())
             throw new IllegalStateException(getName() + " requires elevation data to improve speed calculation based on it. Please enable it in config via e.g. graph.elevation.provider: srtm");
 
@@ -78,7 +81,9 @@ public class Bike2WeightTagParser extends BikeTagParser {
         double incEleSum = 0, incDist2DSum = 0, decEleSum = 0, decDist2DSum = 0;
         // double prevLat = pl.getLat(0), prevLon = pl.getLon(0);
         double prevEle = pl.getEle(0);
-        double fullDist2D = distance;
+        if (!way.hasTag("edge_distance"))
+            throw new IllegalArgumentException("The artificial edge_distance tag is missing");
+        double fullDist2D = way.getTag("edge_distance", 0d);
 
         // for short edges an incline makes no sense and for 0 distances could lead to NaN values for speed, see #432
         if (fullDist2D < 2)

--- a/core/src/main/java/com/graphhopper/routing/util/Bike2WeightTagParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/Bike2WeightTagParser.java
@@ -20,8 +20,6 @@ package com.graphhopper.routing.util;
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.*;
 import com.graphhopper.storage.IntsRef;
-import com.graphhopper.util.EdgeIteratorState;
-import com.graphhopper.util.FetchMode;
 import com.graphhopper.util.PMap;
 import com.graphhopper.util.PointList;
 

--- a/core/src/main/java/com/graphhopper/routing/util/Bike2WeightTagParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/Bike2WeightTagParser.java
@@ -58,6 +58,11 @@ public class Bike2WeightTagParser extends BikeTagParser {
     }
 
     @Override
+    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay way) {
+        edgeFlags = super.handleWayTags(edgeFlags, way);
+        return applyWayTags(way, edgeFlags, way.getTag("point_list", null), way.getTag("edge_distance", 0d));
+    }
+
     public IntsRef applyWayTags(ReaderWay way, IntsRef intsRef, PointList pl, double distance) {
         if (!pl.is3D())
             throw new IllegalStateException(getName() + " requires elevation data to improve speed calculation based on it. Please enable it in config via e.g. graph.elevation.provider: srtm");

--- a/core/src/main/java/com/graphhopper/routing/util/HikeTagParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/HikeTagParser.java
@@ -90,10 +90,13 @@ public class HikeTagParser extends FootTagParser {
     @Override
     public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay way) {
         edgeFlags = super.handleWayTags(edgeFlags, way);
-        return applyWayTags(way, edgeFlags, way.getTag("point_list", null), way.getTag("edge_distance", 0d));
+        return applyWayTags(way, edgeFlags);
     }
 
-    public IntsRef applyWayTags(ReaderWay way, IntsRef edgeFlags, PointList pl, double distance) {
+    public IntsRef applyWayTags(ReaderWay way, IntsRef edgeFlags) {
+        PointList pl = way.getTag("point_list", null);
+        if (pl == null)
+            throw new IllegalArgumentException("The artificial point_list tag is missing");
         if (!pl.is3D())
             return edgeFlags;
 
@@ -104,7 +107,9 @@ public class HikeTagParser extends FootTagParser {
 
         // Decrease the speed for ele increase (incline), and slightly decrease the speed for ele decrease (decline)
         double prevEle = pl.getEle(0);
-        double fullDistance = distance;
+        if (!way.hasTag("edge_distance"))
+            throw new IllegalArgumentException("The artificial edge_distance tag is missing");
+        double fullDistance = way.getTag("edge_distance", 0d);
 
         // for short edges an incline makes no sense and for 0 distances could lead to NaN values for speed, see #432
         if (fullDistance < 2)

--- a/core/src/main/java/com/graphhopper/routing/util/HikeTagParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/HikeTagParser.java
@@ -20,7 +20,9 @@ package com.graphhopper.routing.util;
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.*;
 import com.graphhopper.storage.IntsRef;
-import com.graphhopper.util.*;
+import com.graphhopper.util.Helper;
+import com.graphhopper.util.PMap;
+import com.graphhopper.util.PointList;
 
 import java.util.TreeMap;
 

--- a/core/src/main/java/com/graphhopper/routing/util/HikeTagParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/HikeTagParser.java
@@ -87,8 +87,12 @@ public class HikeTagParser extends FootTagParser {
             weightToPrioMap.put(44d, SLIGHT_AVOID.getValue());
     }
 
-
     @Override
+    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay way) {
+        edgeFlags = super.handleWayTags(edgeFlags, way);
+        return applyWayTags(way, edgeFlags, way.getTag("point_list", null), way.getTag("edge_distance", 0d));
+    }
+
     public IntsRef applyWayTags(ReaderWay way, IntsRef edgeFlags, PointList pl, double distance) {
         if (!pl.is3D())
             return edgeFlags;

--- a/core/src/main/java/com/graphhopper/routing/util/OSMParsers.java
+++ b/core/src/main/java/com/graphhopper/routing/util/OSMParsers.java
@@ -28,8 +28,6 @@ import com.graphhopper.routing.util.parsers.TagParser;
 import com.graphhopper.routing.util.parsers.TurnCostParser;
 import com.graphhopper.storage.Graph;
 import com.graphhopper.storage.IntsRef;
-import com.graphhopper.util.EdgeIteratorState;
-import com.graphhopper.util.PointList;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/core/src/main/java/com/graphhopper/routing/util/OSMParsers.java
+++ b/core/src/main/java/com/graphhopper/routing/util/OSMParsers.java
@@ -91,13 +91,11 @@ public class OSMParsers {
             relParser.handleWayTags(edgeFlags, way, relationFlags);
         for (TagParser parser : wayTagParsers)
             parser.handleWayTags(edgeFlags, way, relationFlags);
-        for (VehicleTagParser vehicleTagParser : vehicleTagParsers)
+        for (VehicleTagParser vehicleTagParser : vehicleTagParsers) {
             vehicleTagParser.handleWayTags(edgeFlags, way, relationFlags);
+            vehicleTagParser.applyWayTags(way, edgeFlags, way.getTag("point_list", null), way.getTag("edge_distance", 0d));
+        }
         return edgeFlags;
-    }
-
-    public void applyWayTags(ReaderWay way, IntsRef edgeFlags, PointList pointList, double distance) {
-        vehicleTagParsers.forEach(t -> t.applyWayTags(way, edgeFlags, pointList, distance));
     }
 
     public void handleTurnRelationTags(OSMTurnRelation turnRelation, TurnCostParser.ExternalInternalMap map, Graph graph) {

--- a/core/src/main/java/com/graphhopper/routing/util/OSMParsers.java
+++ b/core/src/main/java/com/graphhopper/routing/util/OSMParsers.java
@@ -91,10 +91,8 @@ public class OSMParsers {
             relParser.handleWayTags(edgeFlags, way, relationFlags);
         for (TagParser parser : wayTagParsers)
             parser.handleWayTags(edgeFlags, way, relationFlags);
-        for (VehicleTagParser vehicleTagParser : vehicleTagParsers) {
+        for (VehicleTagParser vehicleTagParser : vehicleTagParsers)
             vehicleTagParser.handleWayTags(edgeFlags, way, relationFlags);
-            vehicleTagParser.applyWayTags(way, edgeFlags, way.getTag("point_list", null), way.getTag("edge_distance", 0d));
-        }
         return edgeFlags;
     }
 

--- a/core/src/main/java/com/graphhopper/routing/util/OSMParsers.java
+++ b/core/src/main/java/com/graphhopper/routing/util/OSMParsers.java
@@ -29,6 +29,7 @@ import com.graphhopper.routing.util.parsers.TurnCostParser;
 import com.graphhopper.storage.Graph;
 import com.graphhopper.storage.IntsRef;
 import com.graphhopper.util.EdgeIteratorState;
+import com.graphhopper.util.PointList;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -95,8 +96,8 @@ public class OSMParsers {
         return edgeFlags;
     }
 
-    public void applyWayTags(ReaderWay way, EdgeIteratorState edge) {
-        vehicleTagParsers.forEach(t -> t.applyWayTags(way, edge));
+    public void applyWayTags(ReaderWay way, IntsRef edgeFlags, PointList pointList, double distance) {
+        vehicleTagParsers.forEach(t -> t.applyWayTags(way, edgeFlags, pointList, distance));
     }
 
     public void handleTurnRelationTags(OSMTurnRelation turnRelation, TurnCostParser.ExternalInternalMap map, Graph graph) {

--- a/core/src/main/java/com/graphhopper/routing/util/VehicleTagParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/VehicleTagParser.java
@@ -200,14 +200,6 @@ public abstract class VehicleTagParser implements TagParser {
         return !Double.isNaN(speed);
     }
 
-    /**
-     * Second parsing step. Invoked after splitting the edges. Currently used to offer a hook to
-     * calculate precise speed values based on elevation data stored in the specified edge.
-     */
-    public IntsRef applyWayTags(ReaderWay way, IntsRef edgeFlags, PointList pointList, double distance) {
-        return edgeFlags;
-    }
-
     public final DecimalEncodedValue getAverageSpeedEnc() {
         return avgSpeedEnc;
     }

--- a/core/src/main/java/com/graphhopper/routing/util/VehicleTagParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/VehicleTagParser.java
@@ -28,8 +28,6 @@ import com.graphhopper.routing.util.parsers.OSMRoadAccessParser;
 import com.graphhopper.routing.util.parsers.TagParser;
 import com.graphhopper.routing.util.parsers.helpers.OSMValueExtractor;
 import com.graphhopper.storage.IntsRef;
-import com.graphhopper.util.EdgeIteratorState;
-import com.graphhopper.util.PointList;
 
 import java.util.*;
 

--- a/core/src/main/java/com/graphhopper/routing/util/VehicleTagParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/VehicleTagParser.java
@@ -29,6 +29,7 @@ import com.graphhopper.routing.util.parsers.TagParser;
 import com.graphhopper.routing.util.parsers.helpers.OSMValueExtractor;
 import com.graphhopper.storage.IntsRef;
 import com.graphhopper.util.EdgeIteratorState;
+import com.graphhopper.util.PointList;
 
 import java.util.*;
 
@@ -203,7 +204,8 @@ public abstract class VehicleTagParser implements TagParser {
      * Second parsing step. Invoked after splitting the edges. Currently used to offer a hook to
      * calculate precise speed values based on elevation data stored in the specified edge.
      */
-    public void applyWayTags(ReaderWay way, EdgeIteratorState edge) {
+    public IntsRef applyWayTags(ReaderWay way, IntsRef edgeFlags, PointList pointList, double distance) {
+        return edgeFlags;
     }
 
     public final DecimalEncodedValue getAverageSpeedEnc() {

--- a/core/src/main/java/com/graphhopper/routing/util/WheelchairTagParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/WheelchairTagParser.java
@@ -20,8 +20,6 @@ package com.graphhopper.routing.util;
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.*;
 import com.graphhopper.storage.IntsRef;
-import com.graphhopper.util.EdgeIteratorState;
-import com.graphhopper.util.FetchMode;
 import com.graphhopper.util.PMap;
 import com.graphhopper.util.PointList;
 

--- a/core/src/main/java/com/graphhopper/routing/util/WheelchairTagParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/WheelchairTagParser.java
@@ -180,6 +180,8 @@ public class WheelchairTagParser extends FootTagParser {
 
         Integer priorityFromRelation = routeMap.get(footRouteEnc.getEnum(false, edgeFlags));
         priorityWayEncoder.setDecimal(false, edgeFlags, PriorityCode.getValue(handlePriority(way, priorityFromRelation)));
+
+        edgeFlags = applyWayTags(way, edgeFlags, way.getTag("point_list", null), way.getTag("edge_distance", 0d));
         return edgeFlags;
     }
 
@@ -188,7 +190,6 @@ public class WheelchairTagParser extends FootTagParser {
      * and maxInclinePercent will reduce speed to SLOW_SPEED. In-/declines above maxInclinePercent will result in zero
      * speed.
      */
-    @Override
     public IntsRef applyWayTags(ReaderWay way, IntsRef edgeFlags, PointList pl, double distance) {
         double fullDist2D = distance;
         if (Double.isInfinite(fullDist2D))

--- a/core/src/main/java/com/graphhopper/routing/util/WheelchairTagParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/WheelchairTagParser.java
@@ -181,7 +181,7 @@ public class WheelchairTagParser extends FootTagParser {
         Integer priorityFromRelation = routeMap.get(footRouteEnc.getEnum(false, edgeFlags));
         priorityWayEncoder.setDecimal(false, edgeFlags, PriorityCode.getValue(handlePriority(way, priorityFromRelation)));
 
-        edgeFlags = applyWayTags(way, edgeFlags, way.getTag("point_list", null), way.getTag("edge_distance", 0d));
+        edgeFlags = applyWayTags(way, edgeFlags);
         return edgeFlags;
     }
 
@@ -190,8 +190,13 @@ public class WheelchairTagParser extends FootTagParser {
      * and maxInclinePercent will reduce speed to SLOW_SPEED. In-/declines above maxInclinePercent will result in zero
      * speed.
      */
-    public IntsRef applyWayTags(ReaderWay way, IntsRef edgeFlags, PointList pl, double distance) {
-        double fullDist2D = distance;
+    public IntsRef applyWayTags(ReaderWay way, IntsRef edgeFlags) {
+        PointList pl = way.getTag("point_list", null);
+        if (pl == null)
+            throw new IllegalArgumentException("The artificial point_list tag is missing");
+        if (!way.hasTag("edge_distance"))
+            throw new IllegalArgumentException("The artificial edge_distance tag is missing");
+        double fullDist2D = way.getTag("edge_distance", 0d);
         if (Double.isInfinite(fullDist2D))
             throw new IllegalStateException("Infinite distance should not happen due to #435. way ID=" + way.getId());
 

--- a/core/src/test/java/com/graphhopper/routing/util/Bike2WeightTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/Bike2WeightTagParserTest.java
@@ -75,7 +75,7 @@ public class Bike2WeightTagParserTest extends BikeTagParserTest {
         Graph graph = initExampleGraph();
         EdgeIteratorState edge = GHUtility.getEdge(graph, 0, 1);
         ReaderWay way = new ReaderWay(1);
-        edge.setFlags(parser.applyWayTags(way, edge.getFlags(), edge.fetchWayGeometry(FetchMode.ALL), edge.getDistance()));
+        edge.setFlags(((Bike2WeightTagParser) parser).applyWayTags(way, edge.getFlags(), edge.fetchWayGeometry(FetchMode.ALL), edge.getDistance()));
 
         IntsRef flags = edge.getFlags();
         // decrease speed
@@ -91,7 +91,7 @@ public class Bike2WeightTagParserTest extends BikeTagParserTest {
         IntsRef oldFlags = IntsRef.deepCopyOf(edge.getFlags());
         ReaderWay way = new ReaderWay(1);
         way.setTag("highway", "steps");
-        edge.setFlags(parser.applyWayTags(way, edge.getFlags(), edge.fetchWayGeometry(FetchMode.ALL), edge.getDistance()));
+        edge.setFlags(((Bike2WeightTagParser) parser).applyWayTags(way, edge.getFlags(), edge.fetchWayGeometry(FetchMode.ALL), edge.getDistance()));
 
         assertEquals(oldFlags, edge.getFlags());
     }

--- a/core/src/test/java/com/graphhopper/routing/util/Bike2WeightTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/Bike2WeightTagParserTest.java
@@ -75,7 +75,7 @@ public class Bike2WeightTagParserTest extends BikeTagParserTest {
         Graph graph = initExampleGraph();
         EdgeIteratorState edge = GHUtility.getEdge(graph, 0, 1);
         ReaderWay way = new ReaderWay(1);
-        parser.applyWayTags(way, edge);
+        edge.setFlags(parser.applyWayTags(way, edge.getFlags(), edge.fetchWayGeometry(FetchMode.ALL), edge.getDistance()));
 
         IntsRef flags = edge.getFlags();
         // decrease speed
@@ -91,7 +91,7 @@ public class Bike2WeightTagParserTest extends BikeTagParserTest {
         IntsRef oldFlags = IntsRef.deepCopyOf(edge.getFlags());
         ReaderWay way = new ReaderWay(1);
         way.setTag("highway", "steps");
-        parser.applyWayTags(way, edge);
+        edge.setFlags(parser.applyWayTags(way, edge.getFlags(), edge.fetchWayGeometry(FetchMode.ALL), edge.getDistance()));
 
         assertEquals(oldFlags, edge.getFlags());
     }

--- a/core/src/test/java/com/graphhopper/routing/util/Bike2WeightTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/Bike2WeightTagParserTest.java
@@ -43,7 +43,15 @@ public class Bike2WeightTagParserTest extends BikeTagParserTest {
 
     @Override
     protected BikeCommonTagParser createBikeTagParser(EncodedValueLookup lookup, PMap pMap) {
-        Bike2WeightTagParser parser = new Bike2WeightTagParser(lookup, pMap);
+        Bike2WeightTagParser parser = new Bike2WeightTagParser(lookup, pMap) {
+            @Override
+            public IntsRef applyWayTags(ReaderWay way, IntsRef intsRef) {
+                if (!way.hasTag("point_list") || !way.hasTag("edge_distance"))
+                    return intsRef;
+                else
+                    return super.applyWayTags(way, intsRef);
+            }
+        };
         parser.init(new DateRangeParser());
         return parser;
     }
@@ -75,7 +83,9 @@ public class Bike2WeightTagParserTest extends BikeTagParserTest {
         Graph graph = initExampleGraph();
         EdgeIteratorState edge = GHUtility.getEdge(graph, 0, 1);
         ReaderWay way = new ReaderWay(1);
-        edge.setFlags(((Bike2WeightTagParser) parser).applyWayTags(way, edge.getFlags(), edge.fetchWayGeometry(FetchMode.ALL), edge.getDistance()));
+        way.setTag("point_list", edge.fetchWayGeometry(FetchMode.ALL));
+        way.setTag("edge_distance", edge.getDistance());
+        edge.setFlags(((Bike2WeightTagParser) parser).applyWayTags(way, edge.getFlags()));
 
         IntsRef flags = edge.getFlags();
         // decrease speed
@@ -91,7 +101,9 @@ public class Bike2WeightTagParserTest extends BikeTagParserTest {
         IntsRef oldFlags = IntsRef.deepCopyOf(edge.getFlags());
         ReaderWay way = new ReaderWay(1);
         way.setTag("highway", "steps");
-        edge.setFlags(((Bike2WeightTagParser) parser).applyWayTags(way, edge.getFlags(), edge.fetchWayGeometry(FetchMode.ALL), edge.getDistance()));
+        way.setTag("point_list", edge.fetchWayGeometry(FetchMode.ALL));
+        way.setTag("edge_distance", edge.getDistance());
+        edge.setFlags(((Bike2WeightTagParser) parser).applyWayTags(way, edge.getFlags()));
 
         assertEquals(oldFlags, edge.getFlags());
     }

--- a/core/src/test/java/com/graphhopper/routing/util/TagParsingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/TagParsingTest.java
@@ -130,27 +130,27 @@ class TagParsingTest {
 
     @Test
     public void testCompatibilityBug() {
-        EncodingManager manager2 = EncodingManager.create("bike2");
+        EncodingManager manager2 = EncodingManager.create("mtb");
         ReaderWay osmWay = new ReaderWay(1);
         osmWay.setTag("highway", "footway");
         osmWay.setTag("name", "test");
 
-        Bike2WeightTagParser parser = new Bike2WeightTagParser(manager2, new PMap());
+        MountainBikeTagParser parser = new MountainBikeTagParser(manager2, new PMap());
         parser.init(new DateRangeParser());
         IntsRef flags = parser.handleWayTags(manager2.createEdgeFlags(), osmWay);
         double singleSpeed = parser.avgSpeedEnc.getDecimal(false, flags);
         assertEquals(BikeCommonTagParser.PUSHING_SECTION_SPEED, singleSpeed, 1e-3);
         assertEquals(singleSpeed, parser.avgSpeedEnc.getDecimal(true, flags), 1e-3);
 
-        EncodingManager manager = EncodingManager.create("bike2,bike,foot");
+        EncodingManager manager = EncodingManager.create("mtb,bike,foot");
         FootTagParser footParser = new FootTagParser(manager, new PMap());
         footParser.init(new DateRangeParser());
-        Bike2WeightTagParser bikeParser = new Bike2WeightTagParser(manager, new PMap());
+        MountainBikeTagParser bikeParser = new MountainBikeTagParser(manager, new PMap());
         bikeParser.init(new DateRangeParser());
 
         flags = footParser.handleWayTags(manager.createEdgeFlags(), osmWay);
         flags = bikeParser.handleWayTags(flags, osmWay);
-        DecimalEncodedValue bikeSpeedEnc = manager.getDecimalEncodedValue(VehicleSpeed.key("bike2"));
+        DecimalEncodedValue bikeSpeedEnc = manager.getDecimalEncodedValue(VehicleSpeed.key("mtb"));
         assertEquals(singleSpeed, bikeSpeedEnc.getDecimal(false, flags), 1e-2);
         assertEquals(singleSpeed, bikeSpeedEnc.getDecimal(true, flags), 1e-2);
 

--- a/core/src/test/java/com/graphhopper/routing/util/WheelchairTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/WheelchairTagParserTest.java
@@ -527,7 +527,10 @@ public class WheelchairTagParserTest {
         GHUtility.setSpeed(5, 5, wheelchairAccessEnc, wheelchairAvSpeedEnc, edge45);
 
 
-        edge01.setFlags(wheelchairParser.applyWayTags(new ReaderWay(1), edge01.getFlags(), edge01.fetchWayGeometry(FetchMode.ALL), edge01.getDistance()));
+        ReaderWay way1 = new ReaderWay(1);
+        way1.setTag("point_list", edge01.fetchWayGeometry(FetchMode.ALL));
+        way1.setTag("edge_distance", edge01.getDistance());
+        edge01.setFlags(wheelchairParser.applyWayTags(way1, edge01.getFlags()));
 
         assertTrue(edge01.get(wheelchairAccessEnc));
         assertTrue(edge01.getReverse(wheelchairAccessEnc));
@@ -535,7 +538,10 @@ public class WheelchairTagParserTest {
         assertEquals(5, edge01.getReverse(wheelchairParser.getAverageSpeedEnc()), 0);
 
 
-        edge23.setFlags(wheelchairParser.applyWayTags(new ReaderWay(2), edge23.getFlags(), edge23.fetchWayGeometry(FetchMode.ALL), edge23.getDistance()));
+        ReaderWay way2 = new ReaderWay(2);
+        way2.setTag("point_list", edge23.fetchWayGeometry(FetchMode.ALL));
+        way2.setTag("edge_distance", edge23.getDistance());
+        edge23.setFlags(wheelchairParser.applyWayTags(new ReaderWay(2), edge23.getFlags()));
 
         assertTrue(edge23.get(wheelchairAccessEnc));
         assertTrue(edge23.getReverse(wheelchairAccessEnc));
@@ -544,7 +550,10 @@ public class WheelchairTagParserTest {
 
 
         // only exclude longer edges with too large incline:
-        edge45.setFlags(wheelchairParser.applyWayTags(new ReaderWay(3), edge45.getFlags(), edge45.fetchWayGeometry(FetchMode.ALL), edge45.getDistance()));
+        ReaderWay way3 = new ReaderWay(3);
+        way3.setTag("point_list", edge45.fetchWayGeometry(FetchMode.ALL));
+        way3.setTag("edge_distance", edge45.getDistance());
+        edge45.setFlags(wheelchairParser.applyWayTags(new ReaderWay(3), edge45.getFlags()));
 
         assertFalse(edge45.get(wheelchairAccessEnc));
         assertFalse(edge45.getReverse(wheelchairAccessEnc));

--- a/core/src/test/java/com/graphhopper/routing/util/WheelchairTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/WheelchairTagParserTest.java
@@ -527,7 +527,7 @@ public class WheelchairTagParserTest {
         GHUtility.setSpeed(5, 5, wheelchairAccessEnc, wheelchairAvSpeedEnc, edge45);
 
 
-        wheelchairParser.applyWayTags(new ReaderWay(1), edge01);
+        edge01.setFlags(wheelchairParser.applyWayTags(new ReaderWay(1), edge01.getFlags(), edge01.fetchWayGeometry(FetchMode.ALL), edge01.getDistance()));
 
         assertTrue(edge01.get(wheelchairAccessEnc));
         assertTrue(edge01.getReverse(wheelchairAccessEnc));
@@ -535,7 +535,7 @@ public class WheelchairTagParserTest {
         assertEquals(5, edge01.getReverse(wheelchairParser.getAverageSpeedEnc()), 0);
 
 
-        wheelchairParser.applyWayTags(new ReaderWay(2), edge23);
+        edge23.setFlags(wheelchairParser.applyWayTags(new ReaderWay(2), edge23.getFlags(), edge23.fetchWayGeometry(FetchMode.ALL), edge23.getDistance()));
 
         assertTrue(edge23.get(wheelchairAccessEnc));
         assertTrue(edge23.getReverse(wheelchairAccessEnc));
@@ -544,7 +544,7 @@ public class WheelchairTagParserTest {
 
 
         // only exclude longer edges with too large incline:
-        wheelchairParser.applyWayTags(new ReaderWay(3), edge45);
+        edge45.setFlags(wheelchairParser.applyWayTags(new ReaderWay(3), edge45.getFlags(), edge45.fetchWayGeometry(FetchMode.ALL), edge45.getDistance()));
 
         assertFalse(edge45.get(wheelchairAccessEnc));
         assertFalse(edge45.getReverse(wheelchairAccessEnc));

--- a/core/src/test/java/com/graphhopper/routing/util/WheelchairTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/WheelchairTagParserTest.java
@@ -54,7 +54,15 @@ public class WheelchairTagParserTest {
                 .add(wheelchairAccessEnc).add(wheelchairAvSpeedEnc).add(wheelchairPriorityEnc).add(new EnumEncodedValue<>(FootNetwork.KEY, RouteNetwork.class))
                 .add(carAccessEnc).add(carAvSpeedEnc)
                 .build();
-        wheelchairParser = new WheelchairTagParser(encodingManager, new PMap());
+        wheelchairParser = new WheelchairTagParser(encodingManager, new PMap()) {
+            @Override
+            public IntsRef applyWayTags(ReaderWay way, IntsRef edgeFlags) {
+                if (!way.hasTag("point_list") || !way.hasTag("edge_distance"))
+                    return edgeFlags;
+                else
+                    return super.applyWayTags(way, edgeFlags);
+            }
+        };
         wheelchairParser.init(new DateRangeParser());
     }
 

--- a/core/src/test/java/com/graphhopper/routing/util/WheelchairTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/WheelchairTagParserTest.java
@@ -549,7 +549,7 @@ public class WheelchairTagParserTest {
         ReaderWay way2 = new ReaderWay(2);
         way2.setTag("point_list", edge23.fetchWayGeometry(FetchMode.ALL));
         way2.setTag("edge_distance", edge23.getDistance());
-        edge23.setFlags(wheelchairParser.applyWayTags(new ReaderWay(2), edge23.getFlags()));
+        edge23.setFlags(wheelchairParser.applyWayTags(way2, edge23.getFlags()));
 
         assertTrue(edge23.get(wheelchairAccessEnc));
         assertTrue(edge23.getReverse(wheelchairAccessEnc));
@@ -561,7 +561,7 @@ public class WheelchairTagParserTest {
         ReaderWay way3 = new ReaderWay(3);
         way3.setTag("point_list", edge45.fetchWayGeometry(FetchMode.ALL));
         way3.setTag("edge_distance", edge45.getDistance());
-        edge45.setFlags(wheelchairParser.applyWayTags(new ReaderWay(3), edge45.getFlags()));
+        edge45.setFlags(wheelchairParser.applyWayTags(way3, edge45.getFlags()));
 
         assertFalse(edge45.get(wheelchairAccessEnc));
         assertFalse(edge45.getReverse(wheelchairAccessEnc));


### PR DESCRIPTION
Everything that was possible with this method is still possible using `VehicleTagParser#handleWayTags` so it is no longer needed. This brings us closer to making the VehicleTagParsers just ordinary TagParsers.