### PR TITLE
Add German footway limits for `highway=footway` and `highway=pedestrian`

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -8,7 +8,7 @@ Here is an overview:
  * AnahitaS, docs for Android, Android, Tomcat
  * andreaswolf, flag encoder versioning and more
  * andreylh, polygon for blocked area #1306
- * Anvoker, fixes like #1614 and helped with JUnit 5 migration #1632 
+ * Anvoker, fixes like #1614 and helped with JUnit 5 migration #1632
  * b3nn0, Android improvements
  * baumboi, path detail and landmark improvements
  * boldtrn, one of the core developers with motorcycle knowledge :)
@@ -31,14 +31,14 @@ Here is an overview:
  * elibar, fix for alternative route calculation
  * fbonzon, several UI improvements like #615
  * florent-morel, improvements regarding fords, #320
- * fredao, translations 
+ * fredao, translations
  * gberaudo, improvements regarding elevation
  * GProbo, fixes like #2241
  * HarelM, improvements regarding elevation
  * HelgeKrueger, modularization of javascript, #590
  * henningvs, doc improvements
  * highsource, more efficient geometry update, UI fixes
- * hoofstephan, bug fix   
+ * hoofstephan, bug fix
  * IsNull, improvements like #708
  * Janekdererste, GUI for public transit
  * jansoe, many improvements regarding A* algorithm, forcing direction, roundabouts etc
@@ -59,6 +59,7 @@ Here is an overview:
  * michaz, one of the core developers
  * mprins, improvements for travis CI and regarding JDK9 #806
  * msbarry, fixes like #1733
+ * Nadyita, maxspeed for German footways
  * naser13, fixes like #1923
  * njanakiev, fixes like #1560
  * NopMap, massive improvements regarding OSM, parsing and encoding, route relations
@@ -73,16 +74,16 @@ Here is an overview:
  * ratrun, route relations, GPX information, bike handling etc
  * rodneyodonnell, improved dead end removal (PrepareRoutingSubnetworks) and fords
  * rodo, more descriptions
- * rory, support milisecond gpx timestamps, see #4 
+ * rory, support milisecond gpx timestamps, see #4
  * samruston, improved point hint matching
  * seeebiii, motorcycle improvements
  * sguill, fixes like #1683
  * shunfan-shao, fix potential flaky tests
  * skienzl, imperial units for /navigate, related to #2071
  * stefanholder, Stefan Holder, BMW AG, creating and integrating the hmm-lib (#49, #66, #69) and penalizing inner-link U-turns (#88, #91), refactored unfavoring of virtual edges #885
- * stevensnoeijen, fixes like #1568 
+ * stevensnoeijen, fixes like #1568
  * Svantulden, improved documentation and nearest API
- * taulinger, hopefully more to come 
+ * taulinger, hopefully more to come
  * thehereward, code cleanups like #620
  * vvikas, ideas for many to many improvements and #616
  * zstadler, multiple fixes and car4wd

--- a/core/src/main/resources/com/graphhopper/routing/util/legal_default_speeds.json
+++ b/core/src/main/resources/com/graphhopper/routing/util/legal_default_speeds.json
@@ -312,6 +312,9 @@
         "expressway": {
             "filter": "expressway=yes"
         },
+        "footway": {
+            "filter": "highway=footway"
+        },
         "frontage road": {
             "filter": "frontage_road=yes or side_road=yes"
         },
@@ -3061,6 +3064,18 @@
         "DE": [
             {
                 "name": "living street",
+                "tags": {
+                    "maxspeed": "walk"
+                }
+            },
+            {
+                "name": "pedestrian zone",
+                "tags": {
+                    "maxspeed": "walk"
+                }
+            },
+            {
+                "name": "footway",
                 "tags": {
                     "maxspeed": "walk"
                 }


### PR DESCRIPTION
In Germany, when a pedestrian street, or a footway is open to vehicles, conditionally or not, these must not drive faster than walking speed. This applies to bicycles and cars alike.

There doesn't seem to be a test I could possibly add for this, as it is purely a declaration.