### PR TITLE
De-prioritize ways tagged with foot=use_sidepath

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/parsers/FootPriorityParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/FootPriorityParser.java
@@ -105,6 +105,8 @@ public class FootPriorityParser implements TagParser {
             weightToPrioMap.put(100d, PREFER);
 
         if (way.hasTag("foot", "use_sidepath")) {
+            // We use VERY_BAD and not REACH_DESTINATION in order to avoid too long detours, see
+            // https://community.openstreetmap.org/t/foot-use-sidepath-sinnvoll-bei-separat-kartierten-gehwegen/115654
             weightToPrioMap.put(100d, VERY_BAD);
         }
 

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/FootPriorityParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/FootPriorityParser.java
@@ -104,6 +104,10 @@ public class FootPriorityParser implements TagParser {
         if (way.hasTag("foot", "designated"))
             weightToPrioMap.put(100d, PREFER);
 
+        if (way.hasTag("foot", "use_sidepath")) {
+            weightToPrioMap.put(100d, VERY_BAD);
+        }
+
         double maxSpeed = Math.max(getMaxSpeed(way, false), getMaxSpeed(way, true));
         if (safeHighwayTags.contains(highway) || (isValidSpeed(maxSpeed) && maxSpeed <= 20)) {
             weightToPrioMap.put(40d, PREFER);

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/FootPriorityParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/FootPriorityParser.java
@@ -105,9 +105,7 @@ public class FootPriorityParser implements TagParser {
             weightToPrioMap.put(100d, PREFER);
 
         if (way.hasTag("foot", "use_sidepath")) {
-            // We use VERY_BAD and not REACH_DESTINATION in order to avoid too long detours, see
-            // https://community.openstreetmap.org/t/foot-use-sidepath-sinnvoll-bei-separat-kartierten-gehwegen/115654
-            weightToPrioMap.put(100d, VERY_BAD);
+            weightToPrioMap.put(100d, VERY_BAD); // see #3035
         }
 
         double maxSpeed = Math.max(getMaxSpeed(way, false), getMaxSpeed(way, true));

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/FootTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/FootTagParserTest.java
@@ -333,7 +333,11 @@ public class FootTagParserTest {
         way.clearTags();
         way.setTag("highway", "tertiary");
         assertEquals(PriorityCode.UNCHANGED.getValue(), prioParser.handlePriority(way, null));
+        way.setTag("foot","use_sidepath");
+        assertEquals(PriorityCode.VERY_BAD.getValue(), prioParser.handlePriority(way, null));
 
+        way.clearTags();
+        way.setTag("highway", "tertiary");
         // tertiary without sidewalk is roughly like primary with sidewalk
         way.setTag("sidewalk", "no");
         assertEquals(PriorityCode.AVOID.getValue(), prioParser.handlePriority(way, null));


### PR DESCRIPTION
Triggered by the discussion in the [OSM community forum](https://community.openstreetmap.org/t/foot-use-sidepath-sinnvoll-bei-separat-kartierten-gehwegen/115654) I discovered that graphhopper does not yet have support for `foot=use_sidepath`. This PR adds it.