### PR TITLE
Add path details for the time, distance and weight of the single legs

### DIFF
--- a/core/src/main/java/com/graphhopper/util/PathMerger.java
+++ b/core/src/main/java/com/graphhopper/util/PathMerger.java
@@ -23,12 +23,13 @@ import com.graphhopper.routing.Path;
 import com.graphhopper.routing.ev.EncodedValueLookup;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.Graph;
-import com.graphhopper.util.details.PathDetail;
 import com.graphhopper.util.details.PathDetailsBuilderFactory;
 import com.graphhopper.util.details.PathDetailsFromEdges;
 import com.graphhopper.util.exceptions.ConnectionNotFoundException;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * This class merges multiple {@link Path} objects into one continuous object that
@@ -135,17 +136,7 @@ public class PathMerger {
                 }
 
                 fullPoints.add(tmpPoints);
-
-                Map<String, List<PathDetail>> details = new LinkedHashMap<>(
-                        PathDetailsFromEdges.calcDetails(path, evLookup, weighting, requestedPathDetails, pathBuilderFactory, origPoints, graph)
-                );
-                int legFirst = origPoints;
-                int legLast = pathIndex < paths.size() - 1 ? fullPoints.size() : fullPoints.size() - 1;
-                details.put("leg_time", createLegDetail(path.getTime(), legFirst, legLast));
-                details.put("leg_distance", createLegDetail(path.getDistance(), legFirst, legLast));
-                details.put("leg_weight", createLegDetail(path.getWeight(), legFirst, legLast));
-                responsePath.addPathDetails(details);
-
+                responsePath.addPathDetails(PathDetailsFromEdges.calcDetails(path, evLookup, weighting, requestedPathDetails, pathBuilderFactory, origPoints, graph));
                 wayPointIndices.add(origPoints);
                 if (pathIndex == paths.size() - 1)
                     wayPointIndices.add(fullPoints.size() - 1);
@@ -188,13 +179,6 @@ public class PathMerger {
             PathSimplification.simplify(responsePath, ramerDouglasPeucker, enableInstructions);
         }
         return responsePath;
-    }
-
-    private List<PathDetail> createLegDetail(Object value, int first, int last) {
-        PathDetail detail = new PathDetail(value);
-        detail.setFirst(first);
-        detail.setLast(last);
-        return new ArrayList<>(Collections.singletonList(detail));
     }
 
     /**

--- a/core/src/main/java/com/graphhopper/util/details/ConstantDetailsBuilder.java
+++ b/core/src/main/java/com/graphhopper/util/details/ConstantDetailsBuilder.java
@@ -1,0 +1,48 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.graphhopper.util.details;
+
+import com.graphhopper.util.EdgeIteratorState;
+
+/**
+ * Simply returns the same value everywhere, useful to represent values that are the same between two (via-)points
+ */
+public class ConstantDetailsBuilder extends AbstractPathDetailsBuilder {
+    private final Object value;
+    private boolean firstEdge = true;
+
+    public ConstantDetailsBuilder(String name, Object value) {
+        super(name);
+        this.value = value;
+    }
+
+    @Override
+    protected Object getCurrentValue() {
+        return value;
+    }
+
+    @Override
+    public boolean isEdgeDifferentToLastEdge(EdgeIteratorState edge) {
+        if (firstEdge) {
+            firstEdge = false;
+            return true;
+        } else
+            return false;
+    }
+}

--- a/core/src/main/java/com/graphhopper/util/details/PathDetailsBuilderFactory.java
+++ b/core/src/main/java/com/graphhopper/util/details/PathDetailsBuilderFactory.java
@@ -17,6 +17,7 @@
  */
 package com.graphhopper.util.details;
 
+import com.graphhopper.routing.Path;
 import com.graphhopper.routing.ev.*;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.Graph;
