### PR TITLE
Add `points_encoded' query param support to PT Routing

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -29,6 +29,7 @@ Here is an overview:
  * easbar, one of the core developers
  * edy, improvements regarding docker #849
  * elibar, fix for alternative route calculation
+ * efesler, fixes like #2531
  * fbonzon, several UI improvements like #615
  * florent-morel, improvements regarding fords, #320
  * fredao, translations 

--- a/reader-gtfs/config-example-pt.yml
+++ b/reader-gtfs/config-example-pt.yml
@@ -21,8 +21,4 @@ server:
     - type: http
       port: 8990
       bind_host: localhost
-logging:
-  level: INFO
-  loggers:
-    "com.graphhopper": 
-      level: DEBUG
+

--- a/reader-gtfs/config-example-pt.yml
+++ b/reader-gtfs/config-example-pt.yml
@@ -8,6 +8,9 @@ graphhopper:
     - name: foot
       vehicle: foot
       weighting: custom
+      custom_model_files: []
+
+  import.osm.ignored_highways: motorway,trunk
 
 server:
   application_connectors:
@@ -18,3 +21,8 @@ server:
     - type: http
       port: 8990
       bind_host: localhost
+logging:
+  level: INFO
+  loggers:
+    "com.graphhopper": 
+      level: DEBUG

--- a/web-bundle/pom.xml
+++ b/web-bundle/pom.xml
@@ -66,6 +66,17 @@
         </dependency>
 
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.locationtech.jts</groupId>
             <artifactId>jts-core</artifactId>
             <version>1.19.0</version>

--- a/web-bundle/src/main/java/com/graphhopper/resources/PtRouteResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/PtRouteResource.java
@@ -40,6 +40,8 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
+import static com.graphhopper.util.Parameters.Routing.CALC_POINTS;
+import static com.graphhopper.util.Parameters.Routing.INSTRUCTIONS;
 import static java.util.stream.Collectors.toList;
 
 @Path("route-pt")
@@ -55,6 +57,10 @@ public class PtRouteResource {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public ObjectNode route(@QueryParam("point") @Size(min=2,max=2) List<GHLocationParam> requestPoints,
+                            @QueryParam(INSTRUCTIONS) @DefaultValue("true") boolean instructions,
+                            @QueryParam(CALC_POINTS) @DefaultValue("true") boolean calcPoints,
+                            @QueryParam("elevation") @DefaultValue("false") boolean enableElevation,
+                            @QueryParam("points_encoded") @DefaultValue("true") boolean pointsEncoded,
                             @QueryParam("pt.earliest_departure_time") @NotNull OffsetDateTimeParam departureTimeParam,
                             @QueryParam("pt.profile_duration") DurationParam profileDuration,
                             @QueryParam("pt.arrive_by") @DefaultValue("false") boolean arriveBy,
@@ -87,7 +93,9 @@ public class PtRouteResource {
         Optional.ofNullable(betaEgressTime).ifPresent(request::setBetaEgressTime);
 
         GHResponse route = ptRouter.route(request);
-        return ResponsePathSerializer.jsonObject(route, "", true, true, false, false, stopWatch.stop().getMillis());
+
+        return ResponsePathSerializer.jsonObject(route, "", instructions, calcPoints, enableElevation, pointsEncoded
+                , stopWatch.stop().getMillis());
     }
 
 }

--- a/web-bundle/src/test/java/com/graphhopper/resources/PtRouteResourceTest.java
+++ b/web-bundle/src/test/java/com/graphhopper/resources/PtRouteResourceTest.java
@@ -1,0 +1,127 @@
+package com.graphhopper.resources;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.graphhopper.GHResponse;
+import com.graphhopper.ResponsePath;
+import com.graphhopper.gtfs.PtRouter;
+import com.graphhopper.gtfs.Request;
+import com.graphhopper.http.DurationParam;
+import com.graphhopper.http.GHLocationParam;
+import com.graphhopper.http.OffsetDateTimeParam;
+import com.graphhopper.jackson.ResponsePathSerializer;
+import com.graphhopper.util.*;
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+
+import javax.ws.rs.core.Response;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Locale;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(DropwizardExtensionsSupport.class)
+public class PtRouteResourceTest {
+
+    private PtRouter mockPtRouter;
+    private PtRouteResource ptRouteResource;
+
+
+    @BeforeEach
+    public void setup() {
+        mockPtRouter = Mockito.mock(PtRouter.class);
+
+        ptRouteResource = new PtRouteResource(mockPtRouter);
+    }
+
+    @Test
+    public void testRouteReturnsProperlyEncodedResponse() {
+        GHResponse ghResponse = new GHResponse();
+        ResponsePath responsePath = new ResponsePath();
+        PointList points = new PointList();
+        points.add(0, 0);
+        points.add(1, 1);
+        responsePath.setPoints(points);
+        InstructionList instructions = new InstructionList(usTR);
+        responsePath.setInstructions(instructions);
+        ghResponse.add(responsePath);
+
+        when(mockPtRouter.route(any(Request.class))).thenReturn(ghResponse);
+
+        ObjectNode response = ptRouteResource.route(Arrays.asList(
+                new GHLocationParam("0,0"),
+                new GHLocationParam("1,1")),
+                true,
+                true,
+                false,
+                false,
+                new OffsetDateTimeParam("2022-01-01T00:00:00Z"),
+                new DurationParam("PT1H"),
+                false,
+                "en",
+                false,
+                false,
+                10,
+                new DurationParam("PT1H"),
+                new DurationParam("PT1H"),
+                "foot",
+                1.0,
+                "foot",
+                1.0);
+
+        ObjectNode encodedResponse = ptRouteResource.route(Arrays.asList(
+                        new GHLocationParam("0,0"),
+                        new GHLocationParam("1,1")),
+                true,
+                true,
+                false,
+                true,
+                new OffsetDateTimeParam("2022-01-01T00:00:00Z"),
+                new DurationParam("PT1H"),
+                false,
+                "en",
+                false,
+                false,
+                10,
+                new DurationParam("PT1H"),
+                new DurationParam("PT1H"),
+                "foot",
+                1.0,
+                "foot",
+                1.0);
+
+        assertEquals(false, response.get("paths").get(0).get("points_encoded").asBoolean());
+        assertEquals(true, encodedResponse.get("paths").get(0).get("points_encoded").asBoolean());
+
+    }
+
+    private static Translation usTR = new Translation() {
+        @Override
+        public String tr(String key, Object... params) {
+            if (key.equals("roundabout_exit_onto"))
+                return "At roundabout, take exit 2 onto streetname";
+            return key;
+        }
+
+        @Override
+        public Map<String, String> asMap() {
+            return Collections.emptyMap();
+        }
+
+        @Override
+        public Locale getLocale() {
+            return Locale.US;
+        }
+
+        @Override
+        public String getLanguage() {
+            return "en";
+        }
+    };
+}


### PR DESCRIPTION
This PR updates the PtRouteResource to support porperly the `points_encoded` query parameter. It also introduces a new test class PtRouteResourceTest to verify the changes. Additionally, it updates the pom.xml file to include Mockito dependencies for testing.
It also updates the reader-gtfs/config-example-pt.yml file to ensure that the PT routing [quickstart](https://github.com/graphhopper/graphhopper/blob/master/reader-gtfs/README.md#quick-start) is working as expected.


