### PR TITLE
Fix for bicycle ETA issue detected in #3078

### DIFF
--- a/core/src/test/java/com/graphhopper/routing/util/parsers/BikeTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/BikeTagParserTest.java
@@ -228,6 +228,12 @@ public class BikeTagParserTest extends AbstractBikeTagParserTester {
 
         way.clearTags();
         way.setTag("highway", "track");
+        way.setTag("surface", "concrete");
+        way.setTag("vehicle", "agricultural");
+        assertPriorityAndSpeed(UNCHANGED, PUSHING_SECTION_SPEED, way);
+
+        way.clearTags();
+        way.setTag("highway", "track");
         way.setTag("tracktype", "grade1");
         assertPriorityAndSpeed(UNCHANGED, 18, way);
 


### PR DESCRIPTION
In issue #3078 it was detected that on a get_off_bike section, which is tagged with a surface tag, the low pushing section speed was boosted up with the surface speed. This modification skips the computation of the surface speed logic in this case.
