### PR TITLE
Use multi-threading for subnetwork preparation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@
 - removed YAML support for custom models on the server-side. Only allow JSON with // comments.
 - Bike2WeightTagParser was removed. Use the bike vehicle with a custom model, see custom_models/bike2.json
 - CurvatureWeighting was removed. Use a custom model with 'curvature' instead, see custom_models/curvature.json (#2665)
-- internal keys for EdgeKVStorage changed to contain the street_ prefix like the path details too. Similarly, the extra_info in the instructions of the API response, see #2661
+- internal keys for EdgeKVStorage changed to contain the street_ prefix like the path details too. Similarly, the
+  extra_info in the instructions of the API response, see #2661
+- subnetwork preparation can now be run in parallel to slightly speed up the base graph import (#2737)
 
 ### 6.0 [13 Sep 2022]
 

--- a/config-example.yml
+++ b/config-example.yml
@@ -153,6 +153,7 @@ graphhopper:
   # allows setting a minimum size (number of edges) for such detached components. This can be used to reduce the number
   # of cases where a connection between locations might not be found.
   prepare.min_network_size: 200
+  prepare.subnetworks.threads: 1
 
 
   #### Routing ####

--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -108,6 +108,7 @@ public class GraphHopper {
     private int maxRegionSearch = 4;
     // subnetworks
     private int minNetworkSize = 200;
+    private int subnetworksThreads = 1;
     // residential areas
     private double residentialAreaRadius = 300;
     private double residentialAreaSensitivity = 60;
@@ -563,6 +564,7 @@ public class GraphHopper {
 
         // optimizable prepare
         minNetworkSize = ghConfig.getInt("prepare.min_network_size", minNetworkSize);
+        subnetworksThreads = ghConfig.getInt("prepare.subnetworks.threads", subnetworksThreads);
 
         // prepare CH&LM
         chPreparationHandler.init(ghConfig);
@@ -1354,6 +1356,7 @@ public class GraphHopper {
     protected void cleanUp() {
         PrepareRoutingSubnetworks preparation = new PrepareRoutingSubnetworks(baseGraph.getBaseGraph(), buildSubnetworkRemovalJobs());
         preparation.setMinNetworkSize(minNetworkSize);
+        preparation.setThreads(subnetworksThreads);
         preparation.doWork();
         properties.put("profiles", getProfilesString());
         logger.info("nodes: " + Helper.nf(baseGraph.getNodes()) + ", edges: " + Helper.nf(baseGraph.getEdges()));

--- a/core/src/main/java/com/graphhopper/routing/subnetwork/PrepareRoutingSubnetworks.java
+++ b/core/src/main/java/com/graphhopper/routing/subnetwork/PrepareRoutingSubnetworks.java
@@ -22,9 +22,9 @@ import com.carrotsearch.hppc.BitSetIterator;
 import com.carrotsearch.hppc.IntArrayList;
 import com.carrotsearch.hppc.cursors.IntCursor;
 import com.graphhopper.routing.ev.BooleanEncodedValue;
+import com.graphhopper.routing.util.AllEdgesIterator;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.BaseGraph;
-import com.graphhopper.util.EdgeIteratorState;
 import com.graphhopper.util.GHUtility;
 import com.graphhopper.util.Helper;
 import com.graphhopper.util.StopWatch;
@@ -32,6 +32,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.graphhopper.util.GHUtility.getEdgeFromEdgeKey;
 
@@ -92,13 +94,23 @@ public class PrepareRoutingSubnetworks {
         logger.info("Start marking subnetworks, prepare.min_network_size: " + minNetworkSize + ", nodes: " +
                 Helper.nf(graph.getNodes()) + ", edges: " + Helper.nf(graph.getEdges()) + ", jobs: " + prepareJobs + ", " + Helper.getMemInfo());
         int total = 0;
-        for (PrepareJob job : prepareJobs)
-            total += setSubnetworks(job.weighting, job.subnetworkEnc);
+        List<BitSet> flags = Stream.generate(() -> new BitSet(graph.getEdges())).limit(prepareJobs.size()).collect(Collectors.toList());
+        for (int i = 0; i < prepareJobs.size(); i++) {
+            PrepareJob job = prepareJobs.get(i);
+            total += setSubnetworks(job.weighting, job.subnetworkEnc.getName().replaceAll("_subnetwork", ""), flags.get(i));
+        }
+        AllEdgesIterator iter = graph.getAllEdges();
+        while (iter.next()) {
+            for (int i = 0; i < prepareJobs.size(); i++) {
+                PrepareJob prepareJob = prepareJobs.get(i);
+                iter.set(prepareJob.subnetworkEnc, flags.get(i).get(iter.getEdge()));
+            }
+        }
         logger.info("Finished finding and marking subnetworks for " + prepareJobs.size() + " jobs, took: " + sw.stop().getSeconds() + "s, " + Helper.getMemInfo());
         return total;
     }
 
-    private int setSubnetworks(Weighting weighting, BooleanEncodedValue subnetworkEnc) {
+    private int setSubnetworks(Weighting weighting, String jobName, BitSet subnetworkFlags) {
         // partition graph into strongly connected components using Tarjan's algorithm
         StopWatch sw = new StopWatch().start();
         EdgeBasedTarjanSCC.ConnectedComponents ccs = EdgeBasedTarjanSCC.findComponents(graph,
@@ -107,7 +119,7 @@ public class PrepareRoutingSubnetworks {
         List<IntArrayList> components = ccs.getComponents();
         BitSet singleEdgeComponents = ccs.getSingleEdgeComponents();
         long numSingleEdgeComponents = singleEdgeComponents.cardinality();
-        logger.info(subnetworkEnc.getName().replaceAll("_subnetwork", "") + " - Found " + ccs.getTotalComponents() + " subnetworks (" + numSingleEdgeComponents + " single edges and "
+        logger.info(jobName + " - Found " + ccs.getTotalComponents() + " subnetworks (" + numSingleEdgeComponents + " single edges and "
                 + components.size() + " components with more than one edge, total nodes: " + ccs.getEdgeKeys() + "), took: " + sw.stop().getSeconds() + "s");
 
         final int minNetworkSizeEdgeKeys = 2 * minNetworkSize;
@@ -125,7 +137,7 @@ public class PrepareRoutingSubnetworks {
 
             if (component.size() < minNetworkSizeEdgeKeys) {
                 for (IntCursor cursor : component)
-                    markedEdges += setSubnetworkEdge(cursor.value, weighting, subnetworkEnc);
+                    markedEdges += setSubnetworkEdge(cursor.value, weighting, subnetworkFlags);
                 subnetworks++;
                 biggestSubnetwork = Math.max(biggestSubnetwork, component.size());
             } else {
@@ -136,7 +148,7 @@ public class PrepareRoutingSubnetworks {
         if (minNetworkSizeEdgeKeys > 0) {
             BitSetIterator iter = singleEdgeComponents.iterator();
             for (int edgeKey = iter.nextSetBit(); edgeKey >= 0; edgeKey = iter.nextSetBit()) {
-                markedEdges += setSubnetworkEdge(edgeKey, weighting, subnetworkEnc);
+                markedEdges += setSubnetworkEdge(edgeKey, weighting, subnetworkFlags);
                 subnetworks++;
                 biggestSubnetwork = Math.max(biggestSubnetwork, 1);
             }
@@ -149,21 +161,21 @@ public class PrepareRoutingSubnetworks {
             throw new IllegalStateException("Too many total (directed) edges were marked as subnetwork edges: " + markedEdges + " out of " + (2 * graph.getEdges()) + "\n" +
                     "The maximum number of subnetwork edges is: " + (2 * allowedMarked));
 
-        logger.info(subnetworkEnc.getName().replaceAll("_subnetwork", "") + " - Marked " + subnetworks + " subnetworks (biggest: " + biggestSubnetwork + " edges) -> " +
+        logger.info(jobName + " - Marked " + subnetworks + " subnetworks (biggest: " + biggestSubnetwork + " edges) -> " +
                 (ccs.getTotalComponents() - subnetworks) + " components(s) remain (smallest: " + smallestNonSubnetwork + ", biggest: " + ccs.getBiggestComponent().size() + " edges)"
                 + ", total marked edges: " + markedEdges + ", took: " + sw.stop().getSeconds() + "s");
         return markedEdges;
     }
 
-    private int setSubnetworkEdge(int edgeKey, Weighting weighting, BooleanEncodedValue subnetworkEnc) {
+    private int setSubnetworkEdge(int edgeKey, Weighting weighting, BitSet subnetworkFlags) {
         // edges that are not accessible anyway are not marked as subnetworks additionally
         if (!Double.isFinite(weighting.calcEdgeWeightWithAccess(graph.getEdgeIteratorStateForKey(edgeKey), false)))
             return 0;
 
         // now get edge again but in stored direction so that subnetwork EV is not overwritten (as it is unidirectional)
-        EdgeIteratorState edgeState = graph.getEdgeIteratorState(getEdgeFromEdgeKey(edgeKey), Integer.MIN_VALUE);
-        if (!edgeState.get(subnetworkEnc)) {
-            edgeState.set(subnetworkEnc, true);
+        int edge = getEdgeFromEdgeKey(edgeKey);
+        if (!subnetworkFlags.get(edge)) {
+            subnetworkFlags.set(edge);
             return 1;
         } else {
             return 0;


### PR DESCRIPTION
Another try after #2733, this time each thread writes the subnetwork flags to a separate bit set and the actual subnetwork encoded values are written synchronously afterwards. This requires `E/8` bytes of memory per thread where `E` is the number of edges. So for a planet-wide import with 500mio edges we need around 60MB of extra memory per thread which shouldn't really matter. 

This feature can be enabled by setting `prepare.subnetworks.threads` to something like `2` or larger in `config.yml`. The maximum sensible value is the number of profiles.