### PR TITLE
Fix flaky tests without adding dependencies

### DIFF
--- a/web-api/src/test/java/com/graphhopper/util/InstructionListRepresentationTest.java
+++ b/web-api/src/test/java/com/graphhopper/util/InstructionListRepresentationTest.java
@@ -30,7 +30,7 @@ public class InstructionListRepresentationTest {
                 .setExitNumber(2)
                 .setExited();
         il.add(instr);
-        assertEquals(objectMapper.readTree(fixture("fixtures/roundabout1.json")).toString(), objectMapper.valueToTree(il).toString());
+        assertEquals(objectMapper.readTree(fixture("fixtures/roundabout1.json")), objectMapper.readTree(objectMapper.writeValueAsString(il)));
     }
 
 
@@ -50,7 +50,7 @@ public class InstructionListRepresentationTest {
                 .setExitNumber(2)
                 .setExited();
         il.add(instr);
-        assertEquals(objectMapper.readTree(fixture("fixtures/roundabout2.json")).toString(), objectMapper.valueToTree(il).toString());
+        assertEquals(objectMapper.readTree(fixture("fixtures/roundabout2.json")),objectMapper.readTree(objectMapper.writeValueAsString(il)));
     }
 
     private static Translation usTR = new Translation() {


### PR DESCRIPTION
This PR is to fix flaky tests `com.graphhopper.jackson.InstructionListRepresentationTest#testRoundaboutJsonIntegrity` and `com.graphhopper.jackson.InstructionListRepresentationTest#testRoundaboutJsonNaN` in module `web-api`. 

## Test failure
- Run the following commands to reproduce test failures, we will take one test as example to illustrate the details:
```
mvn -pl web-api edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=com.graphhopper.jackson.InstructionListRepresentationTest#testRoundaboutJsonIntegrity

```
- Then we get the following test failures:
```
[ERROR]   InstructionListRepresentationTest.testRoundaboutJsonIntegrity:49 expected: <[{"exit_number":2,"distance":0.0,"sign":6,"exited":true,"turn_angle":-1.0,"interval":[0,3],"text":"At roundabout, take exit 2 onto streetname","time":0,"street_name":"streetname"}]> but was: <[{"exit_number":2,"time":0,"interval":[0,3],"distance":0.0,"street_name":"streetname","exited":true,"turn_angle":-1.0,"text":"At roundabout, take exit 2 onto streetname","sign":6}]>
```

## Root cause and fix
Two JSON objects are converted to strings, and then they are asserted to be the same. However, the orders of elements from the JSON objects may be non-deterministic when they are converted to a string by using `toString()`. So the fix is not to convert them to strings but to check if the two JSON objects have the same nodes while ignore the difference of order.