### PR TITLE
Create leg_time/distance entries for duplicate via-points

### DIFF
--- a/core/src/main/java/com/graphhopper/util/details/ConstantDetailsBuilder.java
+++ b/core/src/main/java/com/graphhopper/util/details/ConstantDetailsBuilder.java
@@ -18,7 +18,11 @@
 
 package com.graphhopper.util.details;
 
+import com.graphhopper.coll.MapEntry;
 import com.graphhopper.util.EdgeIteratorState;
+
+import java.util.List;
+import java.util.Map;
 
 /**
  * Simply returns the same value everywhere, useful to represent values that are the same between two (via-)points
@@ -44,5 +48,13 @@ public class ConstantDetailsBuilder extends AbstractPathDetailsBuilder {
             return true;
         } else
             return false;
+    }
+
+    @Override
+    public Map.Entry<String, List<PathDetail>> build() {
+        if (firstEdge)
+            // #2915 if there was no edge at all we need to add a single entry manually here
+            return new MapEntry<>(getName(), List.of(new PathDetail(value)));
+        return super.build();
     }
 }

--- a/web/src/test/java/com/graphhopper/application/resources/RouteResourceClientHCTest.java
+++ b/web/src/test/java/com/graphhopper/application/resources/RouteResourceClientHCTest.java
@@ -397,17 +397,23 @@ public class RouteResourceClientHCTest {
                 addPoint(new GHPoint(42.49833, 1.504619)).
                 addPoint(new GHPoint(42.498217, 1.504377)).
                 addPoint(new GHPoint(42.495611, 1.498368)).
+                // #2915: duplicating the last point yields an empty leg, but there should still be path details for it
+                        addPoint(new GHPoint(42.495611, 1.498368)).
                 setPathDetails(legDetails).
                 setProfile("bike");
 
         GHResponse response = gh.route(req);
         ResponsePath path = response.getBest();
         assertEquals(5428, path.getDistance(), 5);
-        assertEquals(9, path.getWaypoints().size());
+        assertEquals(10, path.getWaypoints().size());
 
         assertEquals(path.getTime(), path.getPathDetails().get("leg_time").stream().mapToLong(d -> (long) d.getValue()).sum(), 1);
         assertEquals(path.getDistance(), path.getPathDetails().get("leg_distance").stream().mapToDouble(d -> (double) d.getValue()).sum(), 1);
         assertEquals(path.getRouteWeight(), path.getPathDetails().get("leg_weight").stream().mapToDouble(d -> (double) d.getValue()).sum(), 1);
+
+        assertEquals(9, path.getPathDetails().get("leg_time").size());
+        assertEquals(9, path.getPathDetails().get("leg_distance").size());
+        assertEquals(9, path.getPathDetails().get("leg_weight").size());
 
         List<PointList> pointListFromInstructions = getPointListFromInstructions(path);
         for (String detail : legDetails) {
@@ -423,7 +429,7 @@ public class RouteResourceClientHCTest {
                 assertEquals(path.getWaypoints().get(i), path.getPoints().get(pathDetails.get(i - 1).getLast()));
 
             List<PointList> pointListFromLegDetails = getPointListFromLegDetails(path, detail);
-            assertEquals(8, pointListFromLegDetails.size());
+            assertEquals(9, pointListFromLegDetails.size());
             assertPointListsEquals(pointListFromInstructions, pointListFromLegDetails);
         }
     }


### PR DESCRIPTION
Fixes #2915. This makes sure there are always N+1 leg_time/distance entries for requests with N via-points, even when some locations are duplicated. The interval of the path detail is empty for duplicate locations, because there are no edges inbetween. Here is the leg_time path detail list for the test mentioned in #2915:

![image](https://github.com/graphhopper/graphhopper/assets/17603532/2e4d972e-d665-4979-b0e3-1a3adfff2031)
