### PR TITLE
Add footway encoded value

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/ev/DefaultEncodedValueFactory.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/DefaultEncodedValueFactory.java
@@ -74,6 +74,8 @@ public class DefaultEncodedValueFactory implements EncodedValueFactory {
             enc = new EnumEncodedValue<>(HazmatWater.KEY, HazmatWater.class);
         } else if (Lanes.KEY.equals(name)) {
             enc = Lanes.create();
+        } else if (Footway.KEY.equals(name)) {
+            enc = new EnumEncodedValue<>(Footway.KEY, Footway.class);
         } else if (OSMWayID.KEY.equals(name)) {
             enc = OSMWayID.create();
         } else if (MtbRating.KEY.equals(name)) {

--- a/core/src/main/java/com/graphhopper/routing/ev/Footway.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/Footway.java
@@ -1,0 +1,48 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.graphhopper.routing.ev;
+
+public enum Footway {
+    MISSING("missing"), SIDEWALK("sidewalk"), CROSSING("crossing"), ACCESS_AISLE("access_aisle"),
+    LINK("link"), TRAFFIC_ISLAND("traffic_island"), ALLEY("alley");
+
+    public static final String KEY = "footway";
+
+    private final String name;
+
+    Footway(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+
+    public static Footway find(String name) {
+        if (name == null || name.isEmpty())
+            return MISSING;
+
+        for (Footway footway : values())
+            if (footway.name().equalsIgnoreCase(name))
+                return footway;
+
+        return MISSING;
+    }
+}

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/DefaultTagParserFactory.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/DefaultTagParserFactory.java
@@ -77,6 +77,8 @@ public class DefaultTagParserFactory implements TagParserFactory {
             return new OSMHikeRatingParser(lookup.getIntEncodedValue(HikeRating.KEY));
         else if (name.equals(HorseRating.KEY))
             return new OSMHorseRatingParser(lookup.getIntEncodedValue(HorseRating.KEY));
+        else if (name.equals(Footway.KEY))
+            return new OSMFootwayParser(lookup.getEnumEncodedValue(Footway.KEY, Footway.class));
         else if (name.equals(Country.KEY))
             return new CountryParser(lookup.getEnumEncodedValue(Country.KEY, Country.class));
         return null;

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMFootwayParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMFootwayParser.java
@@ -1,0 +1,42 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.graphhopper.routing.util.parsers;
+
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.EnumEncodedValue;
+import com.graphhopper.routing.ev.Footway;
+import com.graphhopper.storage.IntsRef;
+
+/**
+ * see: https://wiki.openstreetmap.org/wiki/Key%3Afootway
+ */
+public class OSMFootwayParser implements TagParser {
+    private final EnumEncodedValue<Footway> footwayEnc;
+
+    public OSMFootwayParser(EnumEncodedValue<Footway> footwayEnc) {
+        this.footwayEnc = footwayEnc;
+    }
+
+    @Override
+    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay way, IntsRef relationFlags) {
+        String footway = way.getTag("footway");
+        footwayEnc.setEnum(false, edgeFlags, Footway.find(footway));
+        return edgeFlags;
+    }
+}


### PR DESCRIPTION
Here I added a footway encoded value for the footway=sidewalk,crossing,... etc. tag: https://wiki.openstreetmap.org/wiki/Key%3Afootway, fixes #2692 

I briefly tried calculating some pedestrian routes that avoid crossings in Berlin. Note that almost none of these red-dashed separate footways were mapped in OSM at the beginning of this year! See also here: https://wiki.openstreetmap.org/wiki/Berlin/Verkehrswende. 

The new footway encoded value simply parses the footway=* tag without any further thoughts. Calculating good pedestrian routes is another story though. For example we can easily use a custom model to prevent footway=crossing (see screenshots), but care must be taken that as a result the route does simply use the normal roads (like tertiary) instead. Therefore I also lowered the priority for everything except footway and cycleway here, but whether this is a good idea depends on the area and mapping quality.

![image](https://user-images.githubusercontent.com/17603532/205623454-a2c7e697-4003-4f4c-b5db-0336c99cd737.png)

![image](https://user-images.githubusercontent.com/17603532/205623361-e637aa20-ed94-4721-ae81-6de7889e1a55.png)

Then again, the data can also be used to simply report crossings, without changing the route as it was requested in the forum. 

To make the footway types visible in the elevation diagram for localhost:8989/maps/ we still need to add 'footway' to the list of details here: https://github.com/graphhopper/graphhopper/blob/4ecbd61eafaee01d1812ea5aa3ddf8e6e8d25c2d/web-bundle/src/main/resources/com/graphhopper/maps/config.js#L15-L20 
IMO it would be nice to have an option to show all the available path details here.

@natedx @MonfretAugustin can you check if this is useful for what you were trying to do? Any thoughts?