### PR TITLE
Difference between bad highways for foot

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/parsers/FootPriorityParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/FootPriorityParser.java
@@ -58,10 +58,10 @@ public class FootPriorityParser implements TagParser {
         avoidHighwayTags.put("motorway_link", REACH_DESTINATION);
         avoidHighwayTags.put("trunk", REACH_DESTINATION);
         avoidHighwayTags.put("trunk_link", REACH_DESTINATION);
-        avoidHighwayTags.put("primary", AVOID_MORE);
-        avoidHighwayTags.put("primary_link", AVOID_MORE);
-        avoidHighwayTags.put("secondary", AVOID_MORE);
-        avoidHighwayTags.put("secondary_link", AVOID_MORE);
+        avoidHighwayTags.put("primary", BAD);
+        avoidHighwayTags.put("primary_link", BAD);
+        avoidHighwayTags.put("secondary", BAD);
+        avoidHighwayTags.put("secondary_link", BAD);
         avoidHighwayTags.put("tertiary", AVOID);
         avoidHighwayTags.put("tertiary_link", AVOID);
 
@@ -119,7 +119,7 @@ public class FootPriorityParser implements TagParser {
             if (way.hasTag("sidewalk", sidewalksNoValues))
                 weightToPrioMap.put(40d, priorityCode == null ? BAD : priorityCode);
             else
-                weightToPrioMap.put(40d, priorityCode == null ? AVOID : priorityCode.better());
+                weightToPrioMap.put(40d, priorityCode == null ? AVOID : priorityCode.better().better());
         } else if (way.hasTag("sidewalk", sidewalksNoValues))
             weightToPrioMap.put(40d, AVOID);
 

--- a/core/src/test/java/com/graphhopper/GraphHopperTest.java
+++ b/core/src/test/java/com/graphhopper/GraphHopperTest.java
@@ -866,8 +866,8 @@ public class GraphHopperTest {
         GHResponse rsp = hopper.route(req);
 
         ResponsePath res = rsp.getBest();
-        assertEquals(921, res.getDistance(), 10.);
-        assertEquals(36, res.getPoints().size());
+        assertEquals(575, res.getDistance(), 10.);
+        assertEquals(22, res.getPoints().size());
 
         // headings must be in [0, 360)
         req = new GHRequest().
@@ -1474,9 +1474,9 @@ public class GraphHopperTest {
 
         assertEquals(1, rsp.getAll().size());
         ResponsePath res = rsp.getBest();
-        assertEquals(1.49, rsp.getBest().getDistance() / 1000f, .01);
+        assertEquals(1.47, rsp.getBest().getDistance() / 1000f, .01);
         assertEquals(19, rsp.getBest().getTime() / 1000f / 60, 1);
-        assertEquals(66, res.getPoints().size());
+        assertEquals(64, res.getPoints().size());
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/routing/RoutingAlgorithmWithOSMTest.java
+++ b/core/src/test/java/com/graphhopper/routing/RoutingAlgorithmWithOSMTest.java
@@ -208,9 +208,9 @@ public class RoutingAlgorithmWithOSMTest {
     public void testSidewalkNo() {
         List<Query> queries = new ArrayList<>();
         // roundabout contains sidewalk=no which should be avoided
-        queries.add(new Query(57.154888, -2.101822, 57.153445, -2.099869, 252, 19));
+        queries.add(new Query(57.154888, -2.101822, 57.153445, -2.099869, 329, 31));
         // longer path should go through tertiary, see discussion in #476
-        queries.add(new Query(57.154888, -2.101822, 57.147299, -2.096286, 1040, 56));
+        queries.add(new Query(57.154888, -2.101822, 57.147299, -2.096286, 1118, 68));
 
         Profile profile = TestProfiles.accessSpeedAndPriority("foot");
         GraphHopper hopper = createHopper(DIR + "/map-sidewalk-no.osm.gz", profile);

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/FootTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/FootTagParserTest.java
@@ -330,13 +330,13 @@ public class FootTagParserTest {
         assertEquals(PriorityCode.AVOID.getValue(), prioParser.handlePriority(way, null));
 
         way.setTag("sidewalk", "no");
-        assertEquals(PriorityCode.AVOID_MORE.getValue(), prioParser.handlePriority(way, null));
+        assertEquals(PriorityCode.BAD.getValue(), prioParser.handlePriority(way, null));
 
         way.clearTags();
         way.setTag("highway", "tertiary");
-        assertEquals(PriorityCode.SLIGHT_AVOID.getValue(), prioParser.handlePriority(way, null));
+        assertEquals(PriorityCode.UNCHANGED.getValue(), prioParser.handlePriority(way, null));
 
-        // tertiary without sidewalk is roughly like primary with sidewalk?
+        // tertiary without sidewalk is roughly like primary with sidewalk
         way.setTag("sidewalk", "no");
         assertEquals(PriorityCode.AVOID.getValue(), prioParser.handlePriority(way, null));
 
@@ -365,7 +365,11 @@ public class FootTagParserTest {
         assertEquals(PriorityCode.SLIGHT_AVOID.getValue(), prioParser.handlePriority(way, null));
 
         way.clearTags();
-        way.setTag("highway", "trunk");
+        way.setTag("highway", "secondary");
+        assertEquals(PriorityCode.AVOID.getValue(), prioParser.handlePriority(way, null));
+        way.setTag("highway", "trunk"); // secondary should be better to mostly avoid trunk e.g. here 46.9889,10.5664->47.0172,10.6059
+        assertEquals(PriorityCode.BAD.getValue(), prioParser.handlePriority(way, null));
+
         way.setTag("sidewalk", "no");
         assertEquals(PriorityCode.REACH_DESTINATION.getValue(), prioParser.handlePriority(way, null));
         way.setTag("sidewalk", "none");


### PR DESCRIPTION
Similar to #2796 but for `foot`.

To fix problems like [this route](https://graphhopper.com/maps/?point=46.9889%252C10.5664&point=47.0172%252C10.6059&profile=foot) that suggests to use trunk roads for a large portion although the parallel secondary or track could be used.
