### PR TITLE
New profile for busses

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -18,6 +18,7 @@ Here is an overview:
  * ChristophKaser, agrees to the project's CLA, improved Android compatibility #1207
  * chucre, add special JSON output format, see #41
  * daisy1754, fixed usage of graphhopper.sh script
+ * DanielAMCON, add bus profile
  * dardin88, instructions improved
  * dewos, web API bug fixes
  * devemux86, improvements regarding Android, GPX and more

--- a/config-example.yml
+++ b/config-example.yml
@@ -1,196 +1,20 @@
 graphhopper:
-
-  # OpenStreetMap input file PBF or XML, can be changed via command line -Ddw.graphhopper.datareader.file=some.pbf
   datareader.file: ""
-  # Local folder used by graphhopper to store its data
   graph.location: graph-cache
-
-
-  ##### Vehicles #####
-
-  # More options: foot,hike,bike,bike2,mtb,racingbike,motorcycle,wheelchair (comma separated)
-  # bike2 takes elevation data into account (like up-hill is slower than down-hill) and requires enabling graph.elevation.provider below.
-  # graph.flag_encoders: car
-
-  # Enable turn restrictions for car or motorcycle.
-  # graph.flag_encoders: car|turn_costs=true
-
-  # Add additional information to every edge. Used for path details (#1548), better instructions (#1844) and tunnel/bridge interpolation (#798).
-  # Default values are: road_class,road_class_link,road_environment,max_speed,road_access (since #1805)
-  # More are: surface,smoothness,max_width,max_height,max_weight,hgv,max_axle_load,max_length,hazmat,hazmat_tunnel,hazmat_water,toll,track_type,
-  #           mtb_rating, hike_rating,horse_rating,lanes
-  # graph.encoded_values: surface,toll,track_type
-
-  ##### Routing Profiles ####
-
-  # Routing can be done for the following list of profiles. Note that it is required to specify all the profiles you
-  # would like to use here. The fields of each profile are as follows:
-  # - name (required): a unique string identifier for the profile
-  # - vehicle (required): refers to the `graph.flag_encoders` used for this profile
-  # - weighting (required): the weighting used for this profile, e.g. fastest,shortest or short_fastest
-  # - turn_costs (true/false, default: false): whether or not turn restrictions should be applied for this profile.
-  #   this will only work if the `graph.flag_encoders` for the given `vehicle` is configured with `|turn_costs=true`.
-  #
-  # Depending on the above fields there are other properties that can be used, e.g.
-  # - distance_factor: 0.1 (can be used to fine tune the time/distance trade-off of short_fastest weighting)
-  # - u_turn_costs: 60 (time-penalty for doing a u-turn in seconds (only possible when `turn_costs: true`)).
-  #   Note that since the u-turn costs are given in seconds the weighting you use should also calculate the weight
-  #   in seconds, so for example it does not work with shortest weighting.
-  # - custom_model_file: when you specified "weighting: custom" you need to set a yaml or json file inside your custom_model_folder
-  #   or working directory that defines the custom_model. If you want an empty model you can also set "custom_model_file: empty".
-  #   You can also use th e`custom_model` field instead and specify your custom model in the profile directly.
-  #
-  #   For more information about profiles and especially custom profiles have a look into the documentation
-  #   at docs/core/profiles.md or the examples under web/src/test/java/com/graphhopper/application/resources/ or
-  #   the CustomWeighting class for the raw details.
-  #
-  # To prevent long running routing queries you should usually enable either speed or hybrid mode for all the given
-  # profiles (see below). Otherwise you should at least limit the number of `routing.max_visited_nodes`.
   profiles:
-    - name: car
-      vehicle: car
-      weighting: fastest
     - name: bus
       vehicle: bus
       weighting: fastest
-
-  #  - name: car_with_turn_costs
-  #    vehicle: car
-  #    weighting: short_fastest
-  #    distance_factor: 0.1
-  #    turn_costs: true
-  #    u_turn_costs: 60
-
-  # Speed mode:
-  # Its possible to speed up routing by doing a special graph preparation (Contraction Hierarchies, CH). This requires
-  # more RAM/disk space for holding the prepared graph but also means less memory usage per request. Using the following
-  # list you can define for which of the above routing profiles such preparation shall be performed. Note that to support
-  # profiles with `turn_costs: true` a more elaborate preparation is required (longer preparation time and more memory
-  # usage) and the routing will also be slower than with `turn_costs: false`.
   profiles_ch:
-    - profile: car
     - profile: bus
-  #   - profile: car_with_turn_costs
-
-  # Hybrid mode:
-  # Similar to speed mode, the hybrid mode (Landmarks, LM) also speeds up routing by doing calculating auxiliary data
-  # in advance. Its not as fast as speed mode, but more flexible.
-  #
-  # Advanced usage: It is possible to use the same preparation for multiple profiles which saves memory and preparation
-  # time. To do this use e.g. `preparation_profile: my_other_profile` where `my_other_profile` is the name of another
-  # profile for which an LM profile exists. Important: This only will give correct routing results if the weights
-  # calculated for the profile are equal or larger (for every edge) than those calculated for the profile that was used
-  # for the preparation (`my_other_profile`)
   profiles_lm: []
