### PR TITLE
Fix flaky tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,6 +169,12 @@
             <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.skyscreamer</groupId>
+            <artifactId>jsonassert</artifactId>
+            <version>1.5.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <pluginManagement>

--- a/web-api/src/test/java/com/graphhopper/jackson/InstructionListRepresentationTest.java
+++ b/web-api/src/test/java/com/graphhopper/jackson/InstructionListRepresentationTest.java
@@ -20,7 +20,9 @@ package com.graphhopper.jackson;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.graphhopper.util.*;
+import org.json.JSONException;
 import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -46,7 +48,12 @@ public class InstructionListRepresentationTest {
                 .setExitNumber(2)
                 .setExited();
         il.add(instr);
-        assertEquals(objectMapper.readTree(getClass().getClassLoader().getResourceAsStream("fixtures/roundabout1.json")).toString(), objectMapper.valueToTree(il).toString());
+        try{
+            JSONAssert.assertEquals(objectMapper.readTree(getClass().getClassLoader().getResourceAsStream("fixtures/roundabout1.json")).toString(), objectMapper.valueToTree(il).toString(),false);
+        }
+        catch (JSONException e) {
+            throw new RuntimeException(e);
+        }
     }
 
 
@@ -65,7 +72,12 @@ public class InstructionListRepresentationTest {
                 .setExitNumber(2)
                 .setExited();
         il.add(instr);
-        assertEquals(objectMapper.readTree(getClass().getClassLoader().getResourceAsStream("fixtures/roundabout2.json")).toString(), objectMapper.valueToTree(il).toString());
+        try{
+            JSONAssert.assertEquals(objectMapper.readTree(getClass().getClassLoader().getResourceAsStream("fixtures/roundabout2.json")).toString(), objectMapper.valueToTree(il).toString(),false);
+        }
+        catch (JSONException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private static Translation usTR = new Translation() {


### PR DESCRIPTION
This PR is to fix flaky tests `com.graphhopper.jackson.InstructionListRepresentationTest#testRoundaboutJsonIntegrity` and `com.graphhopper.jackson.InstructionListRepresentationTest#testRoundaboutJsonNaN` in module `web-api`. 

## Test failure
- Run the following commands to reproduce test failures, we will take one test as example to illustrate the details:
```
mvn -pl web-api edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=com.graphhopper.jackson.InstructionListRepresentationTest#testRoundaboutJsonIntegrity

```
- Then we get the following test failures:
```
[ERROR]   InstructionListRepresentationTest.testRoundaboutJsonIntegrity:49 expected: <[{"exit_number":2,"distance":0.0,"sign":6,"exited":true,"turn_angle":-1.0,"interval":[0,3],"text":"At roundabout, take exit 2 onto streetname","time":0,"street_name":"streetname"}]> but was: <[{"exit_number":2,"time":0,"interval":[0,3],"distance":0.0,"street_name":"streetname","exited":true,"turn_angle":-1.0,"text":"At roundabout, take exit 2 onto streetname","sign":6}]>
```

## Root cause and fix
In line 49 and 68, two JSON objects are converted to strings, and then they are asserted to be the same. However, the orders of elements from the JSON objects may be different, when they are converted to a string by `toString()`. So the fix is to use `JSONAssert` to check if the two JSON objects have the same nodes but ignore the difference of order.