### PR TITLE
Modernize Downloader

### DIFF
--- a/core/src/main/java/com/graphhopper/reader/dem/AbstractSRTMElevationProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/AbstractSRTMElevationProvider.java
@@ -46,7 +46,7 @@ public abstract class AbstractSRTMElevationProvider extends TileBasedElevationPr
     public AbstractSRTMElevationProvider(String baseUrl, String cacheDir, int minLat, int maxLat, int defaultWidth) {
         super(cacheDir);
         this.baseUrl = baseUrl;
-        downloader = new Downloader().setTimeout(10000);
+        downloader = new Downloader(10_000);
         this.DEFAULT_WIDTH = defaultWidth;
         this.MIN_LAT = minLat;
         this.MAX_LAT = maxLat;

--- a/core/src/main/java/com/graphhopper/reader/dem/AbstractSRTMElevationProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/AbstractSRTMElevationProvider.java
@@ -25,7 +25,7 @@ import com.graphhopper.util.Helper;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.net.SocketTimeoutException;
+import java.net.http.HttpTimeoutException;
 
 /**
  * Common functionality used when working with SRTM hgt data.
@@ -171,9 +171,9 @@ public abstract class AbstractSRTMElevationProvider extends TileBasedElevationPr
     private void downloadToFile(File file, String zippedURL) throws InterruptedException, IOException {
         for (int i = 0; i < 3; i++) {
             try {
-                downloader.downloadFile(zippedURL, file.getAbsolutePath());
+                downloader.downloadFile(zippedURL, file);
                 break;
-            } catch (SocketTimeoutException ex) {
+            } catch (HttpTimeoutException ex) {
                 // just try again after a little nap
                 Thread.sleep(2000);
             } catch (FileNotFoundException ex) {

--- a/core/src/main/java/com/graphhopper/reader/dem/AbstractSRTMElevationProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/AbstractSRTMElevationProvider.java
@@ -43,10 +43,10 @@ public abstract class AbstractSRTMElevationProvider extends TileBasedElevationPr
     private final double precision = 1e7;
     private final double invPrecision = 1 / precision;
 
-    public AbstractSRTMElevationProvider(String baseUrl, String cacheDir, String downloaderName, int minLat, int maxLat, int defaultWidth) {
+    public AbstractSRTMElevationProvider(String baseUrl, String cacheDir, int minLat, int maxLat, int defaultWidth) {
         super(cacheDir);
         this.baseUrl = baseUrl;
-        downloader = new Downloader(downloaderName).setTimeout(10000);
+        downloader = new Downloader().setTimeout(10000);
         this.DEFAULT_WIDTH = defaultWidth;
         this.MIN_LAT = minLat;
         this.MAX_LAT = maxLat;

--- a/core/src/main/java/com/graphhopper/reader/dem/AbstractTiffElevationProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/AbstractTiffElevationProvider.java
@@ -45,10 +45,10 @@ public abstract class AbstractTiffElevationProvider extends TileBasedElevationPr
     // Degrees of longitude covered by this tile
     final int LON_DEGREE;
 
-    public AbstractTiffElevationProvider(String baseUrl, String cacheDir, String downloaderName, int width, int height, int latDegree, int lonDegree) {
+    public AbstractTiffElevationProvider(String baseUrl, String cacheDir, int width, int height, int latDegree, int lonDegree) {
         super(cacheDir);
         this.baseUrl = baseUrl;
-        this.downloader = new Downloader(downloaderName).setTimeout(10000);
+        this.downloader = new Downloader().setTimeout(10000);
         this.WIDTH = width;
         this.HEIGHT = height;
         this.LAT_DEGREE = latDegree;

--- a/core/src/main/java/com/graphhopper/reader/dem/AbstractTiffElevationProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/AbstractTiffElevationProvider.java
@@ -48,7 +48,7 @@ public abstract class AbstractTiffElevationProvider extends TileBasedElevationPr
     public AbstractTiffElevationProvider(String baseUrl, String cacheDir, int width, int height, int latDegree, int lonDegree) {
         super(cacheDir);
         this.baseUrl = baseUrl;
-        this.downloader = new Downloader().setTimeout(10000);
+        this.downloader = new Downloader(10_000);
         this.WIDTH = width;
         this.HEIGHT = height;
         this.LAT_DEGREE = latDegree;

--- a/core/src/main/java/com/graphhopper/reader/dem/AbstractTiffElevationProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/AbstractTiffElevationProvider.java
@@ -24,7 +24,7 @@ import javax.net.ssl.SSLException;
 import java.awt.image.Raster;
 import java.io.File;
 import java.io.IOException;
-import java.net.SocketTimeoutException;
+import java.net.http.HttpTimeoutException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -167,9 +167,9 @@ public abstract class AbstractTiffElevationProvider extends TileBasedElevationPr
             int max = 3;
             for (int trial = 0; trial < max; trial++) {
                 try {
-                    downloader.downloadFile(url, downloadFile.getAbsolutePath());
+                    downloader.downloadFile(url, downloadFile);
                     return;
-                } catch (SocketTimeoutException ex) {
+                } catch (HttpTimeoutException ex) {
                     if (trial >= max - 1)
                         throw new RuntimeException(ex);
                     try {

--- a/core/src/main/java/com/graphhopper/reader/dem/CGIARProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/CGIARProvider.java
@@ -56,7 +56,6 @@ public class CGIARProvider extends AbstractTiffElevationProvider {
         // Alternative URLs for the CGIAR data can be found in #346
         super("https://srtm.csi.cgiar.org/wp-content/uploads/files/srtm_5x5/TIFF/",
                 cacheDir.isEmpty() ? "/tmp/cgiar" : cacheDir,
-                "GraphHopper CGIARReader",
                 6000, 6000,
                 5, 5);
         downloader.requestCompressed(false);

--- a/core/src/main/java/com/graphhopper/reader/dem/CGIARProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/CGIARProvider.java
@@ -59,6 +59,7 @@ public class CGIARProvider extends AbstractTiffElevationProvider {
                 "GraphHopper CGIARReader",
                 6000, 6000,
                 5, 5);
+        downloader.requestCompressed(false);
     }
 
     public static void main(String[] args) {

--- a/core/src/main/java/com/graphhopper/reader/dem/CGIARProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/CGIARProvider.java
@@ -58,7 +58,7 @@ public class CGIARProvider extends AbstractTiffElevationProvider {
                 cacheDir.isEmpty() ? "/tmp/cgiar" : cacheDir,
                 6000, 6000,
                 5, 5);
-        downloader.requestCompressed(false);
+        downloader.setRequestCompressed(false);
     }
 
     public static void main(String[] args) {

--- a/core/src/main/java/com/graphhopper/reader/dem/GMTEDProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/GMTEDProvider.java
@@ -88,7 +88,6 @@ public class GMTEDProvider extends AbstractTiffElevationProvider {
     public GMTEDProvider(String cacheDir) {
         super("https://edcintl.cr.usgs.gov/downloads/sciweb1/shared/topo/downloads/GMTED/Global_tiles_GMTED/075darcsec/mea/",
                 cacheDir.isEmpty() ? "/tmp/gmted" : cacheDir,
-                "GraphHopper GMTEDReader",
                 14400, 9600,
                 20, 30);
     }

--- a/core/src/main/java/com/graphhopper/reader/dem/HGTProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/HGTProvider.java
@@ -26,7 +26,7 @@ import java.util.zip.ZipInputStream;
 
 public class HGTProvider extends AbstractSRTMElevationProvider {
     public HGTProvider(String dir) {
-        super("", dir, "", Integer.MIN_VALUE, Integer.MAX_VALUE, 3601);
+        super("", dir, Integer.MIN_VALUE, Integer.MAX_VALUE, 3601);
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/reader/dem/SRTMGL1Provider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/SRTMGL1Provider.java
@@ -53,7 +53,6 @@ public class SRTMGL1Provider extends AbstractSRTMElevationProvider {
     public SRTMGL1Provider(String cacheDir) {
         super("https://cloud.sdsc.edu/v1/AUTH_opentopography/Raster/SRTM_GL1/SRTM_GL1_srtm/",
                 cacheDir.isEmpty() ? "/tmp/srtmgl1" : cacheDir,
-                "GraphHopper SRTMReader",
                 -56,
                 60,
                 3601

--- a/core/src/main/java/com/graphhopper/reader/dem/SRTMProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/SRTMProvider.java
@@ -52,7 +52,7 @@ public class SRTMProvider extends AbstractSRTMElevationProvider {
         );
         // move to explicit calls?
         init();
-        downloader.requestCompressed(false);
+        downloader.setRequestCompressed(false);
     }
 
     public static void main(String[] args) throws IOException {

--- a/core/src/main/java/com/graphhopper/reader/dem/SRTMProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/SRTMProvider.java
@@ -46,7 +46,6 @@ public class SRTMProvider extends AbstractSRTMElevationProvider {
         super(
                 "https://srtm.kurviger.de/SRTM3/",
                 cacheDir.isEmpty()? "/tmp/srtm": cacheDir,
-                "GraphHopper SRTMReader",
                 -56,
                 60,
                 1201

--- a/core/src/main/java/com/graphhopper/reader/dem/SRTMProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/SRTMProvider.java
@@ -53,6 +53,7 @@ public class SRTMProvider extends AbstractSRTMElevationProvider {
         );
         // move to explicit calls?
         init();
+        downloader.requestCompressed(false);
     }
 
     public static void main(String[] args) throws IOException {

--- a/core/src/main/java/com/graphhopper/reader/dem/SkadiProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/SkadiProvider.java
@@ -47,7 +47,7 @@ public class SkadiProvider extends AbstractSRTMElevationProvider {
                 90,
                 3601
         );
-        downloader.requestCompressed(false);
+        downloader.setRequestCompressed(false);
     }
 
     public static void main(String[] args) throws IOException {

--- a/core/src/main/java/com/graphhopper/reader/dem/SkadiProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/SkadiProvider.java
@@ -48,6 +48,7 @@ public class SkadiProvider extends AbstractSRTMElevationProvider {
                 90,
                 3601
         );
+        downloader.requestCompressed(false);
     }
 
     public static void main(String[] args) throws IOException {

--- a/core/src/main/java/com/graphhopper/reader/dem/SkadiProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/SkadiProvider.java
@@ -43,7 +43,6 @@ public class SkadiProvider extends AbstractSRTMElevationProvider {
         super(
                 "https://elevation-tiles-prod.s3.amazonaws.com/skadi/",
                 cacheDir.isEmpty()? "/tmp/srtm": cacheDir,
-                "GraphHopper SRTMReader",
                 -90,
                 90,
                 3601

--- a/core/src/main/java/com/graphhopper/reader/dem/SonnyProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/SonnyProvider.java
@@ -19,6 +19,8 @@ package com.graphhopper.reader.dem;
 
 import java.io.*;
 
+import com.graphhopper.util.Downloader;
+
 import static com.graphhopper.util.Helper.close;
 
 /**
@@ -37,17 +39,27 @@ import static com.graphhopper.util.Helper.close;
  */
 public class SonnyProvider extends AbstractSRTMElevationProvider {
 
+	private static final String SONNY_DOWNLOAD_URL = "https://drive.google.com/drive/folders/0BxphPoRgwhnoWkRoTFhMbTM3RDA?resourcekey=0-wRe5bWl96pwvQ9tAfI9cQg";
+
     public SonnyProvider() {
         this("");
     }
 
     public SonnyProvider(String cacheDir) {
-        super("https://drive.google.com/drive/folders/0BxphPoRgwhnoWkRoTFhMbTM3RDA?resourcekey=0-wRe5bWl96pwvQ9tAfI9cQg/", // This base URL cannot be used, as the data is not available via a direct URL
+        super(SONNY_DOWNLOAD_URL + "/", // This base URL cannot be used, as the data is not available via a direct URL
                 cacheDir.isEmpty() ? "/tmp/sonny" : cacheDir,
                 -56,
                 90,
                 3601
         );
+		this.downloader = new Downloader() {
+			@Override
+			public void downloadFile(String url, File toFile) {
+				throw new RuntimeException("Sonny elevation data cannot be downloaded automatically. " +
+						"Please download the data manually from " + SONNY_DOWNLOAD_URL +
+						", unzip it and place the .hgt files in the cache directory: " + getCacheDir());
+			}
+		};
     }
 
     public static void main(String[] args) throws IOException {

--- a/core/src/main/java/com/graphhopper/reader/dem/SonnyProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/SonnyProvider.java
@@ -23,14 +23,14 @@ import static com.graphhopper.util.Helper.close;
 
 /**
  * Sonny's LiDAR Digital Terrain Models contains elevation data for Europe with 1 arc second (~30m) accuracy.
- * The description is available at https://sonny.4lima.de/. Unfortunately the data is provided on a Google Drive
- * https://drive.google.com/drive/folders/0BxphPoRgwhnoWkRoTFhMbTM3RDA?resourcekey=0-wRe5bWl96pwvQ9tAfI9cQg
+ * The description is available at <a href="https://sonny.4lima.de/">https://sonny.4lima.de/</a>. Unfortunately the data is provided on a
+ * <a href="https://drive.google.com/drive/folders/0BxphPoRgwhnoWkRoTFhMbTM3RDA?resourcekey=0-wRe5bWl96pwvQ9tAfI9cQg">Google Drive</a>
  * Therefore, the data is not available via a direct URL and you have to download it manually. After downloading,
  * the data has to be unzipped and placed in the cache directory. The cache directory is expected to contain DTM
  * data files with the naming convention like "N49E011.hgt" for the area around 49°N and 11°E.
  * <p>
  * Please note that the data cannot be used for public hosting or redistribution due to the terms of use of the data. See
- * https://github.com/graphhopper/graphhopper/issues/2823
+ * @see <a href="https://github.com/graphhopper/graphhopper/issues/2823">https://github.com/graphhopper/graphhopper/issues/2823</a>
  * <p>
  *
  * @author ratrun

--- a/core/src/main/java/com/graphhopper/reader/dem/SonnyProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/SonnyProvider.java
@@ -44,7 +44,6 @@ public class SonnyProvider extends AbstractSRTMElevationProvider {
     public SonnyProvider(String cacheDir) {
         super("https://drive.google.com/drive/folders/0BxphPoRgwhnoWkRoTFhMbTM3RDA?resourcekey=0-wRe5bWl96pwvQ9tAfI9cQg/", // This base URL cannot be used, as the data is not available via a direct URL
                 cacheDir.isEmpty() ? "/tmp/sonny" : cacheDir,
-                "GraphHopper SonnyReader",
                 -56,
                 90,
                 3601

--- a/core/src/main/java/com/graphhopper/util/Downloader.java
+++ b/core/src/main/java/com/graphhopper/util/Downloader.java
@@ -17,8 +17,6 @@
  */
 package com.graphhopper.util;
 
-import static java.nio.file.StandardOpenOption.*;
-
 import java.io.*;
 import java.net.*;
 import java.net.http.HttpClient;
@@ -26,6 +24,8 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.*;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.time.Duration;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.Inflater;
@@ -81,9 +81,12 @@ public class Downloader {
             throw new FileNotFoundException("Download of " + url + " failed, response code: " + response.statusCode());
         }
 
-        try (var in = response.body(); var out = Files.newOutputStream(toFile.toPath(), CREATE, WRITE)) {
+		Path target = toFile.toPath();
+	    Path tmpFile = target.resolveSibling(toFile.getName() + ".part");
+        try (var in = response.body(); var out = Files.newOutputStream(tmpFile)) {
             in.transferTo(out);
         }
+		Files.move(tmpFile, target, StandardCopyOption.ATOMIC_MOVE);
     }
 
     private static class UncompressHandler implements BodyHandler<InputStream> {

--- a/core/src/main/java/com/graphhopper/util/Downloader.java
+++ b/core/src/main/java/com/graphhopper/util/Downloader.java
@@ -60,23 +60,17 @@ public class Downloader {
     }
 
     public void downloadFile(String url, File toFile) throws IOException {
-        HttpRequest request;
-        try {
-            var builder = HttpRequest.newBuilder()
-                    .setHeader("User-Agent", "graphhopper/" + Constants.VERSION)
-                    .timeout(Duration.ofMillis(timeout))
-                    .uri(new URI(url));
-            if (requestCompressed) {
-                builder.setHeader("Accept-Encoding", "gzip, deflate");
-            }
-            request = builder.build();
-        } catch (URISyntaxException e) {
-            throw new RuntimeException(e);
+        var requestBuilder = HttpRequest.newBuilder()
+                .setHeader("User-Agent", "graphhopper/" + Constants.VERSION)
+                .timeout(Duration.ofMillis(timeout))
+                .uri(URI.create(url));
+        if (requestCompressed) {
+            requestBuilder.setHeader("Accept-Encoding", "gzip, deflate");
         }
 
         HttpResponse<InputStream> response;
         try {
-            response = client.send(request, new UncompressHandler());
+            response = client.send(requestBuilder.build(), new UncompressHandler());
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }

--- a/core/src/main/java/com/graphhopper/util/Downloader.java
+++ b/core/src/main/java/com/graphhopper/util/Downloader.java
@@ -38,13 +38,11 @@ public class Downloader {
     private static final int BUFFER_SIZE = 8 * 1024;
 
     private final HttpClient client;
-    private final String userAgent;
 
     private boolean requestCompressed = true;
     private long timeout = 4000;
 
-    public Downloader(String userAgent) {
-        this.userAgent = userAgent;
+    public Downloader() {
         this.client = HttpClient.newBuilder()
                 .followRedirects(HttpClient.Redirect.NORMAL)
                 .proxy(ProxySelector.getDefault())
@@ -65,8 +63,7 @@ public class Downloader {
         HttpRequest request;
         try {
             var builder = HttpRequest.newBuilder()
-                    .setHeader("Referrer", "https://www.graphhopper.com/")
-                    .setHeader("User-Agent", userAgent)
+                    .setHeader("User-Agent", "graphhopper/" + Constants.VERSION)
                     .timeout(Duration.ofMillis(timeout))
                     .uri(new URI(url));
             if (requestCompressed) {

--- a/core/src/main/java/com/graphhopper/util/Downloader.java
+++ b/core/src/main/java/com/graphhopper/util/Downloader.java
@@ -37,6 +37,7 @@ import java.util.zip.InflaterInputStream;
 public class Downloader {
     private static final int BUFFER_SIZE = 8 * 1024;
 	private static final long DEFAULT_TIMEOUT = 4_000;
+	private static final String USER_AGENT = "graphhopper/" + Constants.VERSION;
 
     private final HttpClient client;
 	private final Duration timeout;
@@ -61,7 +62,7 @@ public class Downloader {
 
     public void downloadFile(String url, File toFile) throws IOException {
         var requestBuilder = HttpRequest.newBuilder()
-                .setHeader("User-Agent", "graphhopper/" + Constants.VERSION)
+                .setHeader("User-Agent", USER_AGENT)
                 .timeout(timeout)
                 .uri(URI.create(url));
         if (requestCompressed) {

--- a/core/src/main/java/com/graphhopper/util/Downloader.java
+++ b/core/src/main/java/com/graphhopper/util/Downloader.java
@@ -33,6 +33,7 @@ import java.util.zip.InflaterInputStream;
 
 /**
  * @author Peter Karich
+ * @author Thomas Butz
  */
 public class Downloader {
     private static final int BUFFER_SIZE = 8 * 1024;

--- a/core/src/main/java/com/graphhopper/util/Downloader.java
+++ b/core/src/main/java/com/graphhopper/util/Downloader.java
@@ -54,9 +54,8 @@ public class Downloader {
         return this;
     }
 
-    public Downloader requestCompressed(boolean requestCompressed) {
+    public void setRequestCompressed(boolean requestCompressed) {
         this.requestCompressed = requestCompressed;
-        return this;
     }
 
     public void downloadFile(String url, File toFile) throws IOException {

--- a/core/src/main/java/com/graphhopper/util/Downloader.java
+++ b/core/src/main/java/com/graphhopper/util/Downloader.java
@@ -36,22 +36,23 @@ import java.util.zip.InflaterInputStream;
  */
 public class Downloader {
     private static final int BUFFER_SIZE = 8 * 1024;
+	private static final long DEFAULT_TIMEOUT = 4_000;
 
     private final HttpClient client;
+	private final Duration timeout;
 
     private boolean requestCompressed = true;
-    private long timeout = 4000;
 
-    public Downloader() {
+	public Downloader() {
+		this(DEFAULT_TIMEOUT);
+	}
+
+    public Downloader(long timeout) {
         this.client = HttpClient.newBuilder()
                 .followRedirects(HttpClient.Redirect.NORMAL)
                 .proxy(ProxySelector.getDefault())
                 .build();
-    }
-
-    public Downloader setTimeout(long timeout) {
-        this.timeout = timeout;
-        return this;
+		this.timeout = Duration.ofMillis(timeout);
     }
 
     public void setRequestCompressed(boolean requestCompressed) {
@@ -61,7 +62,7 @@ public class Downloader {
     public void downloadFile(String url, File toFile) throws IOException {
         var requestBuilder = HttpRequest.newBuilder()
                 .setHeader("User-Agent", "graphhopper/" + Constants.VERSION)
-                .timeout(Duration.ofMillis(timeout))
+                .timeout(timeout)
                 .uri(URI.create(url));
         if (requestCompressed) {
             requestBuilder.setHeader("Accept-Encoding", "gzip, deflate");

--- a/core/src/main/java/com/graphhopper/util/Downloader.java
+++ b/core/src/main/java/com/graphhopper/util/Downloader.java
@@ -17,10 +17,16 @@
  */
 package com.graphhopper.util;
 
+import static java.nio.file.StandardOpenOption.*;
+
 import java.io.*;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.util.function.LongConsumer;
+import java.net.*;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.*;
+import java.nio.file.Files;
+import java.time.Duration;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.Inflater;
 import java.util.zip.InflaterInputStream;
@@ -30,105 +36,85 @@ import java.util.zip.InflaterInputStream;
  */
 public class Downloader {
     private static final int BUFFER_SIZE = 8 * 1024;
+
+    private final HttpClient client;
     private final String userAgent;
-    private String referrer = "http://graphhopper.com";
-    private String acceptEncoding = "gzip, deflate";
-    private int timeout = 4000;
+
+    private boolean requestCompressed = true;
+    private long timeout = 4000;
 
     public Downloader(String userAgent) {
         this.userAgent = userAgent;
+        this.client = HttpClient.newBuilder()
+                .followRedirects(HttpClient.Redirect.NORMAL)
+                .proxy(ProxySelector.getDefault())
+                .build();
     }
 
-    public static void main(String[] args) throws IOException {
-        new Downloader("GraphHopper Downloader").downloadAndUnzip("http://graphhopper.com/public/maps/0.1/europe_germany_berlin.ghz", "somefolder",
-                val -> System.out.println("progress:" + val));
-    }
-
-    public Downloader setTimeout(int timeout) {
+    public Downloader setTimeout(long timeout) {
         this.timeout = timeout;
         return this;
     }
 
-    public Downloader setReferrer(String referrer) {
-        this.referrer = referrer;
+    public Downloader requestCompressed(boolean requestCompressed) {
+        this.requestCompressed = requestCompressed;
         return this;
     }
 
-    /**
-     * This method initiates a connect call of the provided connection and returns the response
-     * stream. It only returns the error stream if it is available and readErrorStreamNoException is
-     * true otherwise it throws an IOException if an error happens. Furthermore it wraps the stream
-     * to decompress it if the connection content encoding is specified.
-     */
-    public InputStream fetch(HttpURLConnection connection, boolean readErrorStreamNoException) throws IOException {
-        // create connection but before reading get the correct inputstream based on the compression and if error
-        connection.connect();
-
-        InputStream is;
-        if (readErrorStreamNoException && connection.getResponseCode() >= 400 && connection.getErrorStream() != null)
-            is = connection.getErrorStream();
-        else
-            is = connection.getInputStream();
-
-        if (is == null)
-            throw new IOException("Stream is null. Message:" + connection.getResponseMessage());
-
-        // wrap
+    public void downloadFile(String url, File toFile) throws IOException {
+        HttpRequest request;
         try {
-            String encoding = connection.getContentEncoding();
-            if (encoding != null && encoding.equalsIgnoreCase("gzip"))
-                is = new GZIPInputStream(is, BUFFER_SIZE);
-            else if (encoding != null && encoding.equalsIgnoreCase("deflate"))
-                is = new InflaterInputStream(is, new Inflater(true), BUFFER_SIZE);
-        } catch (IOException ex) {
+            var builder = HttpRequest.newBuilder()
+                    .setHeader("Referrer", "https://www.graphhopper.com/")
+                    .setHeader("User-Agent", userAgent)
+                    .timeout(Duration.ofMillis(timeout))
+                    .uri(new URI(url));
+            if (requestCompressed) {
+                builder.setHeader("Accept-Encoding", "gzip, deflate");
+            }
+            request = builder.build();
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
         }
 
-        return is;
-    }
-
-    public InputStream fetch(String url) throws IOException {
-        return fetch(createConnection(url), false);
-    }
-
-    public HttpURLConnection createConnection(String urlStr) throws IOException {
-        URL url = new URL(urlStr);
-        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-        // Will yield in a POST request: conn.setDoOutput(true);
-        conn.setDoInput(true);
-        conn.setUseCaches(true);
-        conn.setRequestProperty("Referrer", referrer);
-        conn.setRequestProperty("User-Agent", userAgent);
-        // suggest respond to be gzipped or deflated (which is just another compression)
-        // http://stackoverflow.com/q/3932117
-        conn.setRequestProperty("Accept-Encoding", acceptEncoding);
-        conn.setReadTimeout(timeout);
-        conn.setConnectTimeout(timeout);
-        return conn;
-    }
-
-    public void downloadFile(String url, String toFile) throws IOException {
-        HttpURLConnection conn = createConnection(url);
-        InputStream iStream = fetch(conn, false);
-        BufferedOutputStream writer = new BufferedOutputStream(new FileOutputStream(toFile), BUFFER_SIZE);
-        InputStream in = new BufferedInputStream(iStream, BUFFER_SIZE);
+        HttpResponse<InputStream> response;
         try {
-            in.transferTo(writer);
-        } finally {
-            Helper.close(iStream);
-            Helper.close(writer);
-            Helper.close(in);
+            response = client.send(request, new UncompressHandler());
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+
+        if (response.statusCode() != 200) {
+            throw new FileNotFoundException("Download of " + url + " failed, response code: " + response.statusCode());
+        }
+
+        try (var in = response.body(); var out = Files.newOutputStream(toFile.toPath(), CREATE, WRITE)) {
+            in.transferTo(out);
         }
     }
 
-    public void downloadAndUnzip(String url, String toFolder, final LongConsumer progressListener) throws IOException {
-        HttpURLConnection conn = createConnection(url);
-        final int length = conn.getContentLength();
-        InputStream iStream = fetch(conn, false);
+    private static class UncompressHandler implements BodyHandler<InputStream> {
+        @Override
+        public BodySubscriber<InputStream> apply(ResponseInfo responseInfo) {
+            if (responseInfo.statusCode() != 200) {
+                return BodySubscribers.replacing(null);
+            }
+            String encoding = responseInfo.headers().firstValue("Content-Encoding")
+                    .map(String::toLowerCase).orElse("");
 
-        new Unzipper().unzip(iStream, new File(toFolder), sumBytes -> progressListener.accept((int) (100 * sumBytes / length)));
-    }
-
-    public String downloadAsString(String url, boolean readErrorStreamNoException) throws IOException {
-        return Helper.isToString(fetch(createConnection(url), readErrorStreamNoException));
+            var subscriber = BodySubscribers.ofInputStream();
+            return switch (encoding) {
+                case "deflate" -> BodySubscribers.mapping(subscriber,
+                        in -> new InflaterInputStream(in, new Inflater(true), BUFFER_SIZE));
+                case "gzip" -> BodySubscribers.mapping(subscriber, in -> {
+                    try {
+                        return new GZIPInputStream(in, BUFFER_SIZE);
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                });
+                default -> subscriber;
+            };
+        }
     }
 }

--- a/core/src/test/java/com/graphhopper/reader/dem/CGIARProviderTest.java
+++ b/core/src/test/java/com/graphhopper/reader/dem/CGIARProviderTest.java
@@ -81,7 +81,7 @@ public class CGIARProviderTest {
         file.delete();
         zipFile.delete();
 
-        instance.setDownloader(new Downloader("test GH") {
+        instance.setDownloader(new Downloader() {
             @Override
             public void downloadFile(String url, File toFile) throws IOException {
                 throw new FileNotFoundException("xyz");
@@ -93,7 +93,7 @@ public class CGIARProviderTest {
         assertTrue(file.exists());
         assertEquals(1048676, file.length());
 
-        instance.setDownloader(new Downloader("test GH") {
+        instance.setDownloader(new Downloader() {
             @Override
             public void downloadFile(String url, File toFile) throws IOException {
                 throw new HttpTimeoutException("xyz");

--- a/core/src/test/java/com/graphhopper/reader/dem/CGIARProviderTest.java
+++ b/core/src/test/java/com/graphhopper/reader/dem/CGIARProviderTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.net.SocketTimeoutException;
+import java.net.http.HttpTimeoutException;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -83,7 +83,7 @@ public class CGIARProviderTest {
 
         instance.setDownloader(new Downloader("test GH") {
             @Override
-            public void downloadFile(String url, String toFile) throws IOException {
+            public void downloadFile(String url, File toFile) throws IOException {
                 throw new FileNotFoundException("xyz");
             }
         });
@@ -95,8 +95,8 @@ public class CGIARProviderTest {
 
         instance.setDownloader(new Downloader("test GH") {
             @Override
-            public void downloadFile(String url, String toFile) throws IOException {
-                throw new SocketTimeoutException("xyz");
+            public void downloadFile(String url, File toFile) throws IOException {
+                throw new HttpTimeoutException("xyz");
             }
         });
 

--- a/core/src/test/java/com/graphhopper/reader/dem/GMTEDProviderTest.java
+++ b/core/src/test/java/com/graphhopper/reader/dem/GMTEDProviderTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.net.SocketTimeoutException;
+import java.net.http.HttpTimeoutException;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -90,7 +90,7 @@ public class GMTEDProviderTest {
 
         instance.setDownloader(new Downloader("test GH") {
             @Override
-            public void downloadFile(String url, String toFile) throws IOException {
+            public void downloadFile(String url, File toFile) throws IOException {
                 throw new FileNotFoundException("xyz");
             }
         });
@@ -102,8 +102,8 @@ public class GMTEDProviderTest {
 
         instance.setDownloader(new Downloader("test GH") {
             @Override
-            public void downloadFile(String url, String toFile) throws IOException {
-                throw new SocketTimeoutException("xyz");
+            public void downloadFile(String url, File toFile) throws IOException {
+                throw new HttpTimeoutException("xyz");
             }
         });
 

--- a/core/src/test/java/com/graphhopper/reader/dem/GMTEDProviderTest.java
+++ b/core/src/test/java/com/graphhopper/reader/dem/GMTEDProviderTest.java
@@ -88,7 +88,7 @@ public class GMTEDProviderTest {
         file.delete();
         zipFile.delete();
 
-        instance.setDownloader(new Downloader("test GH") {
+        instance.setDownloader(new Downloader() {
             @Override
             public void downloadFile(String url, File toFile) throws IOException {
                 throw new FileNotFoundException("xyz");
@@ -100,7 +100,7 @@ public class GMTEDProviderTest {
         assertTrue(file.exists());
         assertEquals(1048676, file.length());
 
-        instance.setDownloader(new Downloader("test GH") {
+        instance.setDownloader(new Downloader() {
             @Override
             public void downloadFile(String url, File toFile) throws IOException {
                 throw new HttpTimeoutException("xyz");


### PR DESCRIPTION
* Reimplement Downloader based on java.net HttpClient
* allow callers to skip transport compression
* use a proper User-Agent e.g `graphhopper/11.0`
* handle partial downloads