### PR TITLE
Improve compressed stream handling

### DIFF
--- a/core/src/main/java/com/graphhopper/reader/dem/SkadiProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/SkadiProvider.java
@@ -80,15 +80,10 @@ public class SkadiProvider extends AbstractSRTMElevationProvider {
     @Override
     byte[] readFile(File file) throws IOException {
         InputStream is = new FileInputStream(file);
-        GZIPInputStream gzis = new GZIPInputStream(is);
-        BufferedInputStream buff = new BufferedInputStream(gzis);
-        ByteArrayOutputStream os = new ByteArrayOutputStream();
-        byte[] buffer = new byte[0xFFFF];
-        int len;
-        while ((len = buff.read(buffer)) > 0) {
-            os.write(buffer, 0, len);
-        }
-        os.flush();
+        GZIPInputStream gzis = new GZIPInputStream(is, 8 * 1024);
+        BufferedInputStream buff = new BufferedInputStream(gzis, 16 * 1024);
+        ByteArrayOutputStream os = new ByteArrayOutputStream(64 * 1024);
+        buff.transferTo(os);
         close(buff);
         return os.toByteArray();
     }


### PR DESCRIPTION
The default buffer size for GZIPInputStream and InflaterInputStream is only 512 bytes, resulting in many tiny OS read calls.

I also replaced all custom InputStream to OutputStream piping with [InputStream.transferTo(OutputStream)](https://docs.oracle.com/javase/9/docs/api/java/io/InputStream.html#transferTo-java.io.OutputStream-) calls.