### PR TITLE
Parse maxweightrating

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMMaxWeightParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMMaxWeightParser.java
@@ -31,7 +31,7 @@ import java.util.stream.Collectors;
 public class OSMMaxWeightParser implements TagParser {
 
     // do not include OSM tag "height" here as it has completely different meaning (height of peak)
-    private static final List<String> MAX_WEIGHT_TAGS = Arrays.asList("maxweight", "maxgcweight"/*abandoned*/, "maxweightrating:hgv");
+    private static final List<String> MAX_WEIGHT_TAGS = Arrays.asList("maxweight", "maxweightrating:hgv", "maxgcweight"/*abandoned*/);
     private static final List<String> HGV_RESTRICTIONS = OSMRoadAccessParser.toOSMRestrictions(TransportationMode.HGV).stream()
             .map(e -> e + ":conditional").collect(Collectors.toList());
     private final DecimalEncodedValue weightEncoder;

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMMaxWeightParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMMaxWeightParser.java
@@ -31,7 +31,7 @@ import java.util.stream.Collectors;
 public class OSMMaxWeightParser implements TagParser {
 
     // do not include OSM tag "height" here as it has completely different meaning (height of peak)
-    private static final List<String> MAX_WEIGHT_TAGS = Arrays.asList("maxweight", "maxweightrating:hgv", "maxgcweight"/*abandoned*/);
+    private static final List<String> MAX_WEIGHT_TAGS = Arrays.asList("maxweight", "maxweightrating", "maxweightrating:hgv", "maxgcweight"/*abandoned*/);
     private static final List<String> HGV_RESTRICTIONS = OSMRoadAccessParser.toOSMRestrictions(TransportationMode.HGV).stream()
             .map(e -> e + ":conditional").collect(Collectors.toList());
     private final DecimalEncodedValue weightEncoder;


### PR DESCRIPTION
We currently only parse `maxweightrating:hgv`, but the `maxweightrating` tag is also used in OSM, e.g. in the UK.

OSM wiki: https://wiki.openstreetmap.org/wiki/Key:maxweightrating#maxweightrating_sign

![grafik](https://github.com/graphhopper/graphhopper/assets/22315436/7216918c-add4-4cc7-9c31-001a8298d518)

I also moved the abandoned `maxgcweight` tag to the end of the list, preferring the standard tags if present.