### PR TITLE
[WIP] Display route for public transport

### DIFF
--- a/reader-gtfs/src/main/java/com/conveyal/gtfs/model/Shape.java
+++ b/reader-gtfs/src/main/java/com/conveyal/gtfs/model/Shape.java
@@ -30,9 +30,11 @@ import com.conveyal.gtfs.GTFSFeed;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.Point;
 import org.mapdb.Fun;
 
-import java.util.Map;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * Represents a collection of GTFS shape points. Never saved in MapDB but constructed on the fly.
@@ -54,5 +56,128 @@ public class Shape {
                 .toArray(i -> new Coordinate[i]);
         geometry = geometryFactory.createLineString(coords);
         shape_dist_traveled = points.values().stream().mapToDouble(point -> point.shape_dist_traveled).toArray();
+    }
+    // do pointA -> pointB combination, closest point, without shape dist traveled
+    public Shape(GTFSFeed feed, Point start, Point stop){
+        Set<String> uniqueIds = feed.shape_points.keySet()
+                .stream()
+                .map(pair -> pair.a)
+                .collect(Collectors.toSet());
+
+        List<ShapePoint> finalShape = new ArrayList<>();
+        final double startLat = start.getY();
+        final double startLon = start.getX();
+        final double stopLat = stop.getY();
+        final double stopLon = stop.getX();
+        double finalCloseDistance = -1;
+        for (String shapeId: uniqueIds) {
+            Map<Fun.Tuple2<String, Integer>, ShapePoint> points = feed.shape_points.subMap(
+                    new Fun.Tuple2(shapeId, null), new Fun.Tuple2(shapeId, Fun.HI)
+            );
+            List<ShapePoint> shp = new ArrayList<>();
+            List<ShapePoint> shapePoints = points.values()
+                    .stream()
+                    .sorted(Comparator.comparing(x -> x.shape_dist_traveled))
+                    .toList();
+            Iterator<Fun.Tuple2<Double, ShapePoint>> closestToStart = points.values()
+                    .stream()
+                    .map(s -> {
+                        final double distance = distanceLatLon(startLat, startLon,
+                                s.shape_pt_lat, s.shape_pt_lon);
+                        return new Fun.Tuple2<>(distance, s);
+                    })
+                    .sorted(Comparator.comparing(x -> x.a))
+                    .iterator();
+
+            double previousTotalDistance = -1;
+            int closestPoints = 0;
+            while (closestToStart.hasNext()) {
+                Fun.Tuple2<Double, ShapePoint> close = closestToStart.next();
+                if (closestPoints > 2) // 2 closest point is enough
+                    break;
+
+                int i = shapePoints.indexOf(close.b);
+                double prevCloseDistance = -1;
+                int prevCloseDistanceIndex = -1;
+                for(int j = i; j < shapePoints.size(); j++){
+                    ShapePoint stopPoint1 = shapePoints.get(j);
+                    double distance;
+                    if (j == i)
+                        distance = distanceLatLon(stopLat, stopLon,
+                                stopPoint1.shape_pt_lat, stopPoint1.shape_pt_lon);
+                    else {
+                        ShapePoint stopPoint2 = shapePoints.get(j - 1);
+                        distance = closestPointToLine(stopLat, stopLon,
+                                stopPoint1.shape_pt_lat, stopPoint1.shape_pt_lon,
+                                stopPoint2.shape_pt_lat, stopPoint2.shape_pt_lon);
+                    }
+                    if (prevCloseDistance == -1 || prevCloseDistance > distance){
+                        prevCloseDistance = distance;
+                        prevCloseDistanceIndex = Math.min(j + 1, shapePoints.size() - 1);
+                    }
+                }
+                if (prevCloseDistanceIndex == -1) // Start point at End point?
+                    continue;
+
+                closestPoints++;
+                double totalDistance = prevCloseDistance + close.a;
+                if (previousTotalDistance == -1 || (previousTotalDistance > totalDistance)){
+                    previousTotalDistance = totalDistance;
+                    shp = new ArrayList<>(shapePoints.subList(i, prevCloseDistanceIndex));
+                }
+            }
+
+            if (finalCloseDistance == -1 || (finalCloseDistance > previousTotalDistance)){
+                finalCloseDistance = previousTotalDistance;
+                finalShape = shp;
+            }
+        }
+       Coordinate[] coords = finalShape.stream()
+                .map(point -> new Coordinate(point.shape_pt_lon, point.shape_pt_lat))
+                .toArray(Coordinate[]::new);
+        if (coords.length > 1)
+            geometry = geometryFactory.createLineString(coords);
+        else
+            geometry = geometryFactory.createLineString();
+        shape_dist_traveled = finalShape.stream()
+                .mapToDouble(point -> point.shape_dist_traveled)
+                .toArray();
+    }
+    private static double closestPointToLine(double lat0, double lon0, // target point
+                                             double lat1, double lon1, double lat2, double lon2){
+        double distance;
+        // this should only be use on close distances
+        // due to Perpendicular Distance is for cartesian.
+        // lat = y, lng = x
+        if ((Math.min(lat1, lat2) < lat0 && lat0 < Math.max(lat1, lat2)) ||
+                (Math.min(lon1, lon2) < lon0 && lon0 < Math.max(lon1, lon2))
+        ){
+            // Perpendicular Distance Formula
+            double rawDist = Math.abs((lon1 - lon0) * (lat2 - lat1) - (lon2 - lon1) * (lat1 - lat0)) /
+                    Math.sqrt(Math.pow((lon2 - lon1), 2) + Math.pow((lat2 - lat1), 2));
+            distance = rawDist * 111000;
+        }else{
+            // use haversine formula if closest is not 90deg
+            final double firstPoint = distanceLatLon(lat0, lon0, lat1, lon1);
+            final double secondPoint = distanceLatLon(lat0, lon0, lat2, lon2);
+            distance = Math.min(firstPoint, secondPoint);
+        }
+        return distance;
+    }
+    private static double distanceLatLon(double pt_lat1, double pt_lon1, double pt_lat2, double pt_lon2) {
+        // haversine formula
+        final double deltaLat = numberToRadius(pt_lat2 - pt_lat1);
+        final double deltaLon = numberToRadius(pt_lon2 - pt_lon1);
+        final double fhi1 = numberToRadius(pt_lat1);
+        final double fhi2 = numberToRadius(pt_lat2);
+        final double a = Math.pow(Math.sin(deltaLat / 2), 2) +
+                Math.cos(fhi1) * Math.cos(fhi2) * Math.pow(Math.sin(deltaLon / 2), 2);
+
+        final double R = 6371e3;  // returns meters
+        final double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        return R * c;
+    }
+    private static double numberToRadius(double number){
+        return number * Math.PI / 180;
     }
 }

