### PR TITLE
Make use of node tags like 'highway' or 'crossing'

### DIFF
--- a/core/src/main/java/com/graphhopper/reader/osm/OSMNodeData.java
+++ b/core/src/main/java/com/graphhopper/reader/osm/OSMNodeData.java
@@ -26,14 +26,9 @@ import com.graphhopper.util.PointAccess;
 import com.graphhopper.util.PointList;
 import com.graphhopper.util.shapes.GHPoint3D;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.function.DoubleSupplier;
 import java.util.function.IntUnaryOperator;
-
-import static java.util.Collections.emptyMap;
 
 /**
  * This class stores OSM node data while reading an OSM file in {@link WaySegmentParser}. It is not trivial to do this
@@ -187,7 +182,7 @@ class OSMNodeData {
         if (idsByOsmNodeIds.put(newOsmId, INTERMEDIATE_NODE) != EMPTY_NODE)
             throw new IllegalStateException("Artificial osm node id already exists: " + newOsmId);
         int id = addPillarNode(newOsmId, point.getLat(), point.getLon(), point.getEle());
-        return new SegmentNode(newOsmId, id);
+        return new SegmentNode(newOsmId, id, new LinkedHashMap<>(node.tags));
     }
 
     int convertPillarToTowerNode(int id, long osmNodeId) {
@@ -258,9 +253,9 @@ class OSMNodeData {
         return nodeTags.get(tagIndex);
     }
 
-    public void removeTags(long osmNodeId) {
+    public void removeTag(long osmNodeId, String key) {
         int prev = nodeTagIndicesByOsmNodeIds.put(osmNodeId, -2);
-        nodeTags.set(prev, emptyMap());
+        nodeTags.get(prev).remove(key);
     }
 
     public void release() {

--- a/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
+++ b/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
@@ -228,7 +228,7 @@ public class OSMReader {
      * This method is called during the second pass of {@link WaySegmentParser} and provides an entry point to enrich
      * the given OSM way with additional tags before it is passed on to the tag parsers.
      */
-    protected void setArtificialWayTags(PointList pointList, ReaderWay way, double distance, Map<String, Object> nodeTags) {
+    protected void setArtificialWayTags(PointList pointList, ReaderWay way, double distance, List<Map<String, Object>> nodeTags) {
         way.setTag("node_tags", nodeTags);
         way.setTag("edge_distance", distance);
         way.setTag("point_list", pointList);
@@ -292,14 +292,16 @@ public class OSMReader {
      * @param toIndex   a unique integer id for the last node of this segment
      * @param pointList coordinates of this segment
      * @param way       the OSM way this segment was taken from
-     * @param nodeTags  node tags of this segment if it is an artificial edge, empty otherwise
+     * @param nodeTags  node tags of this segment. there is one map of tags for each point.
      */
-    protected void addEdge(int fromIndex, int toIndex, PointList pointList, ReaderWay way, Map<String, Object> nodeTags) {
+    protected void addEdge(int fromIndex, int toIndex, PointList pointList, ReaderWay way, List<Map<String, Object>> nodeTags) {
         // sanity checks
         if (fromIndex < 0 || toIndex < 0)
             throw new AssertionError("to or from index is invalid for this edge " + fromIndex + "->" + toIndex + ", points:" + pointList);
         if (pointList.getDimension() != nodeAccess.getDimension())
             throw new AssertionError("Dimension does not match for pointList vs. nodeAccess " + pointList.getDimension() + " <-> " + nodeAccess.getDimension());
+        if (pointList.size() != nodeTags.size())
+            throw new AssertionError("there should be as many maps of node tags as there are points. node tags: " + nodeTags.size() + ", points: " + pointList.size());
 
         // todo: in principle it should be possible to delay elevation calculation so we do not need to store
         // elevations during import (saves memory in pillar info during import). also note that we already need to

--- a/core/src/main/java/com/graphhopper/reader/osm/SegmentNode.java
+++ b/core/src/main/java/com/graphhopper/reader/osm/SegmentNode.java
@@ -18,12 +18,16 @@
 
 package com.graphhopper.reader.osm;
 
+import java.util.Map;
+
 class SegmentNode {
     long osmNodeId;
     int id;
+    Map<String, Object> tags;
 
-    public SegmentNode(long osmNodeId, int id) {
+    public SegmentNode(long osmNodeId, int id, Map<String, Object> tags) {
         this.osmNodeId = osmNodeId;
         this.id = id;
+        this.tags = tags;
     }
 }

--- a/core/src/test/java/com/graphhopper/reader/osm/OSMReaderTest.java
+++ b/core/src/test/java/com/graphhopper/reader/osm/OSMReaderTest.java
@@ -925,7 +925,7 @@ public class OSMReaderTest {
         ReaderWay way = new ReaderWay(0L);
         PointList list = new PointList();
         list.add(49.214906, -2.156067);
-        reader.setArtificialWayTags(list, way, 10, new HashMap<>());
+        reader.setArtificialWayTags(list, way, 10, Collections.singletonList(new HashMap<>()));
         assertEquals("JEY", way.getTag("country", null).toString());
     }
 


### PR DESCRIPTION
So far we keep node tags only for barrier nodes, but with a few small changes we can also provide the tags of all nodes belonging to the current edge to the tag parsers. This allows us to write encoded values that consider traffic lights, pedestrian crossings etc.

We read the node tags during the second OSM pass (because only then do we know which nodes belong to the ways we are interested in) and then we need to keep around until we read the ways in the second pass. Keeping all the node tags is not as bad as it sounds, though. I did a test for Germany and there were 540_000 nodes with barrier tags (which we already keep around anyway) and the total number of nodes with tags was around 2_600_000, so around five times as many.

Here are the most frequent node tags (only nodes belonging to highways were counted):

```
highway: 1.12%, 791784
barrier: 0.76%, 537916
name: 0.51%, 364319
crossing: 0.42%, 294333
created_by: 0.39%, 276287
public_transport: 0.35%, 246989
bus: 0.34%, 242477
bicycle: 0.28%, 200287
foot: 0.26%, 182614
tactile_paving: 0.26%, 180970
entrance: 0.25%, 178177
noexit: 0.21%, 150552
traffic_sign: 0.18%, 125280
access: 0.18%, 124076
crossing:island: 0.15%, 108724
direction: 0.14%, 97463
railway: 0.13%, 91601
network: 0.10%, 68049
kerb: 0.09%, 63401
button_operated: 0.09%, 61035
wheelchair: 0.08%, 55419
source: 0.08%, 54207
traffic_signals:sound: 0.08%, 54145
ref:IFOPT: 0.07%, 52075
traffic_signals:direction: 0.07%, 51788
```

We could reduce the number of tags we need to store by excluding some we definitely don't need, like `created_by=JOSM` for example, but not even sure if this is really needed. If we want to save memory we should probably rather focus on using a more efficient way to store the tags as currently this is simply a `List<Map<String, Object>>`. But this is probably something for later and first we should check how useful the node tags can be (hence this draft PR).

The node tags are available to all tag parsers via:

```java
List<Map<String, Object>> nodeTags = (List<Map<String, Object>>) way.getTag("node_tags");
```

and this list contains one entry for each point in the point list of the current edge.

Related: https://github.com/graphhopper/graphhopper/pull/2430#issuecomment-945404775