### PR TITLE
Support ";" access delimiter for bikes

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/BikeCommonTagParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/BikeCommonTagParser.java
@@ -247,8 +247,17 @@ abstract public class BikeCommonTagParser extends VehicleTagParser {
             return WayAccess.CAN_SKIP;
 
         // check access restrictions
-        if (way.hasTag(restrictions, restrictedValues) && !getConditionalTagInspector().isRestrictedWayConditionallyPermitted(way))
-            return WayAccess.CAN_SKIP;
+        boolean notRestrictedWayConditionallyPermitted = !getConditionalTagInspector().isRestrictedWayConditionallyPermitted(way);
+        for (String restriction: restrictions ) {
+            String complexAccess = way.getTag(restriction);
+            if (complexAccess != null) {
+               String[] simpleAccess = complexAccess.split(";");
+               for (String access: simpleAccess) {
+                  if (restrictedValues.contains(access) && notRestrictedWayConditionallyPermitted)
+                     return WayAccess.CAN_SKIP;
+               }
+            }
+        }
 
         if (getConditionalTagInspector().isPermittedWayConditionallyRestricted(way))
             return WayAccess.CAN_SKIP;

--- a/core/src/test/java/com/graphhopper/routing/util/BikeTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/BikeTagParserTest.java
@@ -370,6 +370,12 @@ public class BikeTagParserTest extends AbstractBikeTagParserTester {
         way.setTag("bicycle", "yes");
         assertTrue(parser.getAccess(way).isWay());
 
+        way.clearTags();
+        way.setTag("highway", "track");
+        way.setTag("vehicle", "forestry");
+        assertTrue(parser.getAccess(way).canSkip());
+        way.setTag("vehicle", "agricultural;forestry");
+        assertTrue(parser.getAccess(way).canSkip());
     }
 
     @Test


### PR DESCRIPTION
One example is `vehicle = agricultural;forestry`

Now we block also such combinations for bikes the same way as for cars.