### PR TITLE
Denmark HGV toll 2025

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/countryrules/europe/DenmarkCountryRule.java
+++ b/core/src/main/java/com/graphhopper/routing/util/countryrules/europe/DenmarkCountryRule.java
@@ -23,7 +23,7 @@ import com.graphhopper.routing.ev.Toll;
 import com.graphhopper.routing.util.countryrules.CountryRule;
 
 /**
- * Defines the default rules for Polish roads
+ * Defines the default rules for danish roads
  *
  * @author Thomas Butz
  */

--- a/core/src/main/java/com/graphhopper/routing/util/countryrules/europe/DenmarkCountryRule.java
+++ b/core/src/main/java/com/graphhopper/routing/util/countryrules/europe/DenmarkCountryRule.java
@@ -36,8 +36,9 @@ public class DenmarkCountryRule implements CountryRule {
         }
 
         RoadClass roadClass = RoadClass.find(readerWay.getTag("highway", ""));
-        if (RoadClass.MOTORWAY == roadClass)
-            return Toll.HGV;
-        return currentToll;
+        return switch (roadClass) {
+            case MOTORWAY, TRUNK, PRIMARY -> Toll.HGV;
+            default -> currentToll;
+        };
     }
 }


### PR DESCRIPTION
Denmark changes it's toll rules starting 01.01.2025: https://vejafgifter.dk/en/which-roads/

> As of 1 January 2025 trucks of 12 tons and above will pay toll for driving on the Danish state road network and parts of the Danish municipal road network (approx. 10,900 km).