### PR TITLE
Implementation for issue2477 seasonal restrictions

### DIFF
--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -646,6 +646,8 @@ public class GraphHopper {
         // all these defaults and just use the config as the single source of truth
         if (!encodedValueStrings.contains(Roundabout.KEY))
             osmParsers.addWayTagParser(new OSMRoundaboutParser(encodingManager.getBooleanEncodedValue(Roundabout.KEY)));
+        if (!encodedValueStrings.contains(SeasonalRestricted.KEY))
+            osmParsers.addWayTagParser(new OSMSeasonalRestrictedParser(encodingManager.getBooleanEncodedValue(SeasonalRestricted.KEY)));
         if (!encodedValueStrings.contains(RoadClass.KEY))
             osmParsers.addWayTagParser(new OSMRoadClassParser(encodingManager.getEnumEncodedValue(RoadClass.KEY, RoadClass.class)));
         if (!encodedValueStrings.contains(RoadClassLink.KEY))

--- a/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
+++ b/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
@@ -446,6 +446,15 @@ public class OSMReader {
                 if (way.hasTag("destination:backward"))
                     list.add(new KVStorage.KeyValue(STREET_DESTINATION, fixWayName(way.getTag("destination:backward")), false, true));
             }
+
+            String condition = fixCondition(way.getTag("access:conditional"));
+            if (!condition.isEmpty())
+                list.add(new KVStorage.KeyValue(ACCESS_CONDITION, condition));
+            else {
+                condition = fixCondition(way.getTag("vehicle:conditional"));
+                if (!condition.isEmpty())
+                    list.add(new KVStorage.KeyValue(ACCESS_CONDITION, condition));
+           }
         }
         way.setTag("key_values", list);
 
