### PR TITLE
Handle implicit HGV access

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMHgvParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMHgvParser.java
@@ -5,22 +5,29 @@ import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.EdgeIntAccess;
 import com.graphhopper.routing.ev.EnumEncodedValue;
 import com.graphhopper.routing.ev.Hgv;
+import com.graphhopper.routing.util.TransportationMode;
 import com.graphhopper.storage.IntsRef;
 
 import static com.graphhopper.routing.util.parsers.helpers.OSMValueExtractor.conditionalWeightToTons;
 
-public class OSMHgvParser implements TagParser {
-    EnumEncodedValue<Hgv> hgvEnc;
+public class OSMHgvParser extends OSMRoadAccessParser<Hgv> {
 
     public OSMHgvParser(EnumEncodedValue<Hgv> hgvEnc) {
-        this.hgvEnc = hgvEnc;
+        super(hgvEnc, OSMRoadAccessParser.toOSMRestrictions(TransportationMode.HGV),
+                (readerWay, accessValue) -> accessValue, Hgv::find);
     }
 
     @Override
     public void handleWayTags(int edgeId, EdgeIntAccess edgeIntAccess, ReaderWay way, IntsRef relationFlags) {
         String value = way.getTag("hgv:conditional", "");
         int index = value.indexOf("@");
-        Hgv hgvValue = index > 0 && conditionalWeightToTons(value) == 3.5 ? Hgv.find(value.substring(0, index).trim()) : Hgv.find(way.getTag("hgv"));
-        hgvEnc.setEnum(false, edgeId, edgeIntAccess, hgvValue);
+        if (index > 0 && conditionalWeightToTons(value) == 3.5) {
+            Hgv hgvValue = Hgv.find(value.substring(0, index).trim());
+            if (hgvValue != Hgv.MISSING) {
+                accessEnc.setEnum(false, edgeId, edgeIntAccess, hgvValue);
+                return;
+            }
+        }
+        super.handleWayTags(edgeId, edgeIntAccess, way, relationFlags); // non-conditional access
     }
 }

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMHgvParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMHgvParserTest.java
@@ -33,6 +33,24 @@ class OSMHgvParserTest {
     }
 
     @Test
+    public void testImplicitAccess() {
+        EdgeIntAccess edgeIntAccess = new ArrayEdgeIntAccess(1);
+        ReaderWay readerWay = new ReaderWay(1);
+        readerWay.setTag("highway", "primary");
+        readerWay.setTag("motor_vehicle", "destination");
+        parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
+        assertEquals(Hgv.DESTINATION, hgvEnc.getEnum(false, edgeId, edgeIntAccess));
+
+        edgeIntAccess = new ArrayEdgeIntAccess(1);
+        readerWay = new ReaderWay(1);
+        readerWay.setTag("highway", "primary");
+        readerWay.setTag("access", "yes");
+        readerWay.setTag("motor_vehicle", "no");
+        parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
+        assertEquals(Hgv.NO, hgvEnc.getEnum(false, edgeId, edgeIntAccess));
+    }
+
+    @Test
     public void testConditionalTags() {
         EdgeIntAccess edgeIntAccess = new ArrayEdgeIntAccess(1);
         ReaderWay readerWay = new ReaderWay(1);


### PR DESCRIPTION
The OSMHgvParser in its current form only handles two types of tags: `hgv` and `hgv:conditional`. Other access EVs like `road_access`,  `bike_road_access` or `foot_road_access` are populated by the `OSMRoadAccessParser` which can deal with the hierarchical nature of access tagging and also covers barriers.

This PR changes the `OSMHgvParser` to be a simple extension of the `OSMRoadAccessParser` which only handles the conditional parsing logic.