### PR TITLE
Improve bicycle handling: Now prioritise cycleways with SLIGHT_PREFER

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonPriorityParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonPriorityParser.java
@@ -177,7 +177,7 @@ public abstract class BikeCommonPriorityParser implements TagParser {
 
         String cycleway = way.getFirstPriorityTag(Arrays.asList("cycleway", "cycleway:left", "cycleway:right"));
         if (Arrays.asList("lane", "shared_lane", "share_busway", "shoulder").contains(cycleway)) {
-            weightToPrioMap.put(100d, UNCHANGED.getValue());
+            weightToPrioMap.put(100d, SLIGHT_PREFER.getValue());
         } else if ("track".equals(cycleway)) {
             weightToPrioMap.put(100d, PREFER.getValue());
         }

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/BikeTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/BikeTagParserTest.java
@@ -312,12 +312,12 @@ public class BikeTagParserTest extends AbstractBikeTagParserTester {
         way.clearTags();
         way.setTag("highway", "primary");
         way.setTag("cycleway:left", "lane");
-        assertPriority(UNCHANGED.getValue(), way);
+        assertPriority(SLIGHT_PREFER.getValue(), way);
 
         way.clearTags();
         way.setTag("highway", "primary");
         way.setTag("cycleway:right", "lane");
-        assertPriority(UNCHANGED.getValue(), way);
+        assertPriority(SLIGHT_PREFER.getValue(), way);
 
         way.clearTags();
         way.setTag("highway", "primary");


### PR DESCRIPTION
Now that we have 4 bits for the priority available and not only 3 like in the past we can increase the priority for `cycleway=lane` by one step. Fixes #2784: 