### PR TITLE
Allow skipping the creation of ReaderNodes/Ways/Relations for pbfs, skip nodes in first pass of OSM import

### DIFF
--- a/core/src/main/java/com/graphhopper/reader/osm/OSMInputFile.java
+++ b/core/src/main/java/com/graphhopper/reader/osm/OSMInputFile.java
@@ -55,6 +55,7 @@ public class OSMInputFile implements Sink, OSMInput {
     private Thread pbfReaderThread;
     private boolean hasIncomingData;
     private int workerThreads = -1;
+    private SkipOptions skipOptions = SkipOptions.none();
     private OSMFileHeader fileheader;
 
     public OSMInputFile(File file) throws IOException {
@@ -73,10 +74,19 @@ public class OSMInputFile implements Sink, OSMInput {
     }
 
     /**
-     * Currently on for pbf format. Default is number of cores.
+     * Currently only for pbf format. Default is number of cores.
      */
     public OSMInputFile setWorkerThreads(int threads) {
         workerThreads = threads;
+        return this;
+    }
+
+    /**
+     * Use this to prevent the creation of OSM nodes, ways and/or relations to speed up the file reading process.
+     * This will only affect the reading of pbf files.
+     */
+    public OSMInputFile setSkipOptions(SkipOptions skipOptions) {
+        this.skipOptions = skipOptions;
         return this;
     }
 
@@ -247,7 +257,7 @@ public class OSMInputFile implements Sink, OSMInput {
         if (workerThreads <= 0)
             workerThreads = 1;
 
-        pbfReader = new PbfReader(stream, this, workerThreads);
+        pbfReader = new PbfReader(stream, this, workerThreads, skipOptions);
         pbfReaderThread = new Thread(pbfReader, "PBF Reader");
         pbfReaderThread.start();
     }

--- a/core/src/main/java/com/graphhopper/reader/osm/SkipOptions.java
+++ b/core/src/main/java/com/graphhopper/reader/osm/SkipOptions.java
@@ -1,0 +1,47 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.graphhopper.reader.osm;
+
+public class SkipOptions {
+    private final boolean skipNodes;
+    private final boolean skipWays;
+    private final boolean skipRelations;
+
+    public static SkipOptions none() {
+        return new SkipOptions(false, false, false);
+    }
+
+    public SkipOptions(boolean skipNodes, boolean skipWays, boolean skipRelations) {
+        this.skipNodes = skipNodes;
+        this.skipWays = skipWays;
+        this.skipRelations = skipRelations;
+    }
+
+    public boolean isSkipNodes() {
+        return skipNodes;
+    }
+
+    public boolean isSkipWays() {
+        return skipWays;
+    }
+
+    public boolean isSkipRelations() {
+        return skipRelations;
+    }
+}

--- a/core/src/main/java/com/graphhopper/reader/osm/WaySegmentParser.java
+++ b/core/src/main/java/com/graphhopper/reader/osm/WaySegmentParser.java
@@ -107,7 +107,7 @@ public class WaySegmentParser {
         LOGGER.info("Start reading OSM file: '" + osmFile + "'");
         LOGGER.info("pass1 - start");
         StopWatch sw1 = StopWatch.started();
-        readOSM(osmFile, new Pass1Handler());
+        readOSM(osmFile, new Pass1Handler(), new SkipOptions(true, false, false));
         LOGGER.info("pass1 - finished, took: {}", sw1.stop().getTimeString());
 
         long nodes = nodeData.getNodeCount();
@@ -116,7 +116,7 @@ public class WaySegmentParser {
 
         LOGGER.info("pass2 - start");
         StopWatch sw2 = new StopWatch().start();
-        readOSM(osmFile, new Pass2Handler());
+        readOSM(osmFile, new Pass2Handler(), SkipOptions.none());
         LOGGER.info("pass2 - finished, took: {}", sw2.stop().getTimeString());
 
         nodeData.release();
@@ -389,8 +389,8 @@ public class WaySegmentParser {
         }
     }
 
-    private void readOSM(File file, ReaderElementHandler handler) {
-        try (OSMInput osmInput = openOsmInputFile(file)) {
+    private void readOSM(File file, ReaderElementHandler handler, SkipOptions skipOptions) {
+        try (OSMInput osmInput = openOsmInputFile(file, skipOptions)) {
             ReaderElement elem;
             while ((elem = osmInput.getNext()) != null)
                 handler.handleElement(elem);
@@ -402,8 +402,8 @@ public class WaySegmentParser {
         }
     }
 
-    protected OSMInput openOsmInputFile(File osmFile) throws XMLStreamException, IOException {
-        return new OSMInputFile(osmFile).setWorkerThreads(workerThreads).open();
+    protected OSMInput openOsmInputFile(File osmFile, SkipOptions skipOptions) throws XMLStreamException, IOException {
+        return new OSMInputFile(osmFile).setWorkerThreads(workerThreads).setSkipOptions(skipOptions).open();
     }
 
     public static class Builder {

--- a/core/src/main/java/com/graphhopper/reader/osm/pbf/PbfBlobDecoder.java
+++ b/core/src/main/java/com/graphhopper/reader/osm/pbf/PbfBlobDecoder.java
@@ -8,6 +8,7 @@ import com.graphhopper.reader.ReaderNode;
 import com.graphhopper.reader.ReaderRelation;
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.reader.osm.OSMFileHeader;
+import com.graphhopper.reader.osm.SkipOptions;
 import com.graphhopper.util.Helper;
 import org.openstreetmap.osmosis.osmbinary.Fileformat;
 import org.openstreetmap.osmosis.osmbinary.Osmformat;
@@ -33,6 +34,7 @@ public class PbfBlobDecoder implements Runnable {
     private final byte[] rawBlob;
     private final PbfBlobDecoderListener listener;
     private List<ReaderElement> decodedEntities;
+    private final SkipOptions skipOptions;
 
     /**
      * Creates a new instance.
@@ -42,10 +44,11 @@ public class PbfBlobDecoder implements Runnable {
      * @param rawBlob  The raw data of the blob.
      * @param listener The listener for receiving decoding results.
      */
-    public PbfBlobDecoder(String blobType, byte[] rawBlob, PbfBlobDecoderListener listener) {
+    public PbfBlobDecoder(String blobType, byte[] rawBlob, PbfBlobDecoderListener listener, SkipOptions skipOptions) {
         this.blobType = blobType;
         this.rawBlob = rawBlob;
         this.listener = listener;
+        this.skipOptions = skipOptions;
     }
 
     private byte[] readBlobContent() throws IOException {
@@ -326,10 +329,14 @@ public class PbfBlobDecoder implements Runnable {
         PbfFieldDecoder fieldDecoder = new PbfFieldDecoder(block);
 
         for (Osmformat.PrimitiveGroup primitiveGroup : block.getPrimitivegroupList()) {
-            processNodes(primitiveGroup.getDense(), fieldDecoder);
-            processNodes(primitiveGroup.getNodesList(), fieldDecoder);
-            processWays(primitiveGroup.getWaysList(), fieldDecoder);
-            processRelations(primitiveGroup.getRelationsList(), fieldDecoder);
+            if (!skipOptions.isSkipNodes()) {
+                processNodes(primitiveGroup.getDense(), fieldDecoder);
+                processNodes(primitiveGroup.getNodesList(), fieldDecoder);
+            }
+            if (!skipOptions.isSkipWays())
+                processWays(primitiveGroup.getWaysList(), fieldDecoder);
+            if (!skipOptions.isSkipRelations())
+                processRelations(primitiveGroup.getRelationsList(), fieldDecoder);
         }
     }
 

--- a/core/src/main/java/com/graphhopper/reader/osm/pbf/PbfDecoder.java
+++ b/core/src/main/java/com/graphhopper/reader/osm/pbf/PbfDecoder.java
@@ -2,6 +2,7 @@
 package com.graphhopper.reader.osm.pbf;
 
 import com.graphhopper.reader.ReaderElement;
+import com.graphhopper.reader.osm.SkipOptions;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -26,6 +27,7 @@ public class PbfDecoder {
     private final Lock lock;
     private final Condition dataWaitCondition;
     private final Queue<PbfBlobResult> blobResults;
+    private final SkipOptions skipOptions;
 
     /**
      * Creates a new instance.
@@ -37,11 +39,12 @@ public class PbfDecoder {
      * @param sink            The sink to send all decoded entities to.
      */
     public PbfDecoder(PbfStreamSplitter streamSplitter, ExecutorService executorService, int maxPendingBlobs,
-                      Sink sink) {
+                      Sink sink, SkipOptions skipOptions) {
         this.streamSplitter = streamSplitter;
         this.executorService = executorService;
         this.maxPendingBlobs = maxPendingBlobs;
         this.sink = sink;
+        this.skipOptions = skipOptions;
 
         // Create the thread synchronisation primitives.
         lock = new ReentrantLock();
@@ -140,7 +143,7 @@ public class PbfDecoder {
             };
 
             // Create the blob decoder itself and execute it on a worker thread.
-            PbfBlobDecoder blobDecoder = new PbfBlobDecoder(rawBlob.getType(), rawBlob.getData(), decoderListener);
+            PbfBlobDecoder blobDecoder = new PbfBlobDecoder(rawBlob.getType(), rawBlob.getData(), decoderListener, skipOptions);
             executorService.execute(blobDecoder);
 
             // If the number of pending blobs has reached capacity we must begin

--- a/core/src/main/java/com/graphhopper/reader/osm/pbf/PbfReader.java
+++ b/core/src/main/java/com/graphhopper/reader/osm/pbf/PbfReader.java
@@ -1,6 +1,8 @@
 // This software is released into the Public Domain.  See copying.txt for details.
 package com.graphhopper.reader.osm.pbf;
 
+import com.graphhopper.reader.osm.SkipOptions;
+
 import java.io.DataInputStream;
 import java.io.InputStream;
 import java.util.concurrent.ExecutorService;
@@ -14,9 +16,10 @@ import java.util.concurrent.Executors;
  */
 public class PbfReader implements Runnable {
     private Throwable throwable;
-    private InputStream inputStream;
-    private Sink sink;
-    private int workers;
+    private final InputStream inputStream;
+    private final Sink sink;
+    private final int workers;
+    private final SkipOptions skipOptions;
 
     /**
      * Creates a new instance.
@@ -25,10 +28,11 @@ public class PbfReader implements Runnable {
      * @param in      The file to read.
      * @param workers The number of worker threads for decoding PBF blocks.
      */
-    public PbfReader(InputStream in, Sink sink, int workers) {
+    public PbfReader(InputStream in, Sink sink, int workers, SkipOptions skipOptions) {
         this.inputStream = in;
         this.sink = sink;
         this.workers = workers;
+        this.skipOptions = skipOptions;
     }
 
     @Override
@@ -44,7 +48,7 @@ public class PbfReader implements Runnable {
             // immediately ready for processing when a worker thread completes.
             // The main thread is responsible for splitting blobs from the
             // request stream, and sending decoded entities to the sink.
-            PbfDecoder pbfDecoder = new PbfDecoder(streamSplitter, executorService, workers + 1, sink);
+            PbfDecoder pbfDecoder = new PbfDecoder(streamSplitter, executorService, workers + 1, sink, skipOptions);
             pbfDecoder.run();
 
         } catch (Throwable t) {


### PR DESCRIPTION
Currently we read the OSM file twice during import and there even were some suggestions to read it three times (e.g. for #2765 or #82). With the simple tweak in this PR we can reduce the time it takes to read the file if we are only interested in certain OSM elements.

I did a quick check using a map of Germany with ~356mio nodes, ~58mio ways and ~0.7mio relations, with two worker threads. Reading the file (just counting the elements, and doing nothing else) took around 113s using master, around 73s using this branch when I skipped the nodes and 56s when I skipped both nodes and ways.

We can already use this for our current import where we can skip the reading of nodes in the first pass, which speeds up the import.