### PR TITLE
Improve area check precision

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/weighting/custom/CustomWeightingHelper.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/custom/CustomWeightingHelper.java
@@ -76,10 +76,11 @@ public class CustomWeightingHelper {
     }
 
     public static boolean in(Polygon p, EdgeIteratorState edge) {
-        BBox bbox = GHUtility.createBBox(edge);
-        if (!p.getBounds().intersects(bbox))
+        BBox edgeBBox = GHUtility.createBBox(edge);
+        BBox polyBBOX = p.getBounds();
+        if (!polyBBOX.intersects(edgeBBox))
             return false;
-        if (p.isRectangle())
+        if (p.isRectangle() && polyBBOX.contains(edgeBBox))
             return true;
         return p.intersects(edge.fetchWayGeometry(FetchMode.ALL).makeImmutable()); // TODO PERF: cache bbox and edge wayGeometry for multiple area
     }

--- a/core/src/test/java/com/graphhopper/routing/weighting/custom/CustomWeightingHelperTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/custom/CustomWeightingHelperTest.java
@@ -1,0 +1,49 @@
+package com.graphhopper.routing.weighting.custom;
+
+import com.graphhopper.storage.BaseGraph;
+import com.graphhopper.util.EdgeIteratorState;
+import com.graphhopper.util.FetchMode;
+import com.graphhopper.util.Helper;
+import com.graphhopper.util.shapes.Polygon;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CustomWeightingHelperTest {
+
+    @Test
+    public void testInRectangle() {
+        Polygon square = new Polygon(new double[]{0, 0, 20, 20}, new double[]{0, 20, 20, 0});
+        assertTrue(square.isRectangle());
+
+        BaseGraph g = new BaseGraph.Builder(1).create();
+
+        // (1,1) (2,2) (3,3)
+        // Polygon fully contains the edge and its BBox
+        g.getNodeAccess().setNode(0, 1, 1);
+        g.getNodeAccess().setNode(1, 3, 3);
+        EdgeIteratorState edge = g.edge(0, 1).setWayGeometry(Helper.createPointList(2, 2));
+        assertTrue(CustomWeightingHelper.in(square, edge));
+
+        // (0,0) (20,0) (20,20)
+        // Polygon contains the edge; BBoxes overlap
+        g.getNodeAccess().setNode(2, 0, 0);
+        g.getNodeAccess().setNode(3, 20, 20);
+        edge = g.edge(2, 3).setWayGeometry(Helper.createPointList(20, 0));
+        assertTrue(CustomWeightingHelper.in(square, edge));
+
+        // (0,30) (10,40) (20,50)
+        // Edge is outside the polygon; BBoxes are not intersecting
+        g.getNodeAccess().setNode(4, 0, 30);
+        g.getNodeAccess().setNode(5, 20, 50);
+        edge = g.edge(4, 5).setWayGeometry(Helper.createPointList(10, 40));
+        assertFalse(CustomWeightingHelper.in(square, edge));
+
+        // (0,30) (30,30) (30,0)
+        // Edge is without the polygon; BBoxes are intersecting
+        g.getNodeAccess().setNode(6, 0, 30);
+        g.getNodeAccess().setNode(7, 30, 0);
+        edge = g.edge(6, 7).setWayGeometry(Helper.createPointList(30, 30));
+        assertFalse(CustomWeightingHelper.in(square, edge));
+    }
+}

--- a/core/src/test/java/com/graphhopper/routing/weighting/custom/CustomWeightingHelperTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/custom/CustomWeightingHelperTest.java
@@ -40,7 +40,7 @@ class CustomWeightingHelperTest {
         assertFalse(CustomWeightingHelper.in(square, edge));
 
         // (0,30) (30,30) (30,0)
-        // Edge is without the polygon; BBoxes are intersecting
+        // Edge is outside the polygon; BBoxes are intersecting
         g.getNodeAccess().setNode(6, 0, 30);
         g.getNodeAccess().setNode(7, 30, 0);
         edge = g.edge(6, 7).setWayGeometry(Helper.createPointList(30, 30));


### PR DESCRIPTION
Fixes #2683

We should only early-out if the rectangle fully contains the bounding box of the edge. This still avoids costly way geometry checks in most cases but improves accuracy for checks near the borders of the polygons bounding box.