### PR TITLE
New Highway-Tag based Encoded Values

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -86,6 +86,7 @@ Here is an overview:
  * thehereward, code cleanups like #620
  * vvikas, ideas for many to many improvements and #616
  * zstadler, multiple fixes and car4wd
+ * TheDropZone, added new optional encoded values
 
 ## Translations
 

--- a/config-example.yml
+++ b/config-example.yml
@@ -78,7 +78,8 @@ graphhopper:
   # Default values are: road_class,road_class_link,road_environment,max_speed,road_access
   # More are: surface,smoothness,max_width,max_height,max_weight,max_weight_except,hgv,max_axle_load,max_length,
   #           hazmat,hazmat_tunnel,hazmat_water,lanes,osm_way_id,toll,track_type,mtb_rating,hike_rating,horse_rating,
-  #           country,curvature,average_slope,max_slope,car_temporal_access,bike_temporal_access,foot_temporal_access
+  #           country,curvature,average_slope,max_slope,car_temporal_access,bike_temporal_access,
+  #           foot_temporal_access,highway_feature
   # graph.encoded_values: surface,toll,track_type
 
   #### Speed, hybrid and flexible mode ####

--- a/core/src/main/java/com/graphhopper/routing/ev/DefaultImportRegistry.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/DefaultImportRegistry.java
@@ -185,6 +185,11 @@ public class DefaultImportRegistry implements ImportRegistry {
                     (lookup, props) -> new OSMCrossingParser(
                             lookup.getEnumEncodedValue(Crossing.KEY, Crossing.class))
             );
