### PR TITLE
Slightly increase bicycle priority classification on "good" highway=track

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonPriorityParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonPriorityParser.java
@@ -36,6 +36,7 @@ public abstract class BikeCommonPriorityParser implements TagParser {
     int avoidSpeedLimit;
     EnumEncodedValue<RouteNetwork> bikeRouteEnc;
     Map<RouteNetwork, Integer> routeMap = new HashMap<>();
+    protected final Set<String> goodSurface = new HashSet<>(List.of("paved", "asphalt", "concrete"));
 
     // This is the specific bicycle class
     private String classBicycleKey;
@@ -153,8 +154,11 @@ public abstract class BikeCommonPriorityParser implements TagParser {
      */
     void collect(ReaderWay way, double wayTypeSpeed, TreeMap<Double, PriorityCode> weightToPrioMap) {
         String highway = way.getTag("highway");
+        boolean isTracTypeGrade1 = way.getTag("tracktype", "").equals("grade1");
+        boolean isGoodSurface = goodSurface.contains(way.getTag("surface",""));
         if (isDesignated(way)) {
-            if ("path".equals(highway))
+            if ("path".equals(highway) ||
+                ("track".equals(highway) && (isTracTypeGrade1 || isGoodSurface )))
                 weightToPrioMap.put(100d, VERY_NICE);
             else
                 weightToPrioMap.put(100d, PREFER);

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/MountainBikePriorityParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/MountainBikePriorityParser.java
@@ -45,8 +45,9 @@ public class MountainBikePriorityParser extends BikeCommonPriorityParser {
         String highway = way.getTag("highway");
         if ("track".equals(highway)) {
             String trackType = way.getTag("tracktype");
-            if ("grade1".equals(trackType))
-                weightToPrioMap.put(50d, UNCHANGED);
+            boolean isGoodSurface = goodSurface.contains(way.getTag("surface",""));
+            if ("grade1".equals(trackType) || isGoodSurface)
+                weightToPrioMap.put(50d, SLIGHT_PREFER);
             else if (trackType == null)
                 weightToPrioMap.put(90d, PREFER);
             else if (trackType.startsWith("grade"))

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikePriorityParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikePriorityParser.java
@@ -55,9 +55,10 @@ public class RacingBikePriorityParser extends BikeCommonPriorityParser {
         if ("service".equals(highway) || "residential".equals(highway)) {
             weightToPrioMap.put(40d, SLIGHT_AVOID);
         } else if ("track".equals(highway)) {
+            boolean isGoodSurface = goodSurface.contains(way.getTag("surface",""));
             String trackType = way.getTag("tracktype");
-            if ("grade1".equals(trackType))
-                weightToPrioMap.put(110d, PREFER);
+            if ("grade1".equals(trackType) || isGoodSurface )
+                weightToPrioMap.put(110d, VERY_NICE);
             else if (trackType == null || trackType.startsWith("grade"))
                 weightToPrioMap.put(110d, AVOID_MORE);
         }

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/BikeTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/BikeTagParserTest.java
@@ -163,6 +163,18 @@ public class BikeTagParserTest extends AbstractBikeTagParserTester {
         assertPriorityAndSpeed(PREFER, 18, way);
 
         way.clearTags();
+        way.setTag("highway", "track");
+        way.setTag("bicycle", "designated");
+        way.setTag("segregated","no");
+        assertPriorityAndSpeed(PREFER, 12, way);
+        way.setTag("surface", "asphalt");
+        assertPriorityAndSpeed(VERY_NICE, cyclewaySpeed, way);
+        way.setTag("tracktype","grade1");
+        assertPriorityAndSpeed(VERY_NICE, cyclewaySpeed, way);
+        way.removeTag("surface");
+        assertPriorityAndSpeed(VERY_NICE, cyclewaySpeed, way);
+
+        way.clearTags();
         way.setTag("highway", "path");
         assertPriorityAndSpeed(SLIGHT_AVOID, PUSHING_SECTION_SPEED, way);
 

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/MountainBikeTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/MountainBikeTagParserTest.java
@@ -78,8 +78,6 @@ public class MountainBikeTagParserTest extends AbstractBikeTagParserTester {
         way.setTag("highway", "track");
         assertPriorityAndSpeed(PREFER, 18, way);
 
-        // test speed for allowed pushing section types
-        way.setTag("highway", "track");
         way.setTag("bicycle", "yes");
         assertPriorityAndSpeed(PREFER, 18, way);
 
@@ -87,9 +85,11 @@ public class MountainBikeTagParserTest extends AbstractBikeTagParserTester {
         way.setTag("bicycle", "yes");
         way.setTag("tracktype", "grade3");
         assertPriorityAndSpeed(VERY_NICE, 12, way);
+        way.setTag("tracktype", "grade1");
+        assertPriorityAndSpeed(SLIGHT_PREFER, 18, way);
 
         way.setTag("surface", "paved");
-        assertPriorityAndSpeed(VERY_NICE, 18, way);
+        assertPriorityAndSpeed(SLIGHT_PREFER, 18, way);
 
         way.clearTags();
         way.setTag("highway", "path");

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/RacingBikeTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/RacingBikeTagParserTest.java
@@ -97,6 +97,19 @@ public class RacingBikeTagParserTest extends AbstractBikeTagParserTester {
     }
 
     @Test
+    public void testTrack() {
+        ReaderWay way = new ReaderWay(1);
+        way.setTag("highway", "track");
+        way.setTag("bicycle", "designated");
+        way.setTag("segregated","no");
+        assertPriorityAndSpeed(AVOID_MORE, 2, way);
+        way.setTag("surface", "asphalt");
+        assertPriorityAndSpeed(VERY_NICE, 20, way);
+        way.setTag("tracktype","grade1");
+        assertPriorityAndSpeed(VERY_NICE, 20, way);
+    }
+
+    @Test
     @Override
     public void testSacScale() {
         ReaderWay way = new ReaderWay(1);
@@ -208,7 +221,7 @@ public class RacingBikeTagParserTest extends AbstractBikeTagParserTester {
 
         // Now we assume bicycle=yes, and paved
         osmWay.setTag("tracktype", "grade1");
-        assertPriorityAndSpeed(PREFER, 20, osmWay, osmRel);
+        assertPriorityAndSpeed(VERY_NICE, 20, osmWay, osmRel);
 
         // Now we assume bicycle=yes, and unpaved as part of a cycle relation
         osmWay.setTag("tracktype", "grade2");


### PR DESCRIPTION
Triggered by the discussion in the [forum](https://discuss.graphhopper.com/t/directions-with-track-path-with-bicycle-designated-gone-wrong/8728/10) about cycleway-like infrastructure along a `highway=secondary` I created this PR, which slightly increases the bicycle priority classification on `highway=track` with good surface.  

Here is the [link](http://localhost:8989/maps/?point=49.197814%2C8.277993&point=49.231811%2C8.248564&profile=racingbike&layer=OpenStreetMap) I used for verification that the changes improve the current route.