### PR TITLE
Add landuse encoded value based on closed-ring ways tagged with landuse=*

### DIFF
--- a/core/src/main/java/com/graphhopper/reader/osm/OSMAreaData.java
+++ b/core/src/main/java/com/graphhopper/reader/osm/OSMAreaData.java
@@ -1,0 +1,90 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.graphhopper.reader.osm;
+
+import com.carrotsearch.hppc.LongArrayList;
+import com.carrotsearch.hppc.cursors.LongCursor;
+import com.graphhopper.coll.GHLongIntBTree;
+import com.graphhopper.coll.LongIntMap;
+import com.graphhopper.routing.util.CustomArea;
+import com.graphhopper.storage.Directory;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Polygon;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class OSMAreaData {
+    private final List<OSMArea> osmAreas;
+    private final LongIntMap nodeIndexByOSMNodeId;
+    private final PillarInfo coordinates;
+
+    public OSMAreaData(Directory directory) {
+        osmAreas = new ArrayList<>();
+        nodeIndexByOSMNodeId = new GHLongIntBTree(200);
+        coordinates = new PillarInfo(false, directory, "_osm_area");
+    }
+
+    public void addArea(Map<String, Object> tags, LongArrayList nodes) {
+        osmAreas.add(new OSMArea(tags, nodes));
+        for (LongCursor node : nodes)
+            if (nodeIndexByOSMNodeId.get(node.value) < 0)
+                nodeIndexByOSMNodeId.put(node.value, Math.toIntExact(nodeIndexByOSMNodeId.getSize()));
+    }
+
+    public void setCoordinate(long osmNodeId, double lat, double lon) {
+        int nodeIndex = nodeIndexByOSMNodeId.get(osmNodeId);
+        if (nodeIndex >= 0)
+            coordinates.setNode(nodeIndex, lat, lon);
+    }
+
+    public List<CustomArea> buildOSMAreas() {
+        GeometryFactory geometryFactory = new GeometryFactory();
+        return osmAreas.stream().map(a -> {
+                    Coordinate[] cs = new Coordinate[a.nodes.size()];
+                    for (LongCursor node : a.nodes) {
+                        int nodeIndex = nodeIndexByOSMNodeId.get(node.value);
+                        cs[node.index] = new Coordinate(coordinates.getLon(nodeIndex), coordinates.getLat(nodeIndex));
+                    }
+                    try {
+                        List<Polygon> polygons = Collections.singletonList(geometryFactory.createPolygon(cs));
+                        return new CustomArea(a.tags, polygons);
+                    } catch (IllegalArgumentException e) {
+                        // todonow: apparently, some areas do not form a closed ring or something, looks like these are tagging errors in OSM!
+                        System.out.println(e.getMessage());
+                        System.out.println(a.tags);
+                        System.out.println(Arrays.toString(cs));
+                        return null;
+                    }
+                })
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+    }
+
+    public static class OSMArea {
+        Map<String, Object> tags;
+        LongArrayList nodes;
+
+        public OSMArea(Map<String, Object> tags, LongArrayList nodes) {
+            this.tags = tags;
+            this.nodes = nodes;
+        }
+    }
+}

--- a/core/src/main/java/com/graphhopper/reader/osm/OSMNodeData.java
+++ b/core/src/main/java/com/graphhopper/reader/osm/OSMNodeData.java
@@ -85,7 +85,7 @@ class OSMNodeData {
         // entries.
         idsByOsmNodeIds = new GHLongIntBTree(200);
         towerNodes = nodeAccess;
-        pillarNodes = new PillarInfo(towerNodes.is3D(), directory);
+        pillarNodes = new PillarInfo(towerNodes.is3D(), directory, "");
 
         nodeTagIndicesByOsmNodeIds = new GHLongIntBTree(200);
         nodeTags = new ArrayList<>();

--- a/core/src/main/java/com/graphhopper/reader/osm/PillarInfo.java
+++ b/core/src/main/java/com/graphhopper/reader/osm/PillarInfo.java
@@ -35,10 +35,10 @@ public class PillarInfo implements PointAccess {
     private final int rowSizeInBytes;
     private final Directory dir;
 
-    public PillarInfo(boolean enabled3D, Directory dir) {
+    public PillarInfo(boolean enabled3D, Directory dir, String suffix) {
         this.enabled3D = enabled3D;
         this.dir = dir;
-        this.da = dir.create("tmp_pillar_info").create(100);
+        this.da = dir.create("tmp_pillar_info" + suffix).create(100);
         this.rowSizeInBytes = getDimension() * 4;
     }
 

--- a/core/src/main/java/com/graphhopper/routing/ev/DefaultEncodedValueFactory.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/DefaultEncodedValueFactory.java
@@ -87,6 +87,8 @@ public class DefaultEncodedValueFactory implements EncodedValueFactory {
             return AverageSlope.create();
         } else if (Curvature.KEY.equals(name)) {
             return Curvature.create();
+        } else if (Landuse.KEY.equals(name)) {
+            return new EnumEncodedValue<>(Landuse.KEY, Landuse.class);
         } else
             throw new IllegalArgumentException("DefaultEncodedValueFactory cannot find EncodedValue " + name);
     }

--- a/core/src/main/java/com/graphhopper/routing/ev/Landuse.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/Landuse.java
@@ -1,0 +1,51 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.graphhopper.routing.ev;
+
+import com.graphhopper.util.Helper;
+
+public enum Landuse {
+    OTHER("other"), FARMLAND("farmland"), RESIDENTIAL("residential"),
+    GRASS("grass"), FOREST("forest"), MEADOW("meadow"), ORCHARD("orchard"), FARMYARD("farmyard"),
+    INDUSTRIAL("industrial"), VINEYARD("vineyard"), CEMETRY("cemetry"), COMMERCIAL("commercial"), ALLOTMENTS("allotments"),
+    RETAIL("retail"), BASIN("basin"), RESERVOIR("reservoir"), CONSTRUCTION("construction"), QUARRY("quarry");
+
+    public static final String KEY = "landuse";
+
+    private final String name;
+
+    Landuse(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+
+    public static Landuse find(String name) {
+        if (name == null)
+            return OTHER;
+        try {
+            return Landuse.valueOf(Helper.toUpperCase(name));
+        } catch (IllegalArgumentException ex) {
+            return OTHER;
+        }
+    }
+}

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/DefaultTagParserFactory.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/DefaultTagParserFactory.java
@@ -77,6 +77,8 @@ public class DefaultTagParserFactory implements TagParserFactory {
             return new OSMFootwayParser(lookup.getEnumEncodedValue(Footway.KEY, Footway.class));
         else if (name.equals(Country.KEY))
             return new CountryParser(lookup.getEnumEncodedValue(Country.KEY, Country.class));
+        else if (name.equals(Landuse.KEY))
+            return new OSMLanduseParser(lookup.getEnumEncodedValue(Landuse.KEY, Landuse.class));
         return null;
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMLanduseParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMLanduseParser.java
@@ -1,0 +1,52 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.routing.util.parsers;
+
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.EnumEncodedValue;
+import com.graphhopper.routing.ev.Landuse;
+import com.graphhopper.routing.util.CustomArea;
+import com.graphhopper.storage.IntsRef;
+
+import java.util.Comparator;
+import java.util.List;
+
+import static com.graphhopper.routing.ev.Landuse.OTHER;
+
+public class OSMLanduseParser implements TagParser {
+
+    private final EnumEncodedValue<Landuse> landuseEnc;
+
+    public OSMLanduseParser(EnumEncodedValue<Landuse> landuseEnc) {
+        this.landuseEnc = landuseEnc;
+    }
+
+    @Override
+    public void handleWayTags(IntsRef edgeFlags, ReaderWay readerWay, IntsRef relationFlags) {
+        List<CustomArea> osmAreas = readerWay.getTag("gh:osm_areas", null);
+        if (!osmAreas.isEmpty()) {
+            osmAreas.sort(Comparator.comparing(CustomArea::getArea));
+            // todonow: we simply use the smallest one for now
+            CustomArea osmArea = osmAreas.get(0);
+            String landuseStr = (String) osmArea.getProperties().get("landuse");
+            Landuse landuse = Landuse.find(landuseStr);
+            if (landuse != OTHER)
+                landuseEnc.setEnum(false, edgeFlags, landuse);
+        }
+    }
+}


### PR DESCRIPTION
I built a quick prototype, which:

* stores the way tags and OSM node Ids for all OSM ways tagged with `landuse=*` in memory during the first pass of OSMReader

* finds all the corresponding node coordinates in the second pass

* builds an area index for all these (closed-ring) polygons before we read the OSM ways again in the second pass

* finds the areas each edge is contained in and feeds them to the tag parsers

* adds a tag parser for the new landuse encoded value, which uses the smallest of these areas to set the landuse value

This way we can, e.g., use custom models that prefer forest areas, or slow down the speed in residential areas etc.
We can also just look at the landuse values using path details:

![image](https://user-images.githubusercontent.com/17603532/223201359-b8a055e6-7835-4269-a52a-2627b85b8595.png)

My first quick test resulted in an import time of 117s compared to 80s for a map of Bavaria with the master branch. 

The biggest issue I ran into so far was that many forest areas seem to be mapped as relations with such polygons as members. Parsing the relations wouldn't be much harder, but since we only get to see them at the end of the first pass (after the ways) we would have to read the OSM file a third time :(

