### PR TITLE
Fix toll rule for Switzerland

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/countryrules/europe/SwitzerlandCountryRule.java
+++ b/core/src/main/java/com/graphhopper/routing/util/countryrules/europe/SwitzerlandCountryRule.java
@@ -36,9 +36,6 @@ public class SwitzerlandCountryRule implements CountryRule {
         }
 
         RoadClass roadClass = RoadClass.find(readerWay.getTag("highway", ""));
-        if (currentToll != null)
-            return currentToll;
-
         switch (roadClass) {
             case MOTORWAY:
             case TRUNK:


### PR DESCRIPTION
`currentToll` is never `null` here so I assume this is just a mistake. [Here](https://graphhopper.com/maps/?point=46.304352%2C7.79255&point=46.306621%2C7.749343&profile=car&layer=Omniscale) is an example for a [Swiss motorway](https://www.openstreetmap.org/node/3035330632) that doesn't have an explicit `toll` tag and should be covered by the rule (but currently we get `toll = MISSING`). 