### PR TITLE
Create loop edges for nodes tagged as highway=turning_circle or turning_loop

### DIFF
--- a/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
+++ b/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
@@ -165,6 +165,7 @@ public class OSMReader {
                 .setElevationProvider(eleProvider)
                 .setWayFilter(this::acceptWay)
                 .setSplitNodeFilter(this::isBarrierNode)
+                .setAddLoopNodeFilter(this::isTurningCircleNode)
                 .setWayPreprocessor(this::preprocessWay)
                 .setRelationPreprocessor(this::preprocessRelations)
                 .setRelationProcessor(this::processRelation)
@@ -211,6 +212,13 @@ public class OSMReader {
      */
     protected boolean isBarrierNode(ReaderNode node) {
         return node.hasTag("barrier") || node.hasTag("ford");
+    }
+
+    /**
+     * @return true if a loop edge should be created at the given node.
+     */
+    protected boolean isTurningCircleNode(ReaderNode node) {
+        return node.hasTag("highway", "turning_circle", "turning_loop");
     }
 
     /**

--- a/core/src/main/java/com/graphhopper/reader/osm/SegmentNode.java
+++ b/core/src/main/java/com/graphhopper/reader/osm/SegmentNode.java
@@ -26,4 +26,9 @@ class SegmentNode {
         this.osmNodeId = osmNodeId;
         this.id = id;
     }
+
+    @Override
+    public String toString() {
+        return "id: " + id + ", osm-node-id: " + osmNodeId;
+    }
 }

--- a/core/src/test/java/com/graphhopper/GraphHopperTest.java
+++ b/core/src/test/java/com/graphhopper/GraphHopperTest.java
@@ -2451,6 +2451,31 @@ public class GraphHopperTest {
     }
 
     @Test
+    public void turningCircles() {
+        final String profile = "profile";
+        GraphHopper hopper = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
+                setOSMFile("../map-matching/files/leipzig_germany.osm.pbf").
+                setProfiles(new Profile("profile").setVehicle("car").setWeighting("fastest").setTurnCosts(true).putHint("u_turn_costs", 80)).
+                setMinNetworkSize(200);
+        hopper.importOrLoad();
+        GHRequest req = new GHRequest(51.360382, 12.288217, 51.359849, 12.290267).setProfile(profile).setCurbsides(asList("right", "any"));
+        GHResponse res = hopper.route(req);
+        assertFalse(res.hasErrors(), res.getErrors().toString());
+        // we want the route to continue until the end of Parkweg to turn around at the turning circle, *not* the junction before
+        assertEquals(456, res.getBest().getDistance(), 1);
+        // todonow: there should be a single instruction for the u-turn
+        System.out.println(res.getBest().getInstructions());
+
+        req = new GHRequest(51.272279, 12.313779, 51.272202, 12.312342).setProfile(profile).setCurbsides(asList("right", "any"));
+        res = hopper.route(req);
+        assertFalse(res.hasErrors(), res.getErrors().toString());
+        assertEquals(479, res.getBest().getDistance(), 1);
+        // todonow: there should be a single instruction for the u-turn
+        System.out.println(res.getBest().getInstructions());
+    }
+
+    @Test
     public void testBarriers() {
         GraphHopper hopper = new GraphHopper().
                 setGraphHopperLocation(GH_LOCATION).

--- a/core/src/test/java/com/graphhopper/reader/osm/OSMReaderTest.java
+++ b/core/src/test/java/com/graphhopper/reader/osm/OSMReaderTest.java
@@ -44,10 +44,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
+import java.util.*;
 
 import static com.graphhopper.util.GHUtility.readCountries;
 import static org.junit.jupiter.api.Assertions.*;
@@ -382,6 +379,28 @@ public class OSMReaderTest {
                 loops++;
         }
         assertEquals(5, loops);
+    }
+
+    @Test
+    public void testTurningCircle() {
+        GraphHopper hopper = new GraphHopperFacade("test-turning-circle.xml").
+                setMinNetworkSize(0).
+                importOrLoad();
+
+        // it should look somewhat like this: there are artificial 'loops' at nodes 1, 2, 4 and 6, each of which are
+        // realized by inserting an extra node (3, 5, 7, 8, 9). at node 1 there are two loops because it connects two ways.
+        // 3   5 7 8
+        // o   o o o
+        // 2-0-4-6-1-10
+        //   |     o
+        //  11     9
+        Graph graph = hopper.getBaseGraph();
+        assertEquals(12, graph.getNodes());
+        assertEquals(16, graph.getEdges());
+        EnumEncodedValue<RoadClass> roadClassEnc = hopper.getEncodingManager().getEnumEncodedValue(RoadClass.KEY, RoadClass.class);
+        assertEquals(RoadClass.TERTIARY, graph.getEdgeIteratorState(0, 3).get(roadClassEnc));
+        assertEquals(RoadClass.TERTIARY, graph.getEdgeIteratorState(9, 8).get(roadClassEnc));
+        assertEquals(RoadClass.FOOTWAY, graph.getEdgeIteratorState(12, 9).get(roadClassEnc));
     }
 
     @Test

--- a/core/src/test/resources/com/graphhopper/reader/osm/test-turning-circle.xml
+++ b/core/src/test/resources/com/graphhopper/reader/osm/test-turning-circle.xml
@@ -1,0 +1,52 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version="0.6">
+    <node id="10" lat="51.01" lon="9.4" version="1">
+        <tag k="highway" v="turning_circle"/>
+    </node>
+    <node id="20" lat="51.02" lon="9.4" version="1">
+    </node>
+    <node id="30" lat="51.03" lon="9.4" version="1">
+    </node>
+    <node id="40" lat="51.04" lon="9.4" version="1">
+        <tag k="highway" v="turning_loop"/>
+    </node>
+    <node id="50" lat="51.05" lon="9.4" version="1">
+        <tag k="highway" v="turning_loop"/>
+    </node>
+    <node id="60" lat="51.06" lon="9.4" version="1">
+        <tag k="highway" v="turning_circle"/>
+    </node>
+    <node id="70" lat="51.07" lon="9.4" version="1">
+    </node>
+    <node id="80" lat="51.08" lon="9.4" version="1">
+    </node>
+    <node id="90" lat="51.09" lon="9.39" version="1">
+    </node>
+    <!--  o        o  o  o       -->
+    <!-- 10-20-30-40-50-60-70-80
+             |
+            90
+    -->
+    <way id="10" version="1">
+        <nd ref="10"/>
+        <nd ref="20"/>
+        <nd ref="30"/>
+        <nd ref="40"/>
+        <nd ref="50"/>
+        <nd ref="60"/>
+        <tag k="highway" v="tertiary"/>
+    </way>
+
+    <way id="20" version="1">
+        <nd ref="60"/>
+        <nd ref="70"/>
+        <nd ref="80"/>
+        <tag k="highway" v="footway"/>
+    </way>
+
+    <way id="30" version="1">
+        <nd ref="20"/>
+        <nd ref="90"/>
+        <tag k="highway" v="tertiary"/>
+    </way>
+</osm>


### PR DESCRIPTION
The node (!) tags `highway=turning_circle` and `highway=turning_loop` are quite popular in OSM and can be used as an indicator for places where it is easy to turn around your vehicle. They are often used instead of an actual 'loop' of OSM ways at the end of dead-end streets and also rendered as such, like here at the end of Friedrich-Ebert-Straße:

[![image](https://user-images.githubusercontent.com/17603532/220718512-938aad70-1231-417e-a066-9c37fb3c9b48.png)](https://www.openstreetmap.org/node/4190956354)

So far we did not use these tags and simply applied the standard u-turn costs for every junction and dead-end. We also did not consider turning around at nodes tagged as `turning_circle` or `turning_loop` that were not junctions (somewhere in the middle of a road). 

In this PR I modified the OSM import such that helper 'loop' edges (to be more precise: one extra node with two edges) are added to the graph that represent the turning_circle/loop. Without further changes this would mean that there is no turning penalty when we do a 'u-turn' at these nodes. This means that the routing algorithms will prefer turning around at these nodes compared to turning around at junctions and other dead-ends.

I'm not yet sure if this is an improvement, because there can be cases where suggesting to go into some residential area for example, just to turn around at the next turning_circle, makes little sense. Then again, it could easily be better than simply suggesting to turn around at the next 'junction', which could just as well be a crossing with some random footway etc.

todo: 

* [ ] show the u-turns in turn instructions
* [ ] maybe still apply some kind of penalty for u-turns at turning_circle/loop nodes? currently the costs and even the distance of the helper loops is simply zero.

