### PR TITLE
fix to be able to import and run as server on different machines

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -40,6 +40,7 @@ Here is an overview:
  * highsource, more efficient geometry update, UI fixes
  * hoofstephan, bug fix   
  * IsNull, improvements like #708
+ * IldarKhayrutdinov, use cache on different machines
  * Janekdererste, GUI for public transit
  * jansoe, many improvements regarding A* algorithm, forcing direction, roundabouts etc
  * jansonhanson, general host config

--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -69,6 +69,10 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import java.util.logging.Level;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
 import static com.graphhopper.util.GHUtility.readCountries;
 import static com.graphhopper.util.Helper.*;
 import static com.graphhopper.util.Parameters.Algorithms.RoundTrip;
@@ -1487,11 +1491,15 @@ public class GraphHopper {
         if (!customAreasDirectory.isEmpty()) {
             ObjectMapper mapper = new ObjectMapper().registerModule(new JtsModule());
             try (DirectoryStream<Path> stream = Files.newDirectoryStream(Paths.get(customAreasDirectory), "*.{geojson,json}")) {
-                for (Path customAreaFile : stream) {
-                    try (BufferedReader reader = Files.newBufferedReader(customAreaFile, StandardCharsets.UTF_8)) {
-                        globalAreas.getFeatures().addAll(mapper.readValue(reader, JsonFeatureCollection.class).getFeatures());
-                    }
-                }
+                StreamSupport.stream(stream.spliterator(), false)
+                        .sorted(Comparator.comparing(Path::toString))
+                        .forEach(customAreaFile -> {
+                            try (BufferedReader reader = Files.newBufferedReader(customAreaFile, StandardCharsets.UTF_8)) {
+                                globalAreas.getFeatures().addAll(mapper.readValue(reader, JsonFeatureCollection.class).getFeatures());
+                            } catch (IOException e) {
+                                throw new UncheckedIOException(e);
+                            }
+                        });
                 logger.info("Will make " + globalAreas.getFeatures().size() + " areas available to all custom profiles. Found in " + customAreasDirectory);
             } catch (IOException e) {
                 throw new UncheckedIOException(e);


### PR DESCRIPTION
The elements returned by the `DirectoryStream` iterator are in no specific order:
https://stackoverflow.com/questions/43705981/directorystream-return-path-in-what-kind-of-order-filename-last-modified-file

Then [hints](https://github.com/graphhopper/graphhopper/blob/24df953e29a1c0f5d892a46630cd58905a2778fb/core/src/main/java/com/graphhopper/config/Profile.java#L139C110-L139C115) contains `areas` list in the order in which they are read by `resolveCustomAreas` method (fixed by PR)

thus the [Profile.getVersion](https://github.com/graphhopper/graphhopper/blob/24df953e29a1c0f5d892a46630cd58905a2778fb/core/src/main/java/com/graphhopper/config/Profile.java#L148) can return different hash, in cases where there are custom areas.
