### PR TITLE
Add crossing encoded values for accessible pedestrian routing

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -13,6 +13,7 @@ Here is an overview:
  * baumboi, path detail and landmark improvements
  * boldtrn, one of the core developers with motorcycle knowledge :)
  * bt90, fixes like #2786
+ * CClerger, added encoded values for accessibility
  * cgarreau, increase of routing success rate via subnetwork cleanup
  * chollemans, fixes like #1482
  * ChristianSeitzer, motorcycle improvements

--- a/core/src/main/java/com/graphhopper/routing/ev/Kerb.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/Kerb.java
@@ -1,0 +1,47 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.graphhopper.routing.ev;
+
+import com.graphhopper.util.Helper;
+
+public enum Kerb {
+    MISSING, FLUSH, LOWERED, NO, RAISED, ROLLED, YES;
+
+    public static final String KEY = "kerb";
+
+    public static EnumEncodedValue<Kerb> create() {
+        return new EnumEncodedValue<>(KEY, Kerb.class);
+    }
+
+    @Override
+    public String toString() {
+        return Helper.toLowerCase(super.toString());
+    }
+
+    public static Kerb find(String name) {
+        if (name == null || name.isEmpty())
+            return MISSING;
+
+        try {
+            return Kerb.valueOf(Helper.toUpperCase(name));
+        } catch (IllegalArgumentException ex) {
+            return MISSING;
+        }
+    }
+}

--- a/core/src/main/java/com/graphhopper/routing/ev/TactilePaving.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/TactilePaving.java
@@ -1,0 +1,47 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.graphhopper.routing.ev;
+
+import com.graphhopper.util.Helper;
+
+public enum TactilePaving {
+    MISSING, YES, NO, CONTRASTED, PRIMITIVE, INCORRECT, PARTIAL;
+
+    public static final String KEY = "tactile_paving";
+
+    public static EnumEncodedValue<TactilePaving> create() {
+        return new EnumEncodedValue<>(KEY, TactilePaving.class);
+    }
+
+    @Override
+    public String toString() {
+        return Helper.toLowerCase(super.toString());
+    }
+
+    public static TactilePaving find(String name) {
+        if (name == null || name.isEmpty())
+            return MISSING;
+
+        try {
+            return TactilePaving.valueOf(Helper.toUpperCase(name));
+        } catch (IllegalArgumentException ex) {
+            return MISSING;
+        }
+    }
+}

