### PR TITLE
Fix interchanged parameter names in bit util

### DIFF
--- a/core/src/main/java/com/graphhopper/util/BitUtil.java
+++ b/core/src/main/java/com/graphhopper/util/BitUtil.java
@@ -132,7 +132,7 @@ public abstract class BitUtil {
         return toLong(b, 0);
     }
 
-    public abstract long toLong(int high, int low);
+    public abstract long toLong(int low, int high);
 
     public abstract long toLong(byte[] b, int offset);
 

--- a/core/src/main/java/com/graphhopper/util/BitUtilBig.java
+++ b/core/src/main/java/com/graphhopper/util/BitUtilBig.java
@@ -54,7 +54,7 @@ public class BitUtilBig extends BitUtil {
 
     @Override
     public final long toLong(int int0, int int1) {
-        return ((long) int0 << 32) | (int1 & 0xFFFFFFFFL);
+        return ((long) int1 << 32) | (int0 & 0xFFFFFFFFL);
     }
 
     @Override

--- a/core/src/test/java/com/graphhopper/util/AbstractBitUtilTester.java
+++ b/core/src/test/java/com/graphhopper/util/AbstractBitUtilTester.java
@@ -81,6 +81,16 @@ public abstract class AbstractBitUtilTester {
     }
 
     @Test
+    public void testIntsToLong() {
+        int high = 2565;
+        int low = 9421;
+        long l = bitUtil.toLong(low, high);
+        assertEquals(l, bitUtil.combineIntsToLong(low, high));
+        assertEquals(high, bitUtil.getIntHigh(l));
+        assertEquals(low, bitUtil.getIntLow(l));
+    }
+
+    @Test
     public void testToLastBitString() {
         assertEquals("1", bitUtil.toLastBitString(1L, 1));
         assertEquals("01", bitUtil.toLastBitString(1L, 2));


### PR DESCRIPTION
A bit surprising that this simple method did not seem to be tested and nobody ran into this problem yet.
And why do we even have `bitutil.toLong` and `bitutil.combineIntsToLong`?