### PR TITLE
fix: starting at a barrier for navigation converter

### DIFF
--- a/core/src/main/java/com/graphhopper/util/details/IntersectionValues.java
+++ b/core/src/main/java/com/graphhopper/util/details/IntersectionValues.java
@@ -36,8 +36,8 @@ public class IntersectionValues {
         List<IntersectionValues> list = new ArrayList<>();
 
         List<Integer> bearings = (List<Integer>) intersectionMap.get("bearings");
-        Integer in = (Integer) intersectionMap.get("in");
-        Integer out = (Integer) intersectionMap.get("out");
+        Integer in = (Integer) intersectionMap.getOrDefault("in", -1);
+        Integer out = (Integer) intersectionMap.getOrDefault("out", -1);
         List<Boolean> entry = (List<Boolean>) intersectionMap.get("entries");
 
         if (bearings.size() != entry.size()) {


### PR DESCRIPTION
The previous fix handled two issues: 
* Deduplicating barriers (intersections) for NavigationConverter
* Fixing Arrival and Departures (intersections) for NavigationConverter to have only an in or out link. 
What I missed is an arrival or departure intersection, deduplicating an Arrival or Departure intersection with only an in or out link.

@boldtrn can you check please ?