### PR TITLE
Extend conditional tags supported by MaxWeightExceptParser

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/parsers/MaxWeightExceptParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/MaxWeightExceptParser.java
@@ -7,6 +7,7 @@ import com.graphhopper.routing.ev.MaxWeightExcept;
 import com.graphhopper.routing.util.TransportationMode;
 import com.graphhopper.routing.util.parsers.helpers.OSMValueExtractor;
 import com.graphhopper.storage.IntsRef;
+import com.graphhopper.util.NumHelper;
 
 import java.util.List;
 
@@ -50,7 +51,7 @@ public class MaxWeightExceptParser implements TagParser {
                     break;
                 }
                 // set it only if the weight value is the same as in max_weight
-                if (getMaxWeight(way) == dec) {
+                if (NumHelper.equalsEps(dec, getMaxWeight(way))) {
                     mweEnc.setEnum(false, edgeId, edgeIntAccess, MaxWeightExcept.find(value.substring(0, atIndex).trim()));
                     break;
                 }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/MaxWeightExceptParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/MaxWeightExceptParser.java
@@ -14,6 +14,8 @@ import static com.graphhopper.routing.util.parsers.helpers.OSMValueExtractor.str
 
 public class MaxWeightExceptParser implements TagParser {
     private final EnumEncodedValue<MaxWeightExcept> mweEnc;
+    private static final List<String> MAX_WEIGHT_RESTRICTIONS = OSMMaxWeightParser.MAX_WEIGHT_TAGS.stream()
+            .map(e -> e + ":conditional").toList();
     private static final List<String> HGV_RESTRICTIONS = OSMRoadAccessParser.toOSMRestrictions(TransportationMode.HGV).stream()
             .map(e -> e + ":conditional").toList();
 
@@ -23,7 +25,7 @@ public class MaxWeightExceptParser implements TagParser {
 
     public void handleWayTags(int edgeId, EdgeIntAccess edgeIntAccess, ReaderWay way, IntsRef relationFlags) {
         // tagging like maxweight:conditional=no/none @ destination/delivery/forestry/service
-        String condValue = way.getTag("maxweight:conditional", "");
+        String condValue = way.getFirstValue(MAX_WEIGHT_RESTRICTIONS);
         if (!condValue.isEmpty()) {
             String[] values = condValue.split("@");
             if (values.length == 2) {

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/MaxWeightExceptParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/MaxWeightExceptParser.java
@@ -46,11 +46,13 @@ public class MaxWeightExceptParser implements TagParser {
             int atIndex = value.indexOf("@");
             if (atIndex > 0) {
                 double dec = OSMValueExtractor.conditionalWeightToTons(value);
+                if (Double.isNaN(dec)) {
+                    break;
+                }
                 // set it only if the weight value is the same as in max_weight
-                if (!Double.isNaN(dec)
-                        && (stringToTons(way.getTag("maxweight", "")) == dec
+                if (stringToTons(way.getTag("maxweight", "")) == dec
                         || stringToTons(way.getTag("maxweightrating:hgv", "")) == dec
-                        || stringToTons(way.getTag("maxgcweight", "")) == dec)) {
+                        || stringToTons(way.getTag("maxgcweight", "")) == dec) {
                     mweEnc.setEnum(false, edgeId, edgeIntAccess, MaxWeightExcept.find(value.substring(0, atIndex).trim()));
                     break;
                 }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/MaxWeightExceptParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/MaxWeightExceptParser.java
@@ -9,14 +9,13 @@ import com.graphhopper.routing.util.parsers.helpers.OSMValueExtractor;
 import com.graphhopper.storage.IntsRef;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static com.graphhopper.routing.util.parsers.helpers.OSMValueExtractor.stringToTons;
 
 public class MaxWeightExceptParser implements TagParser {
     private final EnumEncodedValue<MaxWeightExcept> mweEnc;
     private static final List<String> HGV_RESTRICTIONS = OSMRoadAccessParser.toOSMRestrictions(TransportationMode.HGV).stream()
-            .map(e -> e + ":conditional").collect(Collectors.toList());
+            .map(e -> e + ":conditional").toList();
 
     public MaxWeightExceptParser(EnumEncodedValue<MaxWeightExcept> mweEnc) {
         this.mweEnc = mweEnc;

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/MaxWeightExceptParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/MaxWeightExceptParser.java
@@ -50,13 +50,25 @@ public class MaxWeightExceptParser implements TagParser {
                     break;
                 }
                 // set it only if the weight value is the same as in max_weight
-                if (stringToTons(way.getTag("maxweight", "")) == dec
-                        || stringToTons(way.getTag("maxweightrating:hgv", "")) == dec
-                        || stringToTons(way.getTag("maxgcweight", "")) == dec) {
+                if (getMaxWeight(way) == dec) {
                     mweEnc.setEnum(false, edgeId, edgeIntAccess, MaxWeightExcept.find(value.substring(0, atIndex).trim()));
                     break;
                 }
             }
         }
+    }
+
+    private double getMaxWeight(ReaderWay way) {
+        for (String key : OSMMaxWeightParser.MAX_WEIGHT_TAGS) {
+            String value = way.getTag(key, "");
+            if (value.isEmpty()) {
+                continue;
+            }
+            double weight = stringToTons(value);
+            if (!Double.isNaN(weight)) {
+                return weight;
+            }
+        }
+        return Double.NaN;
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMMaxWeightParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMMaxWeightParser.java
@@ -31,7 +31,7 @@ import java.util.stream.Collectors;
 public class OSMMaxWeightParser implements TagParser {
 
     // do not include OSM tag "height" here as it has completely different meaning (height of peak)
-    private static final List<String> MAX_WEIGHT_TAGS = Arrays.asList("maxweight", "maxweightrating", "maxweightrating:hgv", "maxgcweight"/*abandoned*/);
+    public static final List<String> MAX_WEIGHT_TAGS = List.of("maxweight", "maxweightrating", "maxweightrating:hgv", "maxgcweight"/*abandoned*/);
     private static final List<String> HGV_RESTRICTIONS = OSMRoadAccessParser.toOSMRestrictions(TransportationMode.HGV).stream()
             .map(e -> e + ":conditional").collect(Collectors.toList());
     private final DecimalEncodedValue weightEncoder;

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/MaxWeightExceptParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/MaxWeightExceptParserTest.java
@@ -35,6 +35,13 @@ public class MaxWeightExceptParserTest {
         readerWay.setTag("maxweight:conditional", "no@ (destination)");
         parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
         assertEquals(MaxWeightExcept.DESTINATION, mwEnc.getEnum(false, edgeId, edgeIntAccess));
+
+        edgeIntAccess = new ArrayEdgeIntAccess(1);
+        readerWay = new ReaderWay(1);
+        readerWay.setTag("maxweightrating:hgv", "7.5");
+        readerWay.setTag("maxweightrating:hgv:conditional", "none @ destination");
+        parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
+        assertEquals(MaxWeightExcept.DESTINATION, mwEnc.getEnum(false, edgeId, edgeIntAccess));
     }
 
     @Test


### PR DESCRIPTION
I recently updated the [Achenseestraße](https://www.openstreetmap.org/way/71890079) in OSM, which has a conditional weight restriction with an exemption for destination traffic:

```
maxweightrating:hgv=7.5
maxweightrating:hgv:conditional=none @ destination
```

My local instance kept blocking this road even after whitelisting `max_weight_except == DESTINATION` in my custom model. The problem was quite simple, the parser doesn't handle `maxweightrating:hgv:conditional` yet.

With these changes it should cover all conditional variants of the tags supported by the OSMMaxWeightParser.