### PR TITLE
Use surface speed at bridgleways for bicycle profiles

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonAverageSpeedParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonAverageSpeedParser.java
@@ -160,7 +160,8 @@ public abstract class BikeCommonAverageSpeedParser extends AbstractAverageSpeedP
             speed = PUSHING_SECTION_SPEED; // unknown surface
         } else if (way.hasTag("service")) {
             speed = highwaySpeeds.get("living_street");
-        } else if ("track".equals(highwayValue)) {
+        } else if ("track".equals(highwayValue) ||
+                   "bridleway".equals(highwayValue) ) {
             if (surfaceSpeed != null)
                 speed = surfaceSpeed;
             else if (trackTypeSpeeds.containsKey(trackTypeValue))

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/BikeTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/BikeTagParserTest.java
@@ -305,6 +305,14 @@ public class BikeTagParserTest extends AbstractBikeTagParserTester {
         assertPriorityAndSpeed(VERY_NICE, PUSHING_SECTION_SPEED, way);
         way.setTag("bicycle", "yes");
         assertPriorityAndSpeed(VERY_NICE, 18, way);
+
+        way.clearTags();
+        way.setTag("highway", "bridleway");
+        assertPriorityAndSpeed(AVOID, PUSHING_SECTION_SPEED, way);
+        way.setTag("surface", "gravel");
+        assertPriorityAndSpeed(AVOID, 12, way);
+        way.setTag("bicycle", "designated");
+        assertPriorityAndSpeed(PREFER, 12, way);
     }
 
     @Test


### PR DESCRIPTION
This should improve the bicycle routing on `highway=bridleway`, see the discussion in the [graphhopper forum](https://discuss.graphhopper.com/t/bike-routing-ignoring-designated-cycle-routes/8987/2).