### PR TITLE
ferry_speed encoded value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 8.0 [not yet released]
 
+- removed duration:seconds as intermediate tag
 - /info endpoint does no longer return the vehicle used per profile and won't return encoded value of vehicles like car_average_speed
 - Country rules no longer contain maxspeed handling, enable a much better alternative via `max_speed_calculator.enabled: true`. On the client side use `max_speed_estimated` to determine if max_speed is from OSM or an estimation. See #2810
 - bike routing better avoids dangerous roads, see #2796 and #2802

--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -656,6 +656,8 @@ public class GraphHopper {
             osmParsers.addWayTagParser(new OSMMaxSpeedParser(encodingManager.getDecimalEncodedValue(MaxSpeed.KEY)));
         if (!encodedValueStrings.contains(RoadAccess.KEY))
             osmParsers.addWayTagParser(new OSMRoadAccessParser(encodingManager.getEnumEncodedValue(RoadAccess.KEY, RoadAccess.class), OSMRoadAccessParser.toOSMRestrictions(TransportationMode.CAR)));
+        if (!encodedValueStrings.contains(FerrySpeed.KEY))
+            osmParsers.addWayTagParser(new FerrySpeedCalculator(encodingManager.getDecimalEncodedValue(FerrySpeed.KEY)));
         if (encodingManager.hasEncodedValue(AverageSlope.KEY) || encodingManager.hasEncodedValue(MaxSlope.KEY)) {
             if (!encodingManager.hasEncodedValue(AverageSlope.KEY) || !encodingManager.hasEncodedValue(MaxSlope.KEY))
                 throw new IllegalArgumentException("Enable both, average_slope and max_slope");

--- a/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
+++ b/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
@@ -487,11 +487,10 @@ public class OSMReader {
                     " minutes), distance=" + distance + " m");
             return;
         }
-        // These tags will be present if 1) isCalculateWayDistance was true for this way, 2) no OSM nodes were missing
+        // tag will be present if 1) isCalculateWayDistance was true for this way, 2) no OSM nodes were missing
         // such that the distance could actually be calculated, 3) there was a duration tag we could parse, and 4) the
         // derived speed was not unrealistically slow.
         way.setTag("speed_from_duration", speedInKmPerHour);
-        way.setTag("duration:seconds", durationInSeconds);
     }
 
     static String fixWayName(String str) {

--- a/core/src/main/java/com/graphhopper/routing/ev/DefaultEncodedValueFactory.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/DefaultEncodedValueFactory.java
@@ -95,6 +95,8 @@ public class DefaultEncodedValueFactory implements EncodedValueFactory {
             return Curvature.create();
         } else if (Crossing.KEY.equals(name)) {
             return new EnumEncodedValue<>(Crossing.KEY, Crossing.class);
+        } else if (FerrySpeed.KEY.equals(name)) {
+            return FerrySpeed.create();
         } else {
             throw new IllegalArgumentException("DefaultEncodedValueFactory cannot find EncodedValue " + name);
         }

--- a/core/src/main/java/com/graphhopper/routing/ev/FerrySpeed.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/FerrySpeed.java
@@ -1,0 +1,9 @@
+package com.graphhopper.routing.ev;
+
+public class FerrySpeed {
+    public static final String KEY = "ferry_speed";
+
+    public static DecimalEncodedValue create() {
+        return new DecimalEncodedValueImpl(KEY, 5, 2, false);
+    }
+}

--- a/core/src/main/java/com/graphhopper/routing/util/EncodingManager.java
+++ b/core/src/main/java/com/graphhopper/routing/util/EncodingManager.java
@@ -168,7 +168,8 @@ public class EncodingManager implements EncodedValueLookup {
                     RoadClassLink.KEY,
                     RoadEnvironment.KEY,
                     MaxSpeed.KEY,
-                    RoadAccess.KEY
+                    RoadAccess.KEY,
+                    FerrySpeed.KEY
             ));
             if (em.getVehicles().stream().anyMatch(vehicle -> vehicle.contains("bike") || vehicle.contains("mtb") || vehicle.contains("racingbike"))) {
                 keys.add(BikeNetwork.KEY);

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/AbstractAccessParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/AbstractAccessParser.java
@@ -13,7 +13,6 @@ import com.graphhopper.storage.IntsRef;
 import java.util.*;
 
 public abstract class AbstractAccessParser implements TagParser {
-    static final Collection<String> FERRIES = Arrays.asList("shuttle_train", "ferry");
     static final Collection<String> ONEWAYS = Arrays.asList("yes", "true", "1", "-1");
     static final Collection<String> INTENDED = Arrays.asList("yes", "designated", "official", "permissive");
 
@@ -22,7 +21,6 @@ public abstract class AbstractAccessParser implements TagParser {
     protected final Set<String> restrictedValues = new HashSet<>(5);
 
     protected final Set<String> intendedValues = new HashSet<>(INTENDED);
-    protected final Set<String> ferries = new HashSet<>(FERRIES);
     protected final Set<String> oneways = new HashSet<>(ONEWAYS);
     // http://wiki.openstreetmap.org/wiki/Mapfeatures#Barrier
     protected final Set<String> barriers = new HashSet<>(5);

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/AbstractAverageSpeedParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/AbstractAverageSpeedParser.java
@@ -10,17 +10,17 @@ import com.graphhopper.storage.IntsRef;
 import java.util.HashSet;
 import java.util.Set;
 
-import static com.graphhopper.routing.util.parsers.AbstractAccessParser.FERRIES;
+import static com.graphhopper.routing.util.FerrySpeedCalculator.FERRIES;
 
 public abstract class AbstractAverageSpeedParser implements TagParser {
     // http://wiki.openstreetmap.org/wiki/Mapfeatures#Barrier
     protected final DecimalEncodedValue avgSpeedEnc;
     protected final Set<String> ferries = new HashSet<>(FERRIES);
-    protected final FerrySpeedCalculator ferrySpeedCalc;
+    protected final DecimalEncodedValue ferrySpeedEnc;
 
-    protected AbstractAverageSpeedParser(DecimalEncodedValue speedEnc) {
+    protected AbstractAverageSpeedParser(DecimalEncodedValue speedEnc, DecimalEncodedValue ferrySpeedEnc) {
         this.avgSpeedEnc = speedEnc;
-        this.ferrySpeedCalc = new FerrySpeedCalculator(speedEnc.getSmallestNonZeroValue(), speedEnc.getMaxStorableDecimal(), 6);
+        this.ferrySpeedEnc = ferrySpeedEnc;
     }
 
     /**

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/BikeAverageSpeedParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/BikeAverageSpeedParser.java
@@ -7,11 +7,12 @@ public class BikeAverageSpeedParser extends BikeCommonAverageSpeedParser {
 
     public BikeAverageSpeedParser(EncodedValueLookup lookup, PMap properties) {
         this(lookup.getDecimalEncodedValue(VehicleSpeed.key(properties.getString("name", "bike"))),
-                lookup.getEnumEncodedValue(Smoothness.KEY, Smoothness.class));
+                lookup.getEnumEncodedValue(Smoothness.KEY, Smoothness.class),
+                lookup.getDecimalEncodedValue(FerrySpeed.KEY));
     }
 
-    public BikeAverageSpeedParser(DecimalEncodedValue speedEnc, EnumEncodedValue<Smoothness> smoothnessEnc) {
-        super(speedEnc, smoothnessEnc);
+    public BikeAverageSpeedParser(DecimalEncodedValue speedEnc, EnumEncodedValue<Smoothness> smoothnessEnc, DecimalEncodedValue ferrySpeedEnc) {
+        super(speedEnc, smoothnessEnc, ferrySpeedEnc);
         addPushingSection("path");
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonAccessParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonAccessParser.java
@@ -8,6 +8,8 @@ import com.graphhopper.routing.util.WayAccess;
 
 import java.util.*;
 
+import static com.graphhopper.routing.util.FerrySpeedCalculator.FERRIES;
+
 public abstract class BikeCommonAccessParser extends AbstractAccessParser implements TagParser {
 
     private static final Set<String> OPP_LANES = new HashSet<>(Arrays.asList("opposite", "opposite_lane", "opposite_track"));
@@ -41,7 +43,7 @@ public abstract class BikeCommonAccessParser extends AbstractAccessParser implem
         if (highwayValue == null) {
             WayAccess access = WayAccess.CAN_SKIP;
 
-            if (way.hasTag("route", ferries)) {
+            if (way.hasTag("route", FERRIES)) {
                 // if bike is NOT explicitly tagged allow bike but only if foot is not specified either
                 String bikeTag = way.getTag("bicycle");
                 if (bikeTag == null && !way.hasTag("foot") || intendedValues.contains(bikeTag))

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonAverageSpeedParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonAverageSpeedParser.java
@@ -5,6 +5,7 @@ import com.graphhopper.routing.ev.DecimalEncodedValue;
 import com.graphhopper.routing.ev.EdgeIntAccess;
 import com.graphhopper.routing.ev.EnumEncodedValue;
 import com.graphhopper.routing.ev.Smoothness;
+import com.graphhopper.routing.util.FerrySpeedCalculator;
 import com.graphhopper.util.Helper;
 
 import java.util.HashMap;
@@ -25,8 +26,8 @@ public abstract class BikeCommonAverageSpeedParser extends AbstractAverageSpeedP
     private final EnumEncodedValue<Smoothness> smoothnessEnc;
     protected final Set<String> intendedValues = new HashSet<>(5);
 
-    protected BikeCommonAverageSpeedParser(DecimalEncodedValue speedEnc, EnumEncodedValue<Smoothness> smoothnessEnc) {
-        super(speedEnc);
+    protected BikeCommonAverageSpeedParser(DecimalEncodedValue speedEnc, EnumEncodedValue<Smoothness> smoothnessEnc, DecimalEncodedValue ferrySpeedEnc) {
+        super(speedEnc, ferrySpeedEnc);
         this.smoothnessEnc = smoothnessEnc;
 
         // duplicate code as also in BikeCommonPriorityParser
@@ -133,7 +134,7 @@ public abstract class BikeCommonAverageSpeedParser extends AbstractAverageSpeedP
         String highwayValue = way.getTag("highway");
         if (highwayValue == null) {
             if (way.hasTag("route", ferries)) {
-                double ferrySpeed = ferrySpeedCalc.getSpeed(way);
+                double ferrySpeed = FerrySpeedCalculator.minmax(ferrySpeedEnc.getDecimal(false, edgeId, edgeIntAccess), avgSpeedEnc);
                 setSpeed(false, edgeId, edgeIntAccess, ferrySpeed);
                 if (avgSpeedEnc.isStoreTwoDirections())
                     setSpeed(true, edgeId, edgeIntAccess, ferrySpeed);

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonPriorityParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonPriorityParser.java
@@ -11,8 +11,8 @@ import com.graphhopper.storage.IntsRef;
 import java.util.*;
 
 import static com.graphhopper.routing.ev.RouteNetwork.*;
+import static com.graphhopper.routing.util.FerrySpeedCalculator.FERRIES;
 import static com.graphhopper.routing.util.PriorityCode.*;
-import static com.graphhopper.routing.util.parsers.AbstractAccessParser.FERRIES;
 import static com.graphhopper.routing.util.parsers.AbstractAccessParser.INTENDED;
 import static com.graphhopper.routing.util.parsers.AbstractAverageSpeedParser.getMaxSpeed;
 import static com.graphhopper.routing.util.parsers.AbstractAverageSpeedParser.isValidSpeed;
@@ -180,7 +180,7 @@ public abstract class BikeCommonPriorityParser implements TagParser {
             weightToPrioMap.put(50d, priorityCode == null ? AVOID : priorityCode);
             if (way.hasTag("tunnel", intendedValues)) {
                 PriorityCode worse = priorityCode == null ? BAD : priorityCode.worse().worse();
-                weightToPrioMap.put(50d,  worse == EXCLUDE ? REACH_DESTINATION : worse);
+                weightToPrioMap.put(50d, worse == EXCLUDE ? REACH_DESTINATION : worse);
             }
         }
 
@@ -199,14 +199,14 @@ public abstract class BikeCommonPriorityParser implements TagParser {
             PriorityCode pushingSectionPrio = SLIGHT_AVOID;
             if (way.hasTag("bicycle", "yes") || way.hasTag("bicycle", "permissive"))
                 pushingSectionPrio = PREFER;
-            if (isDesignated(way) && (!way.hasTag("highway","steps")))
+            if (isDesignated(way) && (!way.hasTag("highway", "steps")))
                 pushingSectionPrio = VERY_NICE;
             if (way.hasTag("foot", "yes")) {
                 pushingSectionPrio = pushingSectionPrio.worse();
                 if (way.hasTag("segregated", "yes"))
                     pushingSectionPrio = pushingSectionPrio.better();
             }
-            if (way.hasTag("highway","steps")) {
+            if (way.hasTag("highway", "steps")) {
                 pushingSectionPrio = BAD;
             }
             weightToPrioMap.put(100d, pushingSectionPrio);
@@ -231,7 +231,8 @@ public abstract class BikeCommonPriorityParser implements TagParser {
         // Increase the priority for scenic routes or in case that maxspeed limits our average speed as compensation. See #630
         if (way.hasTag("scenic", "yes") || maxSpeed > 0 && maxSpeed <= wayTypeSpeed) {
             PriorityCode lastEntryValue = weightToPrioMap.lastEntry().getValue();
-            if (lastEntryValue.getValue() < BEST.getValue()) weightToPrioMap.put(110d, lastEntryValue.better());
+            if (lastEntryValue.getValue() < BEST.getValue())
+                weightToPrioMap.put(110d, lastEntryValue.better());
         }
     }
 

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/CarAccessParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/CarAccessParser.java
@@ -25,6 +25,8 @@ import com.graphhopper.util.PMap;
 
 import java.util.*;
 
+import static com.graphhopper.routing.util.FerrySpeedCalculator.FERRIES;
+
 public class CarAccessParser extends AbstractAccessParser implements TagParser {
 
     protected final Set<String> trackTypeValues = new HashSet<>();
@@ -80,7 +82,7 @@ public class CarAccessParser extends AbstractAccessParser implements TagParser {
         String highwayValue = way.getTag("highway");
         String firstValue = way.getFirstPriorityTag(restrictions);
         if (highwayValue == null) {
-            if (way.hasTag("route", ferries)) {
+            if (way.hasTag("route", FERRIES)) {
                 if (restrictedValues.contains(firstValue))
                     return WayAccess.CAN_SKIP;
                 if (intendedValues.contains(firstValue) ||

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/CarAverageSpeedParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/CarAverageSpeedParser.java
@@ -18,10 +18,8 @@
 package com.graphhopper.routing.util.parsers;
 
 import com.graphhopper.reader.ReaderWay;
-import com.graphhopper.routing.ev.DecimalEncodedValue;
-import com.graphhopper.routing.ev.EdgeIntAccess;
-import com.graphhopper.routing.ev.EncodedValueLookup;
-import com.graphhopper.routing.ev.VehicleSpeed;
+import com.graphhopper.routing.ev.*;
+import com.graphhopper.routing.util.FerrySpeedCalculator;
 import com.graphhopper.util.Helper;
 import com.graphhopper.util.PMap;
 
@@ -45,11 +43,12 @@ public class CarAverageSpeedParser extends AbstractAverageSpeedParser implements
     protected final Map<String, Integer> defaultSpeedMap = new HashMap<>();
 
     public CarAverageSpeedParser(EncodedValueLookup lookup, PMap properties) {
-        this(lookup.getDecimalEncodedValue(VehicleSpeed.key(properties.getString("name", "car"))));
+        this(lookup.getDecimalEncodedValue(VehicleSpeed.key(properties.getString("name", "car"))),
+                lookup.getDecimalEncodedValue(FerrySpeed.KEY));
     }
 
-    public CarAverageSpeedParser(DecimalEncodedValue speedEnc) {
-        super(speedEnc);
+    public CarAverageSpeedParser(DecimalEncodedValue speedEnc, DecimalEncodedValue ferrySpeed) {
+        super(speedEnc, ferrySpeed);
 
         badSurfaceSpeedMap.add("cobblestone");
         badSurfaceSpeedMap.add("unhewn_cobblestone");
@@ -124,7 +123,7 @@ public class CarAverageSpeedParser extends AbstractAverageSpeedParser implements
     @Override
     public void handleWayTags(int edgeId, EdgeIntAccess edgeIntAccess, ReaderWay way) {
         if (way.hasTag("route", ferries)) {
-            double ferrySpeed = ferrySpeedCalc.getSpeed(way);
+            double ferrySpeed = FerrySpeedCalculator.minmax(ferrySpeedEnc.getDecimal(false, edgeId, edgeIntAccess), avgSpeedEnc);
             setSpeed(false, edgeId, edgeIntAccess, ferrySpeed);
             if (avgSpeedEnc.isStoreTwoDirections())
                 setSpeed(true, edgeId, edgeIntAccess, ferrySpeed);

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/DefaultTagParserFactory.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/DefaultTagParserFactory.java
@@ -18,6 +18,7 @@
 package com.graphhopper.routing.util.parsers;
 
 import com.graphhopper.routing.ev.*;
+import com.graphhopper.routing.util.FerrySpeedCalculator;
 import com.graphhopper.routing.util.TransportationMode;
 import com.graphhopper.util.PMap;
 
@@ -83,6 +84,8 @@ public class DefaultTagParserFactory implements TagParserFactory {
             return new StateParser(lookup.getEnumEncodedValue(State.KEY, State.class));
         else if (name.equals(Crossing.KEY))
             return new OSMCrossingParser(lookup.getEnumEncodedValue(Crossing.KEY, Crossing.class));
+        else if (name.equals(FerrySpeed.KEY))
+            return new FerrySpeedCalculator(lookup.getDecimalEncodedValue(FerrySpeed.KEY));
         return null;
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/FootAccessParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/FootAccessParser.java
@@ -26,6 +26,7 @@ import com.graphhopper.util.PMap;
 import java.util.*;
 
 import static com.graphhopper.routing.ev.RouteNetwork.*;
+import static com.graphhopper.routing.util.FerrySpeedCalculator.FERRIES;
 import static com.graphhopper.routing.util.PriorityCode.UNCHANGED;
 
 public class FootAccessParser extends AbstractAccessParser implements TagParser {
@@ -97,7 +98,7 @@ public class FootAccessParser extends AbstractAccessParser implements TagParser 
         if (highwayValue == null) {
             WayAccess acceptPotentially = WayAccess.CAN_SKIP;
 
-            if (way.hasTag("route", ferries)) {
+            if (way.hasTag("route", FERRIES)) {
                 String footTag = way.getTag("foot");
                 if (footTag == null || intendedValues.contains(footTag))
                     acceptPotentially = WayAccess.FERRY;

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/FootAverageSpeedParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/FootAverageSpeedParser.java
@@ -2,6 +2,7 @@ package com.graphhopper.routing.util.parsers;
 
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.*;
+import com.graphhopper.routing.util.FerrySpeedCalculator;
 import com.graphhopper.util.PMap;
 
 import java.util.HashMap;
@@ -16,11 +17,12 @@ public class FootAverageSpeedParser extends AbstractAverageSpeedParser implement
     protected Map<RouteNetwork, Integer> routeMap = new HashMap<>();
 
     public FootAverageSpeedParser(EncodedValueLookup lookup, PMap properties) {
-        this(lookup.getDecimalEncodedValue(VehicleSpeed.key(properties.getString("name", "foot"))));
+        this(lookup.getDecimalEncodedValue(VehicleSpeed.key(properties.getString("name", "foot"))),
+                lookup.getDecimalEncodedValue(FerrySpeed.KEY));
     }
 
-    protected FootAverageSpeedParser(DecimalEncodedValue speedEnc) {
-        super(speedEnc);
+    protected FootAverageSpeedParser(DecimalEncodedValue speedEnc, DecimalEncodedValue ferrySpeedEnc) {
+        super(speedEnc, ferrySpeedEnc);
 
         routeMap.put(INTERNATIONAL, UNCHANGED.getValue());
         routeMap.put(NATIONAL, UNCHANGED.getValue());
@@ -33,7 +35,7 @@ public class FootAverageSpeedParser extends AbstractAverageSpeedParser implement
         String highwayValue = way.getTag("highway");
         if (highwayValue == null) {
             if (way.hasTag("route", ferries)) {
-                double ferrySpeed = ferrySpeedCalc.getSpeed(way);
+                double ferrySpeed = FerrySpeedCalculator.minmax(ferrySpeedEnc.getDecimal(false, edgeId, edgeIntAccess), avgSpeedEnc);
                 setSpeed(false, edgeId, edgeIntAccess, ferrySpeed);
                 if (avgSpeedEnc.isStoreTwoDirections())
                     setSpeed(true, edgeId, edgeIntAccess, ferrySpeed);

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/FootPriorityParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/FootPriorityParser.java
@@ -9,8 +9,8 @@ import com.graphhopper.util.PMap;
 import java.util.*;
 
 import static com.graphhopper.routing.ev.RouteNetwork.*;
+import static com.graphhopper.routing.util.FerrySpeedCalculator.FERRIES;
 import static com.graphhopper.routing.util.PriorityCode.*;
-import static com.graphhopper.routing.util.parsers.AbstractAccessParser.FERRIES;
 import static com.graphhopper.routing.util.parsers.AbstractAccessParser.INTENDED;
 import static com.graphhopper.routing.util.parsers.AbstractAverageSpeedParser.getMaxSpeed;
 import static com.graphhopper.routing.util.parsers.AbstractAverageSpeedParser.isValidSpeed;

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/MountainBikeAverageSpeedParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/MountainBikeAverageSpeedParser.java
@@ -7,11 +7,12 @@ public class MountainBikeAverageSpeedParser extends BikeCommonAverageSpeedParser
 
     public MountainBikeAverageSpeedParser(EncodedValueLookup lookup, PMap properties) {
         this(lookup.getDecimalEncodedValue(VehicleSpeed.key(properties.getString("name", "mtb"))),
-                lookup.getEnumEncodedValue(Smoothness.KEY, Smoothness.class));
+                lookup.getEnumEncodedValue(Smoothness.KEY, Smoothness.class),
+                lookup.getDecimalEncodedValue(FerrySpeed.KEY));
     }
 
-    protected MountainBikeAverageSpeedParser(DecimalEncodedValue speedEnc, EnumEncodedValue<Smoothness> smoothnessEnc) {
-        super(speedEnc, smoothnessEnc);
+    protected MountainBikeAverageSpeedParser(DecimalEncodedValue speedEnc, EnumEncodedValue<Smoothness> smoothnessEnc, DecimalEncodedValue ferrySpeedEnc) {
+        super(speedEnc, smoothnessEnc, ferrySpeedEnc);
         setTrackTypeSpeed("grade1", 18); // paved
         setTrackTypeSpeed("grade2", 16); // now unpaved ...
         setTrackTypeSpeed("grade3", 12);

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikeAverageSpeedParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikeAverageSpeedParser.java
@@ -7,11 +7,12 @@ public class RacingBikeAverageSpeedParser extends BikeCommonAverageSpeedParser {
 
     public RacingBikeAverageSpeedParser(EncodedValueLookup lookup, PMap properties) {
         this(lookup.getDecimalEncodedValue(VehicleSpeed.key(properties.getString("name", "racingbike"))),
-                lookup.getEnumEncodedValue(Smoothness.KEY, Smoothness.class));
+                lookup.getEnumEncodedValue(Smoothness.KEY, Smoothness.class),
+                lookup.getDecimalEncodedValue(FerrySpeed.KEY));
     }
 
-    protected RacingBikeAverageSpeedParser(DecimalEncodedValue speedEnc, EnumEncodedValue<Smoothness> smoothnessEnc) {
-        super(speedEnc, smoothnessEnc);
+    protected RacingBikeAverageSpeedParser(DecimalEncodedValue speedEnc, EnumEncodedValue<Smoothness> smoothnessEnc, DecimalEncodedValue ferrySpeedEnc) {
+        super(speedEnc, smoothnessEnc, ferrySpeedEnc);
 
         setTrackTypeSpeed("grade1", 20); // paved
         setTrackTypeSpeed("grade2", 10); // now unpaved ...

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/WheelchairAverageSpeedParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/WheelchairAverageSpeedParser.java
@@ -1,21 +1,20 @@
 package com.graphhopper.routing.util.parsers;
 
 import com.graphhopper.reader.ReaderWay;
-import com.graphhopper.routing.ev.DecimalEncodedValue;
-import com.graphhopper.routing.ev.EdgeIntAccess;
-import com.graphhopper.routing.ev.EncodedValueLookup;
-import com.graphhopper.routing.ev.VehicleSpeed;
+import com.graphhopper.routing.ev.*;
+import com.graphhopper.routing.util.FerrySpeedCalculator;
 import com.graphhopper.util.PMap;
 import com.graphhopper.util.PointList;
 
 public class WheelchairAverageSpeedParser extends FootAverageSpeedParser {
 
     public WheelchairAverageSpeedParser(EncodedValueLookup lookup, PMap properties) {
-        this(lookup.getDecimalEncodedValue(properties.getString("name", VehicleSpeed.key("wheelchair"))));
+        this(lookup.getDecimalEncodedValue(properties.getString("name", VehicleSpeed.key("wheelchair"))),
+                lookup.getDecimalEncodedValue(FerrySpeed.KEY));
     }
 
-    protected WheelchairAverageSpeedParser(DecimalEncodedValue speedEnc) {
-        super(speedEnc);
+    protected WheelchairAverageSpeedParser(DecimalEncodedValue speedEnc, DecimalEncodedValue ferrySpeedEnc) {
+        super(speedEnc, ferrySpeedEnc);
     }
 
     @Override
@@ -23,7 +22,7 @@ public class WheelchairAverageSpeedParser extends FootAverageSpeedParser {
         String highwayValue = way.getTag("highway");
         if (highwayValue == null) {
             if (way.hasTag("route", ferries)) {
-                double ferrySpeed = ferrySpeedCalc.getSpeed(way);
+                double ferrySpeed = FerrySpeedCalculator.minmax(ferrySpeedEnc.getDecimal(false, edgeId, edgeIntAccess), avgSpeedEnc);
                 setSpeed(false, edgeId, edgeIntAccess, ferrySpeed);
                 setSpeed(true, edgeId, edgeIntAccess, ferrySpeed);
             }

--- a/core/src/test/java/com/graphhopper/reader/osm/GraphHopperOSMTest.java
+++ b/core/src/test/java/com/graphhopper/reader/osm/GraphHopperOSMTest.java
@@ -518,7 +518,7 @@ public class GraphHopperOSMTest {
                 setGraphHopperLocation(ghLoc);
         instance.load();
         assertEquals(5, instance.getBaseGraph().getNodes());
-        assertEquals("foot_access,foot_average_speed,foot_priority,car_access,car_average_speed,foot_subnetwork,car_subnetwork,roundabout,road_class,road_class_link,road_environment,max_speed,road_access,foot_network",
+        assertEquals("foot_access,foot_average_speed,foot_priority,car_access,car_average_speed,foot_subnetwork,car_subnetwork,roundabout,road_class,road_class_link,road_environment,max_speed,road_access,ferry_speed,foot_network",
                 instance.getEncodingManager().getEncodedValues().stream().map(EncodedValue::getName).collect(Collectors.joining(",")));
     }
 
@@ -558,7 +558,7 @@ public class GraphHopperOSMTest {
                 setOSMFile(testOsm3);
         instance.load();
         assertEquals(5, instance.getBaseGraph().getNodes());
-        assertEquals("foot_access,foot_average_speed,foot_priority,car_access,car_average_speed,foot_subnetwork,car_subnetwork,roundabout,road_class,road_class_link,road_environment,max_speed,road_access,foot_network", instance.getEncodingManager().getEncodedValues().stream().map(EncodedValue::getName).collect(Collectors.joining(",")));
+        assertEquals("foot_access,foot_average_speed,foot_priority,car_access,car_average_speed,foot_subnetwork,car_subnetwork,roundabout,road_class,road_class_link,road_environment,max_speed,road_access,ferry_speed,foot_network", instance.getEncodingManager().getEncodedValues().stream().map(EncodedValue::getName).collect(Collectors.joining(",")));
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/reader/osm/OSMReaderTest.java
+++ b/core/src/test/java/com/graphhopper/reader/osm/OSMReaderTest.java
@@ -224,7 +224,7 @@ public class OSMReaderTest {
         // ~111km (from 54.0,10.1 to 55.0,10.2) in duration=70 minutes => 95km/h => / 1.4 => 68km/h
         iter = carOutExplorer.setBaseNode(n40);
         iter.next();
-        assertEquals(68, iter.get(carSpeedEnc), 1e-1);
+        assertEquals(62, iter.get(carSpeedEnc), 1e-1);
     }
 
     @Test
@@ -698,7 +698,7 @@ public class OSMReaderTest {
                 return new VehicleTagParsers(
                         new CarAccessParser(lookup.getBooleanEncodedValue(VehicleAccess.key("truck")), lookup.getBooleanEncodedValue(Roundabout.KEY), config, TransportationMode.HGV)
                                 .init(config.getObject("date_range_parser", new DateRangeParser())),
-                        new CarAverageSpeedParser(lookup.getDecimalEncodedValue(VehicleSpeed.key("truck"))),
+                        new CarAverageSpeedParser(lookup.getDecimalEncodedValue(VehicleSpeed.key("truck")), lookup.getDecimalEncodedValue(FerrySpeed.KEY)),
                         null
                 );
             }

--- a/core/src/test/java/com/graphhopper/routing/util/FerrySpeedCalculatorTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/FerrySpeedCalculatorTest.java
@@ -19,45 +19,99 @@
 package com.graphhopper.routing.util;
 
 import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.ArrayEdgeIntAccess;
+import com.graphhopper.routing.ev.DecimalEncodedValue;
+import com.graphhopper.routing.ev.EdgeIntAccess;
+import com.graphhopper.routing.ev.FerrySpeed;
+import com.graphhopper.storage.IntsRef;
 import org.junit.jupiter.api.Test;
 
+import static com.graphhopper.routing.util.FerrySpeedCalculator.getSpeed;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class FerrySpeedCalculatorTest {
 
-    @Test
-    void testSpeed() {
-        double minSpeed = 1;
-        double maxSpeed = 55;
-        double unknownSpeed = 5;
-        FerrySpeedCalculator c = new FerrySpeedCalculator(minSpeed, maxSpeed, unknownSpeed);
+    final DecimalEncodedValue ferrySpeedEnc = FerrySpeed.create();
+    final EncodingManager em = new EncodingManager.Builder().add(ferrySpeedEnc).build();
+    final FerrySpeedCalculator calc = new FerrySpeedCalculator(ferrySpeedEnc);
 
+    @Test
+    public void testSpeed() {
+        ReaderWay way = new ReaderWay(1);
+        way.setTag("route", "ferry");
+        way.setTag("edge_distance", 30000.0);
+        way.setTag("speed_from_duration", 30 / 0.5);
+
+        EdgeIntAccess edgeIntAccess = new ArrayEdgeIntAccess(1);
+        int edgeId = 0;
+        calc.handleWayTags(edgeId, edgeIntAccess, way, IntsRef.EMPTY);
+        assertEquals(44, ferrySpeedEnc.getDecimal(false, edgeId, edgeIntAccess));
+
+        way = new ReaderWay(1);
+        way.setTag("route", "shuttle_train");
+        way.setTag("motorcar", "yes");
+        way.setTag("bicycle", "no");
+        // Provide the duration value in seconds:
+        way.setTag("way_distance", 50000.0);
+        way.setTag("speed_from_duration", 50 / (35.0 / 60));
+        edgeIntAccess = new ArrayEdgeIntAccess(1);
+        // calculate speed from tags: speed_from_duration * 1.4 (+ rounded using the speed factor)
+        calc.handleWayTags(edgeId, edgeIntAccess, way, IntsRef.EMPTY);
+        assertEquals(62, ferrySpeedEnc.getDecimal(false, edgeId, edgeIntAccess));
+
+        // test for very short and slow 0.5km/h still realistic ferry
+        way = new ReaderWay(1);
+        way.setTag("route", "ferry");
+        way.setTag("motorcar", "yes");
+        way.setTag("way_distance", 100.0);
+        way.setTag("speed_from_duration", 0.1 / (12.0 / 60));
+
+        // we can't store 0.5km/h, but we expect the lowest possible speed
+        edgeIntAccess = new ArrayEdgeIntAccess(1);
+        calc.handleWayTags(edgeId, edgeIntAccess, way, IntsRef.EMPTY);
+        assertEquals(2, ferrySpeedEnc.getDecimal(false, edgeId, edgeIntAccess));
+
+        edgeIntAccess = new ArrayEdgeIntAccess(1);
+        ferrySpeedEnc.setDecimal(false, edgeId, edgeIntAccess, 2.5);
+        assertEquals(2, ferrySpeedEnc.getDecimal(false, edgeId, edgeIntAccess), 1e-1);
+
+        // test for missing duration
+        way = new ReaderWay(1);
+        way.setTag("route", "ferry");
+        way.setTag("motorcar", "yes");
+        way.setTag("edge_distance", 100.0);
+        calc.handleWayTags(edgeId, edgeIntAccess, way, IntsRef.EMPTY);
+        // we use the unknown speed
+        assertEquals(2, ferrySpeedEnc.getDecimal(false, edgeId, edgeIntAccess));
+    }
+
+    @Test
+    void testRawSpeed() {
         // speed_from_duration is set (edge_distance is not even needed)
-        checkSpeed(c, 30.0, null, Math.round(30 / 1.4));
-        checkSpeed(c, 45.0, null, Math.round(45 / 1.4));
+        checkSpeed(30.0, null, Math.round(30 / 1.4));
+        checkSpeed(45.0, null, Math.round(45 / 1.4));
         // above max (when including waiting time) (capped to max)
-        checkSpeed(c, 100.0, null, maxSpeed);
+        checkSpeed(100.0, null, ferrySpeedEnc.getMaxStorableDecimal());
         // below smallest storable non-zero value
-        checkSpeed(c, 0.5, null, minSpeed);
+        checkSpeed(0.5, null, ferrySpeedEnc.getSmallestNonZeroValue());
 
         // no speed_from_duration, but edge_distance is present
         // minimum speed for short ferries
-        checkSpeed(c, null, 100.0, minSpeed);
+        checkSpeed(null, 100.0, ferrySpeedEnc.getSmallestNonZeroValue());
         // unknown speed for longer ones
-        checkSpeed(c, null, 1000.0, unknownSpeed);
+        checkSpeed(null, 1000.0, 6);
 
         // no speed, no distance -> error. this should never happen as we always set the edge distance.
-        assertThrows(IllegalStateException.class, () -> checkSpeed(c, null, null, unknownSpeed));
+        assertThrows(IllegalStateException.class, () -> checkSpeed(null, null, 6));
     }
 
-    private void checkSpeed(FerrySpeedCalculator calc, Double speedFromDuration, Double edgeDistance, double expected) {
+    private void checkSpeed(Double speedFromDuration, Double edgeDistance, double expected) {
         ReaderWay way = new ReaderWay(0L);
         if (speedFromDuration != null)
             way.setTag("speed_from_duration", speedFromDuration);
         if (edgeDistance != null)
             way.setTag("edge_distance", edgeDistance);
-        assertEquals(expected, calc.getSpeed(way));
+        assertEquals(expected, FerrySpeedCalculator.minmax(getSpeed(way), ferrySpeedEnc));
     }
-
 }

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/FootTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/FootTagParserTest.java
@@ -23,8 +23,10 @@ import com.graphhopper.reader.osm.conditional.DateRangeParser;
 import com.graphhopper.routing.ev.*;
 import com.graphhopper.routing.util.AccessFilter;
 import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.routing.util.FerrySpeedCalculator;
 import com.graphhopper.routing.util.PriorityCode;
 import com.graphhopper.storage.BaseGraph;
+import com.graphhopper.storage.IntsRef;
 import com.graphhopper.util.*;
 import org.junit.jupiter.api.Test;
 
@@ -300,20 +302,6 @@ public class FootTagParserTest {
         accessParser.handleWayTags(edgeId, edgeIntAccess, way);
         assertFalse(footAccessEnc.getBool(false, edgeId, edgeIntAccess));
         assertTrue(footAccessEnc.getBool(true, edgeId, edgeIntAccess));
-    }
-
-    @Test
-    public void testFerrySpeed() {
-        ReaderWay way = new ReaderWay(1);
-        way.setTag("route", "ferry");
-        way.setTag("duration:seconds", 1800L);
-        way.setTag("edge_distance", 30000.0);
-        way.setTag("speed_from_duration", 30 / 0.5);
-        // the speed is truncated to maxspeed (=15)
-        EdgeIntAccess edgeIntAccess = new ArrayEdgeIntAccess(encodingManager.getIntsForFlags());
-        int edgeId = 0;
-        speedParser.handleWayTags(edgeId, edgeIntAccess, way);
-        assertEquals(15, speedParser.getAverageSpeedEnc().getDecimal(false, edgeId, edgeIntAccess));
     }
 
     @Test


### PR DESCRIPTION
This adds a new default encoded value `ferry_speed` (5 bits) and solves the different speed problem for ferries (e.g. #2530).

It is also another step to move vehicle parsers to a custom model.