### PR TITLE
Avoid deprecated constructor

### DIFF
--- a/reader-gtfs/src/main/java/com/conveyal/gtfs/model/Entity.java
+++ b/reader-gtfs/src/main/java/com/conveyal/gtfs/model/Entity.java
@@ -136,9 +136,9 @@ public abstract class Entity implements Serializable, Cloneable {
             } else try {
                 val = Integer.parseInt(str);
                 if (mapping != null) {
-                    Integer mappedVal = mapping.get(new Integer(val));
+                    Integer mappedVal = mapping.get(val);
                     if (mappedVal != null)
-                        val = mappedVal.intValue();
+                        val = mappedVal;
                 }
                 checkRangeInclusive(min, max, val);
             } catch (NumberFormatException nfe) {


### PR DESCRIPTION
The `new Integer(int)` constructor is deprecated for removal since Java 9.

https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/Integer.html#%3Cinit%3E(int)