--- a/core/src/main/java/com/graphhopper/routing/ev/TrafficSignalsSound.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/TrafficSignalsSound.java
@@ -1,0 +1,47 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.graphhopper.routing.ev;
+
+import com.graphhopper.util.Helper;
+
+public enum TrafficSignalsSound {
+    MISSING, YES, NO, LOCATE, WALK;
+
+    public static final String KEY = "traffic_signals_sound";
+
+    public static EnumEncodedValue<TrafficSignalsSound> create() {
+        return new EnumEncodedValue<>(KEY, TrafficSignalsSound.class);
+    }
+
+    @Override
+    public String toString() {
+        return Helper.toLowerCase(super.toString());
+    }
+
+    public static TrafficSignalsSound find(String name) {
+        if (name == null || name.isEmpty())
+            return MISSING;
+
+        try {
+            return TrafficSignalsSound.valueOf(Helper.toUpperCase(name));
+        } catch (IllegalArgumentException ex) {
+            return MISSING;
+        }
+    }
+}

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMKerbParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMKerbParser.java
@@ -1,0 +1,43 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.graphhopper.routing.util.parsers;
+
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.EdgeIntAccess;
+import com.graphhopper.routing.ev.EnumEncodedValue;
+import com.graphhopper.routing.ev.Kerb;
+import com.graphhopper.storage.IntsRef;
+
+/**
+ * see: https://wiki.openstreetmap.org/wiki/Key:kerb
+ */
+public class OSMKerbParser implements TagParser {
+    private final EnumEncodedValue<Kerb> kerbEnc;
+
+    public OSMKerbParser(EnumEncodedValue<Kerb> kerbEnc) {
+        this.kerbEnc = kerbEnc;
+    }
+
+    @Override
+    public void handleWayTags(int edgeId, EdgeIntAccess edgeIntAccess, ReaderWay way,
+                    IntsRef relationFlags) {
+        String kerb = way.getTag("kerb");
+        kerbEnc.setEnum(false, edgeId, edgeIntAccess, Kerb.find(kerb));
+    }
+}

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMTactilePavingParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMTactilePavingParser.java
@@ -1,0 +1,43 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.graphhopper.routing.util.parsers;
+
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.EdgeIntAccess;
+import com.graphhopper.routing.ev.EnumEncodedValue;
+import com.graphhopper.routing.ev.TactilePaving;
+import com.graphhopper.storage.IntsRef;
+
+/**
+ * see: https://wiki.openstreetmap.org/wiki/Key:tactile_paving
+ */
+public class OSMTactilePavingParser implements TagParser {
+    private final EnumEncodedValue<TactilePaving> tactilePavingEnc;
+
+    public OSMTactilePavingParser(EnumEncodedValue<TactilePaving> tactilePavingEnc) {
+        this.tactilePavingEnc = tactilePavingEnc;
+    }
+
+    @Override
+    public void handleWayTags(int edgeId, EdgeIntAccess edgeIntAccess, ReaderWay way,
+                    IntsRef relationFlags) {
+        String tactilePaving = way.getTag("tactile_paving");
+        tactilePavingEnc.setEnum(false, edgeId, edgeIntAccess, TactilePaving.find(tactilePaving));
+    }
+}

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMTrafficSignalsSoundParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMTrafficSignalsSoundParser.java
@@ -1,0 +1,45 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.graphhopper.routing.util.parsers;
+
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.EdgeIntAccess;
+import com.graphhopper.routing.ev.EnumEncodedValue;
+import com.graphhopper.routing.ev.TrafficSignalsSound;
+import com.graphhopper.storage.IntsRef;
+
+/**
+ * see: https://wiki.openstreetmap.org/wiki/Key:traffic_signals:sound
+ */
+public class OSMTrafficSignalsSoundParser implements TagParser {
+    private final EnumEncodedValue<TrafficSignalsSound> trafficSignalsSoundEnc;
+
+    public OSMTrafficSignalsSoundParser(
+                    EnumEncodedValue<TrafficSignalsSound> trafficSignalsSoundEnc) {
+        this.trafficSignalsSoundEnc = trafficSignalsSoundEnc;
+    }
+
+    @Override
+    public void handleWayTags(int edgeId, EdgeIntAccess edgeIntAccess, ReaderWay way,
+                    IntsRef relationFlags) {
+        String trafficSignalsSound = way.getTag("traffic_signals:sound");
+        trafficSignalsSoundEnc.setEnum(false, edgeId, edgeIntAccess,
+                        TrafficSignalsSound.find(trafficSignalsSound));
+    }
+}

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMFootwayParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMFootwayParserTest.java
@@ -1,0 +1,42 @@
+package com.graphhopper.routing.util.parsers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.ArrayEdgeIntAccess;
+import com.graphhopper.routing.ev.EdgeIntAccess;
+import com.graphhopper.routing.ev.EncodedValue;
+import com.graphhopper.routing.ev.EnumEncodedValue;
+import com.graphhopper.routing.ev.Footway;
+import com.graphhopper.storage.IntsRef;
+
+public class OSMFootwayParserTest {
+    private EnumEncodedValue<Footway> footwayEnc;
+    private OSMFootwayParser parser;
+
+    @BeforeEach
+    public void setUp() {
+        footwayEnc = Footway.create();
+        footwayEnc.init(new EncodedValue.InitializerConfig());
+        parser = new OSMFootwayParser(footwayEnc);
+    }
+
+    @Test
+    public void testSimpleTags() {
+        IntsRef relFlags = new IntsRef(2);
+
+        ReaderWay readerWay = new ReaderWay(1);
+        EdgeIntAccess edgeIntAccess = new ArrayEdgeIntAccess(1);
+        int edgeId = 0;
+        readerWay.setTag("highway", "footway");
+        parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
+        assertEquals(Footway.MISSING, footwayEnc.getEnum(false, edgeId, edgeIntAccess));
+
+        readerWay.setTag("footway", "crossing");
+        parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
+        assertEquals(Footway.CROSSING, footwayEnc.getEnum(false, edgeId, edgeIntAccess));
+    }
+}

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMKerbParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMKerbParserTest.java
@@ -1,0 +1,42 @@
+package com.graphhopper.routing.util.parsers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.ArrayEdgeIntAccess;
+import com.graphhopper.routing.ev.EdgeIntAccess;
+import com.graphhopper.routing.ev.EncodedValue;
+import com.graphhopper.routing.ev.EnumEncodedValue;
+import com.graphhopper.routing.ev.Kerb;
+import com.graphhopper.storage.IntsRef;
+
+public class OSMKerbParserTest {
+    private EnumEncodedValue<Kerb> kerbEnc;
+    private OSMKerbParser parser;
+
+    @BeforeEach
+    public void setUp() {
+        kerbEnc = Kerb.create();
+        kerbEnc.init(new EncodedValue.InitializerConfig());
+        parser = new OSMKerbParser(kerbEnc);
+    }
+
+    @Test
+    public void testSimpleTags() {
+        IntsRef relFlags = new IntsRef(2);
+
+        ReaderWay readerWay = new ReaderWay(1);
+        EdgeIntAccess edgeIntAccess = new ArrayEdgeIntAccess(1);
+        int edgeId = 0;
+        readerWay.setTag("highway", "footway");
+        parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
+        assertEquals(Kerb.MISSING, kerbEnc.getEnum(false, edgeId, edgeIntAccess));
+
+        readerWay.setTag("kerb", "raised");
+        parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
+        assertEquals(Kerb.RAISED, kerbEnc.getEnum(false, edgeId, edgeIntAccess));
+    }
+}

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMTactilePavingParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMTactilePavingParserTest.java
@@ -1,0 +1,43 @@
+package com.graphhopper.routing.util.parsers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.ArrayEdgeIntAccess;
+import com.graphhopper.routing.ev.EdgeIntAccess;
+import com.graphhopper.routing.ev.EncodedValue;
+import com.graphhopper.routing.ev.EnumEncodedValue;
+import com.graphhopper.routing.ev.TactilePaving;
+import com.graphhopper.storage.IntsRef;
+
+public class OSMTactilePavingParserTest {
+    private EnumEncodedValue<TactilePaving> tactilePavingEnc;
+    private OSMTactilePavingParser parser;
+
+    @BeforeEach
+    public void setUp() {
+        tactilePavingEnc = TactilePaving.create();
+        tactilePavingEnc.init(new EncodedValue.InitializerConfig());
+        parser = new OSMTactilePavingParser(tactilePavingEnc);
+    }
+
+    @Test
+    public void testSimpleTags() {
+        IntsRef relFlags = new IntsRef(2);
+
+        ReaderWay readerWay = new ReaderWay(1);
+        EdgeIntAccess edgeIntAccess = new ArrayEdgeIntAccess(1);
+        int edgeId = 0;
+        readerWay.setTag("highway", "footway");
+        parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
+        assertEquals(TactilePaving.MISSING, tactilePavingEnc.getEnum(false, edgeId, edgeIntAccess));
+
+        readerWay.setTag("tactile_paving", "incorrect");
+        parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
+        assertEquals(TactilePaving.INCORRECT,
+                        tactilePavingEnc.getEnum(false, edgeId, edgeIntAccess));
+    }
+}

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMTrafficSignalsSoundParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMTrafficSignalsSoundParserTest.java
@@ -1,0 +1,44 @@
+package com.graphhopper.routing.util.parsers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.ArrayEdgeIntAccess;
+import com.graphhopper.routing.ev.EdgeIntAccess;
+import com.graphhopper.routing.ev.EncodedValue;
+import com.graphhopper.routing.ev.EnumEncodedValue;
+import com.graphhopper.routing.ev.TrafficSignalsSound;
+import com.graphhopper.storage.IntsRef;
+
+public class OSMTrafficSignalsSoundParserTest {
+    private EnumEncodedValue<TrafficSignalsSound> trafficSignalsSoundEnc;
+    private OSMTrafficSignalsSoundParser parser;
+
+    @BeforeEach
+    public void setUp() {
+        trafficSignalsSoundEnc = TrafficSignalsSound.create();
+        trafficSignalsSoundEnc.init(new EncodedValue.InitializerConfig());
+        parser = new OSMTrafficSignalsSoundParser(trafficSignalsSoundEnc);
+    }
+
+    @Test
+    public void testSimpleTags() {
+        IntsRef relFlags = new IntsRef(2);
+
+        ReaderWay readerWay = new ReaderWay(1);
+        EdgeIntAccess edgeIntAccess = new ArrayEdgeIntAccess(1);
+        int edgeId = 0;
+        readerWay.setTag("crossing", "traffic_signals");
+        parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
+        assertEquals(TrafficSignalsSound.MISSING,
+                        trafficSignalsSoundEnc.getEnum(false, edgeId, edgeIntAccess));
+
+        readerWay.setTag("traffic_signals:sound", "locate");
+        parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
+        assertEquals(TrafficSignalsSound.LOCATE,
+                        trafficSignalsSoundEnc.getEnum(false, edgeId, edgeIntAccess));
+    }
+}

