### PR TITLE
Add missing setup call

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/DijkstraOneToMany.java
+++ b/core/src/main/java/com/graphhopper/routing/DijkstraOneToMany.java
@@ -67,6 +67,7 @@ public class DijkstraOneToMany extends AbstractRoutingAlgorithm {
 
     @Override
     public Path calcPath(int from, int to) {
+        setupFinishTime();
         fromNode = from;
         endNode = findEndNode(from, to);
         if (endNode < 0 || isWeightLimitExceeded()) {


### PR DESCRIPTION
While DijkstraOneToMany evaluates the timeout, it's missing the setup.