### PR TITLE
Read Via Way Restrictions

### DIFF
--- a/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
+++ b/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
@@ -598,8 +598,8 @@ public class OSMReader {
     }
 
     static List<OSMTurnRestriction> createTurnRestrictions(ReaderRelation relation, String restrictionType,
-                                                           String vehicleTypeRestricted, List<String> vehicleTypesExcept) {
-        OSMTurnRestriction.RestrictionType type = OSMTurnRestriction.RestrictionType.getRestrictionType(restrictionType);
+                                                     String vehicleTypeRestricted, List<String> vehicleTypesExcept) {
+    	OSMTurnRestriction.RestrictionType type = OSMTurnRestriction.RestrictionType.get(restrictionType);
         if (type != OSMTurnRestriction.RestrictionType.UNSUPPORTED) {
             // we use -1 to indicate 'missing', which is fine because we exclude negative OSM IDs (see #2652)
             long viaNodeID = -1;

--- a/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
+++ b/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
@@ -549,10 +549,13 @@ public class OSMReader {
                 }
             };
             for (OSMTurnRestriction turnRestriction : createTurnRestrictions(relation)) {
-                int viaNode = map.getInternalNodeIdOfOsmNode(turnRestriction.getViaOsmNodeId());
-                // street with restriction was not included (access or tag limits etc)
-                if (viaNode >= 0)
-                    osmParsers.handleTurnRestrictionTags(turnRestriction, map, baseGraph);
+                // till now only Via-Node Restrictions are considered 
+                if (turnRestriction.getViaType() == OSMTurnRestriction.ViaType.NODE) {
+                    int viaNode = map.getInternalNodeIdOfOsmNode(turnRestriction.getViaOSMIds().get(0));
+                    // street with restriction was not included (access or tag limits etc)
+                    if (viaNode >= 0)
+                        osmParsers.handleTurnRestrictionTags(turnRestriction, map, baseGraph);
+                }
             }
         }
     }
