### PR TITLE
Treat segments tagged as "lcn=yes" the same way as a bicycle route relation with "network=lcn"

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/BikeCommonTagParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/BikeCommonTagParser.java
@@ -482,6 +482,9 @@ abstract public class BikeCommonTagParser extends VehicleTagParser {
         if (way.hasTag("railway", "tram"))
             weightToPrioMap.put(50d, AVOID_MORE.getValue());
 
+        if (way.hasTag("lcn", "yes"))
+            weightToPrioMap.put(100d, PREFER.getValue());
+
         String classBicycleValue = way.getTag(classBicycleKey);
         if (classBicycleValue != null) {
             // We assume that humans are better in classifying preferences compared to our algorithm above -> weight = 100

--- a/core/src/test/java/com/graphhopper/routing/util/BikeTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/BikeTagParserTest.java
@@ -492,7 +492,12 @@ public class BikeTagParserTest extends AbstractBikeTagParserTester {
         // unchanged
         assertPriorityAndSpeed(UNCHANGED.getValue(), 12, osmWay);
 
-        // relation code is
+        // "lcn=yes" is in fact no relation, but shall be treated the same like a relation with "network=lcn"
+        osmWay.setTag("lcn", "yes");
+        assertPriorityAndSpeed(PREFER.getValue(), 12, osmWay);
+        osmWay.removeTag("lcn");
+
+        // relation code is PREFER
         ReaderRelation osmRel = new ReaderRelation(1);
         osmRel.setTag("route", "bicycle");
         assertPriorityAndSpeed(PREFER.getValue(), 12, osmWay, osmRel);
@@ -503,7 +508,9 @@ public class BikeTagParserTest extends AbstractBikeTagParserTester {
         // relation code is NICE
         osmRel.setTag("network", "rcn");
         assertPriorityAndSpeed(VERY_NICE.getValue(), 12, osmWay, osmRel);
-
+        osmWay.setTag("lcn", "yes");
+        assertPriorityAndSpeed(VERY_NICE.getValue(), 12, osmWay, osmRel);
+        
         // relation code is BEST
         osmRel.setTag("network", "ncn");
         assertPriorityAndSpeed(BEST.getValue(), 12, osmWay, osmRel);


### PR DESCRIPTION
This PR prefers ways tagged with `lcn=yes` with the same priority as a bicycle route relation tagged with `network=lcn`.

See https://wiki.openstreetmap.org/wiki/DE:Tag:lcn%3Dyes, according taginfo the tag has over 188000 usages.

