### PR TITLE
In JTSTriangulator, use DelaunayTriangulationBuilder instead of ConformingDelaunayTriangulator

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -41,6 +41,7 @@ Here is an overview:
  * hoofstephan, bug fix   
  * IsNull, improvements like #708
  * IldarKhayrutdinov, use cache on different machines
+ * james-willis, improved isochrones triangulation robustness
  * Janekdererste, GUI for public transit
  * jansoe, many improvements regarding A* algorithm, forcing direction, roundabouts etc
  * jansonhanson, general host config

--- a/core/src/main/java/com/graphhopper/isochrone/algorithm/JTSTriangulator.java
+++ b/core/src/main/java/com/graphhopper/isochrone/algorithm/JTSTriangulator.java
@@ -27,16 +27,15 @@ import com.graphhopper.util.FetchMode;
 import com.graphhopper.util.PointList;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Polygon;
-import org.locationtech.jts.triangulate.ConformingDelaunayTriangulator;
-import org.locationtech.jts.triangulate.ConstraintVertex;
+import org.locationtech.jts.triangulate.DelaunayTriangulationBuilder;
 import org.locationtech.jts.triangulate.quadedge.QuadEdgeSubdivision;
 import org.locationtech.jts.triangulate.quadedge.Vertex;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.function.ToDoubleFunction;
-import java.util.stream.Collectors;
 
 public class JTSTriangulator implements Triangulator {
 
@@ -84,12 +83,10 @@ public class JTSTriangulator implements Triangulator {
         // But that's okay, the triangulator de-dupes by itself, and it keeps the first z-value it sees, which is
         // what we want.
 
-        Collection<ConstraintVertex> constraintVertices = sites.stream().map(ConstraintVertex::new).collect(Collectors.toList());
-        ConformingDelaunayTriangulator conformingDelaunayTriangulator = new ConformingDelaunayTriangulator(constraintVertices, tolerance);
-        conformingDelaunayTriangulator.setConstraints(new ArrayList<>(), new ArrayList<>());
-        conformingDelaunayTriangulator.formInitialDelaunay();
-        conformingDelaunayTriangulator.enforceConstraints();
-        Geometry convexHull = conformingDelaunayTriangulator.getConvexHull();
+        DelaunayTriangulationBuilder triangulationBuilder = new DelaunayTriangulationBuilder();
+        triangulationBuilder.setSites(sites);
+        triangulationBuilder.setTolerance(tolerance);
+        Geometry convexHull = triangulationBuilder.getEdges(new GeometryFactory()).convexHull();
 
         // If there's only one site (and presumably also if the convex hull is otherwise degenerated),
         // the triangulation only contains the frame, and not the site within the frame. Not sure if I agree with that.
@@ -106,7 +103,7 @@ public class JTSTriangulator implements Triangulator {
                     + "Please try a different 'point' or a larger 'time_limit'.");
         }
 
-        QuadEdgeSubdivision tin = conformingDelaunayTriangulator.getSubdivision();
+        QuadEdgeSubdivision tin = triangulationBuilder.getSubdivision();
         for (Vertex vertex : (Collection<Vertex>) tin.getVertices(true)) {
             if (tin.isFrameVertex(vertex)) {
                 vertex.setZ(Double.MAX_VALUE);


### PR DESCRIPTION
This PR is based on this discussion with Martin (Dr. JTS): https://github.com/locationtech/jts/issues/1121

He suggested that DelaunayTriangulationBuilder is likely the most appropriate way to build this triangulation.

i'm unsure if there are other simplifications that can be made to this class based on the changes in this PR.

I apologize for failing to add a new test, I am struggling to build a test case that captures the bug in the JTS issue above. 