### PR TITLE
Add OSM way ID encoded value

### DIFF
--- a/config-example.yml
+++ b/config-example.yml
@@ -80,8 +80,8 @@ graphhopper:
 
   # Add additional information to every edge. Used for path details (#1548) and custom models (docs/core/custom-models.md)
   # Default values are: road_class,road_class_link,road_environment,max_speed,road_access
-  # More are: surface,smoothness,max_width,max_height,max_weight,hgv,max_axle_load,max_length,hazmat,hazmat_tunnel,hazmat_water,toll,track_type,
-  #           mtb_rating, hike_rating,horse_rating,lanes
+  # More are: surface,smoothness,max_width,max_height,max_weight,hgv,max_axle_load,max_length,hazmat,hazmat_tunnel,hazmat_water,
+  #           lanes,osm_way_id,toll,track_type,mtb_rating,hike_rating,horse_rating
   # graph.encoded_values: surface,toll,track_type
 
   #### Speed, hybrid and flexible mode ####

--- a/core/src/main/java/com/graphhopper/routing/ev/DefaultEncodedValueFactory.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/DefaultEncodedValueFactory.java
@@ -74,6 +74,8 @@ public class DefaultEncodedValueFactory implements EncodedValueFactory {
             enc = new EnumEncodedValue<>(HazmatWater.KEY, HazmatWater.class);
         } else if (Lanes.KEY.equals(name)) {
             enc = Lanes.create();
+        } else if (OSMWayID.KEY.equals(name)) {
+            enc = OSMWayID.create();
         } else if (MtbRating.KEY.equals(name)) {
             enc = MtbRating.create();
         } else if (HikeRating.KEY.equals(name)) {

--- a/core/src/main/java/com/graphhopper/routing/ev/OSMWayID.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/OSMWayID.java
@@ -1,0 +1,27 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.graphhopper.routing.ev;
+
+public class OSMWayID {
+    public static final String KEY = "osm_way_id";
+
+    public static IntEncodedValue create() {
+        return new IntEncodedValueImpl(KEY, 31, false);
+    }
+}

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/DefaultTagParserFactory.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/DefaultTagParserFactory.java
@@ -69,6 +69,8 @@ public class DefaultTagParserFactory implements TagParserFactory {
             return new OSMHazmatWaterParser(lookup.getEnumEncodedValue(HazmatWater.KEY, HazmatWater.class));
         else if (name.equals(Lanes.KEY))
             return new OSMLanesParser(lookup.getIntEncodedValue(Lanes.KEY));
+        else if (name.equals(OSMWayID.KEY))
+            return new OSMWayIDParser(lookup.getIntEncodedValue(OSMWayID.KEY));
         else if (name.equals(MtbRating.KEY))
             return new OSMMtbRatingParser(lookup.getIntEncodedValue(MtbRating.KEY));
         else if (name.equals(HikeRating.KEY))

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMWayIDParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMWayIDParser.java
@@ -1,0 +1,42 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.graphhopper.routing.util.parsers;
+
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.IntEncodedValue;
+import com.graphhopper.storage.IntsRef;
+
+public class OSMWayIDParser implements TagParser {
+    private final IntEncodedValue osmWayIdEnc;
+
+    public OSMWayIDParser(IntEncodedValue osmWayIdEnc) {
+        this.osmWayIdEnc = osmWayIdEnc;
+    }
+
+    @Override
+    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay way, IntsRef relationFlags) {
+        if (way.getId() > osmWayIdEnc.getMaxStorableInt())
+            throw new IllegalArgumentException("Cannot store OSM way ID: " + way.getId() + " as it is too large (> "
+                    + osmWayIdEnc.getMaxStorableInt() + "). You can disable " + osmWayIdEnc.getName() + " if you do not " +
+                    "need to store the OSM way IDs");
+        int wayId = Math.toIntExact(way.getId());
+        osmWayIdEnc.setInt(false, edgeFlags, wayId);
+        return edgeFlags;
+    }
+}

--- a/core/src/test/java/com/graphhopper/routing/ev/IntEncodedValueImplTest.java
+++ b/core/src/test/java/com/graphhopper/routing/ev/IntEncodedValueImplTest.java
@@ -52,6 +52,15 @@ public class IntEncodedValueImplTest {
     }
 
     @Test
+    public void maxValue() {
+        IntEncodedValue prop = new IntEncodedValueImpl("test", 31, false);
+        prop.init(new EncodedValue.InitializerConfig());
+        IntsRef ref = new IntsRef(2);
+        prop.setInt(false, ref, (1 << 31) - 1);
+        assertEquals(2_147_483_647L, prop.getInt(false, ref));
+    }
+
+    @Test
     public void testSignedInt() {
         IntEncodedValue prop = new IntEncodedValueImpl("test", 31, -5, false, true);
         EncodedValue.InitializerConfig config = new EncodedValue.InitializerConfig();


### PR DESCRIPTION
This PR adds a parser and encoded value for OSM way IDs. GraphHopper creates one or more edges for each OSM way and with this PR we can retrieve the ID of the OSM way each edge was created from at runtime. This has been requested many times in the context of map-matching for example or can be used block certain OSM ways (using custom models for example). At the very least it is useful for debugging.

It is important to consider that OSM way IDs can change any time. So whenever one runs a new import with an updated map file their values might change. For this reason the new `osm_way_id` encoded values is not enabled by default, but can be enabled via `graph.encoded_values` in `config.yml`.

OSM uses 64bit integers to store OSM way IDs, but in reality the largest ID is currently around 1.1 billion, so I simply used an IntEncodedValue (31 bits), which works for IDs up to around 2.1 billion.