### PR TITLE
barrier parser

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/ev/Barrier.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/Barrier.java
@@ -1,0 +1,32 @@
+package com.graphhopper.routing.ev;
+
+import com.graphhopper.util.Helper;
+
+public enum Barrier {
+    MISSING,
+    BOLLARD,
+    KERB,
+    STILE,
+    LIFT_GATE,
+    GATE,
+    BLOCK,
+    YES;
+    // wall and fence is mostly ways https://taginfo.openstreetmap.org/keys/barrier#values
+
+    public static final String KEY = "barrier";
+
+    @Override
+    public String toString() {
+        return Helper.toLowerCase(super.toString());
+    }
+
+    public static Barrier find(String name) {
+        if (name == null)
+            return MISSING;
+        try {
+            return Barrier.valueOf(Helper.toUpperCase(name));
+        } catch (IllegalArgumentException ex) {
+            return MISSING;
+        }
+    }
+}

--- a/core/src/main/java/com/graphhopper/routing/ev/DefaultEncodedValueFactory.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/DefaultEncodedValueFactory.java
@@ -95,6 +95,8 @@ public class DefaultEncodedValueFactory implements EncodedValueFactory {
             return Curvature.create();
         } else if (Crossing.KEY.equals(name)) {
             return new EnumEncodedValue<>(Crossing.KEY, Crossing.class);
+        } else if (Barrier.KEY.equals(name)) {
+            return new EnumEncodedValue<>(Barrier.KEY, Barrier.class);
         } else if (FerrySpeed.KEY.equals(name)) {
             return FerrySpeed.create();
         } else {

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/DefaultTagParserFactory.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/DefaultTagParserFactory.java
@@ -84,6 +84,8 @@ public class DefaultTagParserFactory implements TagParserFactory {
             return new StateParser(lookup.getEnumEncodedValue(State.KEY, State.class));
         else if (name.equals(Crossing.KEY))
             return new OSMCrossingParser(lookup.getEnumEncodedValue(Crossing.KEY, Crossing.class));
+        else if (name.equals(Barrier.KEY))
+            return new OSMBarrierParser(lookup.getEnumEncodedValue(Barrier.KEY, Barrier.class));
         else if (name.equals(FerrySpeed.KEY))
             return new FerrySpeedCalculator(lookup.getDecimalEncodedValue(FerrySpeed.KEY));
         return null;

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMBarrierParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMBarrierParser.java
@@ -1,0 +1,43 @@
+package com.graphhopper.routing.util.parsers;
+
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.Barrier;
+import com.graphhopper.routing.ev.EdgeIntAccess;
+import com.graphhopper.routing.ev.EnumEncodedValue;
+import com.graphhopper.storage.IntsRef;
+import com.graphhopper.util.Helper;
+
+import java.util.List;
+import java.util.Map;
+
+public class OSMBarrierParser implements TagParser {
+    protected final EnumEncodedValue<Barrier> barrierEnc;
+
+    public OSMBarrierParser(EnumEncodedValue<Barrier> barrierEnc) {
+        this.barrierEnc = barrierEnc;
+    }
+
+    @Override
+    public void handleWayTags(int edgeId, EdgeIntAccess edgeIntAccess, ReaderWay way, IntsRef relationFlags) {
+        if (way.hasTag("gh:barrier_edge")) return;
+        List<Map<String, Object>> nodeTags = way.getTag("node_tags", null);
+        if (nodeTags == null)
+            return;
+
+        Barrier barrierVal = Barrier.MISSING;
+        for (Map<String, Object> tags : nodeTags) {
+            String barrierStr = (String) tags.get("barrier");
+            if (!Helper.isEmpty(barrierStr)) {
+                Barrier curr = Barrier.find(barrierStr);
+                if (curr == Barrier.MISSING) {
+                    if (barrierStr.equals("kissing_gate")) barrierVal = Barrier.GATE;
+                    else if (barrierStr.equals("swing_gate")) barrierVal = Barrier.LIFT_GATE;
+                    else if (barrierStr.equals("turnstile")) barrierVal = Barrier.STILE;
+                } else if (curr.ordinal() > barrierVal.ordinal())
+                    barrierVal = curr;
+            }
+        }
+
+        barrierEnc.setEnum(false, edgeId, edgeIntAccess, barrierVal);
+    }
+}

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMBarrierParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMBarrierParserTest.java
@@ -1,0 +1,45 @@
+package com.graphhopper.routing.util.parsers;
+
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.*;
+import com.graphhopper.util.PMap;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class OSMBarrierParserTest {
+
+    private OSMBarrierParser parser;
+    private EnumEncodedValue<Barrier> barrierEV;
+
+    @BeforeEach
+    public void setup() {
+        barrierEV = new EnumEncodedValue<>(Barrier.KEY, Barrier.class);
+        barrierEV.init(new EncodedValue.InitializerConfig());
+        parser = new OSMBarrierParser(barrierEV);
+    }
+
+    @Test
+    public void testGate() {
+        EdgeIntAccess edgeIntAccess = new ArrayEdgeIntAccess(1);
+        int edgeId = 0;
+        parser.handleWayTags(edgeId, edgeIntAccess,
+                createReader(new PMap().putObject("barrier", "gate").toMap()), null);
+        assertEquals(Barrier.GATE, barrierEV.getEnum(false, edgeId, edgeIntAccess));
+
+        edgeIntAccess = new ArrayEdgeIntAccess(1);
+        parser.handleWayTags(edgeId, edgeIntAccess,
+                createReader(new PMap().putObject("barrier", "kissing_gate").toMap()), null);
+        assertEquals(Barrier.GATE, barrierEV.getEnum(false, edgeId, edgeIntAccess));
+    }
+
+    ReaderWay createReader(Map<String, Object> map) {
+        ReaderWay way = new ReaderWay(1);
+        way.setTag("node_tags", Collections.singletonList(map));
+        return way;
+    }
+}


### PR DESCRIPTION
Add barrier to encoded_values:

```
  graph.encoded_values: barrier
```

Then you can use it in a custom_model and as path detail

See [discussion](https://discuss.graphhopper.com/t/routing-to-avoid-stiles/8275).