### PR TITLE
Remove georef factor 4 now that there are 5 bytes for georef

### DIFF
--- a/core/src/main/java/com/graphhopper/storage/BaseGraph.java
+++ b/core/src/main/java/com/graphhopper/storage/BaseGraph.java
@@ -173,7 +173,7 @@ public class BaseGraph implements Graph, Closeable {
         }
         setInitialized();
         // 0 stands for no separate geoRef
-        maxGeoRef = 4;
+        maxGeoRef = 1;
         return this;
     }
 
@@ -357,14 +357,14 @@ public class BaseGraph implements Graph, Closeable {
             int len = pillarNodes.size();
             int dim = nodeAccess.getDimension();
             if (existingGeoRef > 0) {
-                final int count = wayGeometry.getInt(existingGeoRef * 4L);
+                final int count = wayGeometry.getInt(existingGeoRef);
                 if (len <= count) {
                     setWayGeometryAtGeoRef(pillarNodes, edgePointer, reverse, existingGeoRef);
                     return;
                 }
             }
 
-            long nextGeoRef = nextGeoRef(len * dim);
+            long nextGeoRef = nextGeoRef(4 + len * dim * 4);
             setWayGeometryAtGeoRef(pillarNodes, edgePointer, reverse, nextGeoRef);
         } else {
             store.setGeoRef(edgePointer, 0L);
@@ -376,10 +376,9 @@ public class BaseGraph implements Graph, Closeable {
     }
 
     private void setWayGeometryAtGeoRef(PointList pillarNodes, long edgePointer, boolean reverse, long geoRef) {
-        long geoRefPosition = geoRef * 4;
         byte[] wayGeometryBytes = createWayGeometryBytes(pillarNodes, reverse);
-        wayGeometry.ensureCapacity(geoRefPosition + wayGeometryBytes.length);
-        wayGeometry.setBytes(geoRefPosition, wayGeometryBytes, wayGeometryBytes.length);
+        wayGeometry.ensureCapacity(geoRef + wayGeometryBytes.length);
+        wayGeometry.setBytes(geoRef, wayGeometryBytes, wayGeometryBytes.length);
         store.setGeoRef(edgePointer, geoRef);
     }
 
@@ -421,9 +420,7 @@ public class BaseGraph implements Graph, Closeable {
         int count = 0;
         byte[] bytes = null;
         if (geoRef > 0) {
-            geoRef *= 4L;
             count = wayGeometry.getInt(geoRef);
-
             geoRef += 4L;
             bytes = new byte[count * nodeAccess.getDimension() * 4];
             wayGeometry.getBytes(geoRef, bytes, bytes.length);
@@ -477,9 +474,9 @@ public class BaseGraph implements Graph, Closeable {
         throw new IllegalArgumentException("Mode isn't handled " + mode);
     }
 
-    private long nextGeoRef(int arrayLength) {
+    private long nextGeoRef(int bytes) {
         long tmp = maxGeoRef;
-        maxGeoRef += arrayLength + 1L;
+        maxGeoRef += bytes;
         return tmp;
     }
 

--- a/core/src/test/java/com/graphhopper/storage/AbstractGraphStorageTester.java
+++ b/core/src/test/java/com/graphhopper/storage/AbstractGraphStorageTester.java
@@ -726,20 +726,20 @@ public abstract class AbstractGraphStorageTester {
 
         EdgeIteratorState iter2 = graph.edge(0, 1).setDistance(100).set(carAccessEnc, true, true);
         final BaseGraph baseGraph = (BaseGraph) graph.getBaseGraph();
-        assertEquals(4, baseGraph.getMaxGeoRef());
+        assertEquals(1, baseGraph.getMaxGeoRef());
         iter2.setWayGeometry(Helper.createPointList3D(1, 2, 3, 3, 4, 5, 5, 6, 7, 7, 8, 9));
-        assertEquals(4 + (1 + 12), baseGraph.getMaxGeoRef());
+        assertEquals(1 + 4 * (1 + 12), baseGraph.getMaxGeoRef());
         iter2.setWayGeometry(Helper.createPointList3D(1, 2, 3, 3, 4, 5, 5, 6, 7));
-        assertEquals(4 + (1 + 12), baseGraph.getMaxGeoRef());
+        assertEquals(1 + 4 * (1 + 12), baseGraph.getMaxGeoRef());
         iter2.setWayGeometry(Helper.createPointList3D(1, 2, 3, 3, 4, 5));
-        assertEquals(4 + (1 + 12), baseGraph.getMaxGeoRef());
+        assertEquals(1 + 4 * (1 + 12), baseGraph.getMaxGeoRef());
         iter2.setWayGeometry(Helper.createPointList3D(1, 2, 3));
-        assertEquals(4 + (1 + 12), baseGraph.getMaxGeoRef());
+        assertEquals(1 + 4 * (1 + 12), baseGraph.getMaxGeoRef());
         iter2.setWayGeometry(Helper.createPointList3D(1.5, 1, 0, 2, 3, 0));
-        assertEquals(4 + (1 + 12) + (1 + 6), baseGraph.getMaxGeoRef());
+        assertEquals(1 + 4 * (1 + 12) + 4 * (1 + 6), baseGraph.getMaxGeoRef());
         EdgeIteratorState iter1 = graph.edge(0, 2).setDistance(200).set(carAccessEnc, true, true);
         iter1.setWayGeometry(Helper.createPointList3D(3.5, 4.5, 0, 5, 6, 0));
-        assertEquals(4 + (1 + 12) + (1 + 6) + (1 + 6), baseGraph.getMaxGeoRef());
+        assertEquals(1 + 4 * (1 + 12) + 4 * (1 + 6) + 4 * (1 + 6), baseGraph.getMaxGeoRef());
     }
 
     @Test


### PR DESCRIPTION
We used to count the byte offset into the way geometry in units of four bytes to reduce the number of required distinct values of the georef. Since we now use five bytes for the georef (#2993) we don't need this scaling anymore. This will also allow reducing the number of used bytes for the elevation data and the geometry byte counter we use for each edge.
