### PR TITLE
DISCO-12224: Basic AllTrails attribute import

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -119,6 +119,11 @@
             <artifactId>logback-classic</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>net.sf.opencsv</groupId>
+            <artifactId>opencsv</artifactId>
+            <version>2.3</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/core/src/main/java/com/graphhopper/AtGlobals.java
+++ b/core/src/main/java/com/graphhopper/AtGlobals.java
@@ -1,0 +1,41 @@
+package com.graphhopper;
+
+import java.io.FileReader;
+import java.util.HashMap;
+
+import au.com.bytecode.opencsv.CSVReader;
+
+/**
+ * Crude hack to allow custom weights to be loaded from a CSV into a HashMap
+ * so they may be merged-in during an OSM import
+ */
+public class AtGlobals {
+    public static HashMap<Long, Double> popularities = new HashMap<Long, Double>();
+    public static HashMap<Long, Double> scenicValues = new HashMap<Long, Double>();
+
+    public static void loadAllTrailsCsv(String filename) {
+      try {
+          CSVReader reader = new CSVReader(new FileReader(filename));
+          String [] nextLine;
+          while ((nextLine = reader.readNext()) != null) {
+              if ("osm_id".equals(nextLine[0]))
+                  continue;
+              try {
+                  // Long wayId = Long.valueOf(nextLine[0]);
+                  Long wayId = Double.valueOf(nextLine[0]).longValue();
+                  Double popularity = Double.valueOf(nextLine[1]);
+                  Double scenic_value = Double.valueOf(nextLine[2]);
+                  if (popularity > 0.0)
+                    popularities.put(wayId, popularity);
+                  if (scenic_value > 0.0)
+                    scenicValues.put(wayId, scenic_value);
+              } catch (Exception ex) {
+                  System.out.println("CSV parse exception: " + ex.getMessage());
+              }
+          }
+          reader.close();
+      } catch (Exception ex) {
+          System.out.println("CSV read exception: " + ex.getMessage());
+      }
+  }
+}

--- a/core/src/main/java/com/graphhopper/routing/ev/AtPopularity.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/AtPopularity.java
@@ -1,0 +1,11 @@
+package com.graphhopper.routing.ev;
+
+public class AtPopularity {
+    public static final String KEY = "at_popularity";
+
+    public static DecimalEncodedValue create() {
+        // Range is 0.0-10.0
+        return new DecimalEncodedValueImpl(KEY, 5, 0.0, 0.3226,
+                false, false, false);
+    }
+}

--- a/core/src/main/java/com/graphhopper/routing/ev/AtScenicValue.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/AtScenicValue.java
@@ -1,0 +1,11 @@
+package com.graphhopper.routing.ev;
+
+public class AtScenicValue {
+    public static final String KEY = "at_scenic_value";
+
+    public static DecimalEncodedValue create() {
+        // Range is 0.0-10.0
+        return new DecimalEncodedValueImpl(KEY, 5, 0.0, 0.3226,
+                false, false, false);
+    }
+}

--- a/core/src/main/java/com/graphhopper/routing/ev/DefaultImportRegistry.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/DefaultImportRegistry.java
@@ -153,6 +153,16 @@ public class DefaultImportRegistry implements ImportRegistry {
                     (lookup, props) -> new OSMFootwayParser(
                             lookup.getEnumEncodedValue(Footway.KEY, Footway.class))
             );