--- a/reader-gtfs/src/main/java/com/graphhopper/gtfs/TripFromLabel.java
+++ b/reader-gtfs/src/main/java/com/graphhopper/gtfs/TripFromLabel.java
@@ -110,7 +110,7 @@ class TripFromLabel {
             Trip.Leg leg = legs.get(i);
             if (leg instanceof Trip.WalkLeg) {
                 final Trip.WalkLeg walkLeg = ((Trip.WalkLeg) leg);
-                List<Instruction> theseInstructions = walkLeg.instructions.subList(0, i < path.getLegs().size() - 1 ? walkLeg.instructions.size() - 1 : walkLeg.instructions.size());
+                List<Instruction> theseInstructions = walkLeg.instructions.subList(0, i < legs.size() - 1 ? walkLeg.instructions.size() - 1 : walkLeg.instructions.size());
                 int previousPointsCount = pointsList.size();
                 for (Instruction instruction : theseInstructions) {
                     pointsList.add(instruction.getPoints());


### PR DESCRIPTION
This PR attempted to implement #1743. Currently, this covers only B] stated by [answerquest](https://github.com/graphhopper/graphhopper/issues/1743#issuecomment-546318623). The routes that are given by `shapes.txt` can be inferred even when you don't have  `shape_dist_traveled`. 
## Sample Output:
![image](https://github.com/graphhopper/graphhopper/assets/70153286/8908fa5e-ffe4-4620-bfad-97e6f4b6a915)

## Thoughts & Problems
1. Once I've generated the polyline, should it be set onto PtLeg.geometry or a new attribute? 
   - I replaced geometry with a multi line string instead
2. There are times when the routes completely disappear, I assume this is due to routes missing/unmatched, should this be replaced with a single line from/to stops?
3. Maybe allow `trip_id` be set via regex or any other string matching within a config to match with `shape_id` in `shapes.txt` and `stop_times.txt` for a more accurate infer? Sample of application:
   - example `stop_times.txt`
![image](https://github.com/graphhopper/graphhopper/assets/70153286/cd5321fd-273a-4cd4-95d5-341941207ead)

   - example `shapes.txt`
![image](https://github.com/graphhopper/graphhopper/assets/70153286/973ca95d-5848-482e-87a5-8801326033f7)
