### PR TITLE
fix missing road_access option in config-example.yml

### DIFF
--- a/config-example.yml
+++ b/config-example.yml
@@ -92,7 +92,7 @@ graphhopper:
   # More are: surface,smoothness,max_width,max_height,max_weight,max_weight_except,hgv,max_axle_load,max_length,
   #           hazmat,hazmat_tunnel,hazmat_water,lanes,osm_way_id,toll,track_type,mtb_rating,hike_rating,horse_rating,
   #           country,curvature,average_slope,max_slope,car_temporal_access,bike_temporal_access,foot_temporal_access
-  graph.encoded_values: car_access, car_average_speed
+  graph.encoded_values: car_access, car_average_speed, road_access
 
   #### Speed, hybrid and flexible mode ####
 


### PR DESCRIPTION
Add missing option `road_access` to the graph.encoded_values in config-example.yml file 

![image](https://github.com/user-attachments/assets/ce20d15d-258a-4b47-8fb9-6b73b9a9dad6)
