### PR TITLE
Speedup path searcher reset

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/ch/NodeBasedWitnessPathSearcher.java
+++ b/core/src/main/java/com/graphhopper/routing/ch/NodeBasedWitnessPathSearcher.java
@@ -18,7 +18,6 @@
 package com.graphhopper.routing.ch;
 
 import com.carrotsearch.hppc.IntArrayList;
-import com.carrotsearch.hppc.procedures.IntProcedure;
 import com.graphhopper.apache.commons.collections.IntFloatBinaryHeap;
 import com.graphhopper.util.Helper;
 
@@ -114,7 +113,9 @@ public class NodeBasedWitnessPathSearcher {
     }
 
     private void reset() {
-        changedNodes.forEach((IntProcedure) i -> weights[i] = Double.POSITIVE_INFINITY);
+        for (int i = 0; i < changedNodes.elementsCount; i++) {
+            weights[changedNodes.buffer[i]] = Double.POSITIVE_INFINITY;
+        }
         changedNodes.elementsCount = 0;
         heap.clear();
         ignoreNode = -1;

--- a/core/src/main/java/com/graphhopper/routing/ch/NodeBasedWitnessPathSearcher.java
+++ b/core/src/main/java/com/graphhopper/routing/ch/NodeBasedWitnessPathSearcher.java
@@ -18,7 +18,7 @@
 package com.graphhopper.routing.ch;
 
 import com.carrotsearch.hppc.IntArrayList;
-import com.carrotsearch.hppc.cursors.IntCursor;
+import com.carrotsearch.hppc.procedures.IntProcedure;
 import com.graphhopper.apache.commons.collections.IntFloatBinaryHeap;
 import com.graphhopper.util.Helper;
 
@@ -114,8 +114,7 @@ public class NodeBasedWitnessPathSearcher {
     }
 
     private void reset() {
-        for (IntCursor c : changedNodes)
-            weights[c.value] = Double.POSITIVE_INFINITY;
+        changedNodes.forEach((IntProcedure) i -> weights[i] = Double.POSITIVE_INFINITY);
         changedNodes.elementsCount = 0;
         heap.clear();
         ignoreNode = -1;


### PR DESCRIPTION
HPPC explicitly calls out Iterator based access as slow: https://labs.carrotsearch.com/hppc-api-and-code-examples.html#iterating-over-lists

The created IntCursor instances add up to a high amount of memory allocation visible in the JFR:

![grafik](https://github.com/user-attachments/assets/92dab673-9d6d-42af-84c7-1faa830ea711)

