### PR TITLE
Allow decimal speeds to be parsed

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -86,6 +86,7 @@ Here is an overview:
  * thehereward, code cleanups like #620
  * vvikas, ideas for many to many improvements and #616
  * zstadler, multiple fixes and car4wd
+ * pantsleftinwash, parsing improvements
 
 ## Translations
 

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/helpers/OSMValueExtractor.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/helpers/OSMValueExtractor.java
@@ -205,7 +205,7 @@ public class OSMValueExtractor {
 
         double value;
         try {
-            value = Integer.parseInt(str) * factor;
+            value = Double.parseDouble(str) * factor;
         } catch (Exception ex) {
             return Double.NaN;
         }

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMValueExtractorTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMValueExtractorTest.java
@@ -92,6 +92,8 @@ public class OSMValueExtractorTest {
         assertEquals(18.52, OSMValueExtractor.stringToKmh("10 knots"), DELTA);
         assertEquals(19, OSMValueExtractor.stringToKmh("19 kph"), DELTA);
         assertEquals(19, OSMValueExtractor.stringToKmh("19kph"), DELTA);
+        assertEquals(100, OSMValueExtractor.stringToKmh("100"), DELTA);
+        assertEquals(100, OSMValueExtractor.stringToKmh("100.0"), DELTA);
 
         assertEquals(MaxSpeed.UNLIMITED_SIGN_SPEED, OSMValueExtractor.stringToKmh("none"), DELTA);
     }
@@ -100,6 +102,7 @@ public class OSMValueExtractorTest {
     public void stringToKmhNaN() {
         assertTrue(Double.isNaN(OSMValueExtractor.stringToKmh(null)));
         assertTrue(Double.isNaN(OSMValueExtractor.stringToKmh("0")));
+        assertTrue(Double.isNaN(OSMValueExtractor.stringToKmh("0.0")));
         assertTrue(Double.isNaN(OSMValueExtractor.stringToKmh("-20")));
     }
 


### PR DESCRIPTION
Add support for decimal values in speed tags, such as `maxspeed:forward 100.0` found in OS Multi Modal Routing Network

https://docs.os.uk/osngd/os-premium-download-products/premium-products-overview/networks/os-multi-modal-routing-network/technical-specification/features/transport-link#maxspeed-forward