@@ -499,6 +508,12 @@ public class OSMReader {
             return "";
         // the KVStorage does not accept too long strings -> Helper.cutStringForKV
         return KVStorage.cutString(WAY_NAME_PATTERN.matcher(str).replaceAll(", "));
+    }
+
+    static String fixCondition(String str) {
+        if (str == null)
+            return "";
+        return KVStorage.cutString(str);
     }
 
     /**

--- a/core/src/main/java/com/graphhopper/reader/osm/conditional/ConditionalOSMTagInspector.java
+++ b/core/src/main/java/com/graphhopper/reader/osm/conditional/ConditionalOSMTagInspector.java
@@ -41,6 +41,11 @@ public class ConditionalOSMTagInspector implements ConditionalTagInspector {
         this(Arrays.asList(new DateRangeParser(value)), tagsToCheck, restrictiveValues, permittedValues, false);
     }
 
+    public ConditionalOSMTagInspector(List<String> tagsToCheck,
+                                      Set<String> restrictiveValues, Set<String> permittedValues) {
+        this(null, tagsToCheck, restrictiveValues, permittedValues, false);
+    }
+
     public ConditionalOSMTagInspector(List<? extends ConditionalValueParser> valueParsers, List<String> tagsToCheck,
                                       Set<String> restrictiveValues, Set<String> permittedValues, boolean enabledLogs) {
         this.tagsToCheck = new ArrayList<>(tagsToCheck.size());
@@ -54,9 +59,11 @@ public class ConditionalOSMTagInspector implements ConditionalTagInspector {
         boolean logUnsupportedFeatures = false;
         this.permitParser = new ConditionalParser(permittedValues, logUnsupportedFeatures);
         this.restrictiveParser = new ConditionalParser(restrictiveValues, logUnsupportedFeatures);
-        for (ConditionalValueParser cvp : valueParsers) {
-            permitParser.addConditionalValueParser(cvp);
-            restrictiveParser.addConditionalValueParser(cvp);
+        if (valueParsers != null) {
+            for (ConditionalValueParser cvp : valueParsers) {
+                permitParser.addConditionalValueParser(cvp);
+                restrictiveParser.addConditionalValueParser(cvp);
+            }
         }
     }
 

--- a/core/src/main/java/com/graphhopper/reader/osm/conditional/ConditionalParser.java
+++ b/core/src/main/java/com/graphhopper/reader/osm/conditional/ConditionalParser.java
@@ -22,7 +22,6 @@ import org.slf4j.LoggerFactory;
 
 import java.text.ParseException;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.List;
 import java.util.Set;
 
@@ -107,6 +106,9 @@ public class ConditionalParser {
     public boolean checkCondition(String conditionalTag) throws ParseException {
         if (conditionalTag == null || conditionalTag.isEmpty() || !conditionalTag.contains("@"))
             return false;
+
+        if (valueParsers.size() == 0)
+            return true;
 
         if (conditionalTag.contains(";")) {
             if (enabledLogs)

--- a/core/src/main/java/com/graphhopper/routing/ev/DefaultEncodedValueFactory.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/DefaultEncodedValueFactory.java
@@ -25,6 +25,8 @@ public class DefaultEncodedValueFactory implements EncodedValueFactory {
     public EncodedValue create(String name, PMap properties) {
         if (Roundabout.KEY.equals(name)) {
             return Roundabout.create();
+        } else if (SeasonalRestricted.KEY.equals(name)) {
+            return SeasonalRestricted.create();
         } else if (GetOffBike.KEY.equals(name)) {
             return GetOffBike.create();
         } else if (RoadClass.KEY.equals(name)) {

--- a/core/src/main/java/com/graphhopper/routing/ev/SeasonalRestricted.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/SeasonalRestricted.java
@@ -1,0 +1,26 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.routing.ev;
+
+public class SeasonalRestricted {
+    public static final String KEY = "seasonal_restricted";
+
+    public static BooleanEncodedValue create() {
+        return new SimpleBooleanEncodedValue(KEY);
+    }
+}

--- a/core/src/main/java/com/graphhopper/routing/util/EncodingManager.java
+++ b/core/src/main/java/com/graphhopper/routing/util/EncodingManager.java
@@ -169,7 +169,8 @@ public class EncodingManager implements EncodedValueLookup {
                     RoadEnvironment.KEY,
                     MaxSpeed.KEY,
                     RoadAccess.KEY,
-                    FerrySpeed.KEY
+                    FerrySpeed.KEY,
+                    SeasonalRestricted.KEY
             ));
             if (em.getVehicles().stream().anyMatch(vehicle -> vehicle.contains("bike") || vehicle.contains("mtb") || vehicle.contains("racingbike"))) {
                 keys.add(BikeNetwork.KEY);

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMSeasonalRestrictedParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMSeasonalRestrictedParser.java
@@ -1,0 +1,46 @@
+package com.graphhopper.routing.util.parsers;
+
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.reader.osm.conditional.ConditionalOSMTagInspector;
+import com.graphhopper.reader.osm.conditional.ConditionalTagInspector;
+import com.graphhopper.routing.ev.BooleanEncodedValue;
+import com.graphhopper.routing.ev.EdgeIntAccess;
+import com.graphhopper.storage.IntsRef;
+
+import java.util.*;
+
+/**
+ * This parser scans different OSM conditional tags to identify if a way has only conditional access
+ */
+public class OSMSeasonalRestrictedParser implements TagParser {
+
+    private final BooleanEncodedValue seasonalRestrictedEnc;
+    private final ConditionalTagInspector acceptor = new ConditionalOSMTagInspector(getConditionalTags(), getSampleRestrictedValues(), new HashSet<>());
+
+     /**
+     * @param seasonalRestrictedEnc used to find out if way access is conditional
+     */
+    public OSMSeasonalRestrictedParser(BooleanEncodedValue seasonalRestrictedEnc) {
+        this.seasonalRestrictedEnc = seasonalRestrictedEnc;
+    }
+
+    private static Set<String> getSampleRestrictedValues() {
+        Set<String> restrictedValues = new HashSet<>();
+        restrictedValues.add("no");
+        restrictedValues.add("restricted");
+        return restrictedValues;
+    }
+
+    private static List<String> getConditionalTags() {
+        List<String> conditionalTags = new ArrayList<>();
+        conditionalTags.add("vehicle");
+        conditionalTags.add("access");
+        return conditionalTags;
+    }
+
+    @Override
+    public void handleWayTags(int edgeId, EdgeIntAccess edgeIntAccess, ReaderWay way, IntsRef relationFlags) {
+        boolean isSeasonalRestricted = acceptor.isPermittedWayConditionallyRestricted(way);
+        seasonalRestrictedEnc.setBool(false, edgeId, edgeIntAccess, isSeasonalRestricted);
+    }
+}

