### PR TITLE
Avoid ArithmeticException

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/AbstractBidirAlgo.java
+++ b/core/src/main/java/com/graphhopper/routing/AbstractBidirAlgo.java
@@ -279,6 +279,11 @@ public abstract class AbstractBidirAlgo implements EdgeToEdgeRoutingAlgorithm {
     }
 
     protected void setupFinishTime() {
+        if (timeoutMillis == Long.MAX_VALUE) {
+            this.finishTimeMillis = Long.MAX_VALUE;
+            return;
+        }
+
         try {
             this.finishTimeMillis = Math.addExact(System.currentTimeMillis(), timeoutMillis);
         } catch (ArithmeticException e) {

--- a/core/src/main/java/com/graphhopper/routing/AbstractRoutingAlgorithm.java
+++ b/core/src/main/java/com/graphhopper/routing/AbstractRoutingAlgorithm.java
@@ -80,6 +80,11 @@ public abstract class AbstractRoutingAlgorithm implements RoutingAlgorithm {
     }
 
     protected void setupFinishTime() {
+        if (timeoutMillis == Long.MAX_VALUE) {
+            this.finishTimeMillis = Long.MAX_VALUE;
+            return;
+        }
+
         try {
             this.finishTimeMillis = Math.addExact(System.currentTimeMillis(), timeoutMillis);
         } catch (ArithmeticException e) {


### PR DESCRIPTION
Without a timeout `Math.addExact()` always triggers an `ArithmeticException` as `timeoutMillis` defaults to `Long.MAX_VALUE`