-
-  ##### Elevation #####
-
-  # To populate your graph with elevation data use SRTM, default is noop (no elevation). Read more about it in docs/core/elevation.md
-  # graph.elevation.provider: srtm
-
-  # default location for cache is /tmp/srtm
-  # graph.elevation.cache_dir: ./srtmprovider/
-
-  # If you have a slow disk or plenty of RAM change the default MMAP to:
-  # graph.elevation.dataaccess: RAM_STORE
-
-  # To enable bilinear interpolation when sampling elevation at points (default uses nearest neighbor):
-  # graph.elevation.interpolate: bilinear
-
-  # Reduce ascend/descend per edge without changing the maximum slope:
-  # graph.elevation.edge_smoothing: ramer
-  # removes elevation fluctuations up to max_elevation (in meter) and replaces the elevation with a value based on the average slope
-  # graph.elevation.edge_smoothing.ramer.max_elevation: 5
-  # A potentially bigger reduction of ascend/descend is possible, but maximum slope will often increase (do not use when average_slope or maximum_slope shall be used in a custom_model)
-  # graph.elevation.edge_smoothing: moving_average
-
-  # To increase elevation profile resolution, use the following two parameters to tune the extra resolution you need
-  # against the additional storage space used for edge geometries. You should enable bilinear interpolation when using
-  # these features (see #1953 for details).
-  # - first, set the distance (in meters) at which elevation samples should be taken on long edges
-  # graph.elevation.long_edge_sampling_distance: 60
-  # - second, set the elevation tolerance (in meters) to use when simplifying polylines since the default ignores
-  #   elevation and will remove the extra points that long edge sampling added
-  # graph.elevation.way_point_max_distance: 10
-
-  #### Urban density (built-up areas) ####
-
-
-  # This feature allows classifying roads into 'rural', 'residential' and 'city' areas (encoded value 'urban_density')
-  # Use 1 or more threads to enable the feature
-  # graph.urban_density.threads: 8
-  # Use higher/lower sensitivities if too little/many roads fall into the according categories.
-  # Using smaller radii will speed up the classification, but only change these values if you know what you are doing.
-  # If you do not need the (rather slow) city classification set city_radius to zero.
-  # graph.urban_density.residential_radius: 300
-  # graph.urban_density.residential_sensitivity: 60
-  # graph.urban_density.city_radius: 2000
-  # graph.urban_density.city_sensitivity: 30
-
-
-  #### Speed, hybrid and flexible mode ####
-
-  # To make CH preparation faster for multiple profiles you can increase the default threads if you have enough RAM.
-  # Change this setting only if you know what you are doing and if the default worked for you.
-  # prepare.ch.threads: 1
-
-  # To tune the performance vs. memory usage for the hybrid mode use
-  # prepare.lm.landmarks: 16
-
-  # Make landmark preparation parallel if you have enough RAM. Change this only if you know what you are doing and if
-  # the default worked for you.
-  # prepare.lm.threads: 1
-
-  # In many cases the road network consists of independent components without any routes going in between. In
-  # the most simple case you can imagine an island without a bridge or ferry connection. The following parameter
-  # allows setting a minimum size (number of edges) for such detached components. This can be used to reduce the number
-  # of cases where a connection between locations might not be found.
   prepare.min_network_size: 200
-
-
-  ##### Routing #####
-
-  # You can define the maximum visited nodes when routing. This may result in not found connections if there is no
-  # connection between two points within the given visited nodes. The default is Integer.MAX_VALUE. Useful for flexibility mode
-  # routing.max_visited_nodes: 1000000
-
-  # Control how many active landmarks are picked per default, this can improve query performance
-  # routing.lm.active_landmarks: 4
-
-  # You can limit the max distance between two consecutive waypoints of flexible routing requests to be less or equal
-  # the given distance in meter. Default is set to 1000km.
   routing.non_ch.max_waypoint_distance: 1000000
-
-
-  ##### Storage #####
-
-  # configure the memory access, use RAM_STORE for well equipped servers (default and recommended)
   graph.dataaccess.default_type: RAM_STORE
-
-
-  # will write way names in the preferred language (language code as defined in ISO 639-1 or ISO 639-2):
-  # datareader.preferred_language: en
-
-
-  # Sort the graph after import to make requests roughly ~10% faster. Note that this requires significantly more RAM on import.
-  # graph.do_sort: true
-
-  ##### Country Rules #####
-  # GraphHopper reads GeoJSON polygon files including their properties from this directory and makes them available
-  # to all tag parsers and flag encoders. Country borders (see countries.geojson) are always included automatically.
-  # custom_areas.directory: path/to/custom_areas
-
-  ##### Country Rules #####
-  # GraphHopper applies country-specific routing rules during import (not enabled by default).
-  # You need to redo the import for changes to take effect.
-  # country_rules.enabled: true
-
-# Dropwizard server configuration
 server:
   application_connectors:
   - type: http
     port: 8989
