### PR TITLE
Suggest that `car4wd` profile obeys turn restrictions

### DIFF
--- a/core/src/main/resources/com/graphhopper/custom_models/car4wd.json
+++ b/core/src/main/resources/com/graphhopper/custom_models/car4wd.json
@@ -2,6 +2,8 @@
 // graph.encoded_values: car_access, car_average_speed, track_type, road_access
 // profiles:
 //    - name: car4wd
+//      turn_costs:
+//        vehicle_types: [motorcar, motor_vehicle
 //      custom_model_files: [car4wd.json]
 
 {


### PR DESCRIPTION
Update the comment that describes the use of the profile. Same as the `car` profile.

Please read [our contributing guide](https://github.com/graphhopper/graphhopper/blob/master/CONTRIBUTING.md) and note that also your contribution falls under the Apache License 2.0 as outlined there.

Your first contribution should include a change where you add yourself to the CONTRIBUTORS.md file.
