### PR TITLE
allow writes (for lockfile) configurable via config file or as vm argument

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -46,6 +46,7 @@ Here is an overview:
  * jansoe, many improvements regarding A* algorithm, forcing direction, roundabouts etc
  * jansonhanson, general host config
  * jessLryan, max elevation can now be negative
+ * jtbaker, allow writes (for lockfile) configurable via config file or as vm argument
  * joe-akeem, improvements like #2158
  * JohannesPelzer, improved GPX information and various other things
  * karussell, one of the core developers

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ See the [documentation](./docs/index.md) that contains e.g. [the elevation guide
 
 The Docker images created by the community from the `master` branch can be found [here](https://hub.docker.com/r/israelhikingmap/graphhopper)
 (currently daily). See the [Dockerfile](https://github.com/IsraelHikingMap/graphhopper-docker-image-push) for more details.
+For usage in Kubernetes with a read-only PVC that already has the graph built, you can pass the argument "-Ddw.graphhopper.graph.allow_writes=false" to avoid Graphhopper placing a lock file in the volume of the graph. [Graphopper Load Graph from K8s read-only PVC](https://github.com/graphhopper/graphhopper/issues/2815)
 
 ## GraphHopper Maps
 

--- a/config-example.yml
+++ b/config-example.yml
@@ -5,7 +5,7 @@ graphhopper:
   # Local folder used by graphhopper to store its data
   graph.location: graph-cache
 
-
+  graph.allow_writes: true
   ##### Routing Profiles ####
 
   # Routing can be done only for profiles listed below. For more information about profiles and custom profiles have a

--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -338,7 +338,17 @@ public class GraphHopper {
             throw new IllegalArgumentException("OSM file cannot be empty.");
 
         this.osmFile = osmFile;
+        ValidateOSMFileAndWritesAllowed();
         return this;
+    }
+
+    /**
+     * Validator to check that allow_writes is true when OSM File is truthy.
+     * This allows for loadig a graph from a read-only file system.
+     */
+    void ValidateOSMFileAndWritesAllowed() throws IllegalArgumentException {
+        if (!isEmpty(this.osmFile) & !allowWrites)
+        throw new IllegalArgumentException("graph.allow_writes must be true if datareader.file is read");
     }
 
     public GraphHopper setMaxSpeedCalculator(MaxSpeedCalculator maxSpeedCalculator) {
@@ -409,6 +419,7 @@ public class GraphHopper {
      */
     public GraphHopper setAllowWrites(boolean allowWrites) {
         this.allowWrites = allowWrites;
+        ValidateOSMFileAndWritesAllowed();
         return this;
     }
 

--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -480,6 +480,11 @@ public class GraphHopper {
         }
         ghLocation = graphHopperFolder;
 
+        this.setAllowWrites( ghConfig.getBool("graph.allow_writes", true));
+        if (!this.isAllowWrites() && osmFile != null ) {
+            throw new IllegalArgumentException("If data is being loaded writing must be enabled via `graph.allow_writes`.");
+        }
+
         countryRuleFactory = ghConfig.getBool("country_rules.enabled", false) ? new CountryRuleFactory() : null;
         customAreasDirectory = ghConfig.getString("custom_areas.directory", customAreasDirectory);
 

--- a/core/src/main/java/com/graphhopper/GraphHopperConfig.java
+++ b/core/src/main/java/com/graphhopper/GraphHopperConfig.java
@@ -142,7 +142,7 @@ public class GraphHopperConfig {
                 map.putObject(key, nativeValue);
             } catch (IOException e) {
                 // If the string is not valid JSON, store as is
-                map.putObject(key, value);
+                map.putObject(key, valueString);
             }
         } else {
             map.putObject(key, value);

--- a/core/src/test/java/com/graphhopper/GraphHopperTest.java
+++ b/core/src/test/java/com/graphhopper/GraphHopperTest.java
@@ -322,8 +322,7 @@ public class GraphHopperTest {
                 setGraphHopperLocation(GH_LOCATION).
                 setOSMFile(MONACO).
                 setProfiles(profile).
-                setStoreOnFlush(true).
-                setAllowWrites(false);
+                setStoreOnFlush(true);
         if (ch) {
             hopper.getCHPreparationHandler()
                     .setCHProfiles(new CHProfile(profileName));
@@ -2875,6 +2874,30 @@ public class GraphHopperTest {
         assertEquals(1, p.get(1).getFirst());
         assertEquals(1, p.get(1).getLast());
         assertEquals(0.0, (double) p.get(1).getValue(), 1.e-3);
+    }
+
+    @Test
+    void setAllowWritesFalseWhenOSMFileisTrue()
+    {
+        GraphHopper hopper = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
+                setEncodedValuesString("car_access, car_average_speed").
+                setOSMFile(MONACO).
+                setProfiles(TestProfiles.accessAndSpeed("car"));
+        assertThrows(IllegalArgumentException.class, ()-> hopper.setAllowWrites(false));
+    }
+
+    @Test
+    void setOSMFileAfterAllowedWritesIsFalse()
+    {
+        GraphHopper hopper = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
+                setEncodedValuesString("car_access, car_average_speed").
+                setProfiles(TestProfiles.accessAndSpeed("car")).
+                setAllowWrites(false);
+                
+        assertThrows(IllegalArgumentException.class, () -> hopper.setOSMFile(MONACO));
+            
     }
 
 }


### PR DESCRIPTION
For certain use cases (like when multiple K8s deployments are reading from a shared readonly PVC with the pre-generated graph stored on it)  it would be nice to configure (via the `config.yaml` or a CLI argument) the `allowWrites` property more dynamically, without needing to make adjustments to the java source code.

This PR adds support for that, adding an entry in the `config.yml` for a `graph.allow_writes` boolean.

Validation and test coverage has been added to make sure that `allow_writes` can only ever be `false` when `datareader.file` is also `false`, meanig a new graph does not need to be generated.

I've also added a few convenience methods from to the Config parser, allowing better parsing of JSON data via the parameters, e.g. passing `-Ddw.graphhopper.graph.allow_writes=false` will resolve naturally to a boolean without needing to do further string manipulation on it.

Resolves https://github.com/graphhopper/graphhopper/issues/2815
