### PR TITLE
Use explicit ignore list for highway values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,8 @@
 ### 7.0 [not yet released]
 
-- there is a new, required 'import.osm.ignored_highways' configuration option that can be used to reduce the graph size
-  and increase
-  performance for motorized-only routing, #2702
-- the parameters vehicle, weighting, edge_based and turn_costs are no longer supported, use the profile parameter
-  instead
+- there is a new, required 'import.osm.ignored_highways' configuration option that can be used to reduce the graph size and increase performance for motorized-only routing, #2702
+- new osm_way_id encoded value, #2701
+- the parameters vehicle, weighting, edge_based and turn_costs are no longer supported, use the profile parameter instead
 - removed motorroad to road_class conversion, #2329
 - removed YAML support for custom models on the server-side. Only allow JSON with // comments.
 - Bike2WeightTagParser was removed. Use the bike vehicle with a custom model, see custom_models/bike2.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 7.0 [not yet released]
 
-- there is a new, required 'import.osm.ignored_highways' configuration option that can be used to reduce the graph size and increase performance for motorized-only routing, #2702
+- there is a new, required 'import.osm.ignored_highways' configuration option that must be used to not increase the
+  graph size and decrease performance for motorized-only routing, #2702
 - new osm_way_id encoded value, #2701
 - the parameters vehicle, weighting, edge_based and turn_costs are no longer supported, use the profile parameter instead
 - removed motorroad to road_class conversion, #2329

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ### 7.0 [not yet released]
 
-- the parameters vehicle, weighting, edge_based and turn_costs are no longer supported, use the profile parameter instead
+- there is a new import.osm.ignored_highways parameter that needs to be set to reduce the graph size and increase
+  performance for motorized-only routing, #2702
+- the parameters vehicle, weighting, edge_based and turn_costs are no longer supported, use the profile parameter
+  instead
 - removed motorroad to road_class conversion, #2329
 - removed YAML support for custom models on the server-side. Only allow JSON with // comments.
 - Bike2WeightTagParser was removed. Use the bike vehicle with a custom model, see custom_models/bike2.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### 7.0 [not yet released]
 
-- there is a new import.osm.ignored_highways parameter that needs to be set to reduce the graph size and increase
+- there is a new 'import.osm.ignored_highways' parameter that needs to be set to reduce the graph size and increase
   performance for motorized-only routing, #2702
 - the parameters vehicle, weighting, edge_based and turn_costs are no longer supported, use the profile parameter
   instead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 ### 7.0 [not yet released]
 
-- there is a new, required 'import.osm.ignored_highways' configuration option that must be used to not increase the
-  graph size and decrease performance for motorized-only routing, #2702
+- there is a new, required 'import.osm.ignored_highways' configuration option that must be used to not increase the graph size and decrease performance for motorized-only routing compared to previous versions, #2702
 - new osm_way_id encoded value, #2701
 - the parameters vehicle, weighting, edge_based and turn_costs are no longer supported, use the profile parameter instead
 - removed motorroad to road_class conversion, #2329

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 7.0 [not yet released]
 
-- there is a new 'import.osm.ignored_highways' parameter that needs to be set to reduce the graph size and increase
+- there is a new, required 'import.osm.ignored_highways' configuration option that can be used to reduce the graph size
+  and increase
   performance for motorized-only routing, #2702
 - the parameters vehicle, weighting, edge_based and turn_costs are no longer supported, use the profile parameter
   instead

--- a/config-example.yml
+++ b/config-example.yml
@@ -171,7 +171,7 @@ graphhopper:
 
   # Excludes certain types of highways during the OSM import to speed up the import and reduce the size of the graph.
   # A typical case is excluding footway,cycleway,path and maybe pedestrian and track for motorized vehicles. This leads
-  # to a smaller graph, because there are less ways (obviously), but also because there are fewer junctions.
+  # to a smaller graph, because there are fewer ways (obviously), but also because there are fewer junctions.
   # Another example is excluding motorway, trunk and maybe primary highways for bicycle or pedestrian routing.
   import.osm.ignored_highways: footway,cycleway,path,pedestrian,steps
 

--- a/config-example.yml
+++ b/config-example.yml
@@ -5,6 +5,32 @@ graphhopper:
   # Local folder used by graphhopper to store its data
   graph.location: graph-cache
 
+  osm.import.accepted_highways: >
+    motorway,motorway_link,
+    trunk,trunk_link,
+    primary,primary_link,
+    secondary,secondary_link,
+    tertiary,tertiary_link,
+    unclassified,
+    residential,
+    living_street,
+    service,
+    pedestrian,
+    track,
+    bus_guideway,
+    escape,
+    raceway,
+    road,
+    busway,
+    footway,
+    bridleway,
+    steps,
+    corridor,
+    path,
+    cycleway,
+    proposed,
+    construction,
+    emergency_bay
 
   ##### Routing Profiles ####
 

--- a/config-example.yml
+++ b/config-example.yml
@@ -169,11 +169,13 @@ graphhopper:
 
   #### Storage ####
 
-  # Excludes certain types of highways during the OSM import to speed up the import and reduce the size of the graph.
-  # A typical case is excluding footway,cycleway,path and maybe pedestrian and track for motorized vehicles. This leads
-  # to a smaller graph, because there are fewer ways (obviously), but also because there are fewer junctions.
-  # Another example is excluding motorway, trunk and maybe primary highways for bicycle or pedestrian routing.
-  import.osm.ignored_highways: footway,cycleway,path,pedestrian,steps
+  # Excludes certain types of highways during the OSM import to speed up the process and reduce the size of the graph.
+  # A typical application is excluding 'footway','cycleway','path' and maybe 'pedestrian' and 'track' highways for
+  # motorized vehicles. This leads to a smaller and less dense graph, because there are fewer ways (obviously),
+  # but also because there are fewer crossings between highways (=junctions).
+  # Another typical example is excluding 'motorway', 'trunk' and maybe 'primary' highways for bicycle or pedestrian routing.
+  import.osm.ignored_highways: footway,cycleway,path,pedestrian,steps # typically useful for motorized-only routing
+  # import.osm.ignored_highways: motorway,trunk # typically useful for non-motorized routing
 
   # configure the memory access, use RAM_STORE for well equipped servers (default and recommended)
   graph.dataaccess.default_type: RAM_STORE

--- a/config-example.yml
+++ b/config-example.yml
@@ -32,8 +32,6 @@ graphhopper:
 
   profiles:
     - name: car
-      # note that as long as you only use motorized vehicles you can decrease the size of the graph
-      # using import.osm.ignored_highways (see below)
       vehicle: car
       weighting: custom
       custom_model:
@@ -42,6 +40,7 @@ graphhopper:
   #   u_turn_costs: 60
 
   # - name: bike
+      # to use the bike vehicle make sure to not ignore cycleways etc., see import.osm.ignored_highways below
   #   vehicle: bike
   #   weighting: custom
   #   # the custom model in bike2.json is defined to avoid hills
@@ -174,7 +173,7 @@ graphhopper:
   # A typical case is excluding footway,cycleway,path and maybe pedestrian and track for motorized vehicles. This leads
   # to a smaller graph, because there are less ways (obviously), but also because there are fewer junctions.
   # Another example is excluding motorway, trunk and maybe primary highways for bicycle or pedestrian routing.
-  # osm.import.ignored_highways: footway,cycleway,path
+  import.osm.ignored_highways: footway,cycleway,path,steps
 
   # configure the memory access, use RAM_STORE for well equipped servers (default and recommended)
   graph.dataaccess.default_type: RAM_STORE

--- a/config-example.yml
+++ b/config-example.yml
@@ -32,6 +32,8 @@ graphhopper:
 
   profiles:
     - name: car
+      # note that as long as you only use motorized vehicles you can decrease the size of the graph
+      # using import.osm.ignored_highways (see below)
       vehicle: car
       weighting: custom
       custom_model:
@@ -168,10 +170,11 @@ graphhopper:
 
   #### Storage ####
 
-  # Excludes certain types of highways during the OSM import to speed up the import and reduce the size of the graph
-  # The most typical case is excluding footway,path and maybe track for motorized vehicles. Excluding motorway, trunk
-  # and maybe primary highways for bicycle or pedestrian routing is also possible, but only has a minor effect.
-  # osm.import.ignored_highways: footway,path
+  # Excludes certain types of highways during the OSM import to speed up the import and reduce the size of the graph.
+  # A typical case is excluding footway,cycleway,path and maybe pedestrian and track for motorized vehicles. This leads
+  # to a smaller graph, because there are less ways (obviously), but also because there are fewer junctions.
+  # Another example is excluding motorway, trunk and maybe primary highways for bicycle or pedestrian routing.
+  # osm.import.ignored_highways: footway,cycleway,path
 
   # configure the memory access, use RAM_STORE for well equipped servers (default and recommended)
   graph.dataaccess.default_type: RAM_STORE

--- a/config-example.yml
+++ b/config-example.yml
@@ -173,7 +173,7 @@ graphhopper:
   # A typical case is excluding footway,cycleway,path and maybe pedestrian and track for motorized vehicles. This leads
   # to a smaller graph, because there are less ways (obviously), but also because there are fewer junctions.
   # Another example is excluding motorway, trunk and maybe primary highways for bicycle or pedestrian routing.
-  import.osm.ignored_highways: footway,cycleway,path,steps
+  import.osm.ignored_highways: footway,cycleway,path,pedestrian,steps
 
   # configure the memory access, use RAM_STORE for well equipped servers (default and recommended)
   graph.dataaccess.default_type: RAM_STORE

--- a/config-example.yml
+++ b/config-example.yml
@@ -17,8 +17,8 @@ graphhopper:
     service,
     pedestrian,
     track,
-    bus_guideway,
-    escape,
+    bus_guideway,busway,
+    escape,emergency_bay,
     raceway,
     road,
     busway,
@@ -30,7 +30,7 @@ graphhopper:
     cycleway,
     proposed,
     construction,
-    emergency_bay
+    platform
 
   ##### Routing Profiles ####
 

--- a/config-example.yml
+++ b/config-example.yml
@@ -5,32 +5,6 @@ graphhopper:
   # Local folder used by graphhopper to store its data
   graph.location: graph-cache
 
-  osm.import.accepted_highways: >
-    motorway,motorway_link,
-    trunk,trunk_link,
-    primary,primary_link,
-    secondary,secondary_link,
-    tertiary,tertiary_link,
-    unclassified,
-    residential,
-    living_street,
-    service,
-    pedestrian,
-    track,
-    bus_guideway,busway,
-    escape,emergency_bay,
-    raceway,
-    road,
-    busway,
-    footway,
-    bridleway,
-    steps,
-    corridor,
-    path,
-    cycleway,
-    proposed,
-    construction,
-    platform
 
   ##### Routing Profiles ####
 
