### PR TITLE
Allow to request path details without path simplification

### DIFF
--- a/core/src/main/java/com/graphhopper/util/PathMerger.java
+++ b/core/src/main/java/com/graphhopper/util/PathMerger.java
@@ -125,7 +125,7 @@ public class PathMerger {
                 }
 
             }
-            if (calcPoints || enableInstructions) {
+            if (calcPoints || enableInstructions || !requestedPathDetails.isEmpty()) {
                 PointList tmpPoints = path.calcPoints();
                 if (fullPoints.isEmpty())
                     fullPoints = new PointList(tmpPoints.size(), tmpPoints.is3D());

--- a/core/src/main/java/com/graphhopper/util/PathMerger.java
+++ b/core/src/main/java/com/graphhopper/util/PathMerger.java
@@ -150,7 +150,7 @@ public class PathMerger {
             calcAscendDescend(responsePath, fullPoints);
 
         if (enableInstructions) {
-            fullInstructions = updateInstructionsWithContext(fullInstructions);
+            updateInstructionsWithContext(fullInstructions);
             responsePath.setInstructions(fullInstructions);
         }
 
@@ -187,7 +187,7 @@ public class PathMerger {
      * points into the opposite direction of the route.
      * At a waypoint it can transform the continue to a u-turn if the route involves turning.
      */
-    private InstructionList updateInstructionsWithContext(InstructionList instructions) {
+    private void updateInstructionsWithContext(InstructionList instructions) {
         Instruction instruction;
         Instruction nextInstruction;
 
@@ -222,8 +222,6 @@ public class PathMerger {
                 }
             }
         }
-
-        return instructions;
     }
 
     private void calcAscendDescend(final ResponsePath responsePath, final PointList pointList) {


### PR DESCRIPTION
Currently it's a bit cumbersome to request path details without path simplification.

This doesn't return any path details, as either `calc_points` or `instructions` are implicitly required:

```java
GHRequest request = new GHRequest(start, destination)
				.setPathDetails(List.of("distance", "country", "toll"))
				.putHint(Parameters.Routing.INSTRUCTIONS, false)
				.putHint(Parameters.Routing.CALC_POINTS, false);
```

Returns path details but also triggers path simplification by default:

```java
GHRequest request = new GHRequest(start, destination)
				.setPathDetails(List.of("distance", "country", "toll"))
				.putHint(Parameters.Routing.INSTRUCTIONS, false);
				.putHint(Parameters.Routing.CALC_POINTS, true);
```

Works, but is arguably kinda ugly:

```java
GHRequest request = new GHRequest(start, destination)
				.setPathDetails(List.of("distance", "country", "toll"))
				.putHint(Parameters.Routing.INSTRUCTIONS, false)
				.putHint(Parameters.Routing.CALC_POINTS, true)
				.putHint(Parameters.Routing.WAY_POINT_MAX_DISTANCE, 0);
```