### PR TITLE
Do not prefer highway=cycleway over lcn bicycle route relations any longer

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonPriorityParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonPriorityParser.java
@@ -76,7 +76,7 @@ public abstract class BikeCommonPriorityParser implements TagParser {
         routeMap.put(INTERNATIONAL, BEST.getValue());
         routeMap.put(NATIONAL, BEST.getValue());
         routeMap.put(REGIONAL, VERY_NICE.getValue());
-        routeMap.put(LOCAL, PREFER.getValue());
+        routeMap.put(LOCAL, VERY_NICE.getValue());
 
         avoidSpeedLimit = 71;
     }
@@ -209,7 +209,7 @@ public abstract class BikeCommonPriorityParser implements TagParser {
             weightToPrioMap.put(50d, AVOID_MORE);
 
         if (way.hasTag("lcn", "yes"))
-            weightToPrioMap.put(100d, PREFER);
+            weightToPrioMap.put(100d, VERY_NICE);
 
         String classBicycleValue = way.getTag(classBicycleKey);
         if (classBicycleValue != null) {

--- a/core/src/test/java/com/graphhopper/GraphHopperTest.java
+++ b/core/src/test/java/com/graphhopper/GraphHopperTest.java
@@ -465,10 +465,10 @@ public class GraphHopperTest {
         assertEquals(3, rsp.getAll().size());
         // via ramsenthal
         assertEquals(2636, rsp.getAll().get(0).getTime() / 1000);
+        // via eselslohe
+        assertEquals(2783, rsp.getAll().get(1).getTime() / 1000);
         // via unterwaiz
-        assertEquals(2985, rsp.getAll().get(1).getTime() / 1000);
-        // via eselslohe -> theta; BTW: here smaller time as 2nd alternative due to priority influences time order
-        assertEquals(2783, rsp.getAll().get(2).getTime() / 1000);
+        assertEquals(2985, rsp.getAll().get(2).getTime() / 1000);
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/BikeTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/BikeTagParserTest.java
@@ -502,16 +502,16 @@ public class BikeTagParserTest extends AbstractBikeTagParserTester {
 
         // "lcn=yes" is in fact no relation, but shall be treated the same like a relation with "network=lcn"
         osmWay.setTag("lcn", "yes");
-        assertPriorityAndSpeed(PREFER, 12, osmWay);
+        assertPriorityAndSpeed(VERY_NICE, 12, osmWay);
         osmWay.removeTag("lcn");
 
-        // relation code is PREFER
+        // relation code is VERY_NICE
         ReaderRelation osmRel = new ReaderRelation(1);
         osmRel.setTag("route", "bicycle");
-        assertPriorityAndSpeed(PREFER, 12, osmWay, osmRel);
+        assertPriorityAndSpeed(VERY_NICE, 12, osmWay, osmRel);
 
         osmRel.setTag("network", "lcn");
-        assertPriorityAndSpeed(PREFER, 12, osmWay, osmRel);
+        assertPriorityAndSpeed(VERY_NICE, 12, osmWay, osmRel);
 
         // relation code is NICE
         osmRel.setTag("network", "rcn");
@@ -528,7 +528,7 @@ public class BikeTagParserTest extends AbstractBikeTagParserTester {
         osmWay.setTag("highway", "tertiary");
         osmRel.setTag("route", "bicycle");
         osmRel.setTag("network", "lcn");
-        assertPriorityAndSpeed(PREFER, 18, osmWay, osmRel);
+        assertPriorityAndSpeed(VERY_NICE, 18, osmWay, osmRel);
     }
 
     @Test


### PR DESCRIPTION
This PR results from the discussion in https://discuss.graphhopper.com/t/bicycle-routing-would-expect-higher-priority-for-bicycle-roads/9223/5
We now prioritize lcn bicycle route relations the same way as rcn route relations.