### PR TITLE
Make car speed parser bad surfaces consistent with surface encoded value

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/parsers/CarAverageSpeedParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/CarAverageSpeedParser.java
@@ -56,11 +56,15 @@ public class CarAverageSpeedParser extends AbstractAverageSpeedParser implements
         super(speedEnc, maxPossibleSpeed);
 
         badSurfaceSpeedMap.add("cobblestone");
+        badSurfaceSpeedMap.add("unhewn_cobblestone");
+        badSurfaceSpeedMap.add("sett");
         badSurfaceSpeedMap.add("grass_paver");
         badSurfaceSpeedMap.add("gravel");
+        badSurfaceSpeedMap.add("pebblestone");
         badSurfaceSpeedMap.add("sand");
         badSurfaceSpeedMap.add("paving_stones");
         badSurfaceSpeedMap.add("dirt");
+        badSurfaceSpeedMap.add("earth");
         badSurfaceSpeedMap.add("ground");
         badSurfaceSpeedMap.add("grass");
         badSurfaceSpeedMap.add("unpaved");


### PR DESCRIPTION
In OSMSurfaceParser we map `sett` and `unhewn_cobblestone` to `COBBLESTONE`, `earth` to `DIRT`, `pebblestone` to `GRAVEL` (!) and `grass_paver` to `GRASS`. 

I think we need to extend the `badSurfaceMap` in CarAverageSpeedParser accordingly to make this consistent.