### PR TITLE
Improve surface parser

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/ev/Surface.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/Surface.java
@@ -70,6 +70,11 @@ public enum Surface {
         if (Helper.isEmpty(name))
             return MISSING;
 
+        int colonIndex = name.indexOf(":");
+        if (colonIndex != -1) {
+            name = name.substring(0, colonIndex);
+        }
+
         return SURFACE_MAP.getOrDefault(name, OTHER);
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/ev/Surface.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/Surface.java
@@ -46,6 +46,7 @@ public enum Surface {
         }
         SURFACE_MAP.put("metal", PAVED);
         SURFACE_MAP.put("sett", COBBLESTONE);
+        SURFACE_MAP.put("unhewn_cobblestone", COBBLESTONE);
         SURFACE_MAP.put("wood", UNPAVED);
         SURFACE_MAP.put("earth", DIRT);
     }

--- a/core/src/main/java/com/graphhopper/routing/ev/Surface.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/Surface.java
@@ -19,6 +19,9 @@ package com.graphhopper.routing.ev;
 
 import com.graphhopper.util.Helper;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * This enum defines the road surface of an edge like unpaved or asphalt. If not tagged the value will be MISSING, which
  * the default and best surface value (as surface is currently often not tagged). All unknown surface tags will get
@@ -33,6 +36,19 @@ public enum Surface {
     OTHER("other");
 
     public static final String KEY = "surface";
+
+    private static final Map<String,Surface> SURFACE_MAP = new HashMap<>();
+    static {
+        for (Surface surface : values()) {
+            if (surface == MISSING || surface == OTHER)
+                continue;
+            SURFACE_MAP.put(surface.name, surface);
+        }
+        SURFACE_MAP.put("metal", PAVED);
+        SURFACE_MAP.put("sett", COBBLESTONE);
+        SURFACE_MAP.put("wood", UNPAVED);
+        SURFACE_MAP.put("earth", DIRT);
+    }
 
     public static EnumEncodedValue<Surface> create() {
         return new EnumEncodedValue<>(KEY, Surface.class);
@@ -52,10 +68,7 @@ public enum Surface {
     public static Surface find(String name) {
         if (Helper.isEmpty(name))
             return MISSING;
-        try {
-            return Surface.valueOf(Helper.toUpperCase(name));
-        } catch (IllegalArgumentException ex) {
-            return OTHER;
-        }
+
+        return SURFACE_MAP.getOrDefault(name, OTHER);
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMSurfaceParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMSurfaceParser.java
@@ -40,15 +40,6 @@ public class OSMSurfaceParser implements TagParser {
         if (surface == MISSING)
             return;
 
-        if (surfaceTag.equals("metal"))
-            surface = PAVED;
-        else if (surfaceTag.equals("sett"))
-            surface = COBBLESTONE;
-        else if (surfaceTag.equals("wood"))
-            surface = UNPAVED;
-        else if (surfaceTag.equals("earth"))
-            surface = DIRT;
-
         surfaceEnc.setEnum(false, edgeId, edgeIntAccess, surface);
     }
 }

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMSurfaceParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMSurfaceParserTest.java
@@ -42,5 +42,9 @@ public class OSMSurfaceParserTest {
         readerWay.setTag("surface", "unhewn_cobblestone");
         parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
         assertEquals(Surface.COBBLESTONE, surfaceEnc.getEnum(false, edgeId, edgeIntAccess));
+
+        readerWay.setTag("surface", "concrete:plates");
+        parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
+        assertEquals(Surface.CONCRETE, surfaceEnc.getEnum(false, edgeId, edgeIntAccess));
     }
 }

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMSurfaceParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMSurfaceParserTest.java
@@ -38,5 +38,9 @@ public class OSMSurfaceParserTest {
         readerWay.setTag("surface", "earth");
         parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
         assertEquals(Surface.DIRT, surfaceEnc.getEnum(false, edgeId, edgeIntAccess));
+
+        readerWay.setTag("surface", "unhewn_cobblestone");
+        parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
+        assertEquals(Surface.COBBLESTONE, surfaceEnc.getEnum(false, edgeId, edgeIntAccess));
     }
 }


### PR DESCRIPTION
Fixes #2751 

* moves synonym handling into Surface
* adds support for `unhewn_cobblestone`
* handles surface subtypes like `concrete:plates`