+        else if (AtPopularity.KEY.equals(name))
+            return ImportUnit.create(name, props -> AtPopularity.create(),
+                    (lookup, props) -> new AtPopularityCalculator(
+                            lookup.getDecimalEncodedValue(AtPopularity.KEY))
+            );
+        else if (AtScenicValue.KEY.equals(name))
+            return ImportUnit.create(name, props -> AtScenicValue.create(),
+                    (lookup, props) -> new AtScenicValueCalculator(
+                            lookup.getDecimalEncodedValue(AtScenicValue.KEY))
+            );
         else if (OSMWayID.KEY.equals(name))
             return ImportUnit.create(name, props -> OSMWayID.create(),
                     (lookup, props) -> new OSMWayIDParser(

--- a/core/src/main/java/com/graphhopper/routing/util/AtPopularityCalculator.java
+++ b/core/src/main/java/com/graphhopper/routing/util/AtPopularityCalculator.java
@@ -1,0 +1,29 @@
+package com.graphhopper.routing.util;
+
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.DecimalEncodedValue;
+import com.graphhopper.routing.ev.EdgeIntAccess;
+import com.graphhopper.routing.util.parsers.TagParser;
+import com.graphhopper.storage.IntsRef;
+
+import com.graphhopper.AtGlobals;
+
+public class AtPopularityCalculator implements TagParser {
+
+    private final DecimalEncodedValue popularityEnc;
+
+    public AtPopularityCalculator(DecimalEncodedValue popularityEnc) {
+        this.popularityEnc = popularityEnc;
+    }
+
+    @Override
+    public void handleWayTags(int edgeId, EdgeIntAccess edgeIntAccess, ReaderWay way, IntsRef relationFlags) {
+        long wayId = way.getId();
+        Double popularity = AtGlobals.popularities.get(wayId);
+        if (popularity != null) {
+            // String name = way.getTag("name", null);
+            // System.out.println(name + ":" + wayId + " popularity: " + popularity);
+            popularityEnc.setDecimal(false, edgeId, edgeIntAccess, popularity);
+        }
+    }
+}

--- a/core/src/main/java/com/graphhopper/routing/util/AtScenicValueCalculator.java
+++ b/core/src/main/java/com/graphhopper/routing/util/AtScenicValueCalculator.java
@@ -1,0 +1,29 @@
+package com.graphhopper.routing.util;
+
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.DecimalEncodedValue;
+import com.graphhopper.routing.ev.EdgeIntAccess;
+import com.graphhopper.routing.util.parsers.TagParser;
+import com.graphhopper.storage.IntsRef;
+
+import com.graphhopper.AtGlobals;
+
+public class AtScenicValueCalculator implements TagParser {
+
+    private final DecimalEncodedValue scenicValueEnc;
+
+    public AtScenicValueCalculator(DecimalEncodedValue scenicValueEnc) {
+        this.scenicValueEnc = scenicValueEnc;
+    }
+
+    @Override
+    public void handleWayTags(int edgeId, EdgeIntAccess edgeIntAccess, ReaderWay way, IntsRef relationFlags) {
+        long wayId = way.getId();
+        Double scenicValue = AtGlobals.scenicValues.get(wayId);
+        if (scenicValue != null) {
+            // String name = way.getTag("name", null);
+            // System.out.println(name + ":" + wayId + " scenicValue: " + scenicValue);
+            scenicValueEnc.setDecimal(false, edgeId, edgeIntAccess, scenicValue);
+        }
+    }
+}

--- a/web-bundle/src/main/resources/com/graphhopper/maps/config.js
+++ b/web-bundle/src/main/resources/com/graphhopper/maps/config.js
@@ -1,5 +1,5 @@
 const config = {
-    routingApi: location.origin + '/',
+    routingApi: location.origin + (location.host == 'alpha.mostpaths.com' ? '/api/alltrails/graphhopper-service/' : '/'),
     geocodingApi: '',
     defaultTiles: 'OpenStreetMap',
     keys: {


### PR DESCRIPTION
First PR against our fork of the Graphhopper repo.

Adds support for importing AllTrails-specific `at_popularity` and `at_scenic_value` attributes from a CSV and merging them into the Graphhopper routing graph edges when it is building the graph from an OSM PBF file.

`AtGlobals` is a kludge, using a global-scope object to hold the imported CSV data so that it is then available during the import process.  But I am not a Java programmer, and this should be easy for a Java-savvy programmer to clean up later.