### PR TITLE
Add ways from highway relations to road network

### DIFF
--- a/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
+++ b/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
@@ -166,6 +166,7 @@ public class OSMReader {
                 .setElevationProvider(eleProvider)
                 .setWayFilter(this::acceptWay)
                 .setSplitNodeFilter(this::isBarrierNode)
+                .setRelationFilterForWays(osmParsers.getRelationFilterForWays())
                 .setWayPreprocessor(this::preprocessWay)
                 .setRelationPreprocessor(this::preprocessRelations)
                 .setRelationProcessor(this::processRelation)

--- a/core/src/main/java/com/graphhopper/routing/util/OSMParsers.java
+++ b/core/src/main/java/com/graphhopper/routing/util/OSMParsers.java
@@ -21,8 +21,8 @@ package com.graphhopper.routing.util;
 import com.graphhopper.reader.ReaderRelation;
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.reader.osm.RestrictionTagParser;
-import com.graphhopper.routing.ev.EncodedValue;
 import com.graphhopper.routing.ev.EdgeIntAccess;
+import com.graphhopper.routing.ev.EncodedValue;
 import com.graphhopper.routing.util.parsers.RelationTagParser;
 import com.graphhopper.routing.util.parsers.TagParser;
 import com.graphhopper.storage.IntsRef;
@@ -30,6 +30,7 @@ import com.graphhopper.storage.IntsRef;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 public class OSMParsers {
     private final List<String> ignoredHighways;
@@ -85,6 +86,17 @@ public class OSMParsers {
             return true;
         else
             return false;
+    }
+
+    public Predicate<ReaderRelation> getRelationFilterForWays() {
+        if (ignoredHighways.contains("pedestrian") && ignoredHighways.contains("footway"))
+            // if are both ignored we can skip pass0 altogether
+            return null;
+        else
+            return relation -> {
+                String highway = relation.getTag("highway");
+                return highway != null && !ignoredHighways.contains(highway);
+            };
     }
 
     public IntsRef handleRelationTags(ReaderRelation relation, IntsRef relFlags) {


### PR DESCRIPTION
Currently [there are around 53k relations tagged as `highway=*`](https://taginfo.openstreetmap.org/keys/highway?filter=relations#values). Many (~18k, c.f. #2805) of them carry the `area=yes` tag, but even without considering that they might represent (routeable) areas, it seems useful to allow routing along the corresponding member ways.

In this PR I added a third (0th) pass for reading the OSM file to create a list of these relations, which is then used to create the corresponding edges in pass1/2. Relation member ways  inherit the tags from their parent relation, but they are only considered if they would not have been accepted based on their (way) tags already.

This screenshot shows highway relations in Paris with (blue) and without (red) an `area=yes` tag:

![image](https://user-images.githubusercontent.com/17603532/234693407-90e48c78-7f62-4499-b4fd-261f3f224d4e.png)

where highway relations are often used to map sidewalks:

![image](https://user-images.githubusercontent.com/17603532/234694583-8e505601-3396-4657-b028-45eccdd9e1de.png)

Adding them allows routing along the sidewalk of course:

|before|after|
|-|-|
|![image](https://user-images.githubusercontent.com/17603532/234694243-d73bfec9-76c9-44c3-9427-6da71050db8f.png)|![image](https://user-images.githubusercontent.com/17603532/234694166-7265ec4b-a5f2-4c9c-bf9d-aee26cd10bde.png)|

An important gotcha here is that we should exclude the 'inner' polygons of the highway relations, because sometimes they are connected to the outer polygons and/or the remaining road network only at one or a few points. This means that when we snap onto the inner polygon we might calculate a route with a long detour that goes to these connecting points and back like this:

![image](https://user-images.githubusercontent.com/17603532/234695136-e19f32e3-872f-4e48-a289-bf578286a2a5.png)

This problem is not completely new, though and exists already in master (for normal highways with a similar shape), like here:

[![image](https://user-images.githubusercontent.com/17603532/234695465-d55aa02e-dc66-43b9-bcb2-eecf55e9e85e.png)](https://graphhopper.com/maps/?point=48.815958%2C2.320979&point=48.815845%2C2.32083&profile=foot&layer=Omniscale)

To fix this we would probably either need to add artificial extra edges as in #2805 and/or extend our greedy snapping algorithm.