--- a/docs/core/custom-models.md
+++ b/docs/core/custom-models.md
@@ -82,6 +82,11 @@ encoded values are the following (some of their possible values are given in bra
 - track_type: (MISSING, GRADE1, GRADE2, ..., GRADE5)
 - urban_density: (RURAL, RESIDENTIAL, CITY)
 - max_weight_except: (NONE, DELIVERY, DESTINATION, FORESTRY)
+- footway: (MISSING, SIDEWALK, CROSSING, ACCESS_AISLE, LINK, TRAFFIC_ISLAND, ALLEY)
+- crossing: (MISSING, RAILWAY_BARRIER, RAILWAY, TRAFFIC_SIGNALS, UNCONTROLLED, MARKED, UNMARKED, NO)
+- tactile_paving: (MISSING, YES, NO, CONTRASTED, PRIMITIVE, INCORRECT, PARTIAL)
+- kerb: (MISSING, FLUSH, LOWERED, NO, RAISED, ROLLED, YES)
+- traffic_signals_sound: (MISSING, YES, NO, LOCATE, WALK)
 
 
 To learn about all available encoded values you can query the `/info` endpoint


### PR DESCRIPTION
See https://github.com/graphhopper/graphhopper/issues/2932

Adding the following `encoded_values`:
- `tactile_paving`: https://wiki.openstreetmap.org/wiki/Key:tactile_paving
- `kerb`: https://wiki.openstreetmap.org/wiki/Key:kerb
- `traffic_signals_sound`: https://wiki.openstreetmap.org/wiki/Key:traffic_signals:sound