### PR TITLE
Use 9 bits to store max_weight

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/ev/MaxWeight.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/MaxWeight.java
@@ -28,11 +28,11 @@ public class MaxWeight {
     public static final String KEY = "max_weight";
 
     /**
-     * Currently enables to store 0.1 to max=0.1*2⁸ tons and infinity. If a value is between the maximum and infinity
+     * Currently enables to store 0.1 to max=0.1*2⁹ tons and infinity. If a value is between the maximum and infinity
      * it is assumed to use the maximum value. To save bits it might make more sense to store only a few values like
      * it was done with the MappedDecimalEncodedValue still handling (or rounding) of unknown values is unclear.
      */
     public static DecimalEncodedValue create() {
-        return new DecimalEncodedValueImpl(KEY, 8, 0, 0.1, false, false, true);
+        return new DecimalEncodedValueImpl(KEY, 9, 0, 0.1, false, false, true);
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/helpers/OSMValueExtractor.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/helpers/OSMValueExtractor.java
@@ -36,9 +36,10 @@ public class OSMValueExtractor {
         if (Double.isNaN(value)) value = Double.POSITIVE_INFINITY;
 
         valueEncoder.setDecimal(false, edgeId, edgeIntAccess, value);
-        // too many
-//        if (value - valueEncoder.getDecimal(false, edgeFlags) > 2)
-//            logger.warn("Value " + value + " for " + valueEncoder.getName() + " was too large and truncated to " + valueEncoder.getDecimal(false, edgeFlags));
+
+        double storedValue = valueEncoder.getDecimal(false, edgeId, edgeIntAccess);
+        if (value - storedValue > 2)
+            logger.warn("Value {} for {} was too large and truncated to {} for way {}", value, valueEncoder.getName(), storedValue, way.getId());
     }
 
     /**

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMMaxWeightParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMMaxWeightParserTest.java
@@ -33,9 +33,9 @@ public class OSMMaxWeightParserTest {
 
         // if value is beyond the maximum then do not use infinity instead fallback to more restrictive maximum
         edgeIntAccess = new ArrayEdgeIntAccess(1);
-        readerWay.setTag("maxweight", "50");
+        readerWay.setTag("maxweight", "54");
         parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
-        assertEquals(25.4, mwEnc.getDecimal(false, edgeId, edgeIntAccess), .01);
+        assertEquals(51, mwEnc.getDecimal(false, edgeId, edgeIntAccess), .01);
     }
 
     @Test


### PR DESCRIPTION
Fixes #2986

* raises the size of MaxWeight EV to 9 bits, which is enough to encode `maxweight` values up to 51t.
* ~~re-enable logging of capped values which should (hopefully) occur less often~~ still the case