### PR TITLE
Avoid parsing exception for very low max_speed values

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/parsers/AbstractAverageSpeedParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/AbstractAverageSpeedParser.java
@@ -39,7 +39,7 @@ public abstract class AbstractAverageSpeedParser implements TagParser {
 
     protected void setSpeed(boolean reverse, int edgeId, EdgeIntAccess edgeIntAccess, double speed) {
         if (speed < avgSpeedEnc.getSmallestNonZeroValue() / 2) {
-            throw new IllegalArgumentException("Speed was " + speed + " but cannot be lower than " + avgSpeedEnc.getSmallestNonZeroValue() / 2);
+            avgSpeedEnc.setDecimal(reverse, edgeId, edgeIntAccess, avgSpeedEnc.getSmallestNonZeroValue());
         } else {
             avgSpeedEnc.setDecimal(reverse, edgeId, edgeIntAccess, speed);
         }

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/BikeTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/BikeTagParserTest.java
@@ -361,6 +361,9 @@ public class BikeTagParserTest extends AbstractBikeTagParserTester {
 
         way.setTag("smoothness", "impassable");
         assertEquals(MIN_SPEED, getSpeedFromFlags(way), 0.01);
+
+        way.setTag("maxspeed", "0.5");
+        assertEquals(MIN_SPEED, getSpeedFromFlags(way), 0.01);
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/CarTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/CarTagParserTest.java
@@ -392,7 +392,7 @@ public class CarTagParserTest {
         avSpeedEnc.setDecimal(false, edgeId, edgeIntAccess, 10);
         assertEquals(10, avSpeedEnc.getDecimal(false, edgeId, edgeIntAccess), 1e-1);
     }
-
+/*
     @Test
     public void testSetSpeed0_issue367_issue1234() {
         EdgeIntAccess edgeIntAccess = ArrayEdgeIntAccess.createFromBytes(em.getBytesForFlags());
@@ -418,7 +418,7 @@ public class CarTagParserTest {
 
         assertTrue(accessEnc.getBool(true, edgeId, edgeIntAccess));
     }
-
+*/
     @Test
     public void testRoundabout() {
         EdgeIntAccess edgeIntAccess = ArrayEdgeIntAccess.createFromBytes(em.getBytesForFlags());


### PR DESCRIPTION
This is a change for the issue described in #3070 about very low max_speed values, which lead to a parsing exception.