### PR TITLE
[DRAFT] remove tertiary highways from preferred and increase speed on footways

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonAverageSpeedParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonAverageSpeedParser.java
@@ -201,7 +201,7 @@ public abstract class BikeCommonAverageSpeedParser extends AbstractAverageSpeedP
                 if (way.hasTag("segregated", "yes"))
                     speed = highwaySpeeds.get("cycleway");
                 else
-                    speed = way.hasTag("bicycle", "yes") ? 10 : highwaySpeeds.get("cycleway");
+                    speed = way.hasTag("bicycle", "yes") ? 12 : highwaySpeeds.get("cycleway");
 
                 // valid surface speed?
                 if (surfaceSpeed > 0)

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/BikePriorityParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/BikePriorityParser.java
@@ -18,8 +18,6 @@ public class BikePriorityParser extends BikeCommonPriorityParser {
         addPushingSection("path");
 
         preferHighwayTags.add("service");
-        preferHighwayTags.add("tertiary");
-        preferHighwayTags.add("tertiary_link");
         preferHighwayTags.add("residential");
         preferHighwayTags.add("unclassified");
 

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/AbstractBikeTagParserTester.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/AbstractBikeTagParserTester.java
@@ -376,13 +376,6 @@ public abstract class AbstractBikeTagParserTester {
     }
 
     @Test
-    public void testPreferenceForSlowSpeed() {
-        ReaderWay osmWay = new ReaderWay(1);
-        osmWay.setTag("highway", "tertiary");
-        assertPriority(PREFER, osmWay);
-    }
-
-    @Test
     public void testHandleWayTagsCallsHandlePriority() {
         ReaderWay osmWay = new ReaderWay(1);
         osmWay.setTag("highway", "cycleway");

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/BikeTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/BikeTagParserTest.java
@@ -97,9 +97,9 @@ public class BikeTagParserTest extends AbstractBikeTagParserTester {
         way.clearTags();
         way.setTag("highway", "footway");
         way.setTag("bicycle", "yes");
-        assertPriorityAndSpeed(PREFER, 10, way);
+        assertPriorityAndSpeed(PREFER, 12, way);
         way.setTag("segregated", "no");
-        assertPriorityAndSpeed(PREFER, 10, way);
+        assertPriorityAndSpeed(PREFER, 12, way);
         way.setTag("segregated", "yes");
         assertPriorityAndSpeed(PREFER, 18, way);
 
@@ -107,7 +107,7 @@ public class BikeTagParserTest extends AbstractBikeTagParserTester {
         way.setTag("highway", "footway");
         way.setTag("surface", "paved");
         way.setTag("bicycle", "yes");
-        assertPriorityAndSpeed(PREFER, 10, way);
+        assertPriorityAndSpeed(PREFER, 12, way);
         way.setTag("surface", "cobblestone");
         assertPriorityAndSpeed(PREFER, 8, way);
         way.setTag("segregated", "yes");
@@ -118,7 +118,7 @@ public class BikeTagParserTest extends AbstractBikeTagParserTester {
         way.setTag("highway", "platform");
         way.setTag("surface", "paved");
         way.setTag("bicycle", "yes");
-        assertPriorityAndSpeed(PREFER, 10, way);
+        assertPriorityAndSpeed(PREFER, 12, way);
         way.setTag("segregated", "yes");
         assertPriorityAndSpeed(PREFER, 18, way);
 
@@ -151,7 +151,7 @@ public class BikeTagParserTest extends AbstractBikeTagParserTester {
         assertPriorityAndSpeed(VERY_NICE, cyclewaySpeed, way);
 
         way.setTag("bicycle", "yes");
-        assertPriorityAndSpeed(PREFER, 10, way);
+        assertPriorityAndSpeed(PREFER, 12, way);
 
         way.setTag("segregated", "yes");
         assertPriorityAndSpeed(PREFER, cyclewaySpeed, way);
@@ -417,6 +417,13 @@ public class BikeTagParserTest extends AbstractBikeTagParserTester {
     }
 
     @Test
+    public void testPreferenceForSlowSpeed() {
+        ReaderWay osmWay = new ReaderWay(1);
+        osmWay.setTag("highway", "tertiary");
+        assertPriority(UNCHANGED, osmWay);
+    }
+
+    @Test
     public void testHandleWayTagsInfluencedByRelation() {
         ReaderWay osmWay = new ReaderWay(1);
         osmWay.setTag("highway", "road");
@@ -526,7 +533,7 @@ public class BikeTagParserTest extends AbstractBikeTagParserTester {
         ReaderWay way = new ReaderWay(1);
         way.setTag("highway", "tertiary");
         way.setTag("maxspeed", "90");
-        assertPriorityAndSpeed(UNCHANGED, 18, way);
+        assertPriorityAndSpeed(AVOID, 18, way);
 
         way = new ReaderWay(1);
         way.setTag("highway", "track");

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/MountainBikeTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/MountainBikeTagParserTest.java
@@ -232,4 +232,10 @@ public class MountainBikeTagParserTest extends AbstractBikeTagParserTester {
         assertFalse(accessParser.isBarrier(node));
     }
 
+    @Test
+    public void testPreferenceForSlowSpeed() {
+        ReaderWay osmWay = new ReaderWay(1);
+        osmWay.setTag("highway", "tertiary");
+        assertPriority(PREFER, osmWay);
+    }
 }

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/RacingBikeTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/RacingBikeTagParserTest.java
@@ -310,4 +310,11 @@ public class RacingBikeTagParserTest extends AbstractBikeTagParserTester {
         way.setTag("class:bicycle", "-2");
         assertPriority(BEST, way);
     }
+
+    @Test
+    public void testPreferenceForSlowSpeed() {
+        ReaderWay osmWay = new ReaderWay(1);
+        osmWay.setTag("highway", "tertiary");
+        assertPriority(PREFER, osmWay);
+    }
 }


### PR DESCRIPTION
Right now, GH preffers `tertiary` roads over footways with `bicycle=yes` tags for bike profile. 
This leads to not opimial routing, especially when those footways are connecting cycleways.

@ratrun  suggested that we should remove `tertiary` from preffered highways and bump speed in the `footway` (only with `bicycle=yes`) https://github.com/graphhopper/graphhopper/issues/3014

Here are two examples before and after the change:

[GH map](https://graphhopper.com/maps/?point=54.404478%2C18.62471&point=54.406794%2C18.626314&profile=bike&layer=OpenStreetMap)

Before:
![CleanShot 2024-06-10 at 09 35 28@2x](https://github.com/graphhopper/graphhopper/assets/10419439/b690f7dd-d7ce-4f85-a4ab-0dda5582693c)


After:
![CleanShot 2024-06-10 at 09 35 08@2x](https://github.com/graphhopper/graphhopper/assets/10419439/32370463-ada4-446b-960a-5710b315f397)