@@ -193,6 +167,11 @@ graphhopper:
 
 
   #### Storage ####
+
+  # Excludes certain types of highways during the OSM import to speed up the import and reduce the size of the graph
+  # The most typical case is excluding footway,path and maybe track for motorized vehicles. Excluding motorway, trunk
+  # and maybe primary highways for bicycle or pedestrian routing is also possible, but only has a minor effect.
+  # osm.import.ignored_highways: footway,path
 
   # configure the memory access, use RAM_STORE for well equipped servers (default and recommended)
   graph.dataaccess.default_type: RAM_STORE

--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -568,7 +568,7 @@ public class GraphHopper {
         lmPreparationHandler.init(ghConfig);
 
         // osm import
-        osmReaderConfig.setAcceptedHighways(Arrays.stream(ghConfig.getString("import.osm.accepted_highways", String.join(",", osmReaderConfig.getAcceptedHighways()))
+        osmReaderConfig.setIgnoredHighways(Arrays.stream(ghConfig.getString("import.osm.ignored_highways", String.join(",", osmReaderConfig.getIgnoredHighways()))
                 .split(",")).map(String::trim).collect(Collectors.toList()));
         osmReaderConfig.setParseWayNames(ghConfig.getBool("datareader.instructions", osmReaderConfig.isParseWayNames()));
         osmReaderConfig.setPreferredLanguage(ghConfig.getString("datareader.preferred_language", osmReaderConfig.getPreferredLanguage()));
@@ -600,7 +600,7 @@ public class GraphHopper {
         return this;
     }
 
-    private void buildEncodingManagerAndOSMParsers(List<String> acceptedHighways, String flagEncodersStr, String encodedValuesStr, String dateRangeParserString, boolean withUrbanDensity, Collection<Profile> profiles) {
+    private void buildEncodingManagerAndOSMParsers(List<String> ignoredHighways, String flagEncodersStr, String encodedValuesStr, String dateRangeParserString, boolean withUrbanDensity, Collection<Profile> profiles) {
         Map<String, String> flagEncodersMap = new LinkedHashMap<>();
         for (String encoderStr : flagEncodersStr.split(",")) {
             String name = encoderStr.split("\\|")[0].trim();
@@ -634,7 +634,7 @@ public class GraphHopper {
         encodingManager = emBuilder.build();
 
         osmParsers = new OSMParsers();
-        acceptedHighways.forEach(osmParsers::addAcceptedHighway);
+        ignoredHighways.forEach(osmParsers::addIgnoredHighway);
 
         for (String s : encodedValueStrings) {
             TagParser tagParser = tagParserFactory.create(encodingManager, s);
@@ -793,7 +793,7 @@ public class GraphHopper {
         GHDirectory directory = new GHDirectory(ghLocation, dataAccessDefaultType);
         directory.configure(dataAccessConfig);
         boolean withUrbanDensity = urbanDensityCalculationThreads > 0;
-        buildEncodingManagerAndOSMParsers(osmReaderConfig.getAcceptedHighways(), vehiclesString, encodedValuesString, dateRangeParserString, withUrbanDensity, profilesByName.values());
+        buildEncodingManagerAndOSMParsers(osmReaderConfig.getIgnoredHighways(), vehiclesString, encodedValuesString, dateRangeParserString, withUrbanDensity, profilesByName.values());
         baseGraph = new BaseGraph.Builder(getEncodingManager())
                 .setDir(directory)
                 .set3D(hasElevation())

--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -568,6 +568,8 @@ public class GraphHopper {
         lmPreparationHandler.init(ghConfig);
 
         // osm import
+        osmReaderConfig.setAcceptedHighways(Arrays.stream(ghConfig.getString("import.osm.accepted_highways", String.join(",", osmReaderConfig.getAcceptedHighways()))
+                .split(",")).map(String::trim).collect(Collectors.toList()));
         osmReaderConfig.setParseWayNames(ghConfig.getBool("datareader.instructions", osmReaderConfig.isParseWayNames()));
         osmReaderConfig.setPreferredLanguage(ghConfig.getString("datareader.preferred_language", osmReaderConfig.getPreferredLanguage()));
         osmReaderConfig.setMaxWayPointDistance(ghConfig.getDouble(Routing.INIT_WAY_POINT_MAX_DISTANCE, osmReaderConfig.getMaxWayPointDistance()));
@@ -598,7 +600,7 @@ public class GraphHopper {
         return this;
     }
 
-    private void buildEncodingManagerAndOSMParsers(String flagEncodersStr, String encodedValuesStr, String dateRangeParserString, boolean withUrbanDensity, Collection<Profile> profiles) {
+    private void buildEncodingManagerAndOSMParsers(List<String> acceptedHighways, String flagEncodersStr, String encodedValuesStr, String dateRangeParserString, boolean withUrbanDensity, Collection<Profile> profiles) {
         Map<String, String> flagEncodersMap = new LinkedHashMap<>();
         for (String encoderStr : flagEncodersStr.split(",")) {
             String name = encoderStr.split("\\|")[0].trim();
@@ -632,6 +634,8 @@ public class GraphHopper {
         encodingManager = emBuilder.build();
 
         osmParsers = new OSMParsers();
+        acceptedHighways.forEach(osmParsers::addAcceptedHighway);
+
         for (String s : encodedValueStrings) {
             TagParser tagParser = tagParserFactory.create(encodingManager, s);
             if (tagParser != null)
@@ -789,7 +793,7 @@ public class GraphHopper {
         GHDirectory directory = new GHDirectory(ghLocation, dataAccessDefaultType);
         directory.configure(dataAccessConfig);
         boolean withUrbanDensity = urbanDensityCalculationThreads > 0;
-        buildEncodingManagerAndOSMParsers(vehiclesString, encodedValuesString, dateRangeParserString, withUrbanDensity, profilesByName.values());
+        buildEncodingManagerAndOSMParsers(osmReaderConfig.getAcceptedHighways(), vehiclesString, encodedValuesString, dateRangeParserString, withUrbanDensity, profilesByName.values());
         baseGraph = new BaseGraph.Builder(getEncodingManager())
                 .setDir(directory)
                 .set3D(hasElevation())

--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -568,6 +568,16 @@ public class GraphHopper {
         lmPreparationHandler.init(ghConfig);
 
         // osm import
+        // We do a few checks for import.osm.ignored_highways to prevent configuration errors when migrating from an older
+        // GH version.
+        if (!ghConfig.has("import.osm.ignored_highways"))
+            throw new IllegalArgumentException("Missing 'import.osm.ignored_highways'. Not using this parameter can decrease performance, see config-example.yml for more details");
+        String ignoredHighwaysString = ghConfig.getString("import.osm.ignored_highways", "");
+        if ((ignoredHighwaysString.contains("footway") || ignoredHighwaysString.contains("path")) && ghConfig.getProfiles().stream().map(Profile::getName).anyMatch(p -> p.contains("foot") || p.contains("hike") || p.contains("wheelchair")))
+            throw new IllegalArgumentException("You should not use import.osm.ignored_highways=footway or =path in conjunction with pedestrian profiles. This is probably an error in your configuration.");
+        if ((ignoredHighwaysString.contains("cycleway") || ignoredHighwaysString.contains("path")) && ghConfig.getProfiles().stream().map(Profile::getName).anyMatch(p -> p.contains("mtb") || p.contains("bike")))
+            throw new IllegalArgumentException("You should not use import.osm.ignored_highways=cycleway or =path in conjunction with bicycle profiles. This is probably an error in your configuration");
+
         osmReaderConfig.setIgnoredHighways(Arrays.stream(ghConfig.getString("import.osm.ignored_highways", String.join(",", osmReaderConfig.getIgnoredHighways()))
                 .split(",")).map(String::trim).collect(Collectors.toList()));
         osmReaderConfig.setParseWayNames(ghConfig.getBool("datareader.instructions", osmReaderConfig.isParseWayNames()));

--- a/core/src/main/java/com/graphhopper/reader/osm/WaySegmentParser.java
+++ b/core/src/main/java/com/graphhopper/reader/osm/WaySegmentParser.java
@@ -137,9 +137,9 @@ public class WaySegmentParser {
     private class Pass1Handler implements ReaderElementHandler {
         private boolean handledWays;
         private boolean handledRelations;
-        private long wayCounter = 1;
+        private long wayCounter = 0;
         private long acceptedWays = 0;
-        private long relationsCounter = -1;
+        private long relationsCounter = 0;
 
         @Override
         public void handleWay(ReaderWay way) {
@@ -198,10 +198,10 @@ public class WaySegmentParser {
         private boolean handledNodes;
         private boolean handledWays;
         private boolean handledRelations;
-        private long nodeCounter = -1;
+        private long nodeCounter = 0;
         private long acceptedNodes = 0;
         private long ignoredSplitNodes = 0;
-        private long wayCounter = -1;
+        private long wayCounter = 0;
 
         @Override
         public void handleNode(ReaderNode node) {

--- a/core/src/main/java/com/graphhopper/routing/OSMReaderConfig.java
+++ b/core/src/main/java/com/graphhopper/routing/OSMReaderConfig.java
@@ -18,7 +18,11 @@
 
 package com.graphhopper.routing;
 
+import java.util.Arrays;
+import java.util.List;
+
 public class OSMReaderConfig {
+    private List<String> acceptedHighways = createDefaultAcceptedHighways();
     private boolean parseWayNames = true;
     private String preferredLanguage = "";
     private double maxWayPointDistance = 1;
@@ -27,6 +31,54 @@ public class OSMReaderConfig {
     private int ramerElevationSmoothingMax = 5;
     private double longEdgeSamplingDistance = Double.MAX_VALUE;
     private int workerThreads = 2;
+
+    public static List<String> createDefaultAcceptedHighways() {
+        return Arrays.asList(
+                "motorway", "motorway_link",
+                "trunk", "trunk_link",
+                "primary", "primary_link",
+                "secondary", "secondary_link",
+                "tertiary", "tertiary_link",
+                "unclassified",
+                "residential",
+                "living_street",
+                "service",
+                "pedestrian",
+                "track",
+                "bus_guideway", "busway",
+                "escape", "emergency_bay",
+                "raceway",
+                "road",
+                "footway",
+                "bridleway",
+                "steps",
+                "corridor",
+                "path",
+                "cycleway",
+                "proposed",
+                "construction"
+        );
+    }
+
+    public List<String> getAcceptedHighways() {
+        return acceptedHighways;
+    }
+
+    /**
+     * Sets the values of the highway tag that shall be considered when we read the OSM file. OSM ways that do not include
+     * a highway tag with one of these values will be ignored entirely during import, but just because they are
+     * accepted does not necessarily mean they will be considered by the route calculations. This still depends on the
+     * weighting and/or the access flags for the corresponding edges. Not including some road types here is mostly a
+     * performance optimization. For example if one is only interested in routing for motorized vehicles the routing
+     * graph size can be reduced by not including tracks, footways and paths (20-50% depending on your area, ~25%
+     * for planet files). Another reason to exclude footways etc. for motorized vehicle routing could be preventing
+     * undesired u-turns (#1858). Similarly, one could exclude motorway, trunk or even primary for bicycle or pedestrian routing, but since there
+     * aren't many such roads the graph size reduction will be very small (<4%).
+     */
+    public OSMReaderConfig setAcceptedHighways(List<String> acceptedHighways) {
+        this.acceptedHighways = acceptedHighways;
+        return this;
+    }
 
     public String getPreferredLanguage() {
         return preferredLanguage;

--- a/core/src/main/java/com/graphhopper/routing/OSMReaderConfig.java
+++ b/core/src/main/java/com/graphhopper/routing/OSMReaderConfig.java
@@ -18,11 +18,11 @@
 
 package com.graphhopper.routing;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
 
 public class OSMReaderConfig {
-    private List<String> acceptedHighways = createDefaultAcceptedHighways();
+    private List<String> ignoredHighways = new ArrayList<>();
     private boolean parseWayNames = true;
     private String preferredLanguage = "";
     private double maxWayPointDistance = 1;
@@ -32,52 +32,21 @@ public class OSMReaderConfig {
     private double longEdgeSamplingDistance = Double.MAX_VALUE;
     private int workerThreads = 2;
 
-    public static List<String> createDefaultAcceptedHighways() {
-        return Arrays.asList(
-                "motorway", "motorway_link",
-                "trunk", "trunk_link",
-                "primary", "primary_link",
-                "secondary", "secondary_link",
-                "tertiary", "tertiary_link",
-                "unclassified",
-                "residential",
-                "living_street",
-                "service",
-                "pedestrian",
-                "track",
-                "bus_guideway", "busway",
-                "escape", "emergency_bay",
-                "raceway",
-                "road",
-                "footway",
-                "bridleway",
-                "steps",
-                "corridor",
-                "path",
-                "cycleway",
-                "proposed",
-                "construction",
-                "platform"
-        );
-    }
-
-    public List<String> getAcceptedHighways() {
-        return acceptedHighways;
+    public List<String> getIgnoredHighways() {
+        return ignoredHighways;
     }
 
     /**
-     * Sets the values of the highway tag that shall be considered when we read the OSM file. OSM ways that do not include
-     * a highway tag with one of these values will be ignored entirely during import, but just because they are
-     * accepted does not necessarily mean they will be considered by the route calculations. This still depends on the
-     * weighting and/or the access flags for the corresponding edges. Not including some road types here is mostly a
-     * performance optimization. For example if one is only interested in routing for motorized vehicles the routing
-     * graph size can be reduced by not including tracks, footways and paths (20-50% depending on your area, ~25%
-     * for planet files). Another reason to exclude footways etc. for motorized vehicle routing could be preventing
-     * undesired u-turns (#1858). Similarly, one could exclude motorway, trunk or even primary for bicycle or pedestrian routing, but since there
-     * aren't many such roads the graph size reduction will be very small (<4%).
+     * Sets the values of the highway tag that shall be ignored when we read the OSM file. This can be used to speed up
+     * the import and reduce the size of the resulting routing graph. For example if one is only interested in routing
+     * for motorized vehicles the routing graph size can be reduced by excluding footways, paths and or tracks
+     * (20-50% depending on your area, ~25% for planet files). Another reason to exclude footways etc. for motorized
+     * vehicle routing could be preventing undesired u-turns (#1858). Similarly, one could exclude motorway, trunk or
+     * even primary highways for bicycle or pedestrian routing. But since there aren't many such roads the graph size
+     * reduction will be very small (<4%).
      */
-    public OSMReaderConfig setAcceptedHighways(List<String> acceptedHighways) {
-        this.acceptedHighways = acceptedHighways;
+    public OSMReaderConfig setIgnoredHighways(List<String> ignoredHighways) {
+        this.ignoredHighways = ignoredHighways;
         return this;
     }
 

--- a/core/src/main/java/com/graphhopper/routing/OSMReaderConfig.java
+++ b/core/src/main/java/com/graphhopper/routing/OSMReaderConfig.java
@@ -39,11 +39,11 @@ public class OSMReaderConfig {
     /**
      * Sets the values of the highway tag that shall be ignored when we read the OSM file. This can be used to speed up
      * the import and reduce the size of the resulting routing graph. For example if one is only interested in routing
-     * for motorized vehicles the routing graph size can be reduced by excluding footways, paths and or tracks
-     * (20-50% depending on your area, ~25% for planet files). Another reason to exclude footways etc. for motorized
-     * vehicle routing could be preventing undesired u-turns (#1858). Similarly, one could exclude motorway, trunk or
-     * even primary highways for bicycle or pedestrian routing. But since there aren't many such roads the graph size
-     * reduction will be very small (<4%).
+     * for motorized vehicles the routing graph size can be reduced by excluding footways, cycleways, paths and/or
+     * tracks. This can be quite significant depending on your area. Not only are there fewer ways to be processed, but
+     * there are also fewer junctions, which means fewer nodes and edges. Another reason to exclude footways etc. for
+     * motorized vehicle routing could be preventing undesired u-turns (#1858). Similarly, one could exclude motorway,
+     * trunk or even primary highways for bicycle or pedestrian routing.
      */
     public OSMReaderConfig setIgnoredHighways(List<String> ignoredHighways) {
         this.ignoredHighways = ignoredHighways;

--- a/core/src/main/java/com/graphhopper/routing/OSMReaderConfig.java
+++ b/core/src/main/java/com/graphhopper/routing/OSMReaderConfig.java
@@ -56,7 +56,8 @@ public class OSMReaderConfig {
                 "path",
                 "cycleway",
                 "proposed",
-                "construction"
+                "construction",
+                "platform"
         );
     }
 

--- a/core/src/main/java/com/graphhopper/routing/util/OSMParsers.java
+++ b/core/src/main/java/com/graphhopper/routing/util/OSMParsers.java
@@ -27,11 +27,13 @@ import com.graphhopper.routing.util.parsers.TagParser;
 import com.graphhopper.storage.IntsRef;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
 
 public class OSMParsers {
     private final List<String> ignoredHighways;
+    private List<String> acceptedRoutes;
     private final List<TagParser> wayTagParsers;
     private final List<VehicleTagParser> vehicleTagParsers;
     private final List<RelationTagParser> relationTagParsers;
@@ -39,12 +41,13 @@ public class OSMParsers {
     private final EncodedValue.InitializerConfig relConfig = new EncodedValue.InitializerConfig();
 
     public OSMParsers() {
-        this(new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
+        this(new ArrayList<>(), Arrays.asList("ferry", "shuttle_train"), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
     }
 
-    public OSMParsers(List<String> ignoredHighways, List<TagParser> wayTagParsers, List<VehicleTagParser> vehicleTagParsers,
+    public OSMParsers(List<String> ignoredHighways, List<String> acceptedRoutes, List<TagParser> wayTagParsers, List<VehicleTagParser> vehicleTagParsers,
                       List<RelationTagParser> relationTagParsers, List<RestrictionTagParser> restrictionTagParsers) {
         this.ignoredHighways = ignoredHighways;
+        this.acceptedRoutes = acceptedRoutes;
         this.wayTagParsers = wayTagParsers;
         this.vehicleTagParsers = vehicleTagParsers;
         this.relationTagParsers = relationTagParsers;
@@ -53,6 +56,11 @@ public class OSMParsers {
 
     public OSMParsers addIgnoredHighway(String highway) {
         ignoredHighways.add(highway);
+        return this;
+    }
+
+    public OSMParsers setAcceptedRoutes(List<String> acceptedRoutes) {
+        this.acceptedRoutes = acceptedRoutes;
         return this;
     }
 
@@ -81,7 +89,12 @@ public class OSMParsers {
 
     public boolean acceptWay(ReaderWay way) {
         String highway = way.getTag("highway");
-        return highway != null && !ignoredHighways.contains(highway);
+        if (highway != null)
+            return !ignoredHighways.contains(highway);
+        else {
+            String route = way.getTag("route");
+            return route != null && acceptedRoutes.contains(route);
+        }
     }
 
     public IntsRef handleRelationTags(ReaderRelation relation, IntsRef relFlags) {

--- a/core/src/main/java/com/graphhopper/routing/util/OSMParsers.java
+++ b/core/src/main/java/com/graphhopper/routing/util/OSMParsers.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.function.Function;
 
 public class OSMParsers {
+    private final List<String> acceptedHighways;
     private final List<TagParser> wayTagParsers;
     private final List<VehicleTagParser> vehicleTagParsers;
     private final List<RelationTagParser> relationTagParsers;
@@ -38,15 +39,21 @@ public class OSMParsers {
     private final EncodedValue.InitializerConfig relConfig = new EncodedValue.InitializerConfig();
 
     public OSMParsers() {
-        this(new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
+        this(new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
     }
 
-    public OSMParsers(List<TagParser> wayTagParsers, List<VehicleTagParser> vehicleTagParsers,
+    public OSMParsers(List<String> acceptedHighways, List<TagParser> wayTagParsers, List<VehicleTagParser> vehicleTagParsers,
                       List<RelationTagParser> relationTagParsers, List<RestrictionTagParser> restrictionTagParsers) {
+        this.acceptedHighways = acceptedHighways;
         this.wayTagParsers = wayTagParsers;
         this.vehicleTagParsers = vehicleTagParsers;
         this.relationTagParsers = relationTagParsers;
         this.restrictionTagParsers = restrictionTagParsers;
+    }
+
+    public OSMParsers addAcceptedHighway(String highway) {
+        acceptedHighways.add(highway);
+        return this;
     }
 
     public OSMParsers addWayTagParser(TagParser tagParser) {
@@ -73,7 +80,8 @@ public class OSMParsers {
     }
 
     public boolean acceptWay(ReaderWay way) {
-        return vehicleTagParsers.stream().anyMatch(v -> !v.getAccess(way).equals(WayAccess.CAN_SKIP));
+        String highway = way.getTag("highway");
+        return highway != null && acceptedHighways.contains(highway);
     }
 
     public IntsRef handleRelationTags(ReaderRelation relation, IntsRef relFlags) {
@@ -98,6 +106,10 @@ public class OSMParsers {
         if (requiredInts > 2)
             throw new IllegalStateException("More than two ints are needed for relation flags, but OSMReader does not allow this");
         return new IntsRef(2);
+    }
+
+    public List<String> getAcceptedHighways() {
+        return acceptedHighways;
     }
 
     public List<VehicleTagParser> getVehicleTagParsers() {

--- a/core/src/main/java/com/graphhopper/routing/util/OSMParsers.java
+++ b/core/src/main/java/com/graphhopper/routing/util/OSMParsers.java
@@ -31,7 +31,7 @@ import java.util.List;
 import java.util.function.Function;
 
 public class OSMParsers {
-    private final List<String> acceptedHighways;
+    private final List<String> ignoredHighways;
     private final List<TagParser> wayTagParsers;
     private final List<VehicleTagParser> vehicleTagParsers;
     private final List<RelationTagParser> relationTagParsers;
@@ -42,17 +42,17 @@ public class OSMParsers {
         this(new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
     }
 
-    public OSMParsers(List<String> acceptedHighways, List<TagParser> wayTagParsers, List<VehicleTagParser> vehicleTagParsers,
+    public OSMParsers(List<String> ignoredHighways, List<TagParser> wayTagParsers, List<VehicleTagParser> vehicleTagParsers,
                       List<RelationTagParser> relationTagParsers, List<RestrictionTagParser> restrictionTagParsers) {
-        this.acceptedHighways = acceptedHighways;
+        this.ignoredHighways = ignoredHighways;
         this.wayTagParsers = wayTagParsers;
         this.vehicleTagParsers = vehicleTagParsers;
         this.relationTagParsers = relationTagParsers;
         this.restrictionTagParsers = restrictionTagParsers;
     }
 
-    public OSMParsers addAcceptedHighway(String highway) {
-        acceptedHighways.add(highway);
+    public OSMParsers addIgnoredHighway(String highway) {
+        ignoredHighways.add(highway);
         return this;
     }
 
@@ -81,7 +81,7 @@ public class OSMParsers {
 
     public boolean acceptWay(ReaderWay way) {
         String highway = way.getTag("highway");
-        return highway != null && acceptedHighways.contains(highway);
+        return highway != null && !ignoredHighways.contains(highway);
     }
 
     public IntsRef handleRelationTags(ReaderRelation relation, IntsRef relFlags) {
@@ -108,8 +108,8 @@ public class OSMParsers {
         return new IntsRef(2);
     }
 
-    public List<String> getAcceptedHighways() {
-        return acceptedHighways;
+    public List<String> getIgnoredHighways() {
+        return ignoredHighways;
     }
 
     public List<VehicleTagParser> getVehicleTagParsers() {

--- a/core/src/test/java/com/graphhopper/GraphHopperTest.java
+++ b/core/src/test/java/com/graphhopper/GraphHopperTest.java
@@ -98,12 +98,12 @@ public class GraphHopperTest {
 
     @ParameterizedTest
     @CsvSource({
-            DIJKSTRA + ",false,511",
-            ASTAR + ",false,256",
-            DIJKSTRA_BI + ",false,228",
-            ASTAR_BI + ",false,142",
-            ASTAR_BI + ",true,41",
-            DIJKSTRA_BI + ",true,48"
+            DIJKSTRA + ",false,708",
+            ASTAR + ",false,363",
+            DIJKSTRA_BI + ",false,346",
+            ASTAR_BI + ",false,192",
+            ASTAR_BI + ",true,42",
+            DIJKSTRA_BI + ",true,47"
     })
     public void testMonacoDifferentAlgorithms(String algo, boolean withCH, int expectedVisitedNodes) {
         final String vehicle = "car";
@@ -150,7 +150,7 @@ public class GraphHopperTest {
                 setAlgorithm(ASTAR).setProfile(profile));
 
         // identify the number of counts to compare with CH foot route
-        assertEquals(706, rsp.getHints().getLong("visited_nodes.sum", 0));
+        assertEquals(712, rsp.getHints().getLong("visited_nodes.sum", 0));
 
         ResponsePath res = rsp.getBest();
         assertEquals(3437.1, res.getDistance(), .1);
@@ -570,6 +570,7 @@ public class GraphHopperTest {
                 setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(BAYREUTH).
                 setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting));
+        hopper.getReaderConfig().setIgnoredHighways(Arrays.asList("footway", "path"));
         hopper.importOrLoad();
 
         GHRequest req = new GHRequest(49.985272, 11.506151, 49.986107, 11.507202).
@@ -1600,17 +1601,17 @@ public class GraphHopperTest {
         hopper.importOrLoad();
 
         // flex
-        testCrossQueryAssert(profile1, hopper, 528.3, 138, true);
-        testCrossQueryAssert(profile2, hopper, 635.8, 138, true);
-        testCrossQueryAssert(profile3, hopper, 815.2, 140, true);
+        testCrossQueryAssert(profile1, hopper, 528.3, 196, true);
+        testCrossQueryAssert(profile2, hopper, 635.8, 198, true);
+        testCrossQueryAssert(profile3, hopper, 815.2, 198, true);
 
         // LM (should be the same as flex, but with less visited nodes!)
-        testCrossQueryAssert(profile1, hopper, 528.3, 74, false);
-        testCrossQueryAssert(profile2, hopper, 635.8, 124, false);
-        // this is actually interesting: the number of visited nodes *increases* once again (while it strictly decreases
-        // with rising distance factor for flex): cross-querying 'works', but performs *worse*, because the landmarks
-        // were not customized for the weighting in use. Creating a separate LM preparation for profile3 yields 74
-        testCrossQueryAssert(profile3, hopper, 815.2, 162, false);
+        testCrossQueryAssert(profile1, hopper, 528.3, 108, false);
+        testCrossQueryAssert(profile2, hopper, 635.8, 162, false);
+        // this is actually interesting: the number of visited nodes increases: cross-querying 'works',
+        // but can even perform *worse*, because the landmarks were not customized for the weighting in use.
+        // Creating a separate LM preparation for profile3 yields 108 (not shown)
+        testCrossQueryAssert(profile3, hopper, 815.2, 236, false);
     }
 
     private void testCrossQueryAssert(String profile, GraphHopper hopper, double expectedWeight, int expectedVisitedNodes, boolean disableLM) {
@@ -2198,13 +2199,13 @@ public class GraphHopperTest {
         GHRequest req = new GHRequest(p, q);
         req.setProfile("my_profile");
         // we force the start/target directions such that there are u-turns right after we start and right before
-        // we reach the target
+        // we reach the target. at the start location we do a u-turn at the crossing with the *steps* ('ghost junction')
         req.setCurbsides(Arrays.asList("right", "right"));
         GHResponse res = h.route(req);
         assertFalse(res.hasErrors(), "routing should not fail");
-        assertEquals(266.8, res.getBest().getRouteWeight(), 0.1);
-        assertEquals(2116, res.getBest().getDistance(), 1);
-        assertEquals(266800, res.getBest().getTime(), 1000);
+        assertEquals(242.9, res.getBest().getRouteWeight(), 0.1);
+        assertEquals(1917, res.getBest().getDistance(), 1);
+        assertEquals(243000, res.getBest().getTime(), 1000);
     }
 
     @Test
@@ -2671,7 +2672,7 @@ public class GraphHopperTest {
                     .setProfiles(new Profile("car").setVehicle("car").setWeighting("fastest"))
                     .setGraphHopperLocation(GH_LOCATION);
             hopper.load();
-            assertEquals(1942, hopper.getBaseGraph().getNodes());
+            assertEquals(2961, hopper.getBaseGraph().getNodes());
         }
     }
 

--- a/core/src/test/java/com/graphhopper/GraphHopperTest.java
+++ b/core/src/test/java/com/graphhopper/GraphHopperTest.java
@@ -570,8 +570,6 @@ public class GraphHopperTest {
                 setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(BAYREUTH).
                 setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting));
-        // todonow: get rid of this?
-        hopper.getReaderConfig().setIgnoredHighways(Arrays.asList("footway", "path"));
         hopper.importOrLoad();
 
         GHRequest req = new GHRequest(49.985272, 11.506151, 49.986107, 11.507202).
@@ -646,9 +644,13 @@ public class GraphHopperTest {
 
         req.putHint(Routing.BLOCK_AREA, "49.984434,11.505212,49.985394,11.506333");
         rsp = hopper.route(req);
-        assertEquals(11.508, rsp.getBest().getWaypoints().getLon(0), 0.001);
+        // we do not snap to Grüngraben (within the blocked area), but onto Lohweg and then we need to go to Hauptstraße
+        // and turn left onto Waldhüttenstraße. Note that if we exclude footway we get an entirely different path, because
+        // the start point snaps all the way to the East onto the end of Bergstraße (because Lohweg gets no longer split
+        // into several edges...)
+        assertEquals(11.506, rsp.getBest().getWaypoints().getLon(0), 0.001);
         assertFalse(rsp.hasErrors(), rsp.getErrors().toString());
-        assertEquals(1185, rsp.getBest().getDistance(), 10);
+        assertEquals(510, rsp.getBest().getDistance(), 10);
 
         // first point is contained in block_area => error
         req = new GHRequest(49.979, 11.516, 49.986107, 11.507202).

--- a/core/src/test/java/com/graphhopper/GraphHopperTest.java
+++ b/core/src/test/java/com/graphhopper/GraphHopperTest.java
@@ -570,6 +570,7 @@ public class GraphHopperTest {
                 setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(BAYREUTH).
                 setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting));
+        // todonow: get rid of this?
         hopper.getReaderConfig().setIgnoredHighways(Arrays.asList("footway", "path"));
         hopper.importOrLoad();
 

--- a/core/src/test/java/com/graphhopper/reader/osm/GraphHopperOSMTest.java
+++ b/core/src/test/java/com/graphhopper/reader/osm/GraphHopperOSMTest.java
@@ -635,6 +635,7 @@ public class GraphHopperOSMTest {
                 setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting)).
                 setGraphHopperLocation(ghLoc).
                 setOSMFile(testOsm3);
+        // exclude motorways which aren't accessible for foot
         instance.getReaderConfig().setIgnoredHighways(Arrays.asList("motorway"));
         instance.getCHPreparationHandler().setCHProfiles(new CHProfile(profile));
         instance.importOrLoad();

--- a/core/src/test/java/com/graphhopper/reader/osm/GraphHopperOSMTest.java
+++ b/core/src/test/java/com/graphhopper/reader/osm/GraphHopperOSMTest.java
@@ -462,6 +462,7 @@ public class GraphHopperOSMTest {
                                 putObject("datareader.file", testOsm3).
                                 putObject("datareader.dataaccess", "RAM").
                                 putObject("graph.vehicles", "foot,car").
+                                putObject("import.osm.ignored_highways", "").
                                 setProfiles(Arrays.asList(
                                         new Profile("foot").setVehicle("foot").setWeighting("fastest"),
                                         new Profile("car").setVehicle("car").setWeighting("fastest")
@@ -477,6 +478,7 @@ public class GraphHopperOSMTest {
                                 putObject("datareader.file", testOsm3).
                                 putObject("datareader.dataaccess", "RAM").
                                 putObject("graph.vehicles", "foot").
+                                putObject("import.osm.ignored_highways", "").
                                 setProfiles(Collections.singletonList(
                                         new Profile("foot").setVehicle("foot").setWeighting("fastest")
                                 ))).
@@ -490,6 +492,7 @@ public class GraphHopperOSMTest {
                         putObject("datareader.file", testOsm3).
                         putObject("datareader.dataaccess", "RAM").
                         putObject("graph.vehicles", "car,foot").
+                        putObject("import.osm.ignored_highways", "").
                         setProfiles(Arrays.asList(
                                 new Profile("car").setVehicle("car").setWeighting("fastest"),
                                 new Profile("foot").setVehicle("foot").setWeighting("fastest")
@@ -506,6 +509,7 @@ public class GraphHopperOSMTest {
                                 putObject("datareader.dataaccess", "RAM").
                                 putObject("graph.encoded_values", "road_class").
                                 putObject("graph.vehicles", "foot,car").
+                                putObject("import.osm.ignored_highways", "").
                                 setProfiles(Arrays.asList(
                                         new Profile("foot").setVehicle("foot").setWeighting("fastest"),
                                         new Profile("car").setVehicle("car").setWeighting("fastest")
@@ -525,6 +529,7 @@ public class GraphHopperOSMTest {
                                 putObject("datareader.file", testOsm3).
                                 putObject("datareader.dataaccess", "RAM").
                                 putObject("graph.vehicles", "foot,car").
+                                putObject("import.osm.ignored_highways", "").
                                 setProfiles(Arrays.asList(
                                         new Profile("foot").setVehicle("foot").setWeighting("fastest"),
                                         new Profile("car").setVehicle("car").setWeighting("fastest")
@@ -545,6 +550,7 @@ public class GraphHopperOSMTest {
                                 putObject("graph.location", ghLoc).
                                 putObject("graph.encoded_values", "road_environment,road_class").
                                 putObject("graph.vehicles", "foot,car").
+                                putObject("import.osm.ignored_highways", "").
                                 setProfiles(Arrays.asList(
                                         new Profile("foot").setVehicle("foot").setWeighting("fastest"),
                                         new Profile("car").setVehicle("car").setWeighting("fastest")
@@ -663,6 +669,7 @@ public class GraphHopperOSMTest {
                         putObject("datareader.file", testOsm3).
                         putObject("prepare.min_network_size", 0).
                         putObject("graph.vehicles", vehicle).
+                        putObject("import.osm.ignored_highways", "").
                         setProfiles(Collections.singletonList(new Profile(profile).setVehicle(vehicle).setWeighting(weighting))).
                         setCHProfiles(Collections.singletonList(new CHProfile(profile)))
                 ).
@@ -861,6 +868,7 @@ public class GraphHopperOSMTest {
         hopper.init(new GraphHopperConfig()
                 .putObject("graph.location", ghLoc)
                 .putObject("datareader.file", testOsm)
+                .putObject("import.osm.ignored_highways", "")
                 .setProfiles(profiles)
         );
         return hopper;

--- a/core/src/test/java/com/graphhopper/reader/osm/GraphHopperOSMTest.java
+++ b/core/src/test/java/com/graphhopper/reader/osm/GraphHopperOSMTest.java
@@ -182,7 +182,7 @@ public class GraphHopperOSMTest {
             }
         });
 
-        assertEquals(57, indexNodeList.size());
+        assertEquals(148, indexNodeList.size());
         for (int nodeId : indexNodeList) {
             if (!bbox.contains(na.getLat(nodeId), na.getLon(nodeId)))
                 fail("bbox " + bbox + " should contain " + nodeId);
@@ -635,6 +635,7 @@ public class GraphHopperOSMTest {
                 setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting(weighting)).
                 setGraphHopperLocation(ghLoc).
                 setOSMFile(testOsm3);
+        instance.getReaderConfig().setIgnoredHighways(Arrays.asList("motorway"));
         instance.getCHPreparationHandler().setCHProfiles(new CHProfile(profile));
         instance.importOrLoad();
 

--- a/core/src/test/java/com/graphhopper/reader/osm/OSMReaderTest.java
+++ b/core/src/test/java/com/graphhopper/reader/osm/OSMReaderTest.java
@@ -886,6 +886,7 @@ public class OSMReaderTest {
         GHResponse response = gh.route(new GHRequest(51.2492152, 9.4317166, 52.133, 9.1)
                 .setProfile("profile")
                 .setPathDetails(Collections.singletonList(RoadClass.KEY)));
+        assertFalse(response.hasErrors(), response.getErrors().toString());
         List<PathDetail> list = response.getBest().getPathDetails().get(RoadClass.KEY);
         assertEquals(3, list.size());
         assertEquals(RoadClass.MOTORWAY.toString(), list.get(0).getValue());

--- a/core/src/test/java/com/graphhopper/routing/RoutingAlgorithmWithOSMTest.java
+++ b/core/src/test/java/com/graphhopper/routing/RoutingAlgorithmWithOSMTest.java
@@ -76,12 +76,12 @@ public class RoutingAlgorithmWithOSMTest {
         Graph g = hopper.getBaseGraph();
 
         // When OSM file stays unchanged make static edge and node IDs a requirement
-        assertEquals(GHUtility.asSet(9, 111, 182), GHUtility.getNeighbors(g.createEdgeExplorer().setBaseNode(10)));
-        assertEquals(GHUtility.asSet(19, 21), GHUtility.getNeighbors(g.createEdgeExplorer().setBaseNode(20)));
-        assertEquals(GHUtility.asSet(478, 84, 83), GHUtility.getNeighbors(g.createEdgeExplorer().setBaseNode(480)));
+        assertEquals(GHUtility.asSet(921, 575, 2), GHUtility.getNeighbors(g.createEdgeExplorer().setBaseNode(10)));
+        assertEquals(GHUtility.asSet(291, 369, 19), GHUtility.getNeighbors(g.createEdgeExplorer().setBaseNode(20)));
+        assertEquals(GHUtility.asSet(277, 478, 474), GHUtility.getNeighbors(g.createEdgeExplorer().setBaseNode(480)));
 
-        assertEquals(43.736989, g.getNodeAccess().getLat(10), 1e-6);
-        assertEquals(7.429758, g.getNodeAccess().getLon(201), 1e-6);
+        assertEquals(43.738776, g.getNodeAccess().getLat(10), 1e-6);
+        assertEquals(7.4170402, g.getNodeAccess().getLon(201), 1e-6);
     }
 
     private List<Query> createMonacoCarQueries() {
@@ -122,7 +122,7 @@ public class RoutingAlgorithmWithOSMTest {
     @Test
     public void testMonacoMotorcycleCurvature() {
         List<Query> queries = new ArrayList<>();
-        queries.add(new Query(43.730729, 7.42135, 43.727697, 7.419199, 2681, 119));
+        queries.add(new Query(43.730729, 7.42135, 43.727697, 7.419199, 2675, 117));
         queries.add(new Query(43.727687, 7.418737, 43.74958, 7.436566, 3727, 170));
         queries.add(new Query(43.728677, 7.41016, 43.739213, 7.4277, 3157, 165));
         queries.add(new Query(43.733802, 7.413433, 43.739662, 7.424355, 2423, 141));
@@ -273,12 +273,12 @@ public class RoutingAlgorithmWithOSMTest {
         Graph g = hopper.getBaseGraph();
 
         // see testMonaco for a similar ID test
-        assertEquals(GHUtility.asSet(2, 909, 571), GHUtility.getNeighbors(g.createEdgeExplorer().setBaseNode(10)));
-        assertEquals(GHUtility.asSet(444, 956, 740), GHUtility.getNeighbors(g.createEdgeExplorer().setBaseNode(441)));
-        assertEquals(GHUtility.asSet(911, 404, 122, 914), GHUtility.getNeighbors(g.createEdgeExplorer().setBaseNode(912)));
+        assertEquals(GHUtility.asSet(921, 575, 2), GHUtility.getNeighbors(g.createEdgeExplorer().setBaseNode(10)));
+        assertEquals(GHUtility.asSet(967, 440, 286), GHUtility.getNeighbors(g.createEdgeExplorer().setBaseNode(441)));
+        assertEquals(GHUtility.asSet(580, 910, 911), GHUtility.getNeighbors(g.createEdgeExplorer().setBaseNode(912)));
 
-        assertEquals(43.743705, g.getNodeAccess().getLat(100), 1e-6);
-        assertEquals(7.426362, g.getNodeAccess().getLon(702), 1e-6);
+        assertEquals(43.7467818, g.getNodeAccess().getLat(100), 1e-6);
+        assertEquals(7.4311381, g.getNodeAccess().getLon(702), 1e-6);
     }
 
     @Test

--- a/example/src/main/java/com/graphhopper/example/RoutingExample.java
+++ b/example/src/main/java/com/graphhopper/example/RoutingExample.java
@@ -111,7 +111,7 @@ public class RoutingExample {
         res = hopper.route(req);
         if (res.hasErrors())
             throw new RuntimeException(res.getErrors().toString());
-        assert res.getAll().size() == 2;
+        assert res.getAll().size() == 1;
         assert Helper.round(res.getBest().getDistance(), -2) == 2300;
     }
 

--- a/example/src/main/java/com/graphhopper/example/RoutingExample.java
+++ b/example/src/main/java/com/graphhopper/example/RoutingExample.java
@@ -105,14 +105,14 @@ public class RoutingExample {
 
         // calculate alternative routes between two points (supported with and without CH)
         req = new GHRequest().setProfile("car").
-                addPoint(new GHPoint(42.502904, 1.514714)).addPoint(new GHPoint(42.511953, 1.535914)).
+                addPoint(new GHPoint(42.502904, 1.514714)).addPoint(new GHPoint(42.508774, 1.537094)).
                 setAlgorithm(Parameters.Algorithms.ALT_ROUTE);
         req.getHints().putObject(Parameters.Algorithms.AltRoute.MAX_PATHS, 3);
         res = hopper.route(req);
         if (res.hasErrors())
             throw new RuntimeException(res.getErrors().toString());
-        assert res.getAll().size() == 1;
-        assert Helper.round(res.getBest().getDistance(), -2) == 2300;
+        assert res.getAll().size() == 2;
+        assert Helper.round(res.getBest().getDistance(), -2) == 2200;
     }
 
     /**

--- a/navigation/src/test/java/com/graphhopper/navigation/NavigateResponseConverterTest.java
+++ b/navigation/src/test/java/com/graphhopper/navigation/NavigateResponseConverterTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Locale;
 
@@ -41,8 +42,9 @@ public class NavigateResponseConverterTest {
                 setOSMFile(osmFile).
                 setStoreOnFlush(true).
                 setGraphHopperLocation(graphFolder).
-                setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting("fastest").setTurnCosts(false)).
-                importOrLoad();
+                setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting("fastest").setTurnCosts(false));
+        hopper.getReaderConfig().setIgnoredHighways(Arrays.asList("footway", "path", "cycleway", "steps", "pedestrian"));
+        hopper.importOrLoad();
     }
 
     @AfterAll

--- a/navigation/src/test/java/com/graphhopper/navigation/NavigateResponseConverterTest.java
+++ b/navigation/src/test/java/com/graphhopper/navigation/NavigateResponseConverterTest.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Locale;
 
@@ -43,7 +42,6 @@ public class NavigateResponseConverterTest {
                 setStoreOnFlush(true).
                 setGraphHopperLocation(graphFolder).
                 setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting("fastest").setTurnCosts(false));
-        hopper.getReaderConfig().setIgnoredHighways(Arrays.asList("footway", "path", "cycleway", "steps", "pedestrian"));
         hopper.importOrLoad();
     }
 

--- a/navigation/src/test/java/com/graphhopper/navigation/NavigateResponseConverterTest.java
+++ b/navigation/src/test/java/com/graphhopper/navigation/NavigateResponseConverterTest.java
@@ -41,8 +41,8 @@ public class NavigateResponseConverterTest {
                 setOSMFile(osmFile).
                 setStoreOnFlush(true).
                 setGraphHopperLocation(graphFolder).
-                setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting("fastest").setTurnCosts(false));
-        hopper.importOrLoad();
+                setProfiles(new Profile(profile).setVehicle(vehicle).setWeighting("fastest").setTurnCosts(false)).
+                importOrLoad();
     }
 
     @AfterAll
@@ -273,7 +273,7 @@ public class NavigateResponseConverterTest {
 
         step = steps.get(4);
         intersection = step.get("intersections").get(3);
-        assertEquals(1, intersection.get("in").asInt());
+        assertEquals(2, intersection.get("in").asInt());
         assertEquals(0, intersection.get("out").asInt());
         location = intersection.get("location");
         assertEquals(1.534679, location.get(0).asDouble(), .000001);

--- a/reader-gtfs/src/test/java/com/graphhopper/AnotherAgencyIT.java
+++ b/reader-gtfs/src/test/java/com/graphhopper/AnotherAgencyIT.java
@@ -54,6 +54,7 @@ public class AnotherAgencyIT {
     public static void init() {
         GraphHopperConfig ghConfig = new GraphHopperConfig();
         ghConfig.putObject("graph.location", GRAPH_LOC);
+        ghConfig.putObject("import.osm.ignored_highways", "");
         ghConfig.putObject("datareader.file", "files/beatty.osm");
         ghConfig.putObject("gtfs.file", "files/sample-feed,files/another-sample-feed");
         ghConfig.setProfiles(Arrays.asList(

--- a/reader-gtfs/src/test/java/com/graphhopper/ExtendedRouteTypeIT.java
+++ b/reader-gtfs/src/test/java/com/graphhopper/ExtendedRouteTypeIT.java
@@ -50,6 +50,7 @@ public class ExtendedRouteTypeIT {
         GraphHopperConfig ghConfig = new GraphHopperConfig();
         ghConfig.putObject("graph.location", GRAPH_LOC);
         ghConfig.putObject("gtfs.file", "files/another-sample-feed-extended-route-type.zip");
+        ghConfig.putObject("import.osm.ignored_highways", "");
         ghConfig.setProfiles(Arrays.asList(
                 new Profile("foot").setVehicle("foot").setWeighting("fastest"),
                 new Profile("car").setVehicle("car").setWeighting("fastest")));

--- a/reader-gtfs/src/test/java/com/graphhopper/FreeWalkIT.java
+++ b/reader-gtfs/src/test/java/com/graphhopper/FreeWalkIT.java
@@ -55,6 +55,7 @@ public class FreeWalkIT {
         ghConfig.putObject("datareader.file", "files/beatty.osm");
         ghConfig.putObject("gtfs.file", "files/sample-feed,files/another-sample-feed");
         ghConfig.putObject("gtfs.max_transfer_interpolation_walk_time_seconds", 0);
+        ghConfig.putObject("import.osm.ignored_highways", "");
         // TODO: This setting vv is currently "dead", as in production it switches to PtRouterFreeWalkImpl, but
         // TODO: here it is instantiated directly. Refactor by having only one Router but two Solvers, similar
         // TODO: to the street router.

--- a/reader-gtfs/src/test/java/com/graphhopper/GraphHopperGtfsIT.java
+++ b/reader-gtfs/src/test/java/com/graphhopper/GraphHopperGtfsIT.java
@@ -56,6 +56,7 @@ public class GraphHopperGtfsIT {
     public static void init() {
         GraphHopperConfig ghConfig = new GraphHopperConfig();
         ghConfig.putObject("graph.location", GRAPH_LOC);
+        ghConfig.putObject("import.osm.ignored_highways", "");
         ghConfig.putObject("gtfs.file", "files/sample-feed");
         ghConfig.setProfiles(Arrays.asList(
                 new Profile("foot").setVehicle("foot").setWeighting("fastest"),

--- a/reader-gtfs/src/test/java/com/graphhopper/GraphHopperMultimodalIT.java
+++ b/reader-gtfs/src/test/java/com/graphhopper/GraphHopperMultimodalIT.java
@@ -57,6 +57,7 @@ public class GraphHopperMultimodalIT {
     public static void init() {
         GraphHopperConfig ghConfig = new GraphHopperConfig();
         ghConfig.putObject("datareader.file", "files/beatty.osm");
+        ghConfig.putObject("import.osm.ignored_highways", "");
         ghConfig.putObject("gtfs.file", "files/sample-feed");
         ghConfig.putObject("graph.location", GRAPH_LOC);
         ghConfig.setProfiles(Arrays.asList(

--- a/reader-gtfs/src/test/java/com/graphhopper/RealtimeIT.java
+++ b/reader-gtfs/src/test/java/com/graphhopper/RealtimeIT.java
@@ -53,6 +53,7 @@ public class RealtimeIT {
         GraphHopperConfig ghConfig = new GraphHopperConfig();
         ghConfig.putObject("gtfs.file", "files/sample-feed");
         ghConfig.putObject("graph.location", GRAPH_LOC);
+        ghConfig.putObject("import.osm.ignored_highways", "");
         ghConfig.setProfiles(Arrays.asList(
                 new Profile("foot").setVehicle("foot").setWeighting("fastest"),
                 new Profile("car").setVehicle("car").setWeighting("fastest")));

--- a/reader-gtfs/src/test/java/com/graphhopper/gtfs/analysis/AnalysisTest.java
+++ b/reader-gtfs/src/test/java/com/graphhopper/gtfs/analysis/AnalysisTest.java
@@ -45,6 +45,7 @@ public class AnalysisTest {
         ghConfig.putObject("graph.location", GRAPH_LOC);
         ghConfig.putObject("datareader.file", "files/beatty.osm");
         ghConfig.putObject("gtfs.file", "files/sample-feed,files/another-sample-feed");
+        ghConfig.putObject("import.osm.ignored_highways", "");
         ghConfig.setProfiles(Arrays.asList(
                 new Profile("foot").setVehicle("foot").setWeighting("fastest"),
                 new Profile("car").setVehicle("car").setWeighting("fastest")));

--- a/web/src/test/java/com/graphhopper/application/GraphHopperLandmarksTest.java
+++ b/web/src/test/java/com/graphhopper/application/GraphHopperLandmarksTest.java
@@ -54,6 +54,7 @@ public class GraphHopperLandmarksTest {
                 putObject("graph.vehicles", "car").
                 putObject("datareader.file", "../core/files/belarus-east.osm.gz").
                 putObject("prepare.min_network_size", 0).
+                putObject("import.osm.ignored_highways", "").
                 putObject("graph.location", DIR)
                 // force landmark creation even for tiny networks
                 .putObject("prepare.lm.min_network_size", 2)

--- a/web/src/test/java/com/graphhopper/application/MapMatchingTest.java
+++ b/web/src/test/java/com/graphhopper/application/MapMatchingTest.java
@@ -141,7 +141,7 @@ public class MapMatchingTest {
         assertEquals(route.getDistance(), mr.getMatchLength(), 0.5);
         // GraphHopper travel times aren't exactly additive
         assertThat(Math.abs(route.getTime() - mr.getMatchMillis()), is(lessThan(1000L)));
-        assertEquals(142, mr.getEdgeMatches().size());
+        assertEquals(208, mr.getEdgeMatches().size());
     }
 
     @ParameterizedTest

--- a/web/src/test/java/com/graphhopper/application/resources/I18nResourceTest.java
+++ b/web/src/test/java/com/graphhopper/application/resources/I18nResourceTest.java
@@ -49,6 +49,7 @@ public class I18nResourceTest {
                 putObject("graph.vehicles", "car").
                 putObject("datareader.file", "../core/files/andorra.osm.pbf").
                 putObject("graph.location", DIR).
+                putObject("import.osm.ignored_highways", "").
                 setProfiles(Collections.singletonList(new Profile("car").setVehicle("car").setWeighting("fastest")));
         return config;
     }

--- a/web/src/test/java/com/graphhopper/application/resources/IsochroneResourceTest.java
+++ b/web/src/test/java/com/graphhopper/application/resources/IsochroneResourceTest.java
@@ -55,6 +55,7 @@ public class IsochroneResourceTest {
         config.getGraphHopperConfiguration().
                 putObject("graph.vehicles", "car|turn_costs=true").
                 putObject("datareader.file", "../core/files/andorra.osm.pbf").
+                putObject("import.osm.ignored_highways", "").
                 putObject("graph.location", DIR).
                 setProfiles(Arrays.asList(
                         new Profile("fast_car").setVehicle("car").setWeighting("fastest").setTurnCosts(true),

--- a/web/src/test/java/com/graphhopper/application/resources/MapMatchingResourceTest.java
+++ b/web/src/test/java/com/graphhopper/application/resources/MapMatchingResourceTest.java
@@ -56,6 +56,7 @@ public class MapMatchingResourceTest {
         config.getGraphHopperConfiguration().
                 putObject("graph.vehicles", "car,bike").
                 putObject("datareader.file", "../map-matching/files/leipzig_germany.osm.pbf").
+                putObject("import.osm.ignored_highways", "").
                 putObject("graph.location", DIR).
                 setProfiles(Arrays.asList(
                         new Profile("fast_car").setVehicle("car").setWeighting("fastest"),

--- a/web/src/test/java/com/graphhopper/application/resources/MapMatchingResourceTurnCostsTest.java
+++ b/web/src/test/java/com/graphhopper/application/resources/MapMatchingResourceTurnCostsTest.java
@@ -20,7 +20,6 @@ package com.graphhopper.application.resources;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.graphhopper.application.GraphHopperApplication;
 import com.graphhopper.application.GraphHopperServerConfiguration;
-import com.graphhopper.application.util.TestUtils;
 import com.graphhopper.config.CHProfile;
 import com.graphhopper.config.LMProfile;
 import com.graphhopper.config.Profile;
@@ -60,6 +59,7 @@ public class MapMatchingResourceTurnCostsTest {
         config.getGraphHopperConfiguration().
                 putObject("graph.vehicles", "car|turn_costs=true,bike").
                 putObject("datareader.file", "../map-matching/files/leipzig_germany.osm.pbf").
+                putObject("import.osm.ignored_highways", "").
                 putObject("graph.location", DIR).
                 setProfiles(Arrays.asList(
                         new Profile("car").setVehicle("car").setWeighting("fastest").setTurnCosts(true),

--- a/web/src/test/java/com/graphhopper/application/resources/MvtResourceTest.java
+++ b/web/src/test/java/com/graphhopper/application/resources/MvtResourceTest.java
@@ -57,6 +57,7 @@ public class MvtResourceTest {
                 putObject("graph.encoded_values", "road_class,road_environment,max_speed,surface").
                 putObject("prepare.min_network_size", 0).
                 putObject("datareader.file", "../core/files/andorra.osm.pbf").
+                putObject("import.osm.ignored_highways", "").
                 putObject("graph.location", DIR).
                 setProfiles(Collections.singletonList(new Profile("car").setVehicle("car").setWeighting("fastest")));
         return config;

--- a/web/src/test/java/com/graphhopper/application/resources/NearestResourceTest.java
+++ b/web/src/test/java/com/graphhopper/application/resources/NearestResourceTest.java
@@ -52,6 +52,7 @@ public class NearestResourceTest {
                 putObject("graph.vehicles", "car").
                 putObject("datareader.file", "../core/files/andorra.osm.pbf").
                 putObject("graph.location", dir).
+                putObject("import.osm.ignored_highways", "").
                 setProfiles(Collections.singletonList(new Profile("car").setVehicle("car").setWeighting("fastest")));
         return config;
     }

--- a/web/src/test/java/com/graphhopper/application/resources/NearestResourceWithEleTest.java
+++ b/web/src/test/java/com/graphhopper/application/resources/NearestResourceWithEleTest.java
@@ -53,6 +53,7 @@ public class NearestResourceWithEleTest {
                 putObject("prepare.min_network_size", 0).
                 putObject("graph.vehicles", "car").
                 putObject("datareader.file", "../core/files/monaco.osm.gz").
+                putObject("import.osm.ignored_highways", "").
                 putObject("graph.location", dir).
                 setProfiles(Collections.singletonList(new Profile("car").setVehicle("car").setWeighting("fastest")));
         return config;

--- a/web/src/test/java/com/graphhopper/application/resources/NearestResourceWithEleTest.java
+++ b/web/src/test/java/com/graphhopper/application/resources/NearestResourceWithEleTest.java
@@ -73,7 +73,7 @@ public class NearestResourceWithEleTest {
         double lon = point.get(0).asDouble();
         double lat = point.get(1).asDouble();
         double ele = point.get(2).asDouble();
-        assertTrue(lat == 43.7307001 && lon == 7.4213923 && ele == 66.0, "nearest point wasn't correct: lat=" + lat + ", lon=" + lon + ", ele=" + ele);
+        assertTrue(lat == 43.73084185257864 && lon == 7.420749379140277 && ele == 59.0, "nearest point wasn't correct: lat=" + lat + ", lon=" + lon + ", ele=" + ele);
     }
 
     @Test
@@ -84,7 +84,7 @@ public class NearestResourceWithEleTest {
         assertEquals(2, point.size(), "returned point is not 2D: " + point);
         double lon = point.get(0).asDouble();
         double lat = point.get(1).asDouble();
-        assertTrue(lat == 43.7307001 && lon == 7.4213923, "nearest point wasn't correct: lat=" + lat + ", lon=" + lon);
+        assertTrue(lat == 43.73084185257864 && lon == 7.420749379140277, "nearest point wasn't correct: lat=" + lat + ", lon=" + lon);
 
         // Default elevation is false        
         json = clientTarget(app, "/nearest?point=43.730864,7.420771").request().buildGet().invoke().readEntity(JsonNode.class);
@@ -93,6 +93,6 @@ public class NearestResourceWithEleTest {
         assertEquals(2, point.size(), "returned point is not 2D: " + point);
         lon = point.get(0).asDouble();
         lat = point.get(1).asDouble();
-        assertTrue(lat == 43.7307001 && lon == 7.4213923, "nearest point wasn't correct: lat=" + lat + ", lon=" + lon);
+        assertTrue(lat == 43.73084185257864 && lon == 7.420749379140277, "nearest point wasn't correct: lat=" + lat + ", lon=" + lon);
     }
 }

--- a/web/src/test/java/com/graphhopper/application/resources/PtIsochroneTest.java
+++ b/web/src/test/java/com/graphhopper/application/resources/PtIsochroneTest.java
@@ -58,7 +58,8 @@ public class PtIsochroneTest {
         config.getGraphHopperConfiguration()
                 .putObject("graph.vehicles", "foot")
                 .putObject("graph.location", GRAPH_LOC)
-                .putObject("gtfs.file", "../reader-gtfs/files/sample-feed").
+                .putObject("gtfs.file", "../reader-gtfs/files/sample-feed")
+                .putObject("import.osm.ignored_highways", "").
                 setProfiles(Collections.singletonList(new Profile("foot").setVehicle("foot").setWeighting("fastest")));
         Helper.removeDir(new File(GRAPH_LOC));
         return config;

--- a/web/src/test/java/com/graphhopper/application/resources/PtRouteResourceTest.java
+++ b/web/src/test/java/com/graphhopper/application/resources/PtRouteResourceTest.java
@@ -54,6 +54,7 @@ public class PtRouteResourceTest {
                 putObject("datareader.file", "../reader-gtfs/files/beatty.osm").
                 putObject("gtfs.file", "../reader-gtfs/files/sample-feed").
                 putObject("graph.location", DIR).
+                putObject("import.osm.ignored_highways", "").
                 setProfiles(Collections.singletonList(new Profile("foot").setVehicle("foot").setWeighting("fastest")));
         return config;
     }

--- a/web/src/test/java/com/graphhopper/application/resources/RouteResourceClientHCTest.java
+++ b/web/src/test/java/com/graphhopper/application/resources/RouteResourceClientHCTest.java
@@ -65,6 +65,7 @@ public class RouteResourceClientHCTest {
                 putObject("graph.elevation.cache_dir", "../core/files/").
                 putObject("datareader.file", "../core/files/andorra.osm.pbf").
                 putObject("graph.encoded_values", "road_class,surface,road_environment,max_speed").
+                putObject("import.osm.ignored_highways", "").
                 putObject("graph.location", DIR)
                 .setProfiles(Arrays.asList(
                         new Profile("car").setVehicle("car").setWeighting("fastest"),

--- a/web/src/test/java/com/graphhopper/application/resources/RouteResourceCustomModelLMTest.java
+++ b/web/src/test/java/com/graphhopper/application/resources/RouteResourceCustomModelLMTest.java
@@ -56,6 +56,7 @@ public class RouteResourceCustomModelLMTest {
                 putObject("graph.vehicles", "car,foot").
                 putObject("datareader.file", "../core/files/andorra.osm.pbf").
                 putObject("graph.location", DIR).
+                putObject("import.osm.ignored_highways", "").
                 putObject("graph.encoded_values", "surface").
                 setProfiles(Arrays.asList(
                         // give strange profile names to ensure that we do not mix vehicle and profile:

--- a/web/src/test/java/com/graphhopper/application/resources/RouteResourceCustomModelTest.java
+++ b/web/src/test/java/com/graphhopper/application/resources/RouteResourceCustomModelTest.java
@@ -64,6 +64,7 @@ public class RouteResourceCustomModelTest {
                 putObject("graph.location", DIR).
                 putObject("graph.encoded_values", "max_height,max_weight,max_width,hazmat,toll,surface,track_type,hgv").
                 putObject("custom_model_folder", "./src/test/resources/com/graphhopper/application/resources").
+                putObject("import.osm.ignored_highways", "").
                 setProfiles(Arrays.asList(
                         new Profile("wheelchair"),
                         new CustomProfile("roads").setCustomModel(new CustomModel()).setVehicle("roads"),

--- a/web/src/test/java/com/graphhopper/application/resources/RouteResourceIssue1574Test.java
+++ b/web/src/test/java/com/graphhopper/application/resources/RouteResourceIssue1574Test.java
@@ -54,6 +54,7 @@ public class RouteResourceIssue1574Test {
                 putObject("graph.vehicles", "car").
                 putObject("prepare.min_network_size", 0).
                 putObject("datareader.file", "../core/files/andorra.osm.pbf").
+                putObject("import.osm.ignored_highways", "").
                 putObject("graph.location", DIR)
                 .setProfiles(Collections.singletonList(
                         new Profile("car_profile").setVehicle("car").setWeighting("fastest")

--- a/web/src/test/java/com/graphhopper/application/resources/RouteResourceIssue2020Test.java
+++ b/web/src/test/java/com/graphhopper/application/resources/RouteResourceIssue2020Test.java
@@ -52,6 +52,7 @@ public class RouteResourceIssue2020Test {
                 putObject("prepare.lm.split_area_location", "../core/files/split.geo.json").
                 putObject("datareader.file", "../core/files/north-bayreuth.osm.gz").
                 putObject("graph.encoded_values", "road_class,surface,road_environment,max_speed").
+                putObject("import.osm.ignored_highways", "").
                 putObject("graph.location", DIR).
                 setProfiles(Collections.singletonList(new Profile("my_car").setVehicle("car").setWeighting("fastest"))).
                 setLMProfiles(Collections.singletonList(new LMProfile("my_car")));

--- a/web/src/test/java/com/graphhopper/application/resources/RouteResourceProfileSelectionTest.java
+++ b/web/src/test/java/com/graphhopper/application/resources/RouteResourceProfileSelectionTest.java
@@ -54,6 +54,7 @@ public class RouteResourceProfileSelectionTest {
                 putObject("prepare.min_network_size", 0).
                 putObject("datareader.file", "../core/files/monaco.osm.gz").
                 putObject("graph.encoded_values", "road_class,surface,road_environment,max_speed").
+                putObject("import.osm.ignored_highways", "").
                 putObject("graph.location", DIR)
                 .setProfiles(Arrays.asList(
                         new Profile("my_car").setVehicle("car").setWeighting("fastest"),

--- a/web/src/test/java/com/graphhopper/application/resources/RouteResourceTest.java
+++ b/web/src/test/java/com/graphhopper/application/resources/RouteResourceTest.java
@@ -82,6 +82,7 @@ public class RouteResourceTest {
                 putObject("prepare.min_network_size", 0).
                 putObject("datareader.file", "../core/files/andorra.osm.pbf").
                 putObject("graph.encoded_values", "road_class,surface,road_environment,max_speed").
+                putObject("import.osm.ignored_highways", "").
                 putObject("graph.location", DIR)
                 // adding this so the corresponding check is not just skipped...
                 .putObject(MAX_NON_CH_POINT_DISTANCE, 10e6)

--- a/web/src/test/java/com/graphhopper/application/resources/RouteResourceTest.java
+++ b/web/src/test/java/com/graphhopper/application/resources/RouteResourceTest.java
@@ -25,7 +25,6 @@ import com.graphhopper.api.GraphHopperWeb;
 import com.graphhopper.application.GraphHopperApplication;
 import com.graphhopper.application.GraphHopperServerConfiguration;
 import com.graphhopper.application.util.GraphHopperServerTestConfiguration;
-import com.graphhopper.application.util.TestUtils;
 import com.graphhopper.config.CHProfile;
 import com.graphhopper.config.Profile;
 import com.graphhopper.routing.ev.RoadClass;
@@ -295,10 +294,10 @@ public class RouteResourceTest {
         assertEquals(5, averageSpeedList.get(1).getLength());
 
         List<PathDetail> edgeIdDetails = pathDetails.get("edge_id");
-        assertEquals(77, edgeIdDetails.size());
-        assertEquals(882L, edgeIdDetails.get(0).getValue());
+        assertEquals(78, edgeIdDetails.size());
+        assertEquals(924L, edgeIdDetails.get(0).getValue());
         assertEquals(2, edgeIdDetails.get(0).getLength());
-        assertEquals(883L, edgeIdDetails.get(1).getValue());
+        assertEquals(925L, edgeIdDetails.get(1).getValue());
         assertEquals(8, edgeIdDetails.get(1).getLength());
 
         long expectedTime = rsp.getBest().getTime();
@@ -353,8 +352,8 @@ public class RouteResourceTest {
         JsonNode edgeIds = details.get("edge_id");
         int firstLink = edgeIds.get(0).get(2).asInt();
         int lastLink = edgeIds.get(edgeIds.size() - 1).get(2).asInt();
-        assertEquals(882, firstLink);
-        assertEquals(1425, lastLink);
+        assertEquals(924, firstLink);
+        assertEquals(1584, lastLink);
 
         JsonNode maxSpeed = details.get("max_speed");
         assertEquals(-1, maxSpeed.get(0).get(2).asDouble(-1), .01);

--- a/web/src/test/java/com/graphhopper/application/resources/RouteResourceTurnCostsTest.java
+++ b/web/src/test/java/com/graphhopper/application/resources/RouteResourceTurnCostsTest.java
@@ -56,6 +56,7 @@ public class RouteResourceTurnCostsTest {
                 putObject("prepare.min_network_size", 0).
                 putObject("datareader.file", "../core/files/moscow.osm.gz").
                 putObject("graph.encoded_values", "road_class,surface,road_environment,max_speed").
+                putObject("import.osm.ignored_highways", "").
                 putObject("graph.location", DIR)
                 .setProfiles(Arrays.asList(
                         new Profile("my_car_turn_costs").setVehicle("car").setWeighting("fastest").setTurnCosts(true),

--- a/web/src/test/java/com/graphhopper/application/resources/RouteResourceWithEleTest.java
+++ b/web/src/test/java/com/graphhopper/application/resources/RouteResourceWithEleTest.java
@@ -54,6 +54,7 @@ public class RouteResourceWithEleTest {
                 putObject("graph.vehicles", "car").
                 putObject("datareader.file", "../core/files/monaco.osm.gz").
                 putObject("graph.location", dir).
+                putObject("import.osm.ignored_highways", "").
                 setProfiles(Collections.singletonList(
                         new Profile("profile").setVehicle("car").setWeighting("fastest")
                 ));

--- a/web/src/test/java/com/graphhopper/application/resources/SPTResourceTest.java
+++ b/web/src/test/java/com/graphhopper/application/resources/SPTResourceTest.java
@@ -72,8 +72,8 @@ public class SPTResourceTest {
         List<String> headers = Arrays.asList(lines[0].split(","));
         assertEquals("[longitude, latitude, time, distance]", headers.toString());
         String[] row = lines[166].split(",");
-        assertEquals(1.574053, Double.parseDouble(row[0]), 0.0001);
-        assertEquals(42.536273, Double.parseDouble(row[1]), 0.0001);
+        assertEquals(1.5740, Double.parseDouble(row[0]), 0.0001);
+        assertEquals(42.5362, Double.parseDouble(row[1]), 0.0001);
         assertEquals(111, Integer.parseInt(row[2]) / 1000, 1);
         assertEquals(1505, Integer.parseInt(row[3]), 1);
 
@@ -115,7 +115,7 @@ public class SPTResourceTest {
         row = lines[249].split(",");
         assertEquals("", row[0]);
         assertEquals("primary", row[1]);
-        assertFalse(Double.isInfinite(Double.parseDouble(row[2])));
+        assertEquals(80, Double.parseDouble(row[2]), .1);
     }
 
     @Test

--- a/web/src/test/java/com/graphhopper/application/resources/SPTResourceTest.java
+++ b/web/src/test/java/com/graphhopper/application/resources/SPTResourceTest.java
@@ -72,10 +72,10 @@ public class SPTResourceTest {
         List<String> headers = Arrays.asList(lines[0].split(","));
         assertEquals("[longitude, latitude, time, distance]", headers.toString());
         String[] row = lines[166].split(",");
-        assertEquals(1.5552, Double.parseDouble(row[0]), 0.0001);
-        assertEquals(42.5179, Double.parseDouble(row[1]), 0.0001);
-        assertEquals(118, Integer.parseInt(row[2]) / 1000, 1);
-        assertEquals(2263, Integer.parseInt(row[3]), 1);
+        assertEquals(1.574053, Double.parseDouble(row[0]), 0.0001);
+        assertEquals(42.536273, Double.parseDouble(row[1]), 0.0001);
+        assertEquals(111, Integer.parseInt(row[2]) / 1000, 1);
+        assertEquals(1505, Integer.parseInt(row[3]), 1);
 
         rsp = clientTarget(app, "/spt?profile=car_without_turncosts&point=42.531073,1.573792&columns=prev_time").request().buildGet().invoke();
         rspCsvString = rsp.readEntity(String.class);
@@ -86,7 +86,7 @@ public class SPTResourceTest {
         assertNotEquals(-1, prevTimeIndex);
 
         row = lines[20].split(",");
-        assertEquals(41, Integer.parseInt(row[prevTimeIndex]) / 1000);
+        assertEquals(50, Integer.parseInt(row[prevTimeIndex]) / 1000);
     }
 
     @Test
@@ -96,9 +96,9 @@ public class SPTResourceTest {
         String[] lines = rspCsvString.split("\n");
         assertTrue(lines.length > 500);
         assertEquals("prev_node_id,edge_id,node_id,time,distance", lines[0]);
-        assertEquals("-1,-1,1948,0,0", lines[1]);
-        assertEquals("1948,2277,1324,3817,74", lines[2]);
-        assertEquals("1948,2276,263,13496,262", lines[3]);
+        assertEquals("-1,-1,2385,0,0", lines[1]);
+        assertEquals("2385,2821,1571,3817,74", lines[2]);
+        assertEquals("2385,2820,274,13496,262", lines[3]);
     }
 
     @Test
@@ -108,14 +108,14 @@ public class SPTResourceTest {
         String[] lines = rspCsvString.split("\n");
 
         String[] row = lines[368].split(",");
-        assertEquals("", row[0]);
-        assertEquals("service", row[1]);
-        assertEquals(20, Double.parseDouble(row[2]), .1);
+        assertEquals("Placeta Na Maria Pla", row[0]);
+        assertEquals("residential", row[1]);
+        assertEquals(50, Double.parseDouble(row[2]), .1);
 
         row = lines[249].split(",");
-        assertEquals("Carretera d'Engolasters", row[0]);
-        assertEquals("secondary", row[1]);
-        assertTrue(Double.isInfinite(Double.parseDouble(row[2])));
+        assertEquals("", row[0]);
+        assertEquals("primary", row[1]);
+        assertFalse(Double.isInfinite(Double.parseDouble(row[2])));
     }
 
     @Test

--- a/web/src/test/java/com/graphhopper/application/resources/SPTResourceTest.java
+++ b/web/src/test/java/com/graphhopper/application/resources/SPTResourceTest.java
@@ -50,6 +50,7 @@ public class SPTResourceTest {
                 putObject("graph.vehicles", "car|turn_costs=true").
                 putObject("graph.encoded_values", "max_speed,road_class").
                 putObject("datareader.file", "../core/files/andorra.osm.pbf").
+                putObject("import.osm.ignored_highways", "").
                 putObject("graph.location", DIR).
                 setProfiles(Arrays.asList(
                         new Profile("car_without_turncosts").setVehicle("car").setWeighting("fastest"),


### PR DESCRIPTION
So far we used `VehicleTagParser#getAccess` to determine whether an OSM way shall be accepted when parsing the OSM file. With this PR all highways will be accepted except those listed in a global list of ignored values ~~there will be only one global list of accepted highway values~~. It is still up to the vehicle tag parsers (and in the near future only up to the access tag parsers) whether a given way is used for the route calculations. Putting a highway value into the global list is therefore mostly a performance optimization. So far this happened automatically by only using certain vehicles. For example if we used only profiles with the car profile footways were rejected automatically. With the new global list this needs to be done manually, but at the same time the mechanism becomes more powerful and easier to understand IMO.

See more comments inline.

Related: https://github.com/graphhopper/graphhopper/issues/2463#issuecomment-1174205767 
