### PR TITLE
Add links to graphhopper repository map

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # GraphHopper Routing Engine
 
 ![Build Status](https://github.com/graphhopper/graphhopper/actions/workflows/build.yml/badge.svg?branch=master)
+[![Project Map](https://sourcespy.com/shield.svg)](https://sourcespy.com/github/graphhoppergraphhopper/)
 
 GraphHopper is a fast and memory-efficient routing engine released under Apache License 2.0. It can be used as a Java library or standalone web server to calculate the distance, time, turn-by-turn instructions and many road attributes for a route between two or more points. Beyond this "A-to-B" routing it supports ["snap to road"](README.md#Map-Matching), [Isochrone calculation](README.md#Analysis), [mobile navigation](README.md#mobile-apps) and [more](README.md#Features). GraphHopper uses OpenStreetMap and GTFS data by default and it can import [other data sources too](README.md#OpenStreetMap-Support).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,6 +67,7 @@ Various topics are explained in more detail separately:
 
  * [Add GraphHopper Maps to your Browser](./web/open-search.md): Instructions how to setup GraphHopper as the standard search engine in your browser.
  * [Embed GraphHopper on your website](https://github.com/karussell/graphhopper-embed-form): A small code snippet on how to integrate GraphHopper Maps in your web site like a contact form
+ * [GraphHopper Repository Map](https://sourcespy.com/github/graphhoppergraphhopper/): A collection of diagrams covering implementation details such as modules, dependencies, class hierarchies and others. 
 
 #### Android & iOS
 


### PR DESCRIPTION
Adding a link to the high-level diagrams including module, library dependency and others (https://sourcespy.com/github/graphhoppergraphhopper/). Built directly from source and updated on schedule. Intended to simplify developer's introduction to the project.

In the spirit of transparency - I am the author of the diagrams. Hope contributors find it useful.