### PR TITLE
fix(sec): upgrade org.webjars:jquery to 3.5.0

### DIFF
--- a/web-bundle/pom.xml
+++ b/web-bundle/pom.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>graphhopper-web-bundle</artifactId>
@@ -95,7 +94,7 @@
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>jquery</artifactId>
-            <version>2.2.3</version>
+            <version>3.5.0</version>
         </dependency>
         <dependency>
             <groupId>org.webjars.npm</groupId>
@@ -168,5 +167,3 @@
     </build>
 
 </project>
-
-


### PR DESCRIPTION
### What happened？
There are 6 security vulnerabilities found in org.webjars:jquery 2.2.3
- [CVE-2020-11022](https://www.oscs1024.com/hd/CVE-2020-11022)
- [CVE-2015-9251](https://www.oscs1024.com/hd/CVE-2015-9251)
- [CVE-2017-16012](https://www.oscs1024.com/hd/CVE-2017-16012)
- [CVE-2019-5428](https://www.oscs1024.com/hd/CVE-2019-5428)
- [CVE-2019-11358](https://www.oscs1024.com/hd/CVE-2019-11358)
- [CVE-2020-11023](https://www.oscs1024.com/hd/CVE-2020-11023)


### What did I do？
Upgrade org.webjars:jquery from 2.2.3 to 3.5.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS