### PR TITLE
Set empty custom model in custom profile constructor

### DIFF
--- a/client-hc/src/main/java/com/graphhopper/api/GraphHopperWeb.java
+++ b/client-hc/src/main/java/com/graphhopper/api/GraphHopperWeb.java
@@ -27,6 +27,7 @@ import com.graphhopper.GHResponse;
 import com.graphhopper.ResponsePath;
 import com.graphhopper.jackson.Jackson;
 import com.graphhopper.jackson.ResponsePathDeserializer;
+import com.graphhopper.util.CustomModel;
 import com.graphhopper.util.Helper;
 import com.graphhopper.util.PMap;
 import com.graphhopper.util.Parameters;
@@ -282,7 +283,7 @@ public class GraphHopperWeb {
         requestJson.put("elevation", ghRequest.getHints().getBool("elevation", elevation));
         requestJson.put("optimize", ghRequest.getHints().getString("optimize", optimize));
         if (ghRequest.getCustomModel() != null)
-            requestJson.putPOJO("custom_model", ghRequest.getCustomModel());
+            requestJson.putPOJO(CustomModel.KEY, ghRequest.getCustomModel());
 
         Map<String, Object> hintsMap = ghRequest.getHints().toMap();
         for (Map.Entry<String, Object> entry : hintsMap.entrySet()) {

--- a/core/src/main/java/com/graphhopper/routing/weighting/custom/CustomProfile.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/custom/CustomProfile.java
@@ -34,6 +34,7 @@ public class CustomProfile extends Profile {
     public CustomProfile(String name) {
         super(name);
         setWeighting(CustomWeighting.NAME);
+        setCustomModel(new CustomModel());
     }
 
     public CustomProfile setCustomModel(CustomModel customModel) {

--- a/core/src/main/java/com/graphhopper/routing/weighting/custom/CustomProfile.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/custom/CustomProfile.java
@@ -38,9 +38,9 @@ public class CustomProfile extends Profile {
     }
 
     public CustomProfile setCustomModel(CustomModel customModel) {
-        customModel.internal();
+        if (customModel != null)
+            customModel.internal();
         getHints().putObject(CustomModel.KEY, customModel);
-        getHints().putObject("custom_model_files", Collections.emptyList());
         return this;
     }
 

--- a/core/src/test/java/com/graphhopper/GraphHopperTest.java
+++ b/core/src/test/java/com/graphhopper/GraphHopperTest.java
@@ -241,7 +241,7 @@ public class GraphHopperTest {
         GraphHopper hopper = new GraphHopper().
                 setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(MONACO).
-                setProfiles(new CustomProfile(profile).setCustomModel(new CustomModel()).setVehicle(vehicle).setTurnCosts(true).putHint(U_TURN_COSTS, 20));
+                setProfiles(new CustomProfile(profile).setVehicle(vehicle).setTurnCosts(true).putHint(U_TURN_COSTS, 20));
         hopper.importOrLoad();
         Translation tr = hopper.getTranslationMap().getWithFallBack(Locale.US);
 
@@ -607,7 +607,7 @@ public class GraphHopperTest {
         GraphHopper hopper = new GraphHopper().
                 setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(BAYREUTH).
-                setProfiles(new CustomProfile(profile).setCustomModel(new CustomModel()).setVehicle(vehicle));
+                setProfiles(new CustomProfile(profile).setVehicle(vehicle));
         hopper.importOrLoad();
 
         GHRequest req = new GHRequest(49.985272, 11.506151, 49.986107, 11.507202).
@@ -1277,7 +1277,7 @@ public class GraphHopperTest {
                 setOSMFile(KREMS).
                 setProfiles(
                         new Profile(footProfile).setVehicle("foot").setWeighting("fastest"),
-                        new CustomProfile(bikeProfile).setCustomModel(new CustomModel()).setVehicle("bike")).
+                        new CustomProfile(bikeProfile).setVehicle("bike")).
                 setStoreOnFlush(true).
                 importOrLoad();
 
@@ -1399,7 +1399,7 @@ public class GraphHopperTest {
         final String bikeProfile = "bike_profile";
         final String carProfile = "car_profile";
         List<Profile> profiles = asList(
-                new CustomProfile(bikeProfile).setCustomModel(new CustomModel()).setVehicle("bike"),
+                new CustomProfile(bikeProfile).setVehicle("bike"),
                 new Profile(carProfile).setVehicle("car").setWeighting("fastest")
         );
         GraphHopper hopper = new GraphHopper().
@@ -2112,7 +2112,7 @@ public class GraphHopperTest {
                 setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(BAYREUTH).
                 setMinNetworkSize(0).
-                setProfiles(new CustomProfile("bike").setCustomModel(new CustomModel()).setVehicle("bike"));
+                setProfiles(new CustomProfile("bike").setVehicle("bike"));
 
         hopper.importOrLoad();
         GHRequest req = new GHRequest(new GHPoint(49.98021, 11.50730), new GHPoint(49.98026, 11.50795));
@@ -2528,9 +2528,9 @@ public class GraphHopperTest {
                 setOSMFile("../map-matching/files/leipzig_germany.osm.pbf").
                 setVehiclesString("car|block_private=false").
                 setProfiles(
-                        new CustomProfile("car").setCustomModel(new CustomModel()).setVehicle("car"),
-                        new CustomProfile("bike").setCustomModel(new CustomModel()).setVehicle("bike"),
-                        new CustomProfile("foot").setCustomModel(new CustomModel()).setVehicle("foot")
+                        new CustomProfile("car").setVehicle("car"),
+                        new CustomProfile("bike").setVehicle("bike"),
+                        new CustomProfile("foot").setVehicle("foot")
                 ).
                 setMinNetworkSize(0);
         hopper.importOrLoad();

--- a/core/src/test/java/com/graphhopper/routing/RoutingAlgorithmWithOSMTest.java
+++ b/core/src/test/java/com/graphhopper/routing/RoutingAlgorithmWithOSMTest.java
@@ -131,7 +131,7 @@ public class RoutingAlgorithmWithOSMTest {
         // reverse route avoids the location
 //        list.add(new OneRun(52.349713, 8.013293, 52.349969, 8.013813, 293, 21));
         GraphHopper hopper = createHopper(DIR + "/map-bug432.osm.gz",
-                new CustomProfile("bike2").setCustomModel(new CustomModel()).setVehicle("bike"));
+                new CustomProfile("bike2").setVehicle("bike"));
         hopper.setElevationProvider(new SRTMProvider(DIR));
         hopper.importOrLoad();
         checkQueries(hopper, queries);
@@ -409,14 +409,14 @@ public class RoutingAlgorithmWithOSMTest {
         // hard to select between secondary and primary (both are AVOID for mtb)
         queries.add(new Query(43.733802, 7.413433, 43.739662, 7.424355, 1867, 107));
 
-        GraphHopper hopper = createHopper(MONACO, new CustomProfile("mtb").setCustomModel(new CustomModel()).setVehicle("mtb"));
+        GraphHopper hopper = createHopper(MONACO, new CustomProfile("mtb").setVehicle("mtb"));
         hopper.importOrLoad();
         checkQueries(hopper, queries);
 
         Helper.removeDir(new File(GH_LOCATION));
 
         hopper = createHopper(MONACO,
-                new CustomProfile("mtb").setCustomModel(new CustomModel()).setVehicle("mtb"),
+                new CustomProfile("mtb").setVehicle("mtb"),
                 new Profile("racingbike").setVehicle("racingbike").setWeighting("fastest"));
         hopper.importOrLoad();
         checkQueries(hopper, queries);
@@ -430,14 +430,14 @@ public class RoutingAlgorithmWithOSMTest {
         queries.add(new Query(43.728677, 7.41016, 43.739213, 7.427806, 2651, 167));
         queries.add(new Query(43.733802, 7.413433, 43.739662, 7.424355, 1516, 86));
 
-        GraphHopper hopper = createHopper(MONACO, new CustomProfile("racingbike").
-                setCustomModel(new CustomModel()).setVehicle("racingbike"));
+        GraphHopper hopper = createHopper(MONACO, new CustomProfile("racingbike").setVehicle("racingbike"));
         hopper.importOrLoad();
         checkQueries(hopper, queries);
 
         Helper.removeDir(new File(GH_LOCATION));
 
-        hopper = createHopper(MONACO, new CustomProfile("racingbike").setCustomModel(new CustomModel()).setVehicle("racingbike"),
+        hopper = createHopper(MONACO,
+                new CustomProfile("racingbike").setVehicle("racingbike"),
                 new Profile("bike").setVehicle("bike").setWeighting("fastest")
         );
         hopper.importOrLoad();
@@ -586,8 +586,7 @@ public class RoutingAlgorithmWithOSMTest {
 
         Helper.removeDir(new File(GH_LOCATION));
 
-        CustomModel model = new CustomModel();
-        hopper = createHopper(BAYREUTH, new CustomProfile("bike2").setCustomModel(model).setVehicle("bike"));
+        hopper = createHopper(BAYREUTH, new CustomProfile("bike2").setVehicle("bike"));
         hopper.setElevationProvider(new SRTMProvider(DIR));
         hopper.importOrLoad();
         checkQueries(hopper, list);

--- a/example/src/main/java/com/graphhopper/example/RoutingExample.java
+++ b/example/src/main/java/com/graphhopper/example/RoutingExample.java
@@ -109,7 +109,8 @@ public class RoutingExample {
         GraphHopper hopper = new GraphHopper();
         hopper.setOSMFile(ghLoc);
         hopper.setGraphHopperLocation("target/routing-custom-graph-cache");
-        hopper.setProfiles(new CustomProfile("car_custom").setCustomModel(new CustomModel()).setVehicle("car"));
+        CustomModel serverSideCustomModel = new CustomModel();
+        hopper.setProfiles(new CustomProfile("car_custom").setCustomModel(serverSideCustomModel).setVehicle("car"));
 
         // The hybrid mode uses the "landmark algorithm" and is up to 15x faster than the flexible mode (Dijkstra).
         // Still it is slower than the speed mode ("contraction hierarchies algorithm") ...

--- a/reader-gtfs/src/test/java/com/graphhopper/GraphHopperMultimodalIT.java
+++ b/reader-gtfs/src/test/java/com/graphhopper/GraphHopperMultimodalIT.java
@@ -65,7 +65,6 @@ public class GraphHopperMultimodalIT {
         CustomProfile carLocal = new CustomProfile("car_custom");
         carLocal.setVehicle("car");
         carLocal.setWeighting("custom");
-        carLocal.setCustomModel(new CustomModel());
         ghConfig.setProfiles(Arrays.asList(
                 new Profile("foot").setVehicle("foot").setWeighting("fastest"),
                 new Profile("car_default").setVehicle("car").setWeighting("fastest"),

--- a/web-bundle/src/main/java/com/graphhopper/http/GraphHopperManaged.java
+++ b/web-bundle/src/main/java/com/graphhopper/http/GraphHopperManaged.java
@@ -94,7 +94,7 @@ public class GraphHopperManaged implements Managed {
                 newProfiles.add(profile);
                 continue;
             }
-            Object cm = profile.getHints().getObject("custom_model", null);
+            Object cm = profile.getHints().getObject(CustomModel.KEY, null);
             CustomModel customModel;
             if (cm != null) {
                 if (!profile.getHints().getObject("custom_model_files", Collections.emptyList()).isEmpty())

--- a/web/src/test/java/com/graphhopper/application/resources/RouteResourceClientHCTest.java
+++ b/web/src/test/java/com/graphhopper/application/resources/RouteResourceClientHCTest.java
@@ -72,8 +72,8 @@ public class RouteResourceClientHCTest {
                 putObject("graph.location", DIR)
                 .setProfiles(Arrays.asList(
                         new Profile("car").setVehicle("car").setWeighting("fastest"),
-                        new CustomProfile("bike").setCustomModel(new CustomModel()).setVehicle("bike"),
-                        new CustomProfile("my_custom_car").setCustomModel(new CustomModel()).setVehicle("car")
+                        new CustomProfile("bike").setVehicle("bike"),
+                        new CustomProfile("my_custom_car").setVehicle("car")
                 ))
                 .setCHProfiles(Arrays.asList(new CHProfile("car"), new CHProfile("bike")));
         return config;

--- a/web/src/test/java/com/graphhopper/application/resources/RouteResourceCustomModelLMTest.java
+++ b/web/src/test/java/com/graphhopper/application/resources/RouteResourceCustomModelLMTest.java
@@ -61,7 +61,7 @@ public class RouteResourceCustomModelLMTest {
                 setProfiles(Arrays.asList(
                         new CustomProfile("car_custom").setCustomModel(new CustomModel().setDistanceInfluence(15d)).setVehicle("car"),
                         new Profile("foot_profile").setVehicle("foot").setWeighting("fastest"),
-                        new CustomProfile("foot_custom").setCustomModel(new CustomModel()).setVehicle("foot"))).
+                        new CustomProfile("foot_custom").setVehicle("foot"))).
                 setLMProfiles(Arrays.asList(new LMProfile("car_custom"), new LMProfile("foot_custom")));
         return config;
     }

--- a/web/src/test/java/com/graphhopper/application/resources/RouteResourceCustomModelTest.java
+++ b/web/src/test/java/com/graphhopper/application/resources/RouteResourceCustomModelTest.java
@@ -72,10 +72,10 @@ public class RouteResourceCustomModelTest {
                         new CustomProfile("car_with_area").setCustomModel(new CustomModel().addToPriority(If("in_external_area52", MULTIPLY, "0.05"))),
                         new CustomProfile("bike").setCustomModel(new CustomModel().setDistanceInfluence(0d)).setVehicle("bike"),
                         new Profile("bike_fastest").setWeighting("fastest").setVehicle("bike"),
-                        new CustomProfile("bus").setVehicle("roads").putHint("custom_model_files", Arrays.asList("bus.json")),
-                        new CustomProfile("cargo_bike").setVehicle("bike").
+                        new CustomProfile("bus").setCustomModel(null).setVehicle("roads").putHint("custom_model_files", Arrays.asList("bus.json")),
+                        new CustomProfile("cargo_bike").setCustomModel(null).setVehicle("bike").
                                 putHint("custom_model_files", Arrays.asList("cargo_bike.json")),
-                        new CustomProfile("json_bike").setVehicle("roads").
+                        new CustomProfile("json_bike").setCustomModel(null).setVehicle("roads").
                                 putHint("custom_model_files", Arrays.asList("bike.json", "bike_elevation.json")),
                         new Profile("foot_profile").setVehicle("foot").setWeighting("fastest"),
                         new CustomProfile("car_no_unclassified").setCustomModel(

--- a/web/src/test/java/com/graphhopper/application/resources/RouteResourceTruckTest.java
+++ b/web/src/test/java/com/graphhopper/application/resources/RouteResourceTruckTest.java
@@ -37,7 +37,7 @@ public class RouteResourceTruckTest {
                 putObject("graph.encoded_values", "max_height,max_weight,max_width,hazmat,toll,surface,hgv").
                 putObject("import.osm.ignored_highways", "").
                 putObject("custom_models.directory", "./src/test/resources/com/graphhopper/application/resources").
-                setProfiles(Arrays.asList(new CustomProfile("truck").setVehicle("roads").putHint("custom_model_files", Arrays.asList("truck.json")))).
+                setProfiles(Arrays.asList(new CustomProfile("truck").setCustomModel(null).setVehicle("roads").putHint("custom_model_files", Arrays.asList("truck.json")))).
                 setCHProfiles(Arrays.asList(new CHProfile("truck")));
         return config;
     }

--- a/web/src/test/java/com/graphhopper/application/resources/RouteResourceTurnCostsTest.java
+++ b/web/src/test/java/com/graphhopper/application/resources/RouteResourceTurnCostsTest.java
@@ -64,8 +64,8 @@ public class RouteResourceTurnCostsTest {
                 .setProfiles(Arrays.asList(
                         new Profile("my_car_turn_costs").setVehicle("car").setWeighting("fastest").setTurnCosts(true),
                         new Profile("my_car_no_turn_costs").setVehicle("car").setWeighting("fastest").setTurnCosts(false),
-                        new CustomProfile("my_custom_car_turn_costs").setCustomModel(new CustomModel()).setVehicle("car").setTurnCosts(true),
-                        new CustomProfile("my_custom_car_no_turn_costs").setCustomModel(new CustomModel()).setVehicle("car").setTurnCosts(false)
+                        new CustomProfile("my_custom_car_turn_costs").setVehicle("car").setTurnCosts(true),
+                        new CustomProfile("my_custom_car_no_turn_costs").setVehicle("car").setTurnCosts(false)
                 ))
                 .setCHProfiles(Arrays.asList(
                         new CHProfile("my_car_turn_costs"),


### PR DESCRIPTION
In the current code base there are three places where we call `CustomProfile#getCustomModel` and none of them expects the custom model to be null. Therefore we almost always need to create a custom profile like this: `new CustomProfile("profile_name").setCustomModel(new CustomModel())`. I moved this into the constructor.

In the rare cases where we use the `custom_model_files` hint (in Java code, for tests etc.) we now need to set the custom model to `null`.