### PR TITLE
Bridleway fix

### DIFF
--- a/core/src/main/resources/com/graphhopper/custom_models/foot.json
+++ b/core/src/main/resources/com/graphhopper/custom_models/foot.json
@@ -1,6 +1,6 @@
 // to use this custom model you need to set the following option in the config.yml
 // graph.elevation.provider: srtm   # enables elevation
-// graph.encoded_values: foot_access, foot_priority, foot_average_speed, foot_road_access, hike_rating, mtb_rating, average_slope
+// graph.encoded_values: foot_access, foot_priority, foot_average_speed, foot_road_access, hike_rating, mtb_rating, average_slope, country, road_class
 // profiles:
 //    - name: foot
 //      custom_model_files: [foot.json, foot_elevation.json]
@@ -9,6 +9,7 @@
   "priority": [
     { "if": "!foot_access || hike_rating >= 2 || mtb_rating > 2", "multiply_by": "0" },
     { "else": "", "multiply_by": "foot_priority"},
+    { "if": "country == DEU && road_class == BRIDLEWAY && foot_road_access != YES", "multiply_by": "0" },
     { "if": "foot_road_access == PRIVATE", "multiply_by": "0" }
   ],
   "speed": [

--- a/core/src/test/java/com/graphhopper/routing/RoutingAlgorithmWithOSMTest.java
+++ b/core/src/test/java/com/graphhopper/routing/RoutingAlgorithmWithOSMTest.java
@@ -711,7 +711,7 @@ public class RoutingAlgorithmWithOSMTest {
                         "bike_access, bike_priority, bike_average_speed, foot_network, roundabout, " +
                         "mtb_access, mtb_priority, mtb_average_speed, mtb_rating, " +
                         "racingbike_access, racingbike_priority, racingbike_average_speed, " +
-                        "foot_road_access, bike_road_access").
+                        "foot_road_access, bike_road_access, country, road_class").
                 setGraphHopperLocation(GH_LOCATION);
         hopper.getRouterConfig().setSimplifyResponse(false);
         hopper.setMinNetworkSize(0);


### PR DESCRIPTION
Based on #3056 this fixes #469. For now without country rules.

Example in berlin: http://localhost:8989/maps/?point=52.47197%2C13.542398&point=52.471377%2C13.544455&profile=foot

[This bridleway](https://www.openstreetmap.org/way/839307719) can be passed due to foot=yes:

![image](https://github.com/user-attachments/assets/2a84f1d4-9bba-41de-ac27-24bcf6c6997d)

But not [this one](https://www.openstreetmap.org/way/73856683) (no `foot` tag):

![image](https://github.com/user-attachments/assets/17277d9c-7a6f-4127-9c35-419fe9fe0a3c)