### PR TITLE
run unit tests on pull request to master in addition to push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,9 @@
 name: Build and Test
-on: push
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 jobs:
   build:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
While working on #3144, I noticed that the maven CI pipeline to run the test suite wasn't triggered. 

Seems like this would be helpful for reviewers to ensure all the tests are passing by run on pull requests in addition to pushes to master, so I've added a configuration in the github action pipeline that will run the test suite on PRs.