@@ -33,8 +34,15 @@ import static com.graphhopper.util.Parameters.Details.*;
  */
 public class PathDetailsBuilderFactory {
 
-    public List<PathDetailsBuilder> createPathDetailsBuilders(List<String> requestedPathDetails, EncodedValueLookup evl, Weighting weighting, Graph graph) {
+    public List<PathDetailsBuilder> createPathDetailsBuilders(List<String> requestedPathDetails, Path path, EncodedValueLookup evl, Weighting weighting, Graph graph) {
         List<PathDetailsBuilder> builders = new ArrayList<>();
+
+        if (requestedPathDetails.contains(LEG_TIME))
+            builders.add(new ConstantDetailsBuilder(LEG_TIME, path.getTime()));
+        if (requestedPathDetails.contains(LEG_DISTANCE))
+            builders.add(new ConstantDetailsBuilder(LEG_DISTANCE, path.getDistance()));
+        if (requestedPathDetails.contains(LEG_WEIGHT))
+            builders.add(new ConstantDetailsBuilder(LEG_WEIGHT, path.getWeight()));
 
         if (requestedPathDetails.contains(STREET_NAME))
             builders.add(new KVStringDetails(STREET_NAME));

--- a/core/src/main/java/com/graphhopper/util/details/PathDetailsFromEdges.java
+++ b/core/src/main/java/com/graphhopper/util/details/PathDetailsFromEdges.java
@@ -52,8 +52,6 @@ public class PathDetailsFromEdges implements Path.EdgeVisitor {
     /**
      * Calculates the PathDetails for a Path. This method will return fast, if there are no calculators.
      *
-     * @param path
-     * @param weighting
      * @param pathBuilderFactory Generates the relevant PathBuilders
      * @return List of PathDetails for this Path
      */
@@ -62,7 +60,7 @@ public class PathDetailsFromEdges implements Path.EdgeVisitor {
                                                             int previousIndex, Graph graph) {
         if (!path.isFound() || requestedPathDetails.isEmpty())
             return Collections.emptyMap();
-        List<PathDetailsBuilder> pathBuilders = pathBuilderFactory.createPathDetailsBuilders(requestedPathDetails, evLookup, weighting, graph);
+        List<PathDetailsBuilder> pathBuilders = pathBuilderFactory.createPathDetailsBuilders(requestedPathDetails, path, evLookup, weighting, graph);
         if (pathBuilders.isEmpty())
             return Collections.emptyMap();
 

--- a/web-api/src/main/java/com/graphhopper/util/Parameters.java
+++ b/web-api/src/main/java/com/graphhopper/util/Parameters.java
@@ -205,6 +205,10 @@ public class Parameters {
         public static final String WEIGHT = "weight";
         public static final String DISTANCE = "distance";
         public static final String INTERSECTION = "intersection";
+
+        public static final String LEG_TIME = "leg_time";
+        public static final String LEG_DISTANCE = "leg_distance";
+        public static final String LEG_WEIGHT = "leg_weight";
     }
 
 }

--- a/web/src/test/java/com/graphhopper/application/resources/RouteResourceClientHCTest.java
+++ b/web/src/test/java/com/graphhopper/application/resources/RouteResourceClientHCTest.java
@@ -46,6 +46,8 @@ import org.junit.jupiter.params.provider.EnumSource;
 import java.io.File;
 import java.util.*;
 
+import static com.graphhopper.util.Instruction.FINISH;
+import static com.graphhopper.util.Instruction.REACHED_VIA;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -378,5 +380,87 @@ public class RouteResourceClientHCTest {
         rsp = gh.route(req);
         assertFalse(rsp.hasErrors(), "errors:" + rsp.getErrors().toString());
         assertEquals(218_000, rsp.getBest().getTime(), 1000);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = TestParam.class)
+    public void testWaypointIndicesAndLegDetails(TestParam p) {
+        GraphHopperWeb gh = createGH(p);
+        List<String> legDetails = Arrays.asList("leg_time", "leg_distance", "leg_weight");
+        GHRequest req = new GHRequest().
+                addPoint(new GHPoint(42.509141, 1.546063)).
+                addPoint(new GHPoint(42.507173, 1.531902)).
+                addPoint(new GHPoint(42.505435, 1.515943)).
+                addPoint(new GHPoint(42.499062, 1.506067)).
+                addPoint(new GHPoint(42.498801, 1.505568)).
+                addPoint(new GHPoint(42.498465, 1.504898)).
+                addPoint(new GHPoint(42.49833, 1.504619)).
+                addPoint(new GHPoint(42.498217, 1.504377)).
+                addPoint(new GHPoint(42.495611, 1.498368)).
+                setPathDetails(legDetails).
+                setProfile("bike");
+
+        GHResponse response = gh.route(req);
+        ResponsePath path = response.getBest();
+        assertEquals(5333, path.getDistance(), 5);
+        assertEquals(9, path.getWaypoints().size());
+
+        assertEquals(path.getTime(), path.getPathDetails().get("leg_time").stream().mapToLong(d -> (long) d.getValue()).sum(), 1);
+        assertEquals(path.getDistance(), path.getPathDetails().get("leg_distance").stream().mapToDouble(d -> (double) d.getValue()).sum(), 1);
+        assertEquals(path.getRouteWeight(), path.getPathDetails().get("leg_weight").stream().mapToDouble(d -> (double) d.getValue()).sum(), 1);
+
+        List<PointList> pointListFromInstructions = getPointListFromInstructions(path);
+        for (String detail : legDetails) {
+            List<PathDetail> pathDetails = path.getPathDetails().get(detail);
+
+            // explicitly check one of the waypoints
+            assertEquals(42.50539, path.getWaypoints().get(2).lat);
+            assertEquals(42.50539, path.getPoints().get(pathDetails.get(1).getLast()).getLat());
+            assertEquals(42.50539, path.getPoints().get(pathDetails.get(2).getFirst()).getLat());
+            // check all the waypoints
+            assertEquals(path.getWaypoints().get(0), path.getPoints().get(pathDetails.get(0).getFirst()));
+            for (int i = 1; i < path.getWaypoints().size(); ++i)
+                assertEquals(path.getWaypoints().get(i), path.getPoints().get(pathDetails.get(i - 1).getLast()));
+
+            List<PointList> pointListFromLegDetails = getPointListFromLegDetails(path, detail);
+            assertEquals(8, pointListFromLegDetails.size());
+            assertPointListsEquals(pointListFromInstructions, pointListFromLegDetails);
+        }
+    }
+
+    private List<PointList> getPointListFromInstructions(ResponsePath path) {
+        List<PointList> legs = new ArrayList<>();
+        PointList perLeg = new PointList();
+        for (Instruction instruction : path.getInstructions()) {
+            perLeg.add(instruction.getPoints());
+            if (instruction.getSign() == REACHED_VIA || instruction.getSign() == FINISH) {
+                legs.add(perLeg);
+                perLeg = new PointList();
+            } else {
+                perLeg.removeLastPoint();
+            }
+        }
+        return legs;
+    }
+
+    private List<PointList> getPointListFromLegDetails(ResponsePath path, String detail) {
+        List<PointList> legs = new ArrayList<>();
+        List<PathDetail> legDetails = path.getPathDetails().get(detail);
+        for (PathDetail legDetail : legDetails) {
+            PointList leg = new PointList(legDetail.getLast() - legDetail.getFirst() + 1, path.getPoints().is3D());
+            for (int j = legDetail.getFirst(); j <= legDetail.getLast(); j++)
+                leg.add(path.getPoints(), j);
+            legs.add(leg);
+        }
+        return legs;
+    }
+
+    private static void assertPointListsEquals(List<PointList> p, List<PointList> q) {
+        assertEquals(p.size(), q.size());
+        for (int i = 0; i < q.size(); i++) {
+            assertEquals(p.get(i).size(), q.get(i).size());
+            for (int j = 0; j < q.get(i).size(); j++)
+                assertEquals(p.get(i).get(j), q.get(i).get(j));
+        }
     }
 }


### PR DESCRIPTION
When we query `/route` with via-points it returns the time, distance, weight and coordinates of the entire route. But so far there is no direct information about the time/distance/weight of the single sections between the (via) points. Also it is not very clear how the global point list can be separated for the single sections ('legs'). We can work around this using instructions or path details like 'time', but this is rather cumbersome and enabling instructions or certain path details just for this purpose can decrease performance. 

Therefore, I added three new path details, e.g. with a single via-point we get two entries (because there are two legs) for each detail:

```json
{
	"details": {
		"leg_time": [
			[
				0,
				6,
				48559
			],
			[
				6,
				10,
				60719
			]
		],
		"leg_distance": [
			[
				0,
				6,
				501.46548797983564
			],
			[
				6,
				10,
				505.98093195638285
			]
		],
		"leg_weight": [
			[
				0,
				6,
				48.55733718679518
			],
			[
				6,
				10,
				60.717711834765936
			]
		],
	}
}
```

`leg_time/distance/weight` simply represent the time/distance/weight for the corresponding leg. 

Also note that the first/last indices are equal for all details. They can be used to obtain the coordinates for a certain leg. In this example the points 0-6 represent the leg between the start and the via-point, and points 6-10 represent the leg between the via-point and the destination point.