-    # for security reasons bind to localhost
     bind_host: localhost
   request_log:
       appenders: []
@@ -198,7 +22,6 @@ server:
   - type: http
     port: 8990
     bind_host: localhost
-# See https://www.dropwizard.io/en/latest/manual/core.html#logging
 logging:
   appenders:
   - type: file

--- a/config-example.yml
+++ b/config-example.yml
@@ -5,8 +5,12 @@ graphhopper:
     - name: bus
       vehicle: bus
       weighting: fastest
+    - name: car
+      vehicle: car
+      weighting: fastest
   profiles_ch:
     - profile: bus
+    - profile: car
   profiles_lm: []
   prepare.min_network_size: 200
   routing.non_ch.max_waypoint_distance: 1000000

--- a/config-example.yml
+++ b/config-example.yml
@@ -50,6 +50,9 @@ graphhopper:
     - name: car
       vehicle: car
       weighting: fastest
+    - name: bus
+      vehicle: bus
+      weighting: fastest
 
   #  - name: car_with_turn_costs
   #    vehicle: car
@@ -66,6 +69,7 @@ graphhopper:
   # usage) and the routing will also be slower than with `turn_costs: false`.
   profiles_ch:
     - profile: car
+    - profile: bus
   #   - profile: car_with_turn_costs
 
   # Hybrid mode:

--- a/config-example.yml
+++ b/config-example.yml
@@ -1,24 +1,192 @@
 graphhopper:
+
+  # OpenStreetMap input file PBF or XML, can be changed via command line -Ddw.graphhopper.datareader.file=some.pbf
   datareader.file: ""
+  # Local folder used by graphhopper to store its data
   graph.location: graph-cache
+
+
+  ##### Vehicles #####
+
+  # More options: foot,hike,bike,bike2,mtb,racingbike,motorcycle,wheelchair (comma separated)
+  # bike2 takes elevation data into account (like up-hill is slower than down-hill) and requires enabling graph.elevation.provider below.
+  # graph.flag_encoders: car
+
+  # Enable turn restrictions for car or motorcycle.
+  # graph.flag_encoders: car|turn_costs=true
+
+  # Add additional information to every edge. Used for path details (#1548), better instructions (#1844) and tunnel/bridge interpolation (#798).
+  # Default values are: road_class,road_class_link,road_environment,max_speed,road_access (since #1805)
+  # More are: surface,smoothness,max_width,max_height,max_weight,hgv,max_axle_load,max_length,hazmat,hazmat_tunnel,hazmat_water,toll,track_type,
+  #           mtb_rating, hike_rating,horse_rating,lanes
+  # graph.encoded_values: surface,toll,track_type
+
+  ##### Routing Profiles ####
+
+  # Routing can be done for the following list of profiles. Note that it is required to specify all the profiles you
+  # would like to use here. The fields of each profile are as follows:
+  # - name (required): a unique string identifier for the profile
+  # - vehicle (required): refers to the `graph.flag_encoders` used for this profile
+  # - weighting (required): the weighting used for this profile, e.g. fastest,shortest or short_fastest
+  # - turn_costs (true/false, default: false): whether or not turn restrictions should be applied for this profile.
+  #   this will only work if the `graph.flag_encoders` for the given `vehicle` is configured with `|turn_costs=true`.
+  #
+  # Depending on the above fields there are other properties that can be used, e.g.
+  # - distance_factor: 0.1 (can be used to fine tune the time/distance trade-off of short_fastest weighting)
+  # - u_turn_costs: 60 (time-penalty for doing a u-turn in seconds (only possible when `turn_costs: true`)).
+  #   Note that since the u-turn costs are given in seconds the weighting you use should also calculate the weight
+  #   in seconds, so for example it does not work with shortest weighting.
+  # - custom_model_file: when you specified "weighting: custom" you need to set a yaml or json file inside your custom_model_folder
+  #   or working directory that defines the custom_model. If you want an empty model you can also set "custom_model_file: empty".
+  #   You can also use th e`custom_model` field instead and specify your custom model in the profile directly.
+  #
+  #   For more information about profiles and especially custom profiles have a look into the documentation
+  #   at docs/core/profiles.md or the examples under web/src/test/java/com/graphhopper/application/resources/ or
+  #   the CustomWeighting class for the raw details.
+  #
+  # To prevent long running routing queries you should usually enable either speed or hybrid mode for all the given
+  # profiles (see below). Otherwise you should at least limit the number of `routing.max_visited_nodes`.
   profiles:
