### PR TITLE
Restrict access to "destination" for living streets in Hungary (by law)

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/countryrules/europe/HungaryCountryRule.java
+++ b/core/src/main/java/com/graphhopper/routing/util/countryrules/europe/HungaryCountryRule.java
@@ -18,8 +18,10 @@
 package com.graphhopper.routing.util.countryrules.europe;
 
 import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.RoadAccess;
 import com.graphhopper.routing.ev.RoadClass;
 import com.graphhopper.routing.ev.Toll;
+import com.graphhopper.routing.util.TransportationMode;
 import com.graphhopper.routing.util.countryrules.CountryRule;
 
 /**
@@ -28,6 +30,26 @@ import com.graphhopper.routing.util.countryrules.CountryRule;
  * @author Thomas Butz
  */
 public class HungaryCountryRule implements CountryRule {
+
+    @Override
+    public RoadAccess getAccess(ReaderWay readerWay, TransportationMode transportationMode, RoadAccess currentRoadAccess) {
+        // Pedestrian traffic and bicycles are not restricted
+		if (transportationMode == TransportationMode.FOOT || transportationMode == TransportationMode.BIKE) {
+            return currentRoadAccess;
+        }
+
+        // Override only bogus "yes" and missing/other
+        if (currentRoadAccess != RoadAccess.YES && currentRoadAccess != RoadAccess.OTHER) {
+            return currentRoadAccess;
+        }
+
+        RoadClass roadClass = RoadClass.find(readerWay.getTag("highway", ""));
+        if (roadClass == RoadClass.LIVING_STREET) {
+            return RoadAccess.DESTINATION;
+        }
+
+        return currentRoadAccess;
+    }
 
     @Override
     public Toll getToll(ReaderWay readerWay, Toll currentToll) {

--- a/core/src/test/java/com/graphhopper/routing/util/countryrules/CountryRuleTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/countryrules/CountryRuleTest.java
@@ -19,9 +19,11 @@ package com.graphhopper.routing.util.countryrules;
 
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.RoadAccess;
+import com.graphhopper.routing.ev.Toll;
 import com.graphhopper.routing.util.TransportationMode;
 import com.graphhopper.routing.util.countryrules.europe.AustriaCountryRule;
 import com.graphhopper.routing.util.countryrules.europe.GermanyCountryRule;
+import com.graphhopper.routing.util.countryrules.europe.HungaryCountryRule;
 
 import org.junit.jupiter.api.Test;
 
@@ -42,6 +44,25 @@ class CountryRuleTest {
         assertEquals(RoadAccess.FORESTRY, rule.getAccess(createReaderWay("track"), TransportationMode.CAR, RoadAccess.YES));
         assertEquals(RoadAccess.YES, rule.getAccess(createReaderWay("primary"), TransportationMode.CAR, RoadAccess.YES));
         assertEquals(RoadAccess.DESTINATION, rule.getAccess(createReaderWay("living_street"), TransportationMode.CAR, RoadAccess.YES));
+    }
+
+    @Test
+    void hungary() {
+        HungaryCountryRule rule = new HungaryCountryRule();
+        assertEquals(RoadAccess.YES, rule.getAccess(createReaderWay("primary"), TransportationMode.CAR, RoadAccess.YES));
+        assertEquals(RoadAccess.DESTINATION, rule.getAccess(createReaderWay("living_street"), TransportationMode.CAR, RoadAccess.YES));
+        assertEquals(RoadAccess.YES, rule.getAccess(createReaderWay("living_street"), TransportationMode.BIKE, RoadAccess.YES));
+        assertEquals(RoadAccess.PRIVATE, rule.getAccess(createReaderWay("living_street"), TransportationMode.CAR, RoadAccess.PRIVATE));
+        assertEquals(RoadAccess.PRIVATE, rule.getAccess(createReaderWay("living_street"), TransportationMode.BIKE, RoadAccess.PRIVATE));
+        assertEquals(Toll.ALL, rule.getToll(createReaderWay("motorway"), Toll.MISSING));
+        assertEquals(Toll.HGV, rule.getToll(createReaderWay("trunk"), Toll.MISSING));
+        assertEquals(Toll.HGV, rule.getToll(createReaderWay("primary"), Toll.MISSING));
+        assertEquals(Toll.MISSING, rule.getToll(createReaderWay("secondary"), Toll.MISSING));
+        assertEquals(Toll.MISSING, rule.getToll(createReaderWay("residential"), Toll.MISSING));
+        assertEquals(Toll.MISSING, rule.getToll(createReaderWay("service"), Toll.MISSING));
+        assertEquals(Toll.ALL, rule.getToll(createReaderWay("service"), Toll.ALL));
+        assertEquals(Toll.HGV, rule.getToll(createReaderWay("service"), Toll.HGV));
+        assertEquals(Toll.NO, rule.getToll(createReaderWay("service"), Toll.NO));
     }
 
     private ReaderWay createReaderWay(String highway) {


### PR DESCRIPTION
Hungarian Traffic Code says living streets can be accessed only on foot or on bicycle, and all other traffic (motorised or not) may be only to destination.