@@ -598,24 +601,47 @@ public class OSMReader {
     }
 
     static List<OSMTurnRestriction> createTurnRestrictions(ReaderRelation relation, String restrictionType,
-                                                     String vehicleTypeRestricted, List<String> vehicleTypesExcept) {
-    	OSMTurnRestriction.RestrictionType type = OSMTurnRestriction.RestrictionType.get(restrictionType);
+                                                        String vehicleTypeRestricted, List<String> vehicleTypesExcept) {
+        OSMTurnRestriction.RestrictionType type = OSMTurnRestriction.RestrictionType.get(restrictionType);
         if (type != OSMTurnRestriction.RestrictionType.UNSUPPORTED) {
+            ArrayList<Long> viaIDs = new ArrayList<>();
+            OSMTurnRestriction.ViaType viaType = OSMTurnRestriction.ViaType.UNSUPPORTED;
             // we use -1 to indicate 'missing', which is fine because we exclude negative OSM IDs (see #2652)
-            long viaNodeID = -1;
             long toWayID = -1;
 
+            // A Turn Restriction (https://wiki.openstreetmap.org/wiki/Relation:restriction) can consist of...
+
             for (ReaderRelation.Member member : relation.getMembers()) {
-                if (ReaderElement.Type.WAY == member.getType() && "to".equals(member.getRole()))
+                // ONE TO Way (a "no_exit" restriction can have ONE OR MORE TO ways)
+                if (ReaderElement.Type.WAY == member.getType() && "to".equals(member.getRole())) {
                     toWayID = member.getRef();
-                else if (ReaderElement.Type.NODE == member.getType() && "via".equals(member.getRole()))
-                    viaNodeID = member.getRef();
+                }
+
+                // ONE VIA NODE or
+                else if (ReaderElement.Type.NODE == member.getType() && "via".equals(member.getRole())) {
+                    if (viaType == OSMTurnRestriction.ViaType.UNSUPPORTED) {
+                        viaIDs.add(member.getRef());
+                        viaType = OSMTurnRestriction.ViaType.NODE;
+                    }
+                }
+                // ONE OR MORE VIA WAYS
+                else if (ReaderElement.Type.WAY == member.getType() && "via".equals(member.getRole())) {
+                    if (viaType == OSMTurnRestriction.ViaType.UNSUPPORTED) {
+                        viaIDs.add(member.getRef());
+                        viaType = OSMTurnRestriction.ViaType.WAY;
+                    } else if (viaType == OSMTurnRestriction.ViaType.WAY || viaType == OSMTurnRestriction.ViaType.MULTI_WAY) {
+                        viaIDs.add(member.getRef());
+                        viaType = OSMTurnRestriction.ViaType.MULTI_WAY;
+                    }
+                }
             }
-            if (toWayID >= 0 && viaNodeID >= 0) {
+
+            // ONE FROM Way (a "no_entry" restriction can have ONE OR MORE FROM ways)
+            if (toWayID >= 0 && viaIDs.size() > 0) {
                 List<OSMTurnRestriction> res = new ArrayList<>(2);
                 for (ReaderRelation.Member member : relation.getMembers()) {
                     if (ReaderElement.Type.WAY == member.getType() && "from".equals(member.getRole())) {
-                        OSMTurnRestriction osmTurnRestriction = new OSMTurnRestriction(member.getRef(), viaNodeID, toWayID, type);
+                        OSMTurnRestriction osmTurnRestriction = new OSMTurnRestriction(member.getRef(), viaIDs, toWayID, type, viaType);
                         osmTurnRestriction.setVehicleTypeRestricted(vehicleTypeRestricted);
                         osmTurnRestriction.setVehicleTypesExcept(vehicleTypesExcept);
                         res.add(osmTurnRestriction);

--- a/core/src/main/java/com/graphhopper/reader/osm/OSMTurnRestriction.java
+++ b/core/src/main/java/com/graphhopper/reader/osm/OSMTurnRestriction.java
@@ -26,21 +26,27 @@ import java.util.*;
  */
 public class OSMTurnRestriction {
     private final long fromOsmWayId;
-    private final long viaOsmNodeId;
+    private final List<Long> viaOSMIds;
     private final long toOsmWayId;
     private final RestrictionType restriction;
+    private final ViaType viaType;
     // vehicleTypeRestricted contains the dedicated vehicle type
     // example: restriction:bus = no_left_turn => vehicleTypeRestricted = "bus";
     private String vehicleTypeRestricted;
     private List<String> vehicleTypesExcept;
 
-    public OSMTurnRestriction(long fromWayID, long viaNodeID, long toWayID, RestrictionType restrictionType) {
+    public OSMTurnRestriction(long fromWayID, List<Long> viaOSMIds, long toWayID, RestrictionType restrictionType, ViaType viaType) {
         this.fromOsmWayId = fromWayID;
-        this.viaOsmNodeId = viaNodeID;
+        this.viaOSMIds = viaOSMIds;
         this.toOsmWayId = toWayID;
         this.restriction = restrictionType;
+        this.viaType = viaType;
         this.vehicleTypeRestricted = "";
         this.vehicleTypesExcept = new ArrayList<>();
+    }
+
+    public OSMTurnRestriction(long fromWayID, long viaId, long toWayID, RestrictionType restrictionType, ViaType viaType) {
+        this(fromWayID, new ArrayList<>(Arrays.asList(viaId)), toWayID, restrictionType, viaType);
     }
 
     public long getOsmIdFrom() {
@@ -51,12 +57,16 @@ public class OSMTurnRestriction {
         return toOsmWayId;
     }
 
-    public long getViaOsmNodeId() {
-        return viaOsmNodeId;
+    public List<Long> getViaOSMIds() {
+        return viaOSMIds;
     }
 
     public RestrictionType getRestriction() {
         return restriction;
+    }
+
+    public ViaType getViaType() {
+        return viaType;
     }
 
     public String getVehicleTypeRestricted() {
@@ -89,7 +99,7 @@ public class OSMTurnRestriction {
 
     @Override
     public String toString() {
-        return "*-(" + fromOsmWayId + ")->" + viaOsmNodeId + "-(" + toOsmWayId + ")->*";
+        return "*-(" + fromOsmWayId + ")->" + viaOSMIds + "-(" + toOsmWayId + ")->*";
     }
 
     public enum RestrictionType {
@@ -109,7 +119,7 @@ public class OSMTurnRestriction {
         }
 
         public static RestrictionType get(String tag) {
-        	RestrictionType result = null;
+            RestrictionType result = null;
             if (tag != null) {
                 result = tags.get(tag);
             }
@@ -118,6 +128,6 @@ public class OSMTurnRestriction {
     }
 
     public enum ViaType {
-        VIA_NODE, VIA_WAY, MULTI_VIA_WAY;
+        UNSUPPORTED, NODE, WAY, MULTI_WAY;
     }
 }

--- a/core/src/main/java/com/graphhopper/reader/osm/OSMTurnRestriction.java
+++ b/core/src/main/java/com/graphhopper/reader/osm/OSMTurnRestriction.java
@@ -108,8 +108,8 @@ public class OSMTurnRestriction {
             tags.put("only_straight_on", ONLY);
         }
 
-        public static RestrictionType getRestrictionType(String tag) {
-            RestrictionType result = null;
+        public static RestrictionType get(String tag) {
+        	RestrictionType result = null;
             if (tag != null) {
                 result = tags.get(tag);
             }
@@ -117,4 +117,7 @@ public class OSMTurnRestriction {
         }
     }
 
+    public enum ViaType {
+        VIA_NODE, VIA_WAY, MULTI_VIA_WAY;
+    }
 }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMTurnRestrictionParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMTurnRestrictionParser.java
@@ -66,7 +66,8 @@ public class OSMTurnRestrictionParser implements TurnCostParser {
      */
     void addRelationToTCStorage(OSMTurnRestriction osmTurnRestriction, ExternalInternalMap map, Graph graph) {
         TurnCostStorage tcs = graph.getTurnCostStorage();
-        int viaNode = map.getInternalNodeIdOfOsmNode(osmTurnRestriction.getViaOsmNodeId());
+        int viaNode = map.getInternalNodeIdOfOsmNode(osmTurnRestriction.getViaOSMIds().get(0));
+
         EdgeExplorer edgeOutExplorer = getOutExplorer(graph), edgeInExplorer = getInExplorer(graph);
 
         try {
@@ -100,7 +101,7 @@ public class OSMTurnRestrictionParser implements TurnCostParser {
                 }
             }
         } catch (Exception e) {
-            throw new IllegalStateException("Could not built turn table entry for relation of node with osmId:" + osmTurnRestriction.getViaOsmNodeId(), e);
+            throw new IllegalStateException("Could not built turn table entry for relation of node with osmId:" + viaNode, e);
         }
     }
 

--- a/core/src/test/java/com/graphhopper/reader/osm/OSMReaderTest.java
+++ b/core/src/test/java/com/graphhopper/reader/osm/OSMReaderTest.java
@@ -46,6 +46,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -577,6 +578,41 @@ public class OSMReaderTest {
 
         assertTrue(tcStorage.get(carTCEnc, edge10_11, n11, edge11_14) == 0);
         assertTrue(tcStorage.get(bikeTCEnc, edge10_11, n11, edge11_14) > 0);
+    }
+
+    @Test
+    void testViaWayTurnRestrictions() {
+        ReaderRelation rel = new ReaderRelation(1L);
+
+        rel.setTag("restriction", "no_u_turn");
+        rel.add(new ReaderRelation.Member(ReaderElement.Type.WAY, 1L, "from"));
+        rel.add(new ReaderRelation.Member(ReaderElement.Type.WAY, 2L, "via"));
+        rel.add(new ReaderRelation.Member(ReaderElement.Type.WAY, 3L, "to"));
+
+        List<OSMTurnRestriction> osmRel = OSMReader.createTurnRestrictions(rel);
+        assertEquals(osmRel.get(0).getViaType(), OSMTurnRestriction.ViaType.WAY);
+        assertEquals(osmRel.get(0).getViaOSMIds().get(0), 2);
+    }
+
+    @Test
+    void testMultiViaWayTurnRestrictions() {
+        ReaderRelation rel = new ReaderRelation(1L);
+
+        rel.setTag("restriction", "no_u_turn");
+        rel.add(new ReaderRelation.Member(ReaderElement.Type.WAY, 1L, "from"));
+        rel.add(new ReaderRelation.Member(ReaderElement.Type.WAY, 2L, "via"));
+        rel.add(new ReaderRelation.Member(ReaderElement.Type.WAY, 3L, "via"));
+        rel.add(new ReaderRelation.Member(ReaderElement.Type.WAY, 4L, "via"));
+        rel.add(new ReaderRelation.Member(ReaderElement.Type.WAY, 5L, "to"));
+
+        ArrayList<Long> viaOSMIds = new ArrayList<>();
+        viaOSMIds.add(2L);
+        viaOSMIds.add(3L);
+        viaOSMIds.add(4L);
+
+        List<OSMTurnRestriction> osmRel = OSMReader.createTurnRestrictions(rel);
+        assertEquals(osmRel.get(0).getViaType(), OSMTurnRestriction.ViaType.MULTI_WAY);
+        assertEquals(osmRel.get(0).getViaOSMIds(), viaOSMIds);
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/reader/osm/OSMTurnRestrictionTest.java
+++ b/core/src/test/java/com/graphhopper/reader/osm/OSMTurnRestrictionTest.java
@@ -34,7 +34,7 @@ public class OSMTurnRestrictionTest {
     public void testAcceptsTurnRestriction() {
         List<String> vehicleTypes = new ArrayList<>(Arrays.asList("motorcar", "motor_vehicle", "vehicle"));
         List<String> vehicleTypesExcept = new ArrayList<>();
-        OSMTurnRestriction osmTurnRestriction = new OSMTurnRestriction(1, 1, 1, OSMTurnRestriction.RestrictionType.NOT);
+        OSMTurnRestriction osmTurnRestriction = new OSMTurnRestriction(1, 1, 1, OSMTurnRestriction.RestrictionType.NOT, OSMTurnRestriction.ViaType.WAY);
         assertTrue(osmTurnRestriction.isVehicleTypeConcernedByTurnRestriction(vehicleTypes));
 
         vehicleTypesExcept.add("bus");

--- a/core/src/test/java/com/graphhopper/reader/osm/OSMTurnRestrictionTest.java
+++ b/core/src/test/java/com/graphhopper/reader/osm/OSMTurnRestrictionTest.java
@@ -34,7 +34,8 @@ public class OSMTurnRestrictionTest {
     public void testAcceptsTurnRestriction() {
         List<String> vehicleTypes = new ArrayList<>(Arrays.asList("motorcar", "motor_vehicle", "vehicle"));
         List<String> vehicleTypesExcept = new ArrayList<>();
-        OSMTurnRestriction osmTurnRestriction = new OSMTurnRestriction(1, 1, 1, OSMTurnRestriction.RestrictionType.NOT, OSMTurnRestriction.ViaType.WAY);
+        OSMTurnRestriction osmTurnRestriction = new OSMTurnRestriction(1, 1, 1, OSMTurnRestriction.RestrictionType.NOT, OSMTurnRestriction.ViaType.NODE);
+
         assertTrue(osmTurnRestriction.isVehicleTypeConcernedByTurnRestriction(vehicleTypes));
 
         vehicleTypesExcept.add("bus");

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMTurnRestrictionParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMTurnRestrictionParserTest.java
@@ -51,7 +51,7 @@ public class OSMTurnRestrictionParserTest {
         };
 
         // TYPE == ONLY
-        OSMTurnRestriction instance = new OSMTurnRestriction(4, 3, 3, OSMTurnRestriction.RestrictionType.ONLY);
+        OSMTurnRestriction instance = new OSMTurnRestriction(4, 3, 3, OSMTurnRestriction.RestrictionType.ONLY, OSMTurnRestriction.ViaType.NODE);
         parser.addRelationToTCStorage(instance, map, graph);
 
         TurnCostStorage tcs = graph.getTurnCostStorage();
@@ -60,7 +60,7 @@ public class OSMTurnRestrictionParserTest {
         assertTrue(Double.isInfinite(tcs.get(turnCostEnc, 4, 3, 2)));
 
         // TYPE == NOT
-        instance = new OSMTurnRestriction(4, 3, 3, OSMTurnRestriction.RestrictionType.NOT);
+        instance = new OSMTurnRestriction(4, 3, 3, OSMTurnRestriction.RestrictionType.NOT, OSMTurnRestriction.ViaType.NODE);
         parser.addRelationToTCStorage(instance, map, graph);
         assertTrue(Double.isInfinite(tcs.get(turnCostEnc, 4, 3, 3)));
     }


### PR DESCRIPTION
https://github.com/graphhopper/graphhopper/pull/2670 with a new branch.

To be able to process more complex turn restrictions (with one ore more via ways instead of one via node), the functionality to read the restrictions are updated.