-    - name: bus
-      vehicle: bus
-      weighting: fastest
     - name: car
       vehicle: car
       weighting: fastest
+
+  #  - name: car_with_turn_costs
+  #    vehicle: car
+  #    weighting: short_fastest
+  #    distance_factor: 0.1
+  #    turn_costs: true
+  #    u_turn_costs: 60
+
+  # Speed mode:
+  # Its possible to speed up routing by doing a special graph preparation (Contraction Hierarchies, CH). This requires
+  # more RAM/disk space for holding the prepared graph but also means less memory usage per request. Using the following
+  # list you can define for which of the above routing profiles such preparation shall be performed. Note that to support
+  # profiles with `turn_costs: true` a more elaborate preparation is required (longer preparation time and more memory
+  # usage) and the routing will also be slower than with `turn_costs: false`.
   profiles_ch:
-    - profile: bus
     - profile: car
+  #   - profile: car_with_turn_costs
+
+  # Hybrid mode:
+  # Similar to speed mode, the hybrid mode (Landmarks, LM) also speeds up routing by doing calculating auxiliary data
+  # in advance. Its not as fast as speed mode, but more flexible.
+  #
+  # Advanced usage: It is possible to use the same preparation for multiple profiles which saves memory and preparation
+  # time. To do this use e.g. `preparation_profile: my_other_profile` where `my_other_profile` is the name of another
+  # profile for which an LM profile exists. Important: This only will give correct routing results if the weights
+  # calculated for the profile are equal or larger (for every edge) than those calculated for the profile that was used
+  # for the preparation (`my_other_profile`)
   profiles_lm: []
+
+  ##### Elevation #####
+
+  # To populate your graph with elevation data use SRTM, default is noop (no elevation). Read more about it in docs/core/elevation.md
+  # graph.elevation.provider: srtm
+
+  # default location for cache is /tmp/srtm
+  # graph.elevation.cache_dir: ./srtmprovider/
+
+  # If you have a slow disk or plenty of RAM change the default MMAP to:
+  # graph.elevation.dataaccess: RAM_STORE
+
+  # To enable bilinear interpolation when sampling elevation at points (default uses nearest neighbor):
+  # graph.elevation.interpolate: bilinear
+
+  # Reduce ascend/descend per edge without changing the maximum slope:
+  # graph.elevation.edge_smoothing: ramer
+  # removes elevation fluctuations up to max_elevation (in meter) and replaces the elevation with a value based on the average slope
+  # graph.elevation.edge_smoothing.ramer.max_elevation: 5
+  # A potentially bigger reduction of ascend/descend is possible, but maximum slope will often increase (do not use when average_slope or maximum_slope shall be used in a custom_model)
+  # graph.elevation.edge_smoothing: moving_average
+
+  # To increase elevation profile resolution, use the following two parameters to tune the extra resolution you need
+  # against the additional storage space used for edge geometries. You should enable bilinear interpolation when using
+  # these features (see #1953 for details).
+  # - first, set the distance (in meters) at which elevation samples should be taken on long edges
+  # graph.elevation.long_edge_sampling_distance: 60
+  # - second, set the elevation tolerance (in meters) to use when simplifying polylines since the default ignores
+  #   elevation and will remove the extra points that long edge sampling added
+  # graph.elevation.way_point_max_distance: 10
+
+  #### Urban density (built-up areas) ####
+
+
+  # This feature allows classifying roads into 'rural', 'residential' and 'city' areas (encoded value 'urban_density')
+  # Use 1 or more threads to enable the feature
+  # graph.urban_density.threads: 8
+  # Use higher/lower sensitivities if too little/many roads fall into the according categories.
+  # Using smaller radii will speed up the classification, but only change these values if you know what you are doing.
+  # If you do not need the (rather slow) city classification set city_radius to zero.
+  # graph.urban_density.residential_radius: 300
+  # graph.urban_density.residential_sensitivity: 60
+  # graph.urban_density.city_radius: 2000
+  # graph.urban_density.city_sensitivity: 30
+
+
+  #### Speed, hybrid and flexible mode ####
+
+  # To make CH preparation faster for multiple profiles you can increase the default threads if you have enough RAM.
+  # Change this setting only if you know what you are doing and if the default worked for you.
+  # prepare.ch.threads: 1
+
+  # To tune the performance vs. memory usage for the hybrid mode use
+  # prepare.lm.landmarks: 16
+
+  # Make landmark preparation parallel if you have enough RAM. Change this only if you know what you are doing and if
+  # the default worked for you.
+  # prepare.lm.threads: 1
+
+  # In many cases the road network consists of independent components without any routes going in between. In
+  # the most simple case you can imagine an island without a bridge or ferry connection. The following parameter
+  # allows setting a minimum size (number of edges) for such detached components. This can be used to reduce the number
+  # of cases where a connection between locations might not be found.
   prepare.min_network_size: 200
