### PR TITLE
Add metadata to public transportation legs.

### DIFF
--- a/reader-gtfs/src/main/java/com/graphhopper/gtfs/TripFromLabel.java
+++ b/reader-gtfs/src/main/java/com/graphhopper/gtfs/TripFromLabel.java
@@ -21,6 +21,7 @@ package com.graphhopper.gtfs;
 import com.conveyal.gtfs.GTFSFeed;
 import com.conveyal.gtfs.model.Stop;
 import com.conveyal.gtfs.model.StopTime;
+import com.conveyal.gtfs.model.Route;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -356,11 +357,17 @@ class TripFromLabel {
                             .forEach(stopsFromBoardHopDwellEdges::next);
                     stopsFromBoardHopDwellEdges.finish();
                     List<Trip.Stop> stops = stopsFromBoardHopDwellEdges.stops;
+                    GTFSFeed gtfsFeed = gtfsStorage.getGtfsFeeds().get(feedId);
+                    Route route = gtfsFeed.routes.get(tripDescriptor.getRouteId());
 
                     result.add(new Trip.PtLeg(
                             feedId, partition.get(0).edge.getTransfers() == 0,
                             tripDescriptor.getTripId(),
                             tripDescriptor.getRouteId(),
+                            route.route_type,
+                            route.route_url == null ? "" : route.route_url.toString(),
+                            route.route_short_name,
+                            route.route_long_name,
                             Optional.ofNullable(gtfsStorage.getGtfsFeeds().get(feedId).trips.get(tripDescriptor.getTripId())).map(t -> t.trip_headsign).orElse("extra"),
                             stops,
                             partition.stream().mapToDouble(t -> t.edge.getDistance()).sum(),

--- a/reader-gtfs/src/main/java/com/graphhopper/gtfs/TripFromLabel.java
+++ b/reader-gtfs/src/main/java/com/graphhopper/gtfs/TripFromLabel.java
@@ -358,16 +358,27 @@ class TripFromLabel {
                     stopsFromBoardHopDwellEdges.finish();
                     List<Trip.Stop> stops = stopsFromBoardHopDwellEdges.stops;
                     GTFSFeed gtfsFeed = gtfsStorage.getGtfsFeeds().get(feedId);
+
+                    int routeType = -1;
+                    String routeUrl = null;
+                    String routeShortName = "";
+                    String routeLongName = "";
                     Route route = gtfsFeed.routes.get(tripDescriptor.getRouteId());
+                    if (route != null) {
+                        routeType = route.route_type;
+                        routeUrl = route.route_url == null ? "" : route.route_url.toString();
+                        routeShortName = route.route_short_name;
+                        routeLongName = route.route_long_name;
+                    }
 
                     result.add(new Trip.PtLeg(
                             feedId, partition.get(0).edge.getTransfers() == 0,
                             tripDescriptor.getTripId(),
                             tripDescriptor.getRouteId(),
-                            route.route_type,
-                            route.route_url == null ? "" : route.route_url.toString(),
-                            route.route_short_name,
-                            route.route_long_name,
+                            routeType,
+                            routeUrl,
+                            routeShortName,
+                            routeLongName,
                             Optional.ofNullable(gtfsStorage.getGtfsFeeds().get(feedId).trips.get(tripDescriptor.getTripId())).map(t -> t.trip_headsign).orElse("extra"),
                             stops,
                             partition.stream().mapToDouble(t -> t.edge.getDistance()).sum(),

--- a/web-api/src/main/java/com/graphhopper/Trip.java
+++ b/web-api/src/main/java/com/graphhopper/Trip.java
@@ -102,8 +102,12 @@ public class Trip {
         public final List<Stop> stops;
         public final String trip_id;
         public final String route_id;
+        public final int route_type;
+        public final String route_url;
+        public final String route_short_name;
+        public final String route_long_name;
 
-        public PtLeg(String feedId, boolean isInSameVehicleAsPrevious, String tripId, String routeId, String headsign, List<Stop> stops, double distance, long travelTime, Geometry geometry) {
+        public PtLeg(String feedId, boolean isInSameVehicleAsPrevious, String tripId, String routeId, int routeType, String routeUrl, String routeShortName, String routeLongName, String headsign, List<Stop> stops, double distance, long travelTime, Geometry geometry) {
             super("pt", stops.get(0).stop_name, geometry, distance);
             this.feed_id = feedId;
             this.isInSameVehicleAsPrevious = isInSameVehicleAsPrevious;
@@ -112,6 +116,10 @@ public class Trip {
             this.trip_headsign = headsign;
             this.travelTime = travelTime;
             this.stops = stops;
+            this.route_type = routeType;
+            this.route_url = routeUrl;
+            this.route_short_name = routeShortName;
+            this.route_long_name = routeLongName;
         }
 
         @Override


### PR DESCRIPTION
I already suggested a [PR, which is now closed](https://github.com/graphhopper/graphhopper/pull/2483). You can still check [my post on the forum](https://discuss.graphhopper.com/t/get-the-type-of-vehicle-when-querying-public-transport-itinerary/6964).

This one is cleaner and passes all the tests.
Let me know if something is missing.