### PR TITLE
improve handling of low speed

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/VehicleTagParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/VehicleTagParser.java
@@ -195,6 +195,9 @@ public abstract class VehicleTagParser implements TagParser {
     }
 
     protected void setSpeed(boolean reverse, IntsRef edgeFlags, double speed) {
+        // special case when speed is non-zero but would be "rounded down" to 0 due to the low precision of the EncodedValue
+        if (speed > 0.1 && speed < avgSpeedEnc.getSmallestNonZeroValue())
+            speed = avgSpeedEnc.getSmallestNonZeroValue();
         if (speed < avgSpeedEnc.getSmallestNonZeroValue()) {
             avgSpeedEnc.setDecimal(reverse, edgeFlags, 0);
             accessEnc.setBool(reverse, edgeFlags, false);

--- a/core/src/test/java/com/graphhopper/routing/util/CarTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/CarTagParserTest.java
@@ -360,12 +360,12 @@ public class CarTagParserTest {
     }
 
     @Test
-    public void testSetSpeed0_issue367() {
+    public void testSetSpeed0_issue367_issue1234() {
         IntsRef edgeFlags = em.createEdgeFlags();
         accessEnc.setBool(false, edgeFlags, true);
         accessEnc.setBool(true, edgeFlags, true);
 
-        parser.setSpeed(false, edgeFlags, parser.avgSpeedEnc.getSmallestNonZeroValue() - 0.01);
+        parser.setSpeed(false, edgeFlags, 0.01);
 
         // one direction effects the other direction as one encoder for speed but this is not true for access
         assertEquals(0, avSpeedEnc.getDecimal(false, edgeFlags), .1);
@@ -374,7 +374,7 @@ public class CarTagParserTest {
         assertTrue(accessEnc.getBool(true, edgeFlags));
 
         // so always call this method with reverse=true too
-        parser.setSpeed(true, edgeFlags, parser.avgSpeedEnc.getSmallestNonZeroValue() - 0.01);
+        parser.setSpeed(true, edgeFlags, 0.01);
         assertFalse(accessEnc.getBool(true, edgeFlags));
     }
 


### PR DESCRIPTION
This change was originally only for #1234, see [VehicleTagParser.setSpeed](https://github.com/graphhopper/graphhopper/pull/2726/files#diff-e97fad3b84a2b3bfe14f9025b391ff2bbca64b440b26792568a2d37867147fc4R192).

Will try to move the other changes into another PR... the other changes are a bit too involved and now some further problems occurred ... 

~Now it is a broader fix that fixes a second problem that was mentioned in testSetSpeed0_issue367: in case when the speed only has one value for both directions but the access values are directed which leads to inconsistent behaviour. So we now force two directions for the speed (for car) which further lead me to the changes regarding the max speed and fixes #2662 too (no tests added, existing tests were only adapted).~

~Furthermore now the better value "maximum max_speed" is picked for bike parser decisions instead of the "minimum max_speed".~