+
+
+  ##### Routing #####
+
+  # You can define the maximum visited nodes when routing. This may result in not found connections if there is no
+  # connection between two points within the given visited nodes. The default is Integer.MAX_VALUE. Useful for flexibility mode
+  # routing.max_visited_nodes: 1000000
+
+  # Control how many active landmarks are picked per default, this can improve query performance
+  # routing.lm.active_landmarks: 4
+
+  # You can limit the max distance between two consecutive waypoints of flexible routing requests to be less or equal
+  # the given distance in meter. Default is set to 1000km.
   routing.non_ch.max_waypoint_distance: 1000000
+
+
+  ##### Storage #####
+
+  # configure the memory access, use RAM_STORE for well equipped servers (default and recommended)
   graph.dataaccess.default_type: RAM_STORE
+
+
+  # will write way names in the preferred language (language code as defined in ISO 639-1 or ISO 639-2):
+  # datareader.preferred_language: en
+
+
+  # Sort the graph after import to make requests roughly ~10% faster. Note that this requires significantly more RAM on import.
+  # graph.do_sort: true
+
+  ##### Country Rules #####
+  # GraphHopper reads GeoJSON polygon files including their properties from this directory and makes them available
+  # to all tag parsers and flag encoders. Country borders (see countries.geojson) are always included automatically.
+  # custom_areas.directory: path/to/custom_areas
+
+  ##### Country Rules #####
+  # GraphHopper applies country-specific routing rules during import (not enabled by default).
+  # You need to redo the import for changes to take effect.
+  # country_rules.enabled: true
+
+# Dropwizard server configuration
 server:
   application_connectors:
   - type: http
     port: 8989
+    # for security reasons bind to localhost
     bind_host: localhost
   request_log:
       appenders: []
@@ -26,6 +194,7 @@ server:
   - type: http
     port: 8990
     bind_host: localhost
+# See https://www.dropwizard.io/en/latest/manual/core.html#logging
 logging:
   appenders:
   - type: file

