### PR TITLE
Enchantments to the routing output with GTFS data.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - road_access now contains value of highest transportation mode for CAR, i.e. access=private, motorcar=yes will now return YES and not PRIVATE
 - car.json by default avoids private roads
 - maxspeed<5 is ignored, maxspeed=none is ignored with some exceptions, maxspeed parsing and related constants were renamed #3077
-- Added route_type in Trip.PtLeg to describe the vehicle type used in public transport
+- Added agency_id, agency_name, and route_type to Trip.PtLeg to describe the operator and the vehicle type used in public transport.
 
 ### 10.0 [5 Nov 2024]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - road_access now contains value of highest transportation mode for CAR, i.e. access=private, motorcar=yes will now return YES and not PRIVATE
 - car.json by default avoids private roads
 - maxspeed<5 is ignored, maxspeed=none is ignored with some exceptions, maxspeed parsing and related constants were renamed #3077
+- Added route_type in Trip.PtLeg to describe the vehicle type used in public transport
 
 ### 10.0 [5 Nov 2024]
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -29,6 +29,7 @@ Here is an overview:
  * easbar, one of the core developers
  * edy, improvements regarding docker #849
  * elibar, fix for alternative route calculation
+ * elvedin-hamzagic, improvements regarding output data
  * fbonzon, several UI improvements like #615
  * florent-morel, improvements regarding fords, #320
  * fredao, translations 

--- a/config-example.yml
+++ b/config-example.yml
@@ -201,7 +201,7 @@ graphhopper:
   # motorized vehicles. This leads to a smaller and less dense graph, because there are fewer ways (obviously),
   # but also because there are fewer crossings between highways (=junctions).
   # Another typical example is excluding 'motorway', 'trunk' and maybe 'primary' highways for bicycle or pedestrian routing.
-  import.osm.ignored_highways: footway,cycleway,path,pedestrian,steps # typically useful for motorized-only routing
+  import.osm.ignored_highways: footway,construction,cycleway,path,pedestrian,steps # typically useful for motorized-only routing
   # import.osm.ignored_highways: motorway,trunk # typically useful for non-motorized routing
 
   # configure the memory access, use RAM_STORE for well equipped servers (default and recommended)

--- a/reader-gtfs/src/main/java/com/graphhopper/gtfs/TripFromLabel.java
+++ b/reader-gtfs/src/main/java/com/graphhopper/gtfs/TripFromLabel.java
@@ -344,6 +344,7 @@ class TripFromLabel {
             String feedId = path.get(1).edge.getPlatformDescriptor().feed_id;
             List<Trip.Leg> result = new ArrayList<>();
             long boardTime = -1;
+            int routeType = -1;
             List<Label.Transition> partition = null;
             for (int i = 1; i < path.size(); i++) {
                 Label.Transition transition = path.get(i);
@@ -351,6 +352,8 @@ class TripFromLabel {
                 if (edge.getType() == GtfsStorage.EdgeType.BOARD) {
                     boardTime = transition.label.currentTime;
                     partition = new ArrayList<>();
+                } else if (edge.getType() == GtfsStorage.EdgeType.ENTER_PT) {
+                    routeType = edge.getRouteType();
                 }
                 if (partition != null) {
                     partition.add(path.get(i));
@@ -368,6 +371,7 @@ class TripFromLabel {
                             feedId, partition.get(0).edge.getTransfers() == 0,
                             tripDescriptor.getTripId(),
                             tripDescriptor.getRouteId(),
+                            routeType,
                             Optional.ofNullable(gtfsStorage.getGtfsFeeds().get(feedId).trips.get(tripDescriptor.getTripId())).map(t -> t.trip_headsign).orElse("extra"),
                             stops,
                             partition.stream().mapToDouble(t -> t.edge.getDistance()).sum(),

--- a/web-api/src/main/java/com/graphhopper/Trip.java
+++ b/web-api/src/main/java/com/graphhopper/Trip.java
@@ -102,13 +102,15 @@ public class Trip {
         public final List<Stop> stops;
         public final String trip_id;
         public final String route_id;
+        public final int route_type;
 
-        public PtLeg(String feedId, boolean isInSameVehicleAsPrevious, String tripId, String routeId, String headsign, List<Stop> stops, double distance, long travelTime, Geometry geometry) {
+        public PtLeg(String feedId, boolean isInSameVehicleAsPrevious, String tripId, String routeId, int routeType, String headsign, List<Stop> stops, double distance, long travelTime, Geometry geometry) {
             super("pt", stops.get(0).stop_name, geometry, distance);
             this.feed_id = feedId;
             this.isInSameVehicleAsPrevious = isInSameVehicleAsPrevious;
             this.trip_id = tripId;
             this.route_id = routeId;
+            this.route_type = routeType;
             this.trip_headsign = headsign;
             this.travelTime = travelTime;
             this.stops = stops;

--- a/web-api/src/main/java/com/graphhopper/Trip.java
+++ b/web-api/src/main/java/com/graphhopper/Trip.java
@@ -96,6 +96,8 @@ public class Trip {
     }
     public static class PtLeg extends Leg {
         public final String feed_id;
+        public final String agency_id;
+        public final String agency_name;
         public final boolean isInSameVehicleAsPrevious;
         public final String trip_headsign;
         public final long travelTime;
@@ -104,9 +106,11 @@ public class Trip {
         public final String route_id;
         public final int route_type;
 
-        public PtLeg(String feedId, boolean isInSameVehicleAsPrevious, String tripId, String routeId, int routeType, String headsign, List<Stop> stops, double distance, long travelTime, Geometry geometry) {
+        public PtLeg(String feedId, String agencyId, String agencyName, boolean isInSameVehicleAsPrevious, String tripId, String routeId, int routeType, String headsign, List<Stop> stops, double distance, long travelTime, Geometry geometry) {
             super("pt", stops.get(0).stop_name, geometry, distance);
             this.feed_id = feedId;
+            this.agency_id = agencyId;
+            this.agency_name = agencyName;
             this.isInSameVehicleAsPrevious = isInSameVehicleAsPrevious;
             this.trip_id = tripId;
             this.route_id = routeId;


### PR DESCRIPTION
Added route_type, agency_id and agency_name to a route leg for 'pt' legs.

route_type - type of the vehicle used in public transport, e.g. 3 for a bus, 0 for a tram and 11 for a trolley
agency_id - the ID of the operator as stated in the GTFS table agencies.txt
agency_name - the name of the operator
