### PR TITLE
Remove the name property from vehicle parsers

### DIFF
--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -695,7 +695,7 @@ public class GraphHopper {
                     if (encodingManager.hasEncodedValue(FootNetwork.KEY) && added.add(FootNetwork.KEY))
                         osmParsers.addRelationTagParser(relConfig -> new OSMFootNetworkTagParser(encodingManager.getEnumEncodedValue(FootNetwork.KEY, RouteNetwork.class), relConfig));
                 }
-                String turnRestrictionKey = TurnRestriction.key(new PMap(vehicleStr).getString("name", name));
+                String turnRestrictionKey = TurnRestriction.key(name);
                 if (encodingManager.hasTurnEncodedValue(turnRestrictionKey)
                         // need to make sure we do not add the same restriction parsers multiple times
                         && osmParsers.getRestrictionTagParsers().stream().noneMatch(r -> r.getTurnRestrictionEnc().getName().equals(turnRestrictionKey))) {

--- a/core/src/main/java/com/graphhopper/routing/util/DefaultVehicleTagParserFactory.java
+++ b/core/src/main/java/com/graphhopper/routing/util/DefaultVehicleTagParserFactory.java
@@ -26,7 +26,7 @@ import static com.graphhopper.routing.util.VehicleEncodedValuesFactory.*;
 public class DefaultVehicleTagParserFactory implements VehicleTagParserFactory {
     public VehicleTagParsers createParsers(EncodedValueLookup lookup, String name, PMap configuration) {
         if (name.equals(ROADS))
-            return VehicleTagParsers.roads(lookup, configuration);
+            return VehicleTagParsers.roads(lookup);
         if (name.equals(CAR))
             return VehicleTagParsers.car(lookup, configuration);
         if (name.equals(BIKE))

--- a/core/src/main/java/com/graphhopper/routing/util/VehicleEncodedValues.java
+++ b/core/src/main/java/com/graphhopper/routing/util/VehicleEncodedValues.java
@@ -36,7 +36,7 @@ public class VehicleEncodedValues {
     private final BooleanEncodedValue turnRestrictionEnc;
 
     public static VehicleEncodedValues foot(PMap properties) {
-        String name = properties.getString("name", "foot");
+        String name = "foot";
         int speedBits = properties.getInt("speed_bits", 4);
         double speedFactor = properties.getDouble("speed_factor", 1);
         boolean speedTwoDirections = properties.getBool("speed_two_directions", false);
@@ -49,7 +49,18 @@ public class VehicleEncodedValues {
     }
 
     public static VehicleEncodedValues bike(PMap properties) {
-        String name = properties.getString("name", "bike");
+        return createBike(properties, "bike");
+    }
+
+    public static VehicleEncodedValues racingbike(PMap properties) {
+        return createBike(properties, "racingbike");
+    }
+
+    public static VehicleEncodedValues mountainbike(PMap properties) {
+        return createBike(properties, "mtb");
+    }
+
+    private static VehicleEncodedValues createBike(PMap properties, String name) {
         int speedBits = properties.getInt("speed_bits", 4);
         double speedFactor = properties.getDouble("speed_factor", 2);
         boolean speedTwoDirections = properties.getBool("speed_two_directions", false);
@@ -61,16 +72,8 @@ public class VehicleEncodedValues {
         return new VehicleEncodedValues(name, accessEnc, speedEnc, priorityEnc, turnRestrictionEnc);
     }
 
-    public static VehicleEncodedValues racingbike(PMap properties) {
-        return bike(new PMap(properties).putObject("name", properties.getString("name", "racingbike")));
-    }
-
-    public static VehicleEncodedValues mountainbike(PMap properties) {
-        return bike(new PMap(properties).putObject("name", properties.getString("name", "mtb")));
-    }
-
     public static VehicleEncodedValues car(PMap properties) {
-        String name = properties.getString("name", "car");
+        String name = "car";
         int speedBits = properties.getInt("speed_bits", 7);
         double speedFactor = properties.getDouble("speed_factor", 2);
         boolean turnCosts = properties.getBool("turn_costs", false);
@@ -81,7 +84,7 @@ public class VehicleEncodedValues {
     }
 
     public static VehicleEncodedValues roads(PMap properties) {
-        String name = properties.getString("name", "roads");
+        String name = "roads";
         int speedBits = properties.getInt("speed_bits", 7);
         double speedFactor = properties.getDouble("speed_factor", 2);
         boolean speedTwoDirections = properties.getBool("speed_two_directions", true);

--- a/core/src/main/java/com/graphhopper/routing/util/VehicleTagParsers.java
+++ b/core/src/main/java/com/graphhopper/routing/util/VehicleTagParsers.java
@@ -31,10 +31,10 @@ public class VehicleTagParsers {
     private final TagParser speedParser;
     private final TagParser priorityParser;
 
-    public static VehicleTagParsers roads(EncodedValueLookup lookup, PMap properties) {
+    public static VehicleTagParsers roads(EncodedValueLookup lookup) {
         return new VehicleTagParsers(
-                new RoadsAccessParser(lookup, properties),
-                new RoadsAverageSpeedParser(lookup, properties),
+                new RoadsAccessParser(lookup),
+                new RoadsAverageSpeedParser(lookup),
                 null
         );
     }
@@ -42,7 +42,7 @@ public class VehicleTagParsers {
     public static VehicleTagParsers car(EncodedValueLookup lookup, PMap properties) {
         return new VehicleTagParsers(
                 new CarAccessParser(lookup, properties).init(properties.getObject("date_range_parser", new DateRangeParser())),
-                new CarAverageSpeedParser(lookup, properties),
+                new CarAverageSpeedParser(lookup),
                 null
         );
     }
@@ -50,32 +50,32 @@ public class VehicleTagParsers {
     public static VehicleTagParsers bike(EncodedValueLookup lookup, PMap properties) {
         return new VehicleTagParsers(
                 new BikeAccessParser(lookup, properties).init(properties.getObject("date_range_parser", new DateRangeParser())),
-                new BikeAverageSpeedParser(lookup, properties),
-                new BikePriorityParser(lookup, properties)
+                new BikeAverageSpeedParser(lookup),
+                new BikePriorityParser(lookup)
         );
     }
 
     public static VehicleTagParsers racingbike(EncodedValueLookup lookup, PMap properties) {
         return new VehicleTagParsers(
                 new RacingBikeAccessParser(lookup, properties).init(properties.getObject("date_range_parser", new DateRangeParser())),
-                new RacingBikeAverageSpeedParser(lookup, properties),
-                new RacingBikePriorityParser(lookup, properties)
+                new RacingBikeAverageSpeedParser(lookup),
+                new RacingBikePriorityParser(lookup)
         );
     }
 
     public static VehicleTagParsers mtb(EncodedValueLookup lookup, PMap properties) {
         return new VehicleTagParsers(
                 new MountainBikeAccessParser(lookup, properties).init(properties.getObject("date_range_parser", new DateRangeParser())),
-                new MountainBikeAverageSpeedParser(lookup, properties),
-                new MountainBikePriorityParser(lookup, properties)
+                new MountainBikeAverageSpeedParser(lookup),
+                new MountainBikePriorityParser(lookup)
         );
     }
 
     public static VehicleTagParsers foot(EncodedValueLookup lookup, PMap properties) {
         return new VehicleTagParsers(
                 new FootAccessParser(lookup, properties).init(properties.getObject("date_range_parser", new DateRangeParser())),
-                new FootAverageSpeedParser(lookup, properties),
-                new FootPriorityParser(lookup, properties)
+                new FootAverageSpeedParser(lookup),
+                new FootPriorityParser(lookup)
         );
     }
 

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/BikeAccessParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/BikeAccessParser.java
@@ -9,7 +9,7 @@ import com.graphhopper.util.PMap;
 public class BikeAccessParser extends BikeCommonAccessParser {
 
     public BikeAccessParser(EncodedValueLookup lookup, PMap properties) {
-        this(lookup.getBooleanEncodedValue(VehicleAccess.key(properties.getString("name", "bike"))),
+        this(lookup.getBooleanEncodedValue(VehicleAccess.key("bike")),
                 lookup.getBooleanEncodedValue(Roundabout.KEY));
         blockPrivate(properties.getBool("block_private", true));
         blockFords(properties.getBool("block_fords", false));

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/BikeAverageSpeedParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/BikeAverageSpeedParser.java
@@ -1,11 +1,10 @@
 package com.graphhopper.routing.util.parsers;
 
 import com.graphhopper.routing.ev.*;
-import com.graphhopper.util.PMap;
 
 public class BikeAverageSpeedParser extends BikeCommonAverageSpeedParser {
 
-    public BikeAverageSpeedParser(EncodedValueLookup lookup, PMap properties) {
+    public BikeAverageSpeedParser(EncodedValueLookup lookup) {
         this(lookup.getDecimalEncodedValue(VehicleSpeed.key("bike")),
                 lookup.getEnumEncodedValue(Smoothness.KEY, Smoothness.class),
                 lookup.getDecimalEncodedValue(FerrySpeed.KEY));

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/BikeAverageSpeedParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/BikeAverageSpeedParser.java
@@ -6,7 +6,7 @@ import com.graphhopper.util.PMap;
 public class BikeAverageSpeedParser extends BikeCommonAverageSpeedParser {
 
     public BikeAverageSpeedParser(EncodedValueLookup lookup, PMap properties) {
-        this(lookup.getDecimalEncodedValue(VehicleSpeed.key(properties.getString("name", "bike"))),
+        this(lookup.getDecimalEncodedValue(VehicleSpeed.key("bike")),
                 lookup.getEnumEncodedValue(Smoothness.KEY, Smoothness.class),
                 lookup.getDecimalEncodedValue(FerrySpeed.KEY));
     }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/BikePriorityParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/BikePriorityParser.java
@@ -7,8 +7,8 @@ public class BikePriorityParser extends BikeCommonPriorityParser {
 
     public BikePriorityParser(EncodedValueLookup lookup, PMap properties) {
         this(
-                lookup.getDecimalEncodedValue(VehiclePriority.key(properties.getString("name", "bike"))),
-                lookup.getDecimalEncodedValue(VehicleSpeed.key(properties.getString("name", "bike"))),
+                lookup.getDecimalEncodedValue(VehiclePriority.key("bike")),
+                lookup.getDecimalEncodedValue(VehicleSpeed.key("bike")),
                 lookup.getEnumEncodedValue(BikeNetwork.KEY, RouteNetwork.class)
         );
     }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/BikePriorityParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/BikePriorityParser.java
@@ -1,11 +1,10 @@
 package com.graphhopper.routing.util.parsers;
 
 import com.graphhopper.routing.ev.*;
-import com.graphhopper.util.PMap;
 
 public class BikePriorityParser extends BikeCommonPriorityParser {
 
-    public BikePriorityParser(EncodedValueLookup lookup, PMap properties) {
+    public BikePriorityParser(EncodedValueLookup lookup) {
         this(
                 lookup.getDecimalEncodedValue(VehiclePriority.key("bike")),
                 lookup.getDecimalEncodedValue(VehicleSpeed.key("bike")),

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/CarAccessParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/CarAccessParser.java
@@ -34,7 +34,7 @@ public class CarAccessParser extends AbstractAccessParser implements TagParser {
 
     public CarAccessParser(EncodedValueLookup lookup, PMap properties) {
         this(
-                lookup.getBooleanEncodedValue(VehicleAccess.key(properties.getString("name", "car"))),
+                lookup.getBooleanEncodedValue(VehicleAccess.key("car")),
                 lookup.getBooleanEncodedValue(Roundabout.KEY),
                 properties,
                 TransportationMode.CAR
@@ -87,7 +87,7 @@ public class CarAccessParser extends AbstractAccessParser implements TagParser {
                 if (intendedValues.contains(firstValue) ||
                         // implied default is allowed only if foot and bicycle is not specified:
                         firstValue.isEmpty() && !way.hasTag("foot") && !way.hasTag("bicycle") ||
-                        // if hgv is allowed than smaller trucks and cars are allowed too
+                        // if hgv is allowed then smaller trucks and cars are allowed too
                         way.hasTag("hgv", "yes"))
                     return WayAccess.FERRY;
             }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/CarAverageSpeedParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/CarAverageSpeedParser.java
@@ -43,7 +43,7 @@ public class CarAverageSpeedParser extends AbstractAverageSpeedParser implements
     protected final Map<String, Integer> defaultSpeedMap = new HashMap<>();
 
     public CarAverageSpeedParser(EncodedValueLookup lookup, PMap properties) {
-        this(lookup.getDecimalEncodedValue(VehicleSpeed.key(properties.getString("name", "car"))),
+        this(lookup.getDecimalEncodedValue(VehicleSpeed.key("car")),
                 lookup.getDecimalEncodedValue(FerrySpeed.KEY));
     }
 

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/CarAverageSpeedParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/CarAverageSpeedParser.java
@@ -21,7 +21,6 @@ import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.*;
 import com.graphhopper.routing.util.FerrySpeedCalculator;
 import com.graphhopper.util.Helper;
-import com.graphhopper.util.PMap;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -42,7 +41,7 @@ public class CarAverageSpeedParser extends AbstractAverageSpeedParser implements
      */
     protected final Map<String, Integer> defaultSpeedMap = new HashMap<>();
 
-    public CarAverageSpeedParser(EncodedValueLookup lookup, PMap properties) {
+    public CarAverageSpeedParser(EncodedValueLookup lookup) {
         this(lookup.getDecimalEncodedValue(VehicleSpeed.key("car")),
                 lookup.getDecimalEncodedValue(FerrySpeed.KEY));
     }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/FootAccessParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/FootAccessParser.java
@@ -37,7 +37,7 @@ public class FootAccessParser extends AbstractAccessParser implements TagParser 
     protected Map<RouteNetwork, Integer> routeMap = new HashMap<>();
 
     public FootAccessParser(EncodedValueLookup lookup, PMap properties) {
-        this(lookup.getBooleanEncodedValue(VehicleAccess.key(properties.getString("name", "foot"))));
+        this(lookup.getBooleanEncodedValue(VehicleAccess.key("foot")));
         blockPrivate(properties.getBool("block_private", true));
         blockFords(properties.getBool("block_fords", false));
     }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/FootAverageSpeedParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/FootAverageSpeedParser.java
@@ -3,7 +3,6 @@ package com.graphhopper.routing.util.parsers;
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.*;
 import com.graphhopper.routing.util.FerrySpeedCalculator;
-import com.graphhopper.util.PMap;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -16,7 +15,7 @@ public class FootAverageSpeedParser extends AbstractAverageSpeedParser implement
     static final int MEAN_SPEED = 5;
     protected Map<RouteNetwork, Integer> routeMap = new HashMap<>();
 
-    public FootAverageSpeedParser(EncodedValueLookup lookup, PMap properties) {
+    public FootAverageSpeedParser(EncodedValueLookup lookup) {
         this(lookup.getDecimalEncodedValue(VehicleSpeed.key("foot")),
                 lookup.getDecimalEncodedValue(FerrySpeed.KEY));
     }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/FootAverageSpeedParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/FootAverageSpeedParser.java
@@ -17,7 +17,7 @@ public class FootAverageSpeedParser extends AbstractAverageSpeedParser implement
     protected Map<RouteNetwork, Integer> routeMap = new HashMap<>();
 
     public FootAverageSpeedParser(EncodedValueLookup lookup, PMap properties) {
-        this(lookup.getDecimalEncodedValue(VehicleSpeed.key(properties.getString("name", "foot"))),
+        this(lookup.getDecimalEncodedValue(VehicleSpeed.key("foot")),
                 lookup.getDecimalEncodedValue(FerrySpeed.KEY));
     }
 

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/FootPriorityParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/FootPriorityParser.java
@@ -5,7 +5,6 @@ import com.graphhopper.routing.ev.*;
 import com.graphhopper.routing.util.FerrySpeedCalculator;
 import com.graphhopper.routing.util.PriorityCode;
 import com.graphhopper.storage.IntsRef;
-import com.graphhopper.util.PMap;
 
 import java.util.*;
 
@@ -25,7 +24,7 @@ public class FootPriorityParser implements TagParser {
     protected EnumEncodedValue<RouteNetwork> footRouteEnc;
     protected Map<RouteNetwork, Integer> routeMap = new HashMap<>();
 
-    public FootPriorityParser(EncodedValueLookup lookup, PMap properties) {
+    public FootPriorityParser(EncodedValueLookup lookup) {
         this(lookup.getDecimalEncodedValue(VehiclePriority.key("foot")),
                 lookup.getEnumEncodedValue(FootNetwork.KEY, RouteNetwork.class)
         );

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/FootPriorityParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/FootPriorityParser.java
@@ -26,7 +26,7 @@ public class FootPriorityParser implements TagParser {
     protected Map<RouteNetwork, Integer> routeMap = new HashMap<>();
 
     public FootPriorityParser(EncodedValueLookup lookup, PMap properties) {
-        this(lookup.getDecimalEncodedValue(VehiclePriority.key(properties.getString("name", "foot"))),
+        this(lookup.getDecimalEncodedValue(VehiclePriority.key("foot")),
                 lookup.getEnumEncodedValue(FootNetwork.KEY, RouteNetwork.class)
         );
     }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/MountainBikeAccessParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/MountainBikeAccessParser.java
@@ -9,7 +9,7 @@ import com.graphhopper.util.PMap;
 public class MountainBikeAccessParser extends BikeCommonAccessParser {
 
     public MountainBikeAccessParser(EncodedValueLookup lookup, PMap properties) {
-        this(lookup.getBooleanEncodedValue(VehicleAccess.key(properties.getString("name", "mtb"))),
+        this(lookup.getBooleanEncodedValue(VehicleAccess.key("mtb")),
                 lookup.getBooleanEncodedValue(Roundabout.KEY));
         blockPrivate(properties.getBool("block_private", true));
         blockFords(properties.getBool("block_fords", false));

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/MountainBikeAverageSpeedParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/MountainBikeAverageSpeedParser.java
@@ -6,7 +6,7 @@ import com.graphhopper.util.PMap;
 public class MountainBikeAverageSpeedParser extends BikeCommonAverageSpeedParser {
 
     public MountainBikeAverageSpeedParser(EncodedValueLookup lookup, PMap properties) {
-        this(lookup.getDecimalEncodedValue(VehicleSpeed.key(properties.getString("name", "mtb"))),
+        this(lookup.getDecimalEncodedValue(VehicleSpeed.key("mtb")),
                 lookup.getEnumEncodedValue(Smoothness.KEY, Smoothness.class),
                 lookup.getDecimalEncodedValue(FerrySpeed.KEY));
     }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/MountainBikeAverageSpeedParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/MountainBikeAverageSpeedParser.java
@@ -1,11 +1,10 @@
 package com.graphhopper.routing.util.parsers;
 
 import com.graphhopper.routing.ev.*;
-import com.graphhopper.util.PMap;
 
 public class MountainBikeAverageSpeedParser extends BikeCommonAverageSpeedParser {
 
-    public MountainBikeAverageSpeedParser(EncodedValueLookup lookup, PMap properties) {
+    public MountainBikeAverageSpeedParser(EncodedValueLookup lookup) {
         this(lookup.getDecimalEncodedValue(VehicleSpeed.key("mtb")),
                 lookup.getEnumEncodedValue(Smoothness.KEY, Smoothness.class),
                 lookup.getDecimalEncodedValue(FerrySpeed.KEY));

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/MountainBikePriorityParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/MountainBikePriorityParser.java
@@ -13,8 +13,8 @@ import static com.graphhopper.routing.util.PriorityCode.*;
 public class MountainBikePriorityParser extends BikeCommonPriorityParser {
 
     public MountainBikePriorityParser(EncodedValueLookup lookup, PMap properties) {
-        this(lookup.getDecimalEncodedValue(VehicleSpeed.key(properties.getString("name", "mtb"))),
-                lookup.getDecimalEncodedValue(VehiclePriority.key(properties.getString("name", "mtb"))),
+        this(lookup.getDecimalEncodedValue(VehicleSpeed.key("mtb")),
+                lookup.getDecimalEncodedValue(VehiclePriority.key("mtb")),
                 lookup.getEnumEncodedValue(BikeNetwork.KEY, RouteNetwork.class));
     }
 

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/MountainBikePriorityParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/MountainBikePriorityParser.java
@@ -3,7 +3,6 @@ package com.graphhopper.routing.util.parsers;
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.*;
 import com.graphhopper.routing.util.PriorityCode;
-import com.graphhopper.util.PMap;
 
 import java.util.TreeMap;
 
@@ -12,7 +11,7 @@ import static com.graphhopper.routing.util.PriorityCode.*;
 
 public class MountainBikePriorityParser extends BikeCommonPriorityParser {
 
-    public MountainBikePriorityParser(EncodedValueLookup lookup, PMap properties) {
+    public MountainBikePriorityParser(EncodedValueLookup lookup) {
         this(lookup.getDecimalEncodedValue(VehicleSpeed.key("mtb")),
                 lookup.getDecimalEncodedValue(VehiclePriority.key("mtb")),
                 lookup.getEnumEncodedValue(BikeNetwork.KEY, RouteNetwork.class));

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikeAccessParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikeAccessParser.java
@@ -9,7 +9,7 @@ import com.graphhopper.util.PMap;
 public class RacingBikeAccessParser extends BikeCommonAccessParser {
 
     public RacingBikeAccessParser(EncodedValueLookup lookup, PMap properties) {
-        this(lookup.getBooleanEncodedValue(VehicleAccess.key(properties.getString("name", "racingbike"))),
+        this(lookup.getBooleanEncodedValue(VehicleAccess.key("racingbike")),
                 lookup.getBooleanEncodedValue(Roundabout.KEY));
         blockPrivate(properties.getBool("block_private", true));
         blockFords(properties.getBool("block_fords", false));

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikeAverageSpeedParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikeAverageSpeedParser.java
@@ -6,7 +6,7 @@ import com.graphhopper.util.PMap;
 public class RacingBikeAverageSpeedParser extends BikeCommonAverageSpeedParser {
 
     public RacingBikeAverageSpeedParser(EncodedValueLookup lookup, PMap properties) {
-        this(lookup.getDecimalEncodedValue(VehicleSpeed.key(properties.getString("name", "racingbike"))),
+        this(lookup.getDecimalEncodedValue(VehicleSpeed.key("racingbike")),
                 lookup.getEnumEncodedValue(Smoothness.KEY, Smoothness.class),
                 lookup.getDecimalEncodedValue(FerrySpeed.KEY));
     }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikeAverageSpeedParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikeAverageSpeedParser.java
@@ -1,11 +1,10 @@
 package com.graphhopper.routing.util.parsers;
 
 import com.graphhopper.routing.ev.*;
-import com.graphhopper.util.PMap;
 
 public class RacingBikeAverageSpeedParser extends BikeCommonAverageSpeedParser {
 
-    public RacingBikeAverageSpeedParser(EncodedValueLookup lookup, PMap properties) {
+    public RacingBikeAverageSpeedParser(EncodedValueLookup lookup) {
         this(lookup.getDecimalEncodedValue(VehicleSpeed.key("racingbike")),
                 lookup.getEnumEncodedValue(Smoothness.KEY, Smoothness.class),
                 lookup.getDecimalEncodedValue(FerrySpeed.KEY));

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikePriorityParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikePriorityParser.java
@@ -13,8 +13,8 @@ import static com.graphhopper.routing.util.PriorityCode.*;
 public class RacingBikePriorityParser extends BikeCommonPriorityParser {
 
     public RacingBikePriorityParser(EncodedValueLookup lookup, PMap properties) {
-        this(lookup.getDecimalEncodedValue(VehiclePriority.key(properties.getString("name", "racingbike"))),
-                lookup.getDecimalEncodedValue(VehicleSpeed.key(properties.getString("name", "racingbike"))),
+        this(lookup.getDecimalEncodedValue(VehiclePriority.key("racingbike")),
+                lookup.getDecimalEncodedValue(VehicleSpeed.key("racingbike")),
                 lookup.getEnumEncodedValue(BikeNetwork.KEY, RouteNetwork.class));
     }
 

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikePriorityParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikePriorityParser.java
@@ -3,7 +3,6 @@ package com.graphhopper.routing.util.parsers;
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.*;
 import com.graphhopper.routing.util.PriorityCode;
-import com.graphhopper.util.PMap;
 
 import java.util.TreeMap;
 
@@ -12,7 +11,7 @@ import static com.graphhopper.routing.util.PriorityCode.*;
 
 public class RacingBikePriorityParser extends BikeCommonPriorityParser {
 
-    public RacingBikePriorityParser(EncodedValueLookup lookup, PMap properties) {
+    public RacingBikePriorityParser(EncodedValueLookup lookup) {
         this(lookup.getDecimalEncodedValue(VehiclePriority.key("racingbike")),
                 lookup.getDecimalEncodedValue(VehicleSpeed.key("racingbike")),
                 lookup.getEnumEncodedValue(BikeNetwork.KEY, RouteNetwork.class));

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/RoadsAccessParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/RoadsAccessParser.java
@@ -16,7 +16,7 @@ public class RoadsAccessParser implements TagParser {
     private final BooleanEncodedValue accessEnc;
 
     public RoadsAccessParser(EncodedValueLookup lookup, PMap properties) {
-        this(lookup.getBooleanEncodedValue(VehicleAccess.key(properties.getString("name", "roads"))));
+        this(lookup.getBooleanEncodedValue(VehicleAccess.key("roads")));
     }
 
     public RoadsAccessParser(BooleanEncodedValue accessEnc) {

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/RoadsAccessParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/RoadsAccessParser.java
@@ -6,7 +6,6 @@ import com.graphhopper.routing.ev.EdgeIntAccess;
 import com.graphhopper.routing.ev.EncodedValueLookup;
 import com.graphhopper.routing.ev.VehicleAccess;
 import com.graphhopper.storage.IntsRef;
-import com.graphhopper.util.PMap;
 
 /**
  * Access parser (boolean) for the 'roads' vehicle. Not to be confused with OSMRoadAccessParser that fills road_access
@@ -15,7 +14,7 @@ import com.graphhopper.util.PMap;
 public class RoadsAccessParser implements TagParser {
     private final BooleanEncodedValue accessEnc;
 
-    public RoadsAccessParser(EncodedValueLookup lookup, PMap properties) {
+    public RoadsAccessParser(EncodedValueLookup lookup) {
         this(lookup.getBooleanEncodedValue(VehicleAccess.key("roads")));
     }
 

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/RoadsAverageSpeedParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/RoadsAverageSpeedParser.java
@@ -2,8 +2,8 @@ package com.graphhopper.routing.util.parsers;
 
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.DecimalEncodedValue;
-import com.graphhopper.routing.ev.EncodedValueLookup;
 import com.graphhopper.routing.ev.EdgeIntAccess;
+import com.graphhopper.routing.ev.EncodedValueLookup;
 import com.graphhopper.routing.ev.VehicleSpeed;
 import com.graphhopper.storage.IntsRef;
 import com.graphhopper.util.PMap;
@@ -13,7 +13,7 @@ public class RoadsAverageSpeedParser implements TagParser {
     private final double maxPossibleSpeed;
 
     public RoadsAverageSpeedParser(EncodedValueLookup lookup, PMap properties) {
-        this(lookup.getDecimalEncodedValue(VehicleSpeed.key(properties.getString("name", "roads"))));
+        this(lookup.getDecimalEncodedValue(VehicleSpeed.key("roads")));
     }
 
     public RoadsAverageSpeedParser(DecimalEncodedValue avgSpeedEnc) {

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/RoadsAverageSpeedParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/RoadsAverageSpeedParser.java
@@ -6,13 +6,12 @@ import com.graphhopper.routing.ev.EdgeIntAccess;
 import com.graphhopper.routing.ev.EncodedValueLookup;
 import com.graphhopper.routing.ev.VehicleSpeed;
 import com.graphhopper.storage.IntsRef;
-import com.graphhopper.util.PMap;
 
 public class RoadsAverageSpeedParser implements TagParser {
     private final DecimalEncodedValue avgSpeedEnc;
     private final double maxPossibleSpeed;
 
-    public RoadsAverageSpeedParser(EncodedValueLookup lookup, PMap properties) {
+    public RoadsAverageSpeedParser(EncodedValueLookup lookup) {
         this(lookup.getDecimalEncodedValue(VehicleSpeed.key("roads")));
     }
 

--- a/core/src/test/java/com/graphhopper/routing/TrafficChangeWithNodeOrderingReusingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/TrafficChangeWithNodeOrderingReusingTest.java
@@ -60,7 +60,7 @@ public class TrafficChangeWithNodeOrderingReusingTest {
             BooleanEncodedValue accessEnc = VehicleAccess.create("car");
             DecimalEncodedValue speedEnc = VehicleSpeed.create("car", 5, 5, false);
             em = EncodingManager.start().add(accessEnc).add(speedEnc).build();
-            CarAverageSpeedParser carParser = new CarAverageSpeedParser(em, new PMap());
+            CarAverageSpeedParser carParser = new CarAverageSpeedParser(em);
             osmParsers = new OSMParsers()
                     .addWayTagParser(carParser);
             baseCHConfig = CHConfig.nodeBased("base", CustomModelParser.createFastestWeighting(accessEnc, speedEnc, em));

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/CarTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/CarTagParserTest.java
@@ -22,10 +22,8 @@ import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.reader.osm.conditional.DateRangeParser;
 import com.graphhopper.routing.ev.*;
 import com.graphhopper.routing.util.EncodingManager;
-import com.graphhopper.routing.util.FerrySpeedCalculator;
 import com.graphhopper.routing.util.PriorityCode;
 import com.graphhopper.routing.util.WayAccess;
-import com.graphhopper.storage.IntsRef;
 import com.graphhopper.util.Helper;
 import com.graphhopper.util.PMap;
 import org.junit.jupiter.api.Test;
@@ -44,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class CarTagParserTest {
     private final EncodingManager em = createEncodingManager("car");
     final CarAccessParser parser = createParser(em, new PMap("block_fords=true"));
-    final CarAverageSpeedParser speedParser = new CarAverageSpeedParser(em, new PMap("block_fords=true"));
+    final CarAverageSpeedParser speedParser = new CarAverageSpeedParser(em);
     private final BooleanEncodedValue roundaboutEnc = em.getBooleanEncodedValue(Roundabout.KEY);
     private final BooleanEncodedValue accessEnc = parser.getAccessEnc();
     private final DecimalEncodedValue avSpeedEnc = speedParser.getAverageSpeedEnc();
@@ -610,7 +608,7 @@ public class CarTagParserTest {
                 .add(smallFactorSpeedEnc)
                 .addTurnCostEncodedValue(TurnCost.create("car", 1))
                 .build();
-        CarAverageSpeedParser speedParser = new CarAverageSpeedParser(em, new PMap());
+        CarAverageSpeedParser speedParser = new CarAverageSpeedParser(em);
         ReaderWay way = new ReaderWay(1);
         way.setTag("highway", "motorway_link");
         way.setTag("maxspeed", "60 mph");
@@ -692,7 +690,7 @@ public class CarTagParserTest {
                 .add(lowFactorSpeedEnc)
                 .build();
         edgeIntAccess = new ArrayEdgeIntAccess(lowFactorEm.getIntsForFlags());
-        new CarAverageSpeedParser(lowFactorEm, new PMap()).handleWayTags(edgeId, edgeIntAccess, way);
+        new CarAverageSpeedParser(lowFactorEm).handleWayTags(edgeId, edgeIntAccess, way);
         assertEquals(1, lowFactorSpeedEnc.getDecimal(false, edgeId, edgeIntAccess), .1);
     }
 

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/FootTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/FootTagParserTest.java
@@ -23,15 +23,16 @@ import com.graphhopper.reader.osm.conditional.DateRangeParser;
 import com.graphhopper.routing.ev.*;
 import com.graphhopper.routing.util.AccessFilter;
 import com.graphhopper.routing.util.EncodingManager;
-import com.graphhopper.routing.util.FerrySpeedCalculator;
 import com.graphhopper.routing.util.PriorityCode;
 import com.graphhopper.storage.BaseGraph;
-import com.graphhopper.storage.IntsRef;
 import com.graphhopper.util.*;
 import org.junit.jupiter.api.Test;
 
 import java.text.DateFormat;
-import java.util.*;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 
 import static com.graphhopper.routing.util.parsers.FootAverageSpeedParser.MEAN_SPEED;
 import static com.graphhopper.routing.util.parsers.FootAverageSpeedParser.SLOW_SPEED;
@@ -54,8 +55,8 @@ public class FootTagParserTest {
             .add(carAccessEnc).add(carAvSpeedEnc)
             .build();
     private final FootAccessParser accessParser = new FootAccessParser(encodingManager, new PMap());
-    private final FootAverageSpeedParser speedParser = new FootAverageSpeedParser(encodingManager, new PMap());
-    private final FootPriorityParser prioParser = new FootPriorityParser(encodingManager, new PMap());
+    private final FootAverageSpeedParser speedParser = new FootAverageSpeedParser(encodingManager);
+    private final FootPriorityParser prioParser = new FootPriorityParser(encodingManager);
 
     public FootTagParserTest() {
         accessParser.init(new DateRangeParser());

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/HikeCustomModelTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/HikeCustomModelTest.java
@@ -14,7 +14,6 @@ import com.graphhopper.util.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.io.File;
 import java.io.InputStreamReader;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -39,7 +38,7 @@ public class HikeCustomModelTest {
 
         for (TagParser p : VehicleTagParsers.foot(em, new PMap()).getTagParsers())
             parsers.addWayTagParser(p);
-        for (TagParser p : VehicleTagParsers.roads(em, new PMap()).getTagParsers())
+        for (TagParser p : VehicleTagParsers.roads(em).getTagParsers())
             parsers.addWayTagParser(p);
     }
 

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/RacingBikeTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/RacingBikeTagParserTest.java
@@ -222,8 +222,8 @@ public class RacingBikeTagParserTest extends AbstractBikeTagParserTester {
                 .add(Smoothness.create())
                 .build();
         List<TagParser> parsers = Arrays.asList(
-                new RacingBikeAverageSpeedParser(encodingManager, new PMap()),
-                new RacingBikePriorityParser(encodingManager, new PMap())
+                new RacingBikeAverageSpeedParser(encodingManager),
+                new RacingBikePriorityParser(encodingManager)
         );
         ReaderWay osmWay = new ReaderWay(1);
         osmWay.setTag("highway", "tertiary");

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/RoadsTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/RoadsTagParserTest.java
@@ -17,7 +17,7 @@ class RoadsTagParserTest {
     private final RoadsAverageSpeedParser parser;
 
     public RoadsTagParserTest() {
-        parser = new RoadsAverageSpeedParser(encodingManager, new PMap());
+        parser = new RoadsAverageSpeedParser(encodingManager);
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/TagParsingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/TagParsingTest.java
@@ -55,8 +55,8 @@ class TagParsingTest {
                 .add(bikeNetworkEnc)
                 .add(Smoothness.create())
                 .build();
-        BikePriorityParser bike1Parser = new BikePriorityParser(em, new PMap("name=bike1"));
-        BikePriorityParser bike2Parser = new BikePriorityParser(em, new PMap("name=bike2")) {
+        BikePriorityParser bike1Parser = new BikePriorityParser(bike1PriorityEnc, bike1SpeedEnc, bikeNetworkEnc);
+        BikePriorityParser bike2Parser = new BikePriorityParser(bike2PriorityEnc, bike2SpeedEnc, bikeNetworkEnc) {
             @Override
             public void handleWayTags(int edgeId, EdgeIntAccess intAccess, ReaderWay way, IntsRef relTags) {
                 // accept less relations

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/TagParsingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/TagParsingTest.java
@@ -103,8 +103,8 @@ class TagParsingTest {
                 .add(bikeNetworkEnc)
                 .add(Smoothness.create())
                 .build();
-        BikePriorityParser bikeTagParser = new BikePriorityParser(em, new PMap());
-        MountainBikePriorityParser mtbTagParser = new MountainBikePriorityParser(em, new PMap());
+        BikePriorityParser bikeTagParser = new BikePriorityParser(em);
+        MountainBikePriorityParser mtbTagParser = new MountainBikePriorityParser(em);
         OSMParsers osmParsers = new OSMParsers()
                 .addRelationTagParser(relConfig -> new OSMBikeNetworkTagParser(bikeNetworkEnc, relConfig))
                 .addWayTagParser(new OSMRoadClassParser(em.getEnumEncodedValue(RoadClass.KEY, RoadClass.class)))


### PR DESCRIPTION
This is leftover code of the old flag encoder approach and I don't think it has a real use case. The only thing I could think of that could be useful is using [multiple roads vehicles with different transportation modes](https://discuss.graphhopper.com/t/how-to-using-road-vehicle-for-multi-profile/8375/6) but this doesn't even work currently, because we ignore the 'name' field [here](https://github.com/graphhopper/graphhopper/blob/ddb0471520a2e9f5a6d318942c88a604edc3aedb/core/src/main/java/com/graphhopper/GraphHopper.java#L728-L735)