--- a/core/src/main/java/com/graphhopper/search/KVStorage.java
+++ b/core/src/main/java/com/graphhopper/search/KVStorage.java
@@ -478,6 +478,7 @@ public class KVStorage {
         public static final String STREET_REF = "street_ref";
         public static final String STREET_DESTINATION = "street_destination";
         public static final String STREET_DESTINATION_REF = "street_destination_ref";
+        public static final String ACCESS_CONDITION = "access_condition";
 
         public String key;
         public Object value;

--- a/core/src/test/java/com/graphhopper/reader/osm/GraphHopperOSMTest.java
+++ b/core/src/test/java/com/graphhopper/reader/osm/GraphHopperOSMTest.java
@@ -518,7 +518,7 @@ public class GraphHopperOSMTest {
                 setGraphHopperLocation(ghLoc);
         instance.load();
         assertEquals(5, instance.getBaseGraph().getNodes());
-        assertEquals("foot_access,foot_average_speed,foot_priority,car_access,car_average_speed,foot_subnetwork,car_subnetwork,roundabout,road_class,road_class_link,road_environment,max_speed,road_access,ferry_speed,foot_network",
+        assertEquals("foot_access,foot_average_speed,foot_priority,car_access,car_average_speed,foot_subnetwork,car_subnetwork,roundabout,road_class,road_class_link,road_environment,max_speed,road_access,ferry_speed,seasonal_restricted,foot_network",
                 instance.getEncodingManager().getEncodedValues().stream().map(EncodedValue::getName).collect(Collectors.joining(",")));
     }
 
@@ -558,7 +558,7 @@ public class GraphHopperOSMTest {
                 setOSMFile(testOsm3);
         instance.load();
         assertEquals(5, instance.getBaseGraph().getNodes());
-        assertEquals("foot_access,foot_average_speed,foot_priority,car_access,car_average_speed,foot_subnetwork,car_subnetwork,roundabout,road_class,road_class_link,road_environment,max_speed,road_access,ferry_speed,foot_network", instance.getEncodingManager().getEncodedValues().stream().map(EncodedValue::getName).collect(Collectors.joining(",")));
+        assertEquals("foot_access,foot_average_speed,foot_priority,car_access,car_average_speed,foot_subnetwork,car_subnetwork,roundabout,road_class,road_class_link,road_environment,max_speed,road_access,ferry_speed,seasonal_restricted,foot_network", instance.getEncodingManager().getEncodedValues().stream().map(EncodedValue::getName).collect(Collectors.joining(",")));
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMSeasonalRestrictedParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMSeasonalRestrictedParserTest.java
@@ -1,0 +1,45 @@
+package com.graphhopper.routing.util.parsers;
+
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.*;
+import com.graphhopper.storage.IntsRef;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class OSMSeasonalRestrictedParserTest {
+    private BooleanEncodedValue seasonalRestrictedEnc;
+    private OSMSeasonalRestrictedParser parser;
+
+    @BeforeEach
+    public void setUp() {
+        seasonalRestrictedEnc = SeasonalRestricted.create();
+        seasonalRestrictedEnc.init(new EncodedValue.InitializerConfig());
+        parser = new OSMSeasonalRestrictedParser(seasonalRestrictedEnc);
+    }
+
+    @Test
+    public void testSeasonalRestrictedTags() {
+        IntsRef relFlags = new IntsRef(2);
+
+        ReaderWay readerWay = new ReaderWay(1);
+        EdgeIntAccess edgeIntAccess = new ArrayEdgeIntAccess(1);
+        int edgeId = 0;
+        readerWay.setTag("highway", "primary");
+        parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
+        assertFalse(seasonalRestrictedEnc.getBool(false, edgeId, edgeIntAccess));
+
+        readerWay.setTag("access:conditional", "no @ Winter");
+        parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
+        assertTrue(seasonalRestrictedEnc.getBool(false, edgeId, edgeIntAccess));
+
+        readerWay.setTag("access:conditional", "no @ Nov-Apr");
+        parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
+        assertTrue(seasonalRestrictedEnc.getBool(false, edgeId, edgeIntAccess));
+
+        readerWay.setTag("access:conditional", "no @ (Nov-Apr; May 19:30-06:00; Jun-Aug 20:30-05:30; Sep-Oct 19:30-06:00)");
+        parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
+        assertTrue(seasonalRestrictedEnc.getBool(false, edgeId, edgeIntAccess));
+    }
+}


### PR DESCRIPTION
This PR implements the `seasonal_restricted` encoded value and a key+value pair containing the access condition as suggested in #2477.
Based on the change it becomes possible to display a warning hint in the web front-end in case that a segment contains conditional access.