### PR TITLE
Fix deprecation warnings

### DIFF
--- a/core/src/main/java/com/graphhopper/isochrone/algorithm/ContourBuilder.java
+++ b/core/src/main/java/com/graphhopper/isochrone/algorithm/ContourBuilder.java
@@ -13,7 +13,7 @@
 
 package com.graphhopper.isochrone.algorithm;
 
-import org.locationtech.jts.algorithm.CGAlgorithms;
+import org.locationtech.jts.algorithm.Area;
 import org.locationtech.jts.geom.*;
 import org.locationtech.jts.geom.prep.PreparedPolygon;
 import org.locationtech.jts.triangulate.quadedge.Vertex;
@@ -125,7 +125,7 @@ public class ContourBuilder {
         List<LinearRing> holes = new ArrayList<>(rings.size() / 2);
         // 1. Split the polygon list in two: shells and holes (CCW and CW)
         for (LinearRing ring : rings) {
-            if (CGAlgorithms.signedArea(ring.getCoordinateSequence()) > 0.0)
+            if (Area.ofRingSigned(ring.getCoordinateSequence()) > 0.0)
                 holes.add(ring);
             else
                 shells.add(new PreparedPolygon(geometryFactory.createPolygon(ring)));

--- a/core/src/main/java/com/graphhopper/routing/ev/EncodedValueSerializer.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/EncodedValueSerializer.java
@@ -23,7 +23,7 @@ import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 
 public class EncodedValueSerializer {
     private final static ObjectMapper MAPPER = new ObjectMapper();
@@ -31,7 +31,7 @@ public class EncodedValueSerializer {
     static {
         MAPPER.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.NONE);
         MAPPER.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
-        MAPPER.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
+        MAPPER.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
     }
 
     public static String serializeEncodedValue(EncodedValue encodedValue) {

--- a/web-api/src/main/java/com/graphhopper/jackson/Jackson.java
+++ b/web-api/src/main/java/com/graphhopper/jackson/Jackson.java
@@ -20,7 +20,7 @@ package com.graphhopper.jackson;
 import com.bedatadriven.jackson.datatype.jts.JtsModule;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 
 public class Jackson {
 
@@ -31,7 +31,7 @@ public class Jackson {
     public static ObjectMapper initObjectMapper(ObjectMapper objectMapper) {
         objectMapper.registerModule(new GraphHopperModule());
         objectMapper.registerModule(new JtsModule());
-        objectMapper.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
+        objectMapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
         objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         return objectMapper;
     }


### PR DESCRIPTION
* replaced `PropertyNamingStrategy.SNAKE_CASE` with `PropertyNamingStrategies.SNAKE_CASE`:    
  https://github.com/FasterXML/jackson-databind/issues/2715
* replaced `CGAlgorithms.signedArea(CoordinateSequence)`  with `Area.ofRingSigned(CoordinateSequence)`:    
 https://github.com/locationtech/jts/blob/93f0e35289246e0847a8c09505974e07c10624e2/modules/core/src/main/java/org/locationtech/jts/algorithm/CGAlgorithms.java#L548-L549