### PR TITLE
clarify foot access parser

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/parsers/FootAccessParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/FootAccessParser.java
@@ -30,9 +30,7 @@ import static com.graphhopper.routing.util.PriorityCode.UNCHANGED;
 
 public class FootAccessParser extends AbstractAccessParser implements TagParser {
 
-    final Set<String> safeHighwayTags = new HashSet<>();
     final Set<String> allowedHighwayTags = new HashSet<>();
-    final Set<String> avoidHighwayTags = new HashSet<>();
     final Set<String> allowedSacScale = new HashSet<>();
     protected HashSet<String> sidewalkValues = new HashSet<>(5);
     protected Map<RouteNetwork, Integer> routeMap = new HashMap<>();
@@ -58,27 +56,23 @@ public class FootAccessParser extends AbstractAccessParser implements TagParser 
 
         barriers.add("fence");
 
-        safeHighwayTags.add("footway");
-        safeHighwayTags.add("path");
-        safeHighwayTags.add("steps");
-        safeHighwayTags.add("pedestrian");
-        safeHighwayTags.add("living_street");
-        safeHighwayTags.add("track");
-        safeHighwayTags.add("residential");
-        safeHighwayTags.add("service");
-        safeHighwayTags.add("platform");
-
-        avoidHighwayTags.add("trunk");
-        avoidHighwayTags.add("trunk_link");
-        avoidHighwayTags.add("primary");
-        avoidHighwayTags.add("primary_link");
-        avoidHighwayTags.add("secondary");
-        avoidHighwayTags.add("secondary_link");
-        avoidHighwayTags.add("tertiary");
-        avoidHighwayTags.add("tertiary_link");
-
-        allowedHighwayTags.addAll(safeHighwayTags);
-        allowedHighwayTags.addAll(avoidHighwayTags);
+        allowedHighwayTags.add("footway");
+        allowedHighwayTags.add("path");
+        allowedHighwayTags.add("steps");
+        allowedHighwayTags.add("pedestrian");
+        allowedHighwayTags.add("living_street");
+        allowedHighwayTags.add("track");
+        allowedHighwayTags.add("residential");
+        allowedHighwayTags.add("service");
+        allowedHighwayTags.add("platform");
+        allowedHighwayTags.add("trunk");
+        allowedHighwayTags.add("trunk_link");
+        allowedHighwayTags.add("primary");
+        allowedHighwayTags.add("primary_link");
+        allowedHighwayTags.add("secondary");
+        allowedHighwayTags.add("secondary_link");
+        allowedHighwayTags.add("tertiary");
+        allowedHighwayTags.add("tertiary_link");
         allowedHighwayTags.add("cycleway");
         allowedHighwayTags.add("unclassified");
         allowedHighwayTags.add("road");

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/WheelchairAccessParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/WheelchairAccessParser.java
@@ -33,22 +33,8 @@ public class WheelchairAccessParser extends FootAccessParser {
         barriers.add("kissing_gate");
         barriers.add("stile");
 
-        safeHighwayTags.add("footway");
-        safeHighwayTags.add("pedestrian");
-        safeHighwayTags.add("living_street");
-        safeHighwayTags.add("residential");
-        safeHighwayTags.add("service");
-        safeHighwayTags.add("platform");
-
-        safeHighwayTags.remove("steps");
-        safeHighwayTags.remove("track");
-
-        allowedHighwayTags.clear();
-        allowedHighwayTags.addAll(safeHighwayTags);
-        allowedHighwayTags.addAll(avoidHighwayTags);
-        allowedHighwayTags.add("cycleway");
-        allowedHighwayTags.add("unclassified");
-        allowedHighwayTags.add("road");
+        allowedHighwayTags.remove("steps");
+        allowedHighwayTags.remove("track");
 
         excludeSurfaces.add("cobblestone");
         excludeSurfaces.add("gravel");


### PR DESCRIPTION
I was wondering how you include / exclude highway tags for pedestrian routing.

In `FootAccessParser`, I saw `safeHighwayTags` and `avoidHighwayTags` and was like 

> Okay there is a set with allowed and a set with not allowed highways

However, when looking more closely, all of them are treated as potentially allowed highways. For wheelchairs only steps and tracks are not allowed. 

This PR is to clarify this.

I assume historically the highways where splitted in "good" and "bad" for pedestrians and now the tags became better so there was a switch to analyze the tags.