+        else if (HighwayFeature.KEY.equals(name))
+            return ImportUnit.create(name, props -> HighwayFeature.create(),
+                    (lookup, props) -> new OSMHighwayFeatureParser(
+                            lookup.getEnumEncodedValue(HighwayFeature.KEY, HighwayFeature.class))
+            );
         else if (FerrySpeed.KEY.equals(name))
             return ImportUnit.create(name, props -> FerrySpeed.create(),
                     (lookup, props) -> new FerrySpeedCalculator(

--- a/core/src/main/java/com/graphhopper/routing/ev/HighwayFeature.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/HighwayFeature.java
@@ -1,0 +1,30 @@
+package com.graphhopper.routing.ev;
+
+import com.graphhopper.util.Helper;
+
+public enum HighwayFeature {
+    MISSING, // no information
+    TRAFFIC_SIGNALS, // Lights that control the traffic
+    STOP, // A Stop sign
+    CROSSING; // A.k.a. crosswalk. Pedestrians can cross a street here; e.g., zebra crossing
+    public static final String KEY = "highway_feature";
+
+    public static EnumEncodedValue<HighwayFeature> create() {
+        return new EnumEncodedValue<>(HighwayFeature.KEY, HighwayFeature.class);
+    }
+
+    @Override
+    public String toString() {
+        return Helper.toLowerCase(super.toString());
+    }
+
+    public static HighwayFeature find(String name) {
+        if (name == null)
+            return MISSING;
+        try {
+            return HighwayFeature.valueOf(Helper.toUpperCase(name));
+        } catch (IllegalArgumentException ex) {
+            return MISSING;
+        }
+    }
+}

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMHighwayFeatureParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMHighwayFeatureParser.java
@@ -1,0 +1,56 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.routing.util.parsers;
+
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.EdgeIntAccess;
+import com.graphhopper.routing.ev.EnumEncodedValue;
+import com.graphhopper.routing.ev.HighwayFeature;
+import com.graphhopper.storage.IntsRef;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Can be used to parse out Highway features from OSM tag data. See
+ * <a href="https://wiki.openstreetmap.org/wiki/Key:highway">osm highway tag</a>
+ * - 'Other highway features' section for potentially more values to add here in the future.
+ */
+public class OSMHighwayFeatureParser implements TagParser {
+
+    protected final EnumEncodedValue<HighwayFeature> highwayFeatureEnc;
+
+    public OSMHighwayFeatureParser(EnumEncodedValue<HighwayFeature> highwayFeatureEnc) {
+        this.highwayFeatureEnc = highwayFeatureEnc;
+    }
+
+    @Override
+    public void handleWayTags(int edgeId, EdgeIntAccess edgeIntAccess, ReaderWay readerWay, IntsRef relationFlags) {
+        List<Map<String, Object>> nodeTags = readerWay.getTag("node_tags", null);
+        if (nodeTags == null)
+            return;
+
+        for (int i = 0; i < nodeTags.size(); i++) {
+            Map<String, Object> tags = nodeTags.get(i);
+            String crossingValue = (String) tags.get("highway");
+            HighwayFeature highwayFeature = HighwayFeature.find(crossingValue);
+            if (highwayFeature != HighwayFeature.MISSING) {
+                highwayFeatureEnc.setEnum(false, edgeId, edgeIntAccess, highwayFeature);
+            }
+        }
+    }
+}

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMHighwayFeatureParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMHighwayFeatureParserTest.java
@@ -1,0 +1,64 @@
+package com.graphhopper.routing.util.parsers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.ArrayEdgeIntAccess;
+import com.graphhopper.routing.ev.Crossing;
+import com.graphhopper.routing.ev.EdgeIntAccess;
+import com.graphhopper.routing.ev.EncodedValue;
+import com.graphhopper.routing.ev.EnumEncodedValue;
+import com.graphhopper.routing.ev.HighwayFeature;
+import com.graphhopper.util.PMap;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class OSMHighwayFeatureParserTest {
+
+    private OSMHighwayFeatureParser parser;
+    private EnumEncodedValue<HighwayFeature> highwayFeatureEV;
+
+    @BeforeEach
+    public void setup() {
+        highwayFeatureEV = new EnumEncodedValue<>(HighwayFeature.KEY, HighwayFeature.class);
+        highwayFeatureEV.init(new EncodedValue.InitializerConfig());
+        parser = new OSMHighwayFeatureParser(highwayFeatureEV);
+    }
+
+    @Test
+    public void testCrossing() {
+        EdgeIntAccess edgeIntAccess = new ArrayEdgeIntAccess(1);
+        int edgeId = 0;
+        parser.handleWayTags(edgeId, edgeIntAccess,
+                createReader(new PMap().putObject("highway", "crossing").toMap()), null);
+        assertEquals(HighwayFeature.CROSSING, highwayFeatureEV.getEnum(false, edgeId, edgeIntAccess));
+    }
+
+    @Test
+    public void testTrafficSignals() {
+        EdgeIntAccess edgeIntAccess = new ArrayEdgeIntAccess(1);
+        int edgeId = 0;
+        parser.handleWayTags(edgeId, edgeIntAccess,
+                createReader(new PMap().putObject("highway", "traffic_signals").toMap()), null);
+        assertEquals(HighwayFeature.TRAFFIC_SIGNALS, highwayFeatureEV.getEnum(false, edgeId, edgeIntAccess));
+    }
+
+    @Test
+    public void testStopSigns() {
+        EdgeIntAccess edgeIntAccess = new ArrayEdgeIntAccess(1);
+        int edgeId = 0;
+        parser.handleWayTags(edgeId, edgeIntAccess,
+                createReader(new PMap().putObject("highway", "stop").toMap()), null);
+        assertEquals(HighwayFeature.STOP, highwayFeatureEV.getEnum(false, edgeId, edgeIntAccess));
+    }
+
+    ReaderWay createReader(Map<String, Object> map) {
+        ReaderWay way = new ReaderWay(1);
+        way.setTag("node_tags", Collections.singletonList(map));
+        return way;
+    }
+
+}


### PR DESCRIPTION
Provide a first pass at adding in `highway` tag based osm data to the options of encoded data. The goal is to provide traffic signal, stop signs, and traffic crossings back in the routing requests.

The encoded data (tags) being targeted are references in the highway-tag wiki page: [https://wiki.openstreetmap.org/wiki/Key:highway](highway-tag) under the "Other highway features".
Currently, the tags that are being included are
- TRAFFIC_SIGNALS
- STOP
- CROSSING

Additionally, this provides a channel to add on additional tags under the `highway` key using this encoded_data tag.
```
graph.encoded_values: highway_feature
```
This also provides the ability to request those highway features (currently traffic signals, stop signs, and crossing) from the web api via the `details` parameter

---

I attempted to model this after other encoded_value tags and parsers, but am very happy to refactor or adjust as needed. If this data is better loaded using other methods, I am glad to refactor as well. Open to any critiques as this is my first contribution here. Thanks for the time!



---
**Note:**
- added username and blurb to CONTRIBUTORS.md file