### PR TITLE
Cache geometries/bbox in the iterator

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/weighting/custom/CachingEdgeIteratorState.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/custom/CachingEdgeIteratorState.java
@@ -1,0 +1,50 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.routing.weighting.custom;
+
+import com.graphhopper.util.DelegatingEdgeIteratorState;
+import com.graphhopper.util.EdgeIteratorState;
+import com.graphhopper.util.FetchMode;
+import com.graphhopper.util.PointList;
+import com.graphhopper.util.shapes.BBox;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+class CachingEdgeIteratorState extends DelegatingEdgeIteratorState {
+
+    private final Map<FetchMode, PointList> geometries = new EnumMap<>(FetchMode.class);
+    private BBox bbox;
+
+    public CachingEdgeIteratorState(EdgeIteratorState edgeState) {
+        super(edgeState);
+    }
+
+    @Override
+    public PointList fetchWayGeometry(FetchMode mode) {
+        return geometries.computeIfAbsent(mode, m -> getDelegate().fetchWayGeometry(m).makeImmutable());
+    }
+
+    @Override
+    public BBox getBounds() {
+        if (bbox == null) {
+            bbox = getDelegate().getBounds();
+        }
+        return bbox;
+    }
+}

--- a/core/src/main/java/com/graphhopper/routing/weighting/custom/CustomWeighting.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/custom/CustomWeighting.java
@@ -105,6 +105,7 @@ public final class CustomWeighting extends AbstractWeighting {
 
     @Override
     public double calcEdgeWeight(EdgeIteratorState edgeState, boolean reverse) {
+        edgeState = new CachingEdgeIteratorState(edgeState);
         final double distance = edgeState.getDistance();
         double seconds = calcSeconds(distance, edgeState, reverse);
         if (Double.isInfinite(seconds)) return Double.POSITIVE_INFINITY;
@@ -140,6 +141,7 @@ public final class CustomWeighting extends AbstractWeighting {
 
     @Override
     public long calcEdgeMillis(EdgeIteratorState edgeState, boolean reverse) {
+        edgeState = new CachingEdgeIteratorState(edgeState);
         // we truncate to long here instead of rounding to make it consistent with FastestWeighting, maybe change to rounding later
         return Math.round(calcSeconds(edgeState.getDistance(), edgeState, reverse) * 1000);
     }

--- a/core/src/main/java/com/graphhopper/routing/weighting/custom/CustomWeightingHelper.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/custom/CustomWeightingHelper.java
@@ -76,8 +76,7 @@ public class CustomWeightingHelper {
     }
 
     public static boolean in(Polygon p, EdgeIteratorState edge) {
-        BBox bbox = GHUtility.createBBox(edge);
-        if (!p.getBounds().intersects(bbox))
+        if (!p.getBounds().intersects(edge.getBounds()))
             return false;
         if (p.isRectangle())
             return true;

--- a/core/src/main/java/com/graphhopper/storage/GraphEdgeIdFinder.java
+++ b/core/src/main/java/com/graphhopper/storage/GraphEdgeIdFinder.java
@@ -222,7 +222,7 @@ public class GraphEdgeIdFinder {
 
                 // compromise: avoid expensive fetch of pillar nodes, which isn't yet fast for being used in Weighting.calc
                 if (bbox == null)
-                    bbox = GHUtility.createBBox(edgeState);
+                    bbox = edgeState.getBounds();
 
                 Shape shape = blockedShapes.get(shapeIdx);
                 if (shape.getBounds().intersects(bbox)) {

--- a/core/src/main/java/com/graphhopper/util/DelegatingEdgeIteratorState.java
+++ b/core/src/main/java/com/graphhopper/util/DelegatingEdgeIteratorState.java
@@ -1,0 +1,250 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.util;
+
+import com.graphhopper.routing.ev.*;
+import com.graphhopper.search.EdgeKVStorage;
+import com.graphhopper.storage.IntsRef;
+
+import java.util.List;
+
+/**
+ * Implementation of the {@link EdgeIteratorState} interface which delegates all calls by default.
+ */
+public class DelegatingEdgeIteratorState implements EdgeIteratorState {
+
+    private final EdgeIteratorState delegate;
+
+    public DelegatingEdgeIteratorState(EdgeIteratorState delegate) {
+        this.delegate = delegate;
+    }
+
+    protected EdgeIteratorState getDelegate() {
+        return delegate;
+    }
+
+    @Override
+    public int getEdge() {
+        return delegate.getEdge();
+    }
+
+    @Override
+    public int getEdgeKey() {
+        return delegate.getEdgeKey();
+    }
+
+    @Override
+    public int getReverseEdgeKey() {
+        return delegate.getReverseEdgeKey();
+    }
+
+    @Override
+    public int getBaseNode() {
+        return delegate.getBaseNode();
+    }
+
+    @Override
+    public int getAdjNode() {
+        return delegate.getAdjNode();
+    }
+
+    @Override
+    public PointList fetchWayGeometry(FetchMode mode) {
+        return delegate.fetchWayGeometry(mode);
+    }
+
+    @Override
+    public EdgeIteratorState setWayGeometry(PointList list) {
+        return delegate.setWayGeometry(list);
+    }
+
+    @Override
+    public double getDistance() {
+        return delegate.getDistance();
+    }
+
+    @Override
+    public EdgeIteratorState setDistance(double dist) {
+        return delegate.setDistance(dist);
+    }
+
+    @Override
+    public IntsRef getFlags() {
+        return delegate.getFlags();
+    }
+
+    @Override
+    public EdgeIteratorState setFlags(IntsRef edgeFlags) {
+        return delegate.setFlags(edgeFlags);
+    }
+
+    @Override
+    public boolean get(BooleanEncodedValue property) {
+        return delegate.get(property);
+    }
+
+    @Override
+    public EdgeIteratorState set(BooleanEncodedValue property, boolean value) {
+        return delegate.set(property, value);
+    }
+
+    @Override
+    public boolean getReverse(BooleanEncodedValue property) {
+        return delegate.getReverse(property);
+    }
+
+    @Override
+    public EdgeIteratorState setReverse(BooleanEncodedValue property, boolean value) {
+        return delegate.setReverse(property, value);
+    }
+
+    @Override
+    public EdgeIteratorState set(BooleanEncodedValue property, boolean fwd, boolean bwd) {
+        return delegate.set(property, fwd, bwd);
+    }
+
+    @Override
+    public int get(IntEncodedValue property) {
+        return delegate.get(property);
+    }
+
+    @Override
+    public EdgeIteratorState set(IntEncodedValue property, int value) {
+        return delegate.set(property, value);
+    }
+
+    @Override
+    public int getReverse(IntEncodedValue property) {
+        return delegate.getReverse(property);
+    }
+
+    @Override
+    public EdgeIteratorState setReverse(IntEncodedValue property, int value) {
+        return delegate.setReverse(property, value);
+    }
+
+    @Override
+    public EdgeIteratorState set(IntEncodedValue property, int fwd, int bwd) {
+        return delegate.set(property, fwd, bwd);
+    }
+
+    @Override
+    public double get(DecimalEncodedValue property) {
+        return delegate.get(property);
+    }
+
+    @Override
+    public EdgeIteratorState set(DecimalEncodedValue property, double value) {
+        return delegate.set(property, value);
+    }
+
+    @Override
+    public double getReverse(DecimalEncodedValue property) {
+        return delegate.getReverse(property);
+    }
+
+    @Override
+    public EdgeIteratorState setReverse(DecimalEncodedValue property, double value) {
+        return delegate.setReverse(property, value);
+    }
+
+    @Override
+    public EdgeIteratorState set(DecimalEncodedValue property, double fwd, double bwd) {
+        return delegate.set(property, fwd, bwd);
+    }
+
+    @Override
+    public <T extends Enum<?>> T get(EnumEncodedValue<T> property) {
+        return delegate.get(property);
+    }
+
+    @Override
+    public <T extends Enum<?>> EdgeIteratorState set(EnumEncodedValue<T> property, T value) {
+        return delegate.set(property, value);
+    }
+
+    @Override
+    public <T extends Enum<?>> T getReverse(EnumEncodedValue<T> property) {
+        return delegate.getReverse(property);
+    }
+
+    @Override
+    public <T extends Enum<?>> EdgeIteratorState setReverse(EnumEncodedValue<T> property, T value) {
+        return delegate.setReverse(property, value);
+    }
+
+    @Override
+    public <T extends Enum<?>> EdgeIteratorState set(EnumEncodedValue<T> property, T fwd, T bwd) {
+        return delegate.set(property, fwd, bwd);
+    }
+
+    @Override
+    public String get(StringEncodedValue property) {
+        return delegate.get(property);
+    }
+
+    @Override
+    public EdgeIteratorState set(StringEncodedValue property, String value) {
+        return delegate.set(property, value);
+    }
+
+    @Override
+    public String getReverse(StringEncodedValue property) {
+        return delegate.getReverse(property);
+    }
+
+    @Override
+    public EdgeIteratorState setReverse(StringEncodedValue property, String value) {
+        return delegate.setReverse(property, value);
+    }
+
+    @Override
+    public EdgeIteratorState set(StringEncodedValue property, String fwd, String bwd) {
+        return delegate.set(property, fwd, bwd);
+    }
+
+    @Override
+    public String getName() {
+        return delegate.getName();
+    }
+
+    @Override
+    public EdgeIteratorState setKeyValues(List<EdgeKVStorage.KeyValue> map) {
+        return delegate.setKeyValues(map);
+    }
+
+    @Override
+    public List<EdgeKVStorage.KeyValue> getKeyValues() {
+        return delegate.getKeyValues();
+    }
+
+    @Override
+    public Object getValue(String key) {
+        return delegate.getValue(key);
+    }
+
+    @Override
+    public EdgeIteratorState detach(boolean reverse) {
+        return delegate.detach(reverse);
+    }
+
+    @Override
+    public EdgeIteratorState copyPropertiesFrom(EdgeIteratorState e) {
+        return delegate.copyPropertiesFrom(e);
+    }
+}

--- a/core/src/main/java/com/graphhopper/util/EdgeIteratorState.java
+++ b/core/src/main/java/com/graphhopper/util/EdgeIteratorState.java
@@ -21,6 +21,7 @@ import com.graphhopper.routing.ev.*;
 import com.graphhopper.search.EdgeKVStorage;
 import com.graphhopper.storage.Graph;
 import com.graphhopper.storage.IntsRef;
+import com.graphhopper.util.shapes.BBox;
 
 import java.util.List;
 
@@ -118,6 +119,13 @@ public interface EdgeIteratorState {
      * @return the pillar and/or tower nodes depending on the mode.
      */
     PointList fetchWayGeometry(FetchMode mode);
+
+    default BBox getBounds() {
+        PointList towerNodes = fetchWayGeometry(FetchMode.TOWER_ONLY);
+        int secondIndex = towerNodes.size() == 1 ? 0 : 1;
+        return BBox.fromPoints(towerNodes.getLat(0), towerNodes.getLon(0),
+                towerNodes.getLat(secondIndex), towerNodes.getLon(secondIndex));
+    }
 
     /**
      * @param list is a sorted collection of coordinates between the base node and the current adjacent node. Specify

--- a/core/src/main/java/com/graphhopper/util/GHUtility.java
+++ b/core/src/main/java/com/graphhopper/util/GHUtility.java
@@ -963,11 +963,4 @@ public class GHUtility {
         }
 
     }
-
-    public static BBox createBBox(EdgeIteratorState edgeState) {
-        PointList towerNodes = edgeState.fetchWayGeometry(FetchMode.TOWER_ONLY);
-        int secondIndex = towerNodes.size() == 1 ? 0 : 1;
-        return BBox.fromPoints(towerNodes.getLat(0), towerNodes.getLon(0),
-                towerNodes.getLat(secondIndex), towerNodes.getLon(secondIndex));
-    }
 }


### PR DESCRIPTION
Less invasive variant of https://github.com/graphhopper/graphhopper/pull/2338

* promotes `GHUtility.createBBox()` as a default interface method of the EdgeIteratorState
* `EdgeIteratorState` implementation which simply delegates all calls and allows subclasses to only override specific methods
* `EdgeIteratorState` implementation for the CustomWeighting which caches Edge geometries and BBoxes