--- a/core/src/main/java/com/graphhopper/routing/util/BusTagParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/BusTagParser.java
@@ -17,7 +17,7 @@ public class BusTagParser extends CarTagParser {
 
     public BusTagParser(BooleanEncodedValue accessEnc, DecimalEncodedValue speedEnc, DecimalEncodedValue turnCostEnc,
                         BooleanEncodedValue roundaboutEnc, PMap properties, TransportationMode transportationMode) {
-        super(accessEnc, speedEnc, turnCostEnc, roundaboutEnc, new PMap(properties).putObject("name", "bus"), transportationMode, speedEnc.getNextStorableValue(100));
+        super(accessEnc, speedEnc, turnCostEnc, roundaboutEnc, new PMap(properties).putObject("name", "bus"), transportationMode, speedEnc.getNextStorableValue(60));
 
         restrictedValues.remove("no");
         restrictedValues.remove("private");

--- a/core/src/main/java/com/graphhopper/routing/util/BusTagParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/BusTagParser.java
@@ -1,0 +1,34 @@
+package com.graphhopper.routing.util;
+
+import com.graphhopper.routing.ev.*;
+import com.graphhopper.util.PMap;
+
+import static com.graphhopper.routing.util.EncodingManager.getKey;
+
+public class BusTagParser extends CarTagParser {
+    public BusTagParser(EncodedValueLookup lookup, PMap properties) {
+        this(
+                lookup.getBooleanEncodedValue(VehicleAccess.key("bus")),
+                lookup.getDecimalEncodedValue(VehicleSpeed.key("bus")),
+                lookup.hasEncodedValue(TurnCost.key("bus")) ? lookup.getDecimalEncodedValue(TurnCost.key("bus")) : null,
+                lookup.getBooleanEncodedValue(Roundabout.KEY),
+                new PMap(properties).putObject("name", "bus"),
+                TransportationMode.PSV
+        );
+    }
+
+    public BusTagParser(BooleanEncodedValue accessEnc, DecimalEncodedValue speedEnc, DecimalEncodedValue turnCostEnc,
+                        BooleanEncodedValue roundaboutEnc, PMap properties, TransportationMode transportationMode) {
+        super(accessEnc, speedEnc, turnCostEnc, roundaboutEnc, new PMap(properties).putObject("name", "bus"), transportationMode, speedEnc.getNextStorableValue(100));
+
+        restrictions.remove("motorcar");
+        restrictions.add("psv");
+        restrictions.add("bus");
+
+        restrictedValues.remove("no");
+        restrictedValues.remove("private");
+
+        barriers.remove("bus_trap");
+        barriers.remove("sump_buster");
+    }
+}

--- a/core/src/main/java/com/graphhopper/routing/util/BusTagParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/BusTagParser.java
@@ -3,8 +3,6 @@ package com.graphhopper.routing.util;
 import com.graphhopper.routing.ev.*;
 import com.graphhopper.util.PMap;
 
-import static com.graphhopper.routing.util.EncodingManager.getKey;
-
 public class BusTagParser extends CarTagParser {
     public BusTagParser(EncodedValueLookup lookup, PMap properties) {
         this(
@@ -13,17 +11,13 @@ public class BusTagParser extends CarTagParser {
                 lookup.hasEncodedValue(TurnCost.key("bus")) ? lookup.getDecimalEncodedValue(TurnCost.key("bus")) : null,
                 lookup.getBooleanEncodedValue(Roundabout.KEY),
                 new PMap(properties).putObject("name", "bus"),
-                TransportationMode.PSV
+                TransportationMode.BUS
         );
     }
 
     public BusTagParser(BooleanEncodedValue accessEnc, DecimalEncodedValue speedEnc, DecimalEncodedValue turnCostEnc,
                         BooleanEncodedValue roundaboutEnc, PMap properties, TransportationMode transportationMode) {
         super(accessEnc, speedEnc, turnCostEnc, roundaboutEnc, new PMap(properties).putObject("name", "bus"), transportationMode, speedEnc.getNextStorableValue(100));
-
-        restrictions.remove("motorcar");
-        restrictions.add("psv");
-        restrictions.add("bus");
 
         restrictedValues.remove("no");
         restrictedValues.remove("private");

--- a/core/src/main/java/com/graphhopper/routing/util/DefaultVehicleEncodedValuesFactory.java
+++ b/core/src/main/java/com/graphhopper/routing/util/DefaultVehicleEncodedValuesFactory.java
@@ -60,6 +60,9 @@ public class DefaultVehicleEncodedValuesFactory implements VehicleEncodedValuesF
         if (name.equals(WHEELCHAIR))
             return VehicleEncodedValues.wheelchair(configuration);
 
+        if (name.equals(BUS))
+            return VehicleEncodedValues.bus(configuration);
+
         throw new IllegalArgumentException("entry in vehicle list not supported: " + name);
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/util/DefaultVehicleTagParserFactory.java
+++ b/core/src/main/java/com/graphhopper/routing/util/DefaultVehicleTagParserFactory.java
@@ -45,6 +45,8 @@ public class DefaultVehicleTagParserFactory implements VehicleTagParserFactory {
             return new MotorcycleTagParser(lookup, configuration);
         if (name.equals(WHEELCHAIR))
             return new WheelchairTagParser(lookup, configuration);
+        if (name.equals(BUS))
+            return new BusTagParser(lookup, configuration);
 
         throw new IllegalArgumentException("Unknown name for vehicle tag parser: " + name);
     }

--- a/core/src/main/java/com/graphhopper/routing/util/TransportationMode.java
+++ b/core/src/main/java/com/graphhopper/routing/util/TransportationMode.java
@@ -26,7 +26,7 @@ package com.graphhopper.routing.util;
  */
 public enum TransportationMode {
     OTHER(false), FOOT(false), VEHICLE(false), BIKE(false),
-    CAR(true), MOTORCYCLE(true), HGV(true), PSV(true);
+    CAR(true), MOTORCYCLE(true), HGV(true), PSV(true), BUS(true);
 
     private final boolean motorVehicle;
 

--- a/core/src/main/java/com/graphhopper/routing/util/VehicleEncodedValues.java
+++ b/core/src/main/java/com/graphhopper/routing/util/VehicleEncodedValues.java
@@ -131,6 +131,18 @@ public class VehicleEncodedValues {
         return new VehicleEncodedValues(name, accessEnc, speedEnc, null, null, turnCostEnc);
     }
 
+    public static VehicleEncodedValues bus(PMap properties) {
+        String name = properties.getString("name", "bus");
+        int speedBits = properties.getInt("speed_bits", 5);
+        double speedFactor = properties.getDouble("speed_factor", 5);
+        boolean speedTwoDirections = properties.getBool("speed_two_directions", false);
+        int maxTurnCosts = properties.getInt("max_turn_costs", properties.getBool("turn_costs", false) ? 1 : 0);
+        BooleanEncodedValue accessEnc = VehicleAccess.create(name);
+        DecimalEncodedValue speedEnc = VehicleSpeed.create(name, speedBits, speedFactor, speedTwoDirections);
+        DecimalEncodedValue turnCostEnc = maxTurnCosts > 0 ? TurnCost.create(name, maxTurnCosts) : null;
+        return new VehicleEncodedValues(name, accessEnc, speedEnc, null, null, turnCostEnc);
+    }
+
     public VehicleEncodedValues(String name, BooleanEncodedValue accessEnc, DecimalEncodedValue avgSpeedEnc,
                                 DecimalEncodedValue priorityEnc, DecimalEncodedValue curvatureEnc,
                                 DecimalEncodedValue turnCostEnc) {

--- a/core/src/main/java/com/graphhopper/routing/util/VehicleEncodedValuesFactory.java
+++ b/core/src/main/java/com/graphhopper/routing/util/VehicleEncodedValuesFactory.java
@@ -33,6 +33,7 @@ public interface VehicleEncodedValuesFactory {
     String HIKE = "hike";
     String MOTORCYCLE = "motorcycle";
     String WHEELCHAIR = "wheelchair";
+    String BUS = "bus";
 
     VehicleEncodedValues createVehicleEncodedValues(String name, PMap configuration);
 

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMRoadAccessParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMRoadAccessParser.java
@@ -79,6 +79,8 @@ public class OSMRoadAccessParser implements TagParser {
                 return Arrays.asList("hgv", "motor_vehicle", "vehicle", "access");
             case PSV:
                 return Arrays.asList("psv", "motor_vehicle", "vehicle", "access");
+            case BUS:
+                return Arrays.asList("bus", "psv", "motor_vehicle", "vehicle", "access");
             default:
                 throw new IllegalArgumentException("Cannot convert TransportationMode " + mode + " to list of restrictions");
         }

--- a/core/src/test/java/com/graphhopper/routing/util/BusTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/BusTagParserTest.java
@@ -1,0 +1,197 @@
+package com.graphhopper.routing.util;
+
+import com.graphhopper.reader.ReaderNode;
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.reader.osm.conditional.DateRangeParser;
+import com.graphhopper.routing.ev.*;
+import com.graphhopper.storage.IntsRef;
+import com.graphhopper.util.PMap;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class BusTagParserTest {
+    private static final String BUS_NAME = "bus";
+
+    private final EncodingManager em = EncodingManager.create(BUS_NAME);
+    private final BusTagParser parser = createParser(em);
+    private final DecimalEncodedValue avSpeedEnc = parser.getAverageSpeedEnc();
+
+    private EncodingManager createEncodingManager(String busName) {
+        return new EncodingManager.Builder()
+                .add(VehicleAccess.create(busName))
+                .add(VehicleSpeed.create(busName, 5, 5, true))
+                .addTurnCostEncodedValue(TurnCost.create(busName, 1))
+                .add(VehicleAccess.create("bike"))
+                .add(VehicleSpeed.create("bike", 4, 2, false))
+                .add(VehiclePriority.create("bike", 4, PriorityCode.getFactor(1), false))
+                .add(new EnumEncodedValue<>(BikeNetwork.KEY, RouteNetwork.class))
+                .add(new EnumEncodedValue<>(Smoothness.KEY, Smoothness.class))
+                .build();
+    }
+
+    private BusTagParser createParser(EncodedValueLookup lookup) {
+        BusTagParser busTagParser = new BusTagParser(lookup, new PMap());
+        busTagParser.init(new DateRangeParser());
+        return busTagParser;
+    }
+
+    @Test
+    public void testAccess() {
+        ReaderWay way = new ReaderWay(1);
+        assertTrue(parser.getAccess(way).canSkip());
+        way.setTag("highway", "service");
+        assertTrue(parser.getAccess(way).isWay());
+        way.setTag("access", "no");
+        assertFalse(parser.getAccess(way).canSkip());
+
+        way.clearTags();
+        way.setTag("highway", "track");
+        assertTrue(parser.getAccess(way).isWay());
+
+        way.setTag("motorcar", "no");
+        assertFalse(parser.getAccess(way).canSkip());
+
+        way.clearTags();
+        way.setTag("highway", "track");
+        way.setTag("tracktype", "grade2");
+        assertTrue(parser.getAccess(way).isWay());
+        way.setTag("tracktype", "grade4");
+        assertTrue(parser.getAccess(way).canSkip());
+
+        way.clearTags();
+        way.setTag("highway", "service");
+        way.setTag("access", "delivery");
+        assertTrue(parser.getAccess(way).canSkip());
+
+        way.clearTags();
+        way.setTag("highway", "unclassified");
+        way.setTag("ford", "yes");
+        assertFalse(parser.getAccess(way).canSkip());
+        way.setTag("motorcar", "yes");
+        assertTrue(parser.getAccess(way).isWay());
+
+        way.clearTags();
+        way.setTag("access", "yes");
+        way.setTag("motor_vehicle", "no");
+        assertTrue(parser.getAccess(way).canSkip());
+
+        way.clearTags();
+        way.setTag("highway", "service");
+        way.setTag("access", "yes");
+        way.setTag("motor_vehicle", "no");
+        assertFalse(parser.getAccess(way).canSkip());
+
+        way.clearTags();
+        way.setTag("highway", "track");
+        way.setTag("motor_vehicle", "agricultural");
+        assertTrue(parser.getAccess(way).canSkip());
+        way.setTag("motor_vehicle", "agricultural;forestry");
+        assertTrue(parser.getAccess(way).canSkip());
+        way.setTag("motor_vehicle", "forestry;agricultural");
+        assertTrue(parser.getAccess(way).canSkip());
+        way.setTag("motor_vehicle", "forestry;agricultural;unknown");
+        assertTrue(parser.getAccess(way).canSkip());
+        way.setTag("motor_vehicle", "yes;forestry;agricultural");
+        assertTrue(parser.getAccess(way).isWay());
+
+        way.clearTags();
+        way.setTag("highway", "service");
+        way.setTag("access", "no");
+        way.setTag("motorcar", "yes");
+        assertTrue(parser.getAccess(way).isWay());
+
+        way.clearTags();
+        way.setTag("highway", "service");
+        way.setTag("access", "emergency");
+        assertTrue(parser.getAccess(way).canSkip());
+        way.setTag("access", "private");
+        assertFalse(parser.getAccess(way).canSkip());
+
+        way.clearTags();
+        way.setTag("highway", "service");
+        way.setTag("motor_vehicle", "emergency");
+        assertTrue(parser.getAccess(way).canSkip());
+
+        way.clearTags();
+        way.setTag("highway", "service");
+        way.setTag("service", "emergency_access");
+        assertTrue(parser.getAccess(way).canSkip());
+    }
+
+    @Test
+    public void testBarrierAccess() {
+        ReaderNode node = new ReaderNode(1, -1, -1);
+        node.setTag("barrier", "lift_gate");
+        node.setTag("access", "yes");
+        assertFalse(parser.isBarrier(node));
+
+        node = new ReaderNode(1, -1, -1);
+        node.setTag("barrier", "lift_gate");
+        node.setTag("bicycle", "yes");
+        assertFalse(parser.isBarrier(node));
+
+        node = new ReaderNode(1, -1, -1);
+        node.setTag("barrier", "lift_gate");
+        node.setTag("access", "no");
+        node.setTag("motorcar", "yes");
+        assertFalse(parser.isBarrier(node));
+
+        node = new ReaderNode(1, -1, -1);
+        node.setTag("barrier", "bollard");
+        assertTrue(parser.isBarrier(node));
+
+        node = new ReaderNode(1, -1, -1);
+        node.setTag("barrier", "cattle_grid");
+        assertFalse(parser.isBarrier(node));
+
+        node = new ReaderNode(1, -1, -1);
+        node.setTag("barrier", "bus_trap");
+        assertFalse(parser.isBarrier(node));
+
+        node = new ReaderNode(1, -1, -1);
+        node.setTag("barrier", "sump_buster");
+        assertFalse(parser.isBarrier(node));
+    }
+
+    @Test
+    public void testMaxSpeed() {
+        ReaderWay way = new ReaderWay(1);
+        way.setTag("highway", "trunk");
+        way.setTag("maxspeed", "500");
+        IntsRef edgeFlags = em.createEdgeFlags();
+        parser.handleWayTags(edgeFlags, way);
+        assertEquals(60, avSpeedEnc.getDecimal(false, edgeFlags), 1e-1);
+
+        way = new ReaderWay(1);
+        way.setTag("highway", "primary");
+        way.setTag("maxspeed:backward", "10");
+        way.setTag("maxspeed:forward", "20");
+        edgeFlags = parser.handleWayTags(edgeFlags, way);
+        assertEquals(10, avSpeedEnc.getDecimal(false, edgeFlags), 1e-1);
+
+        way = new ReaderWay(1);
+        way.setTag("highway", "primary");
+        way.setTag("maxspeed:forward", "20");
+        edgeFlags = parser.handleWayTags(edgeFlags, way);
+        assertEquals(20, avSpeedEnc.getDecimal(false, edgeFlags), 1e-1);
+
+        way = new ReaderWay(1);
+        way.setTag("highway", "primary");
+        way.setTag("maxspeed:backward", "20");
+        edgeFlags = parser.handleWayTags(edgeFlags, way);
+        assertEquals(20, avSpeedEnc.getDecimal(false, edgeFlags), 1e-1);
+
+        way = new ReaderWay(1);
+        way.setTag("highway", "motorway");
+        way.setTag("maxspeed", "none");
+        edgeFlags = parser.handleWayTags(edgeFlags, way);
+        assertEquals(60, avSpeedEnc.getDecimal(false, edgeFlags), .1);
+
+        way = new ReaderWay(1);
+        way.setTag("highway", "motorway_link");
+        way.setTag("maxspeed", "70 mph");
+        IntsRef flags = parser.handleWayTags(em.createEdgeFlags(), way);
+        assertEquals(60, avSpeedEnc.getDecimal(true, flags), 1e-1);
+    }
+}


### PR DESCRIPTION
My company needed to be able to calculate routes specifically for buses. As discussed in #2659 , I created a new profile for this purpose. We would like to make this available for others.

As already explained in the issue, the VehicleTagParser will also be removed in the long run. Therefore, I can understand if the PR will not be merged. If the case I described can now be implemented by other means, I will of course not merge the PR either. I am pleased about your feedback.