### PR TITLE
Use geo ref to identify copied edges

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/parsers/RestrictionSetter.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/RestrictionSetter.java
@@ -72,12 +72,7 @@ public class RestrictionSetter {
                 int viaEdge = p.first.getViaEdges().get(0);
                 int artificialEdge = artificialEdgesByEdges.getOrDefault(viaEdge, -1);
                 if (artificialEdge < 0) {
-                    EdgeIteratorState viaEdgeState = baseGraph.getEdgeIteratorState(p.first.getViaEdges().get(0), Integer.MIN_VALUE);
-                    EdgeIteratorState artificialEdgeState = baseGraph.edge(viaEdgeState.getBaseNode(), viaEdgeState.getAdjNode())
-                            .setFlags(viaEdgeState.getFlags())
-                            .setWayGeometry(viaEdgeState.fetchWayGeometry(FetchMode.PILLAR_ONLY))
-                            .setDistance(viaEdgeState.getDistance())
-                            .setKeyValues(viaEdgeState.getKeyValues());
+                    EdgeIteratorState artificialEdgeState = baseGraph.copyEdge(p.first.getViaEdges().get(0), true);
                     artificialEdge = artificialEdgeState.getEdge();
                     artificialEdgesByEdges.put(viaEdge, artificialEdge);
                 }

--- a/core/src/main/java/com/graphhopper/util/EdgeIteratorState.java
+++ b/core/src/main/java/com/graphhopper/util/EdgeIteratorState.java
@@ -120,8 +120,9 @@ public interface EdgeIteratorState {
 
     /**
      * @param list is a sorted collection of coordinates between the base node and the current adjacent node. Specify
-     *             the list without the adjacent and base node. This method can be called multiple times, but if the
-     *             distance changes, the setDistance method is not called automatically.
+     *             the list without the adjacent and base node. This method can be called multiple times, unless the
+     *             given point list is longer than the first time the method was called. Also keep in
+     *             mind that if the distance changes the setDistance method is not called automatically.
      */
     EdgeIteratorState setWayGeometry(PointList list);
 

--- a/core/src/test/java/com/graphhopper/storage/AbstractGraphStorageTester.java
+++ b/core/src/test/java/com/graphhopper/storage/AbstractGraphStorageTester.java
@@ -735,11 +735,10 @@ public abstract class AbstractGraphStorageTester {
         assertEquals(4 + (1 + 12), baseGraph.getMaxGeoRef());
         iter2.setWayGeometry(Helper.createPointList3D(1, 2, 3));
         assertEquals(4 + (1 + 12), baseGraph.getMaxGeoRef());
-        iter2.setWayGeometry(Helper.createPointList3D(1.5, 1, 0, 2, 3, 0));
-        assertEquals(4 + (1 + 12) + (1 + 6), baseGraph.getMaxGeoRef());
+        assertThrows(IllegalStateException.class, () -> iter2.setWayGeometry(Helper.createPointList3D(1.5, 1, 0, 2, 3, 0)));
         EdgeIteratorState iter1 = graph.edge(0, 2).setDistance(200).set(carAccessEnc, true, true);
         iter1.setWayGeometry(Helper.createPointList3D(3.5, 4.5, 0, 5, 6, 0));
-        assertEquals(4 + (1 + 12) + (1 + 6) + (1 + 6), baseGraph.getMaxGeoRef());
+        assertEquals(4 + (1 + 12) + (1 + 6), baseGraph.getMaxGeoRef());
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/storage/BaseGraphTest.java
+++ b/core/src/test/java/com/graphhopper/storage/BaseGraphTest.java
@@ -289,4 +289,22 @@ public class BaseGraphTest extends AbstractGraphStorageTester {
         edge.set(rcEnc, RoadClass.CORRIDOR);
         assertEquals(RoadClass.CORRIDOR, edge.get(rcEnc));
     }
+
+    @Test
+    public void copyEdge() {
+        BaseGraph graph = createGHStorage();
+        EnumEncodedValue<RoadClass> rcEnc = encodingManager.getEnumEncodedValue(RoadClass.KEY, RoadClass.class);
+        EdgeIteratorState edge1 = graph.edge(3, 5).set(rcEnc, RoadClass.LIVING_STREET);
+        EdgeIteratorState edge2 = graph.edge(3, 5).set(rcEnc, RoadClass.MOTORWAY);
+        EdgeIteratorState edge3 = graph.copyEdge(edge1.getEdge(), true);
+        EdgeIteratorState edge4 = graph.copyEdge(edge1.getEdge(), false);
+        assertEquals(RoadClass.LIVING_STREET, edge1.get(rcEnc));
+        assertEquals(RoadClass.MOTORWAY, edge2.get(rcEnc));
+        assertEquals(edge1.get(rcEnc), edge3.get(rcEnc));
+        assertEquals(edge1.get(rcEnc), edge4.get(rcEnc));
+        graph.forEdgeAndCopyOfEdge(graph.createEdgeExplorer(), edge1, e -> e.set(rcEnc, RoadClass.FOOTWAY));
+        assertEquals(RoadClass.FOOTWAY, edge1.get(rcEnc));
+        assertEquals(RoadClass.FOOTWAY, edge3.get(rcEnc));
+        assertEquals(RoadClass.LIVING_STREET, edge4.get(rcEnc));
+    }
 }


### PR DESCRIPTION
For e.g. https://github.com/graphhopper/graphhopper/issues/2914 we need to be able to tell which edges are copies of which. One possible solution is to assign a common identifier to each original edge and the corresponding copied edges, because then we can find the copies by iterating the edges at one of the nodes of an edge. 

I added a new method `forEdgeAndCopiedEdges()` to `BaseGraph` that can be used to modify edges and their corresponding copied edges. We mainly use these copied edges for via-way turn restrictions so far. **So basically whenever one needs to modify an edge after the via-way turn restriction handling went through it should be done using this method!**

A memory efficient way to do this is using the geometry ref since the geometry for copied edges should be identical to the geometry of the original edge anyway. But unfortunately, not every edge has a geometry (and thus no geo ref). This makes it a bit more tricky but it is still doable by using a dedicated value for the geo ref for each copied edge (that has no geometry). 

The other tricky bit is that by setting the geometry of an edge a second time or by setting the geometry after copying an edge the possibility to identify the copied edges gets lost. Therefore, with this PR we now get an error when we try to set the geometry when it was set already or the edge was copied before. The only exception that still works is when the new geometry has a smaller or equal number of pillar nodes than before, because in this case the geo ref stays the same. Otherwise the current edge elevation interpolation wouldn't work for example.