### PR TITLE
Use fallback speed also for ways that are neither highways nor ferries

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/parsers/CarAverageSpeedParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/CarAverageSpeedParser.java
@@ -105,7 +105,7 @@ public class CarAverageSpeedParser extends AbstractAverageSpeedParser implements
     }
 
     protected double getSpeed(ReaderWay way) {
-        String highwayValue = way.getTag("highway");
+        String highwayValue = way.getTag("highway", "");
         Integer speed = defaultSpeedMap.get(highwayValue);
 
         // even inaccessible edges get a speed assigned
@@ -126,13 +126,11 @@ public class CarAverageSpeedParser extends AbstractAverageSpeedParser implements
     @Override
     public void handleWayTags(int edgeId, EdgeIntAccess edgeIntAccess, ReaderWay way) {
         String highwayValue = way.getTag("highway");
-        if (highwayValue == null) {
-            if (way.hasTag("route", ferries)) {
-                double ferrySpeed = ferrySpeedCalc.getSpeed(way);
-                setSpeed(false, edgeId, edgeIntAccess, ferrySpeed);
-                if (avgSpeedEnc.isStoreTwoDirections())
-                    setSpeed(true, edgeId, edgeIntAccess, ferrySpeed);
-            }
+        if (highwayValue == null && way.hasTag("route", ferries)) {
+            double ferrySpeed = ferrySpeedCalc.getSpeed(way);
+            setSpeed(false, edgeId, edgeIntAccess, ferrySpeed);
+            if (avgSpeedEnc.isStoreTwoDirections())
+                setSpeed(true, edgeId, edgeIntAccess, ferrySpeed);
             return;
         }
 


### PR DESCRIPTION
Currently we accept [the following OSM ways](https://github.com/graphhopper/graphhopper/blob/34fc6eb41bf71fe13226015a4384639ea9a6074c/core/src/main/java/com/graphhopper/routing/util/OSMParsers.java#L73-L87):

* highways
* ferries (route=ferry)
* man_made=pier and railway=platform
* ways that are neither highways nor ferries, but that carry a 'route' tag. (often ski or boat routes, c.f. https://github.com/graphhopper/graphhopper/pull/2702#discussion_r1038093050)

We use `RoadClass.OTHER` for all these ways unless they carry a highway tag value that is listed in the RoadClass enum.
In `CarAverageSpeedParser` we set speeds for ferries and known highways, but for the other two categories the speed simply remains zero. In contrast, we use a fixed speed of 10 km/h for unknown highways, and the speed can even be higher when there is a maxspeed tag! Setting a fixed speed of 10km/h seems very arbitrary, because among the unknown highways there are values like `no`, `razed` and `abandoned`, i.e. they are no more useful than the other categories for which we use speed=0. It's also inconsistent, because all these ways get the same RoadClass and based on the encoded values we can no longer tell why some of these roads use speed 0 and others use speed 10. 

Here I set the speed to 10 also for the third and fourth category. In practice it should hardly even matter, because additionally we have the access encoded values that will block these edges anyway. We could probably just as well set it to 0 for all these ways including the unknown highways?!

Btw it looks like we started to set the speed to 10 for unknown highways here: #2738