### PR TITLE
Added alternative route support for /navigate

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -90,6 +90,7 @@ Here is an overview:
  * thehereward, code cleanups like #620
  * vvikas, ideas for many to many improvements and #616
  * zstadler, multiple fixes and car4wd
+ * mohammad1sadegh1, adding functionality to alternative route for navigation
 
 ## Translations
 


### PR DESCRIPTION
Added alternative route support to graphhopper navigation with the following values:
Max Paths: 3
Max Weight: 1.4
Max Share: 0.6