### PR TITLE
Docs: typofix ton to tonne (metric)

### DIFF
--- a/docs/core/custom-models.md
+++ b/docs/core/custom-models.md
@@ -105,7 +105,7 @@ There are also some that take on a numeric value, like:
 - max_slope: a signed decimal for the maximum slope (100 * "elevation change / distance_i") of an edge with `sum(distance_i)=edge_distance`. Important for longer road segments where ups (or downs) can be much bigger than the average_slope.
 - max_speed: the speed limit from a sign (km/h)
 - max_height (meter), max_width (meter), max_length (meter)
-- max_weight (ton), max_axle_load (in tons)
+- max_weight (tonne), max_axle_load (tonne)
 - with postfix `_average_speed` contains the average speed (km/h) for a specific vehicle
 - with postfix `_priority` contains the road preference without changing the speed for a specific vehicle (0..1)
 


### PR DESCRIPTION
`Ton` is non-metric unit: https://en.wikipedia.org/wiki/Tonne

Default unit of [maxweight](https://wiki.openstreetmap.org/wiki/Key:maxweight) is metric `tonne`.
