### PR TITLE
Add support for bike mtb:scale accessibility

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonAccessParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonAccessParser.java
@@ -71,6 +71,12 @@ public abstract class BikeCommonAccessParser extends AbstractAccessParser implem
                 return WayAccess.CAN_SKIP;
         }
 
+        String mtbScale = way.getTag("mtb:scale");
+        if (mtbScale != null) {
+            if (!isMtbScaleAllowed(mtbScale))
+                return WayAccess.CAN_SKIP;
+        }
+
         // use the way for pushing
         if (way.hasTag("bicycle", "dismount"))
             return WayAccess.WAY;
@@ -103,6 +109,11 @@ public abstract class BikeCommonAccessParser extends AbstractAccessParser implem
     boolean isSacScaleAllowed(String sacScale) {
         // other scales are nearly impossible by an ordinary bike, see http://wiki.openstreetmap.org/wiki/Key:sac_scale
         return "hiking".equals(sacScale);
+    }
+
+    boolean isMtbScaleAllowed(String mtbScale) {
+        // keep even more difficult accessible as one may push, see https://wiki.openstreetmap.org/wiki/Key:mtb:scale
+        return "0".equals(mtbScale) || "1".equals(mtbScale) || "2".equals(mtbScale);
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/MountainBikeAccessParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/MountainBikeAccessParser.java
@@ -25,4 +25,10 @@ public class MountainBikeAccessParser extends BikeCommonAccessParser {
         return "hiking".equals(sacScale) || "mountain_hiking".equals(sacScale)
                 || "demanding_mountain_hiking".equals(sacScale) || "alpine_hiking".equals(sacScale);
     }
+
+    @Override
+    boolean isMtbScaleAllowed(String mtbScale) {
+        return !"6".equals(mtbScale);
+    }
+
 }

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/AbstractBikeTagParserTester.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/AbstractBikeTagParserTester.java
@@ -25,13 +25,9 @@ import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.routing.util.OSMParsers;
 import com.graphhopper.routing.util.PriorityCode;
 import com.graphhopper.storage.IntsRef;
-import com.graphhopper.util.Helper;
 import com.graphhopper.util.PMap;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import java.text.DateFormat;
-import java.util.Date;
 
 import static com.graphhopper.routing.util.PriorityCode.*;
 import static org.junit.jupiter.api.Assertions.*;
@@ -373,14 +369,22 @@ public abstract class AbstractBikeTagParserTester {
     }
 
     @Test
-    public void testSacScale() {
+    public void testSacScaleAccess() {
         ReaderWay way = new ReaderWay(1);
         way.setTag("highway", "service");
         way.setTag("sac_scale", "hiking");
-        // allow
         assertTrue(accessParser.getAccess(way).isWay());
-
         way.setTag("sac_scale", "alpine_hiking");
+        assertTrue(accessParser.getAccess(way).canSkip());
+    }
+
+    @Test
+    public void testMtbScaleAccess() {
+        ReaderWay way = new ReaderWay(1);
+        way.setTag("highway", "path");
+        way.setTag("mtb:scale", "0");
+        assertTrue(accessParser.getAccess(way).isWay());
+        way.setTag("mtb:scale", "3");
         assertTrue(accessParser.getAccess(way).canSkip());
     }
 

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/BikeTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/BikeTagParserTest.java
@@ -528,7 +528,7 @@ public class BikeTagParserTest extends AbstractBikeTagParserTester {
 
     @Test
     @Override
-    public void testSacScale() {
+    public void testSacScaleAccess() {
         ReaderWay way = new ReaderWay(1);
         way.setTag("highway", "path");
         way.setTag("sac_scale", "hiking");

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/MountainBikeTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/MountainBikeTagParserTest.java
@@ -135,7 +135,7 @@ public class MountainBikeTagParserTest extends AbstractBikeTagParserTester {
 
     @Test
     @Override
-    public void testSacScale() {
+    public void testSacScaleAccess() {
         ReaderWay way = new ReaderWay(1);
         way.setTag("highway", "service");
         way.setTag("sac_scale", "hiking");
@@ -149,6 +149,19 @@ public class MountainBikeTagParserTest extends AbstractBikeTagParserTester {
         assertTrue(accessParser.getAccess(way).isWay());
 
         way.setTag("sac_scale", "demanding_alpine_hiking");
+        assertTrue(accessParser.getAccess(way).canSkip());
+    }
+
+    @Test
+    @Override
+    public void testMtbScaleAccess() {
+        ReaderWay way = new ReaderWay(1);
+        way.setTag("highway", "path");
+        way.setTag("mtb:scale", "0");
+        assertTrue(accessParser.getAccess(way).isWay());
+        way.setTag("mtb:scale", "5");
+        assertTrue(accessParser.getAccess(way).isWay());
+        way.setTag("mtb:scale", "6");
         assertTrue(accessParser.getAccess(way).canSkip());
     }
 

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/RacingBikeTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/RacingBikeTagParserTest.java
@@ -111,7 +111,7 @@ public class RacingBikeTagParserTest extends AbstractBikeTagParserTester {
 
     @Test
     @Override
-    public void testSacScale() {
+    public void testSacScaleAccess() {
         ReaderWay way = new ReaderWay(1);
         way.setTag("highway", "service");
         way.setTag("sac_scale", "mountain_hiking");
@@ -126,6 +126,14 @@ public class RacingBikeTagParserTest extends AbstractBikeTagParserTester {
         way.setTag("sac_scale", "mountain_hiking");
         // we are cautious and disallow this
         assertTrue(accessParser.getAccess(way).canSkip());
+    }
+
+    @Test
+    @Override
+    public void testMtbScaleAccess() {
+        // Intentionally use the same accessibility as ordinary bikes as pushing a racebike is easier
+        // compared to an ordinary bike. The problem is more the shoes, which makes the situation comparable
+        super.testMtbScaleAccess();
     }
 
     @Test


### PR DESCRIPTION
Triggered by the discussion in https://community.openstreetmap.org/t/consuming-highway-path-take-2/118175 I detected that currently we do not support the `mtb:scale` tag for the bicycles yet at all. This PR adds support for the detection of the accessibility. This does make sense in order to increase the safety of the suggested routes.

I was thinking about adding additional support for control of the priority detection, but came to the conclusion that this is not necessary as according to [taginfo](https://taginfo.openstreetmap.org/keys/mtb%3Ascale#combinations) we are already handling the most often combined tags. Handling the prioritization stuff twice does not make sense.