### PR TITLE
Show u-turn instruction for plain u-turns

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/InstructionsFromEdges.java
+++ b/core/src/main/java/com/graphhopper/routing/InstructionsFromEdges.java
@@ -332,6 +332,9 @@ public class InstructionsFromEdges implements Path.EdgeVisitor {
     }
 
     private int getTurn(EdgeIteratorState edge, int baseNode, int prevNode, int adjNode, String name, String destinationAndRef) {
+        if (edge.getEdge() == prevEdge.getEdge())
+            // this is the simplest turn to recognize, a plain u-turn.
+            return Instruction.U_TURN_UNKNOWN;
         GHPoint point = InstructionsHelper.getPointForOrientationCalculation(edge, nodeAccess);
         double lat = point.getLat();
         double lon = point.getLon();

--- a/core/src/test/java/com/graphhopper/GraphHopperTest.java
+++ b/core/src/test/java/com/graphhopper/GraphHopperTest.java
@@ -226,15 +226,40 @@ public class GraphHopperTest {
     }
 
     @Test
-    public void testUTurn() {
+    public void testUTurnInstructions() {
         final String profile = "profile";
         final String vehicle = "car";
         GraphHopper hopper = new GraphHopper().
                 setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(MONACO).
-                setProfiles(new CustomProfile(profile).setCustomModel(new CustomModel()).setVehicle(vehicle).setTurnCosts(true));
+                setProfiles(new CustomProfile(profile).setCustomModel(new CustomModel()).setVehicle(vehicle).setTurnCosts(true).putHint(U_TURN_COSTS, 20));
         hopper.importOrLoad();
         Translation tr = hopper.getTranslationMap().getWithFallBack(Locale.US);
+
+        {
+            GHRequest request = new GHRequest();
+            request.addPoint(new GHPoint(43.747418, 7.430371));
+            request.addPoint(new GHPoint(43.746853, 7.42974));
+            request.addPoint(new GHPoint(43.746929, 7.430458));
+            request.setProfile(profile);
+            request.setCurbsides(Arrays.asList("right", "any", "right"));
+            GHResponse rsp = hopper.route(request);
+            assertFalse(rsp.hasErrors(), rsp.getErrors().toString());
+            ResponsePath res = rsp.getBest();
+            assertEquals(286, res.getDistance(), 1);
+            // note that this includes the u-turn time for the second u-turn, but not the first, because it's a waypoint!
+            assertEquals(54351, res.getTime(), 1);
+            // the route follows Avenue de l'Annonciade to the waypoint, u-turns there, then does a sharp right turn onto the parallel (dead-end) road,
+            // does a u-turn at the dead-end and then arrives at the destination
+            InstructionList il = res.getInstructions();
+            assertEquals(6, il.size());
+            assertEquals("continue", il.get(0).getTurnDescription(tr));
+            assertEquals("waypoint 1", il.get(1).getTurnDescription(tr));
+            assertEquals("make a U-turn", il.get(2).getTurnDescription(tr));
+            assertEquals("turn sharp right", il.get(3).getTurnDescription(tr));
+            assertEquals("make a U-turn", il.get(4).getTurnDescription(tr));
+            assertEquals("arrive at destination", il.get(5).getTurnDescription(tr));
+        }
 
         {
             GHRequest request = new GHRequest();


### PR DESCRIPTION
Currently there are no u-turn instructions for 'simple' u-turns where we simply turn around on the same road/edge. We only show instructions for such u-turns when the occur at via-points, and we even show instructions for the (more complicated) u-turns that use a via-way:

![image](https://user-images.githubusercontent.com/17603532/223421733-0fcdf672-b445-42df-b146-41b08ff9a86c.png)

The image shows a u-turn at the via-point 1, blue marker. We get an instruction for this, but not the u-turn at the end of the dead-end road near the red marker. The reason we get this u-turn is a curbside constraint at the red marker.

Here is an example for a u-turn that includes a via-way, and for which we already show a u-turn instruction:

![image](https://user-images.githubusercontent.com/17603532/223422569-aa7079f7-889d-4d26-9684-ae43424bc873.png)

In this PR I added a u-turn instruction for the simple kind of u-turns, like the one near the red marker in the first screenshot.

I also wonder if we should distinguish between these simple (but often dangerous) u-turns and the ones with via-ways, that might be perfectly safe (or completely forbidden when there is a no-u-turn sign...).

Related: #2139 where a user suggested that the sharp/simple/dangerous u-turns should be avoided as much as possible anyway. I think I agree, but at the very least we should make these turns more visible, hence this PR. For example, a navigation application could inform the driver that the route leads to a u-turn and instead of having to turn around all of a sudden the driver could start looking for a safe option to turn around.