### PR TITLE
include osm data date as road_data_timestamp in response

### DIFF
--- a/web-api/src/main/java/com/graphhopper/jackson/ResponsePathSerializer.java
+++ b/web-api/src/main/java/com/graphhopper/jackson/ResponsePathSerializer.java
@@ -86,12 +86,16 @@ public class ResponsePathSerializer {
         sb.append((char) (num));
     }
 
-    public static ObjectNode jsonObject(GHResponse ghRsp, boolean enableInstructions, boolean calcPoints, boolean enableElevation, boolean pointsEncoded, double took) {
+    public static ObjectNode jsonObject(GHResponse ghRsp, String osmDate, boolean enableInstructions,
+                                        boolean calcPoints, boolean enableElevation, boolean pointsEncoded, double took) {
         ObjectNode json = JsonNodeFactory.instance.objectNode();
         json.putPOJO("hints", ghRsp.getHints().toMap());
         final ObjectNode info = json.putObject("info");
         info.putPOJO("copyrights", COPYRIGHTS);
         info.put("took", Math.round(took));
+        if (!osmDate.isEmpty())
+            info.put("road_data_timestamp", osmDate);
+
         ArrayNode jsonPathList = json.putArray("paths");
         for (ResponsePath p : ghRsp.getAll()) {
             ObjectNode jsonPath = jsonPathList.addObject();

--- a/web-bundle/src/main/java/com/graphhopper/resources/IsochroneResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/IsochroneResource.java
@@ -51,12 +51,14 @@ public class IsochroneResource {
     private final GraphHopper graphHopper;
     private final Triangulator triangulator;
     private final ProfileResolver profileResolver;
+    private final String osmDate;
 
     @Inject
     public IsochroneResource(GraphHopper graphHopper, Triangulator triangulator, ProfileResolver profileResolver) {
         this.graphHopper = graphHopper;
         this.triangulator = triangulator;
         this.profileResolver = profileResolver;
+        this.osmDate = graphHopper.getProperties().get("datareader.data.date");
     }
 
     public enum ResponseType {json, geojson}
@@ -160,6 +162,7 @@ public class IsochroneResource {
             final ObjectNode info = json.putObject("info");
             info.putPOJO("copyrights", ResponsePathSerializer.COPYRIGHTS);
             info.put("took", Math.round((float) sw.getMillis()));
+            if (!osmDate.isEmpty()) info.put("road_data_timestamp", osmDate);
             finalJson = json;
         }
 

--- a/web-bundle/src/main/java/com/graphhopper/resources/MapMatchingResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/MapMatchingResource.java
@@ -67,6 +67,7 @@ public class MapMatchingResource {
     private final TranslationMap trMap;
     private final MapMatchingRouterFactory mapMatchingRouterFactory;
     private final ObjectMapper objectMapper = Jackson.newObjectMapper();
+    private final String osmDate;
 
     @Inject
     public MapMatchingResource(GraphHopper graphHopper, ProfileResolver profileResolver, TranslationMap trMap, MapMatchingRouterFactory mapMatchingRouterFactory) {
@@ -74,6 +75,7 @@ public class MapMatchingResource {
         this.profileResolver = profileResolver;
         this.trMap = trMap;
         this.mapMatchingRouterFactory = mapMatchingRouterFactory;
+        this.osmDate = graphHopper.getProperties().get("datareader.data.date");
     }
 
     @POST
@@ -162,7 +164,8 @@ public class MapMatchingResource {
                         header("X-GH-Took", "" + Math.round(sw.getMillisDouble())).
                         build();
             } else {
-                ObjectNode map = ResponsePathSerializer.jsonObject(rsp, instructions, calcPoints, enableElevation, pointsEncoded, sw.getMillisDouble());
+                ObjectNode map = ResponsePathSerializer.jsonObject(rsp, osmDate, instructions,
+                        calcPoints, enableElevation, pointsEncoded, sw.getMillisDouble());
 
                 Map<String, Object> matchStatistics = new HashMap<>();
                 matchStatistics.put("distance", matchResult.getMatchLength());

--- a/web-bundle/src/main/java/com/graphhopper/resources/PtRouteResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/PtRouteResource.java
@@ -87,7 +87,7 @@ public class PtRouteResource {
         Optional.ofNullable(betaEgressTime).ifPresent(request::setBetaEgressTime);
 
         GHResponse route = ptRouter.route(request);
-        return ResponsePathSerializer.jsonObject(route, true, true, false, false, stopWatch.stop().getMillis());
+        return ResponsePathSerializer.jsonObject(route, "", true, true, false, false, stopWatch.stop().getMillis());
     }
 
 }

--- a/web-bundle/src/main/java/com/graphhopper/resources/RouteResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/RouteResource.java
@@ -61,6 +61,7 @@ public class RouteResource {
     private final ProfileResolver profileResolver;
     private final GHRequestTransformer ghRequestTransformer;
     private final Boolean hasElevation;
+    private final String osmDate;
 
     @Inject
     public RouteResource(GraphHopper graphHopper, ProfileResolver profileResolver, GHRequestTransformer ghRequestTransformer, @Named("hasElevation") Boolean hasElevation) {
@@ -68,6 +69,7 @@ public class RouteResource {
         this.profileResolver = profileResolver;
         this.ghRequestTransformer = ghRequestTransformer;
         this.hasElevation = hasElevation;
+        this.osmDate = graphHopper.getProperties().get("datareader.data.date");
     }
 
     @GET
@@ -153,7 +155,7 @@ public class RouteResource {
                             header("X-GH-Took", "" + Math.round(took)).
                             build()
                     :
-                    Response.ok(ResponsePathSerializer.jsonObject(ghResponse, instructions, calcPoints, enableElevation, pointsEncoded, took)).
+                    Response.ok(ResponsePathSerializer.jsonObject(ghResponse, osmDate, instructions, calcPoints, enableElevation, pointsEncoded, took)).
                             header("X-GH-Took", "" + Math.round(took)).
                             type(MediaType.APPLICATION_JSON).
                             build();
@@ -200,7 +202,7 @@ public class RouteResource {
                     + ", time0: " + Math.round(ghResponse.getBest().getTime() / 60000f) + "min"
                     + ", points0: " + ghResponse.getBest().getPoints().size()
                     + ", debugInfo: " + ghResponse.getDebugInfo());
-            return Response.ok(ResponsePathSerializer.jsonObject(ghResponse, instructions, calcPoints, enableElevation, pointsEncoded, took)).
+            return Response.ok(ResponsePathSerializer.jsonObject(ghResponse, osmDate, instructions, calcPoints, enableElevation, pointsEncoded, took)).
                     header("X-GH-Took", "" + Math.round(took)).
                     type(MediaType.APPLICATION_JSON).
                     build();


### PR DESCRIPTION
Fixes #2806 and replaces #2818.

Here I return only one property (as the import date is not a meaningful information). 

(without modifying GHResponse; no call to the `synchronized` StorableProperties.get method in every routing request)