### PR TITLE
Never treat a highway tagged with "cycleway:both" as oneway for bicycles

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonAccessParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonAccessParser.java
@@ -142,6 +142,8 @@ public abstract class BikeCommonAccessParser extends AbstractAccessParser implem
                 || way.hasTag("vehicle:forward", restrictedValues) && !way.hasTag("bicycle:backward", INTENDED)
                 || way.hasTag("bicycle:forward", restrictedValues)
                 || way.hasTag("bicycle:backward", restrictedValues);
+        
+        isOneway &= !way.hasTag("cycleway:both");
 
         if ((isOneway || roundaboutEnc.getBool(false, edgeId, edgeIntAccess))
                 && !way.hasTag("oneway:bicycle", "no")

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/AbstractBikeTagParserTester.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/AbstractBikeTagParserTester.java
@@ -645,6 +645,13 @@ public abstract class AbstractBikeTagParserTester {
         way.setTag("oneway", "yes");
         way.setTag("cycleway:left", "opposite_lane");
         assertAccess(way, true, true);
+
+        way.clearTags();
+        way.setTag("highway", "secondary");
+        way.setTag("cycleway:left:oneway", "-1");
+        way.setTag("cycleway:both","track");
+        assertAccess(way, true, true);
+
     }
 
     private void assertAccess(ReaderWay way, boolean fwd, boolean bwd) {


### PR DESCRIPTION
Fix for #2775.