### PR TITLE
Avoid frequent IllegalArgumentException

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/ev/State.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/State.java
@@ -121,8 +121,13 @@ public enum State {
      * @param iso should be ISO 3166-2 but with hyphen like US-CA
      */
     public static State find(String iso) {
+        iso = iso.replace('-', '_');
+        if (iso.indexOf('_') == -1) {
+            return State.MISSING;
+        }
+
         try {
-            return State.valueOf(iso.replace('-', '_'));
+            return State.valueOf(iso);
         } catch (IllegalArgumentException ex) {
             return State.MISSING;
         }


### PR DESCRIPTION
A regular import of Germany creates an IllegalArgumentException for every way:

![grafik](https://github.com/user-attachments/assets/c5dc0b82-5c33-4877-a810-ecaa360af1b3)

We can skip the entire try-catch if the ISO code doesn't contain a `-`

https://github.com/graphhopper/graphhopper/blob/218f4d9f1fead97ab555ec5ca721eb0778deaf1d/core/src/main/java/com/graphhopper/routing/ev/State.java#L123-L129