### PR TITLE
Make RoadEnvironment.FERRY overrule RoadEnvironment.FORD also for node tags

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/parsers/CarAverageSpeedParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/CarAverageSpeedParser.java
@@ -105,7 +105,7 @@ public class CarAverageSpeedParser extends AbstractAverageSpeedParser implements
     }
 
     protected double getSpeed(ReaderWay way) {
-        String highwayValue = way.getTag("highway");
+        String highwayValue = way.getTag("highway", "");
         Integer speed = defaultSpeedMap.get(highwayValue);
 
         // even inaccessible edges get a speed assigned
@@ -126,13 +126,11 @@ public class CarAverageSpeedParser extends AbstractAverageSpeedParser implements
     @Override
     public void handleWayTags(int edgeId, EdgeIntAccess edgeIntAccess, ReaderWay way) {
         String highwayValue = way.getTag("highway");
-        if (highwayValue == null) {
-            if (way.hasTag("route", ferries)) {
-                double ferrySpeed = ferrySpeedCalc.getSpeed(way);
-                setSpeed(false, edgeId, edgeIntAccess, ferrySpeed);
-                if (avgSpeedEnc.isStoreTwoDirections())
-                    setSpeed(true, edgeId, edgeIntAccess, ferrySpeed);
-            }
+        if (highwayValue == null && way.hasTag("route", ferries)) {
+            double ferrySpeed = ferrySpeedCalc.getSpeed(way);
+            setSpeed(false, edgeId, edgeIntAccess, ferrySpeed);
+            if (avgSpeedEnc.isStoreTwoDirections())
+                setSpeed(true, edgeId, edgeIntAccess, ferrySpeed);
             return;
         }
 

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/CarAverageSpeedParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/CarAverageSpeedParser.java
@@ -105,7 +105,7 @@ public class CarAverageSpeedParser extends AbstractAverageSpeedParser implements
     }
 
     protected double getSpeed(ReaderWay way) {
-        String highwayValue = way.getTag("highway", "");
+        String highwayValue = way.getTag("highway");
         Integer speed = defaultSpeedMap.get(highwayValue);
 
         // even inaccessible edges get a speed assigned
@@ -126,11 +126,13 @@ public class CarAverageSpeedParser extends AbstractAverageSpeedParser implements
     @Override
     public void handleWayTags(int edgeId, EdgeIntAccess edgeIntAccess, ReaderWay way) {
         String highwayValue = way.getTag("highway");
-        if (highwayValue == null && way.hasTag("route", ferries)) {
-            double ferrySpeed = ferrySpeedCalc.getSpeed(way);
-            setSpeed(false, edgeId, edgeIntAccess, ferrySpeed);
-            if (avgSpeedEnc.isStoreTwoDirections())
-                setSpeed(true, edgeId, edgeIntAccess, ferrySpeed);
+        if (highwayValue == null) {
+            if (way.hasTag("route", ferries)) {
+                double ferrySpeed = ferrySpeedCalc.getSpeed(way);
+                setSpeed(false, edgeId, edgeIntAccess, ferrySpeed);
+                if (avgSpeedEnc.isStoreTwoDirections())
+                    setSpeed(true, edgeId, edgeIntAccess, ferrySpeed);
+            }
             return;
         }
 


### PR DESCRIPTION
[This](https://www.openstreetmap.org/node/1306290896) is a fairly exotic example of a barrier node (`ford=yes`) within a ferry route. In this case the question arises which road environment shall be assigned. I think it should be `ferry`, because also for ways `ferry` overrules `ford`.

Btw: It seems a bit odd that there is a special road environment for `ford` but not for the other types of barriers like `gate` etc.?