### PR TITLE
Add a cache filter for static assets

### DIFF
--- a/web-bundle/src/main/java/com/graphhopper/http/CacheFilter.java
+++ b/web-bundle/src/main/java/com/graphhopper/http/CacheFilter.java
@@ -1,0 +1,24 @@
+package com.graphhopper.http;
+
+import org.eclipse.jetty.http.HttpMethod;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpFilter;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+public class CacheFilter extends HttpFilter {
+
+    private static final String CACHE_HEADER = "public, max-age=" + TimeUnit.DAYS.toSeconds(365);
+
+    @Override
+    public void doFilter(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException {
+        if (HttpMethod.GET.is(request.getMethod())) {
+            response.setHeader("Cache-Control", CACHE_HEADER);
+        }
+
+        chain.doFilter(request, response);
+    }
+}

--- a/web/src/main/java/com/graphhopper/application/GraphHopperApplication.java
+++ b/web/src/main/java/com/graphhopper/application/GraphHopperApplication.java
@@ -21,6 +21,7 @@ import com.graphhopper.application.cli.ImportCommand;
 import com.graphhopper.application.cli.MatchCommand;
 import com.graphhopper.application.resources.RootResource;
 import com.graphhopper.http.CORSFilter;
+import com.graphhopper.http.CacheFilter;
 import com.graphhopper.http.GraphHopperBundle;
 import com.graphhopper.http.RealtimeBundle;
 import com.graphhopper.navigation.NavigateResource;
@@ -33,6 +34,8 @@ import javax.servlet.DispatcherType;
 import java.util.EnumSet;
 
 public final class GraphHopperApplication extends Application<GraphHopperServerConfiguration> {
+
+    private static final String[] CACHEABLE_ASSETS = new String[] { "*.css", "*.gif", "*.ico", "*.js", "*.png", "*.svg", "*.ttf" };
 
     public static void main(String[] args) throws Exception {
         new GraphHopperApplication().run(args);
@@ -54,5 +57,6 @@ public final class GraphHopperApplication extends Application<GraphHopperServerC
         environment.jersey().register(new RootResource());
         environment.jersey().register(NavigateResource.class);
         environment.servlets().addFilter("cors", CORSFilter.class).addMappingForUrlPatterns(EnumSet.allOf(DispatcherType.class), false, "*");
+        environment.servlets().addFilter("cache", CacheFilter.class).addMappingForUrlPatterns(EnumSet.of(DispatcherType.REQUEST), true, CACHEABLE_ASSETS);
     }
 }


### PR DESCRIPTION
This adds a `Cache-Control` header for our static assets. Maybe blocked by https://github.com/graphhopper/graphhopper-maps/issues/295