### PR TITLE
Remove extra lm.disable check

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/Router.java
+++ b/core/src/main/java/com/graphhopper/routing/Router.java
@@ -580,7 +580,7 @@ public class Router {
                 throw new IllegalArgumentException("Cannot find LM preparation for the requested profile: '" + profile.getName() + "'" +
                         "\nYou can try disabling LM using " + Parameters.Landmark.DISABLE + "=true" +
                         "\navailable LM profiles: " + landmarks.keySet());
-            if (request.getCustomModel() != null && !request.getHints().getBool("lm.disable", false))
+            if (request.getCustomModel() != null)
                 FindMinMax.checkLMConstraints(profile.getCustomModel(), request.getCustomModel(), lookup);
             RoutingAlgorithmFactory routingAlgorithmFactory = new LMRoutingAlgorithmFactory(landmarkStorage).setDefaultActiveLandmarks(routerConfig.getActiveLandmarkCount());
             return new FlexiblePathCalculator(queryGraph, routingAlgorithmFactory, weighting, getAlgoOpts());


### PR DESCRIPTION
We only arrive at this check if `lm.disable=false` so it is unnecessary. More importantly, if we arrived there and for whatever reason `lm.disable` was `true` we certainly would not want to skip the check, because it is already clear we are going to use LM. 

See this comment: https://github.com/graphhopper/graphhopper/pull/2544/files#r863523145
