### PR TITLE
Increaese speed for compacted surface for MTB

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/parsers/MountainBikeAverageSpeedParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/MountainBikeAverageSpeedParser.java
@@ -26,6 +26,7 @@ public class MountainBikeAverageSpeedParser extends BikeCommonAverageSpeedParser
         setSurfaceSpeed("fine_gravel", 18);
         setSurfaceSpeed("grass", 14);
         setSurfaceSpeed("grass_paver", 14);
+        setSurfaceSpeed("compacted", 16);
         setSurfaceSpeed("gravel", 16);
         setSurfaceSpeed("ground", 16);
         setSurfaceSpeed("ice", MIN_SPEED);


### PR DESCRIPTION
It feels that [compacted](https://wiki.openstreetmap.org/wiki/Tag:surface=compacted?uselang=en-GB) surface type should have similar speed to gravel and ground.
