### PR TITLE
#2826 : Explicit TimeoutException returned

### DIFF
--- a/core/src/main/java/com/graphhopper/util/PathMerger.java
+++ b/core/src/main/java/com/graphhopper/util/PathMerger.java
@@ -26,6 +26,7 @@ import com.graphhopper.storage.Graph;
 import com.graphhopper.util.details.PathDetailsBuilderFactory;
 import com.graphhopper.util.details.PathDetailsFromEdges;
 import com.graphhopper.util.exceptions.ConnectionNotFoundException;
+import com.graphhopper.util.exceptions.TimeoutException;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -155,7 +156,7 @@ public class PathMerger {
         }
 
         if (!allFound) {
-            responsePath.addError(new ConnectionNotFoundException("Connection between locations not found", Collections.emptyMap()));
+            responsePath.addError(new TimeoutException("Connection between locations not found", Collections.emptyMap()));
         }
 
         // make sure the way point indices actually point to the points in waypoints...

--- a/core/src/test/java/com/graphhopper/GraphHopperTest.java
+++ b/core/src/test/java/com/graphhopper/GraphHopperTest.java
@@ -139,7 +139,7 @@ public class GraphHopperTest {
         req.putHint(TIMEOUT_MS, -1);
         rsp = hopper.route(req);
         assertTrue(rsp.hasErrors());
-        assertTrue(rsp.getErrors().toString().contains("ConnectionNotFoundException"), rsp.getErrors().toString());
+        assertTrue(rsp.getErrors().toString().contains("TimeoutException"), rsp.getErrors().toString());
     }
 
     @Test
@@ -2416,7 +2416,7 @@ public class GraphHopperTest {
         GHPoint to = new GHPoint(50.029247, 11.582851);
         GHRequest req = new GHRequest(from, to).setProfile(profile);
         GHResponse res = hopper.route(req);
-        assertEquals("[com.graphhopper.util.exceptions.ConnectionNotFoundException: Connection between locations not found]",
+        assertEquals("[com.graphhopper.util.exceptions.TimeoutException: Connection between locations not found]",
                 res.getErrors().toString());
     }
 

--- a/core/src/test/java/com/graphhopper/routing/RoutingAlgorithmWithOSMTest.java
+++ b/core/src/test/java/com/graphhopper/routing/RoutingAlgorithmWithOSMTest.java
@@ -613,7 +613,7 @@ public class RoutingAlgorithmWithOSMTest {
             request.setProfile(hopper.getProfiles().get(0).getName());
             GHResponse res = hopper.route(request);
             assertTrue(res.hasErrors());
-            assertTrue(res.getErrors().toString().contains("ConnectionNotFound"), res.getErrors().toString());
+            assertTrue(res.getErrors().toString().contains("TimeoutException"), res.getErrors().toString());
         }
     }
 

--- a/web-api/src/main/java/com/graphhopper/util/exceptions/TimeoutException.java
+++ b/web-api/src/main/java/com/graphhopper/util/exceptions/TimeoutException.java
@@ -1,0 +1,34 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.util.exceptions;
+
+import java.util.Map;
+
+/**
+ * Explicit Exception for Timeout
+ *
+ * @author Mandar
+ */
+public class TimeoutException extends ConnectionNotFoundException {
+
+    private static final long serialVersionUID = 1L;
+
+    public TimeoutException(String var1, Map<String, Object> details) {
+        super(var1, details);
+    }
+}


### PR DESCRIPTION
Current code returns ConnectionNotFoundException when timeout occurs in finding the route.
Improvement is to explicitly return TimeoutException.
