### PR TITLE
Allow freezing TurnCostStorage to remove TC_NEXT

### DIFF
--- a/core/src/test/java/com/graphhopper/routing/CHQueryWithTurnCostsTest.java
+++ b/core/src/test/java/com/graphhopper/routing/CHQueryWithTurnCostsTest.java
@@ -316,10 +316,11 @@ public class CHQueryWithTurnCostsTest {
         f.graph.edge(2, 0).setDistance(30).set(f.speedEnc, 10, 0);
         f.graph.edge(0, 3).setDistance(10).set(f.speedEnc, 10, 0);
         f.graph.edge(3, 4).setDistance(30).set(f.speedEnc, 10, 0);
-        f.freeze();
 
         f.setTurnCost(1, 2, 0, 2);
         f.setTurnCost(0, 3, 4, 4);
+
+        f.freeze();
 
         f.setIdentityLevels();
         // from contracting node 0
@@ -490,8 +491,8 @@ public class CHQueryWithTurnCostsTest {
         f.graph.edge(nodeB, 2).setDistance(10).set(f.speedEnc, 10, 0);
         final EdgeIteratorState e3toB = f.graph.edge(3, nodeB).setDistance(20).set(f.speedEnc, 10, 0);
         final EdgeIteratorState e3toA = f.graph.edge(3, nodeA).setDistance(10).set(f.speedEnc, 10, 10);
-        f.freeze();
         f.setRestriction(0, 3, nodeB);
+        f.freeze();
 
         // one shortcut when contracting node 3
         f.setIdentityLevels();

--- a/core/src/test/java/com/graphhopper/routing/ch/CHTurnCostTest.java
+++ b/core/src/test/java/com/graphhopper/routing/ch/CHTurnCostTest.java
@@ -121,9 +121,9 @@ public class CHTurnCostTest {
         graph.edge(1, 0).setDistance(30).set(speedEnc, 10, 10);
         graph.edge(0, 3).setDistance(10).set(speedEnc, 10, 10);
         graph.edge(3, 4).setDistance(30).set(speedEnc, 10, 10);
-        graph.freeze();
         setTurnCost(2, 1, 0, 2);
         setTurnCost(0, 3, 4, 4);
+        graph.freeze();
         checkPathUsingRandomContractionOrder(IntArrayList.from(2, 1, 0, 3, 4), 9, 6, 2, 4);
     }
 
@@ -256,10 +256,10 @@ public class CHTurnCostTest {
         graph.edge(5, 6).setDistance(10).set(speedEnc, 10, 0);
         graph.edge(6, 7).setDistance(10).set(speedEnc, 10, 0);
         graph.edge(7, 8).setDistance(10).set(speedEnc, 10, 0);
-        graph.freeze();
         setTurnCost(1, 2, 3, 4);
         setTurnCost(3, 4, 5, 2);
         setTurnCost(5, 6, 7, 3);
+        graph.freeze();
 
         // we contract the graph such that only a few shortcuts are created and that the fwd/bwd searches for the
         // 0-8 query meet at node 4 (make sure we include all three cases where turn cost times might come to play:
@@ -278,7 +278,6 @@ public class CHTurnCostTest {
         EdgeIteratorState edge3 = graph.edge(3, 4).setDistance(10).set(speedEnc, 10, 10);
         EdgeIteratorState edge4 = graph.edge(4, 5).setDistance(10).set(speedEnc, 10, 10);
         EdgeIteratorState edge5 = graph.edge(5, 6).setDistance(10).set(speedEnc, 10, 10);
-        graph.freeze();
 
         // turn costs ->
         setTurnCost(edge0, edge1, 1, 5);
@@ -292,6 +291,8 @@ public class CHTurnCostTest {
         setTurnCost(edge3, edge2, 3, 4);
         setTurnCost(edge2, edge1, 2, 1);
         setTurnCost(edge1, edge0, 1, 0);
+
+        graph.freeze();
 
         prepareCH(1, 3, 5, 2, 4, 0, 6);
 
@@ -317,12 +318,13 @@ public class CHTurnCostTest {
         graph.edge(3, 2).setDistance(10).set(speedEnc, 10, 10);
         graph.edge(2, 4).setDistance(10).set(speedEnc, 10, 10);
         graph.edge(4, 1).setDistance(10).set(speedEnc, 10, 0);
-        graph.freeze();
 
         // enforce loop (going counter-clockwise)
         setRestriction(0, 4, 1);
         setTurnCost(4, 2, 3, 4);
         setTurnCost(3, 2, 4, 2);
+
+        graph.freeze();
 
         checkPathUsingRandomContractionOrder(IntArrayList.from(0, 4, 3, 2, 4, 1), 7, 2, 0, 1);
     }
@@ -342,10 +344,11 @@ public class CHTurnCostTest {
         graph.edge(1, 5).setDistance(10).set(speedEnc, 10, 0);
         graph.edge(5, 6).setDistance(10).set(speedEnc, 10, 0);
         graph.edge(6, 4).setDistance(20).set(speedEnc, 10, 0);
-        graph.freeze();
 
         setRestriction(7, 5, 6);
         setTurnCost(0, 2, 1, 2);
+
+        graph.freeze();
 
         final IntArrayList expectedPath = IntArrayList.from(3, 7, 5, 0, 2, 1, 5, 6, 4);
         final int roadCosts = 12;
@@ -368,12 +371,13 @@ public class CHTurnCostTest {
         graph.edge(4, 2).setDistance(10).set(speedEnc, 10, 10);
         graph.edge(2, 5).setDistance(10).set(speedEnc, 10, 0);
         graph.edge(5, 6).setDistance(20).set(speedEnc, 10, 0);
-        graph.freeze();
 
         // enforce loop (going counter-clockwise)
         setRestriction(1, 2, 5);
         setTurnCost(3, 4, 2, 2);
         setTurnCost(2, 4, 3, 4);
+
+        graph.freeze();
 
         final IntArrayList expectedPath = IntArrayList.from(0, 1, 2, 3, 4, 2, 5, 6);
         final int roadCosts = 10;
@@ -415,7 +419,6 @@ public class CHTurnCostTest {
         graph.edge(3, 4).setDistance(20).set(speedEnc, 10, 10);
         graph.edge(4, 9).setDistance(10).set(speedEnc, 10, 10);
         graph.edge(9, 14).setDistance(20).set(speedEnc, 10, 10);
-        graph.freeze();
 
         // enforce loop (going counter-clockwise)
         setRestriction(6, 7, 12);
@@ -429,6 +432,8 @@ public class CHTurnCostTest {
         setTurnCost(16, 17, 4, 4);
         setTurnCost(4, 9, 14, 3);
         setTurnCost(3, 4, 9, 3);
+
+        graph.freeze();
 
         final IntArrayList expectedPath = IntArrayList.from(0, 1, 6, 7, 8, 3, 2, 7, 12, 13, 14);
         final int roadCosts = 15;
@@ -498,7 +503,6 @@ public class CHTurnCostTest {
         graph.edge(27, 28).setDistance(1000).set(speedEnc, 10, 10);
         graph.edge(28, 26).setDistance(10).set(speedEnc, 10, 10);
         graph.edge(20, 28).setDistance(10).set(speedEnc, 10, 10);
-        graph.freeze();
 
         // enforce figure of eight curve at node 7
         setRestriction(1, 7, 13);
@@ -520,6 +524,8 @@ public class CHTurnCostTest {
 
         // add some more turn costs on the shortest path
         setTurnCost(7, 13, 14, 2);
+
+        graph.freeze();
 
         // expected costs of the shortest path
         final IntArrayList expectedPath = IntArrayList.from(
@@ -545,8 +551,9 @@ public class CHTurnCostTest {
         graph.edge(0, 3).setDistance(10).set(speedEnc, 10, 0);
         graph.edge(3, 2).setDistance(10).set(speedEnc, 10, 0);
         graph.edge(2, 4).setDistance(10).set(speedEnc, 10, 0);
-        graph.freeze();
         setRestriction(5, 6, 1);
+
+        graph.freeze();
 
         final IntArrayList expectedPath = IntArrayList.from(5, 6, 4, 0, 3, 2, 4, 6, 1);
         checkPath(expectedPath, 8, 0, 5, 1, new int[]{0, 1, 2, 3, 4, 5, 6});
@@ -570,8 +577,9 @@ public class CHTurnCostTest {
         graph.edge(0, 3).setDistance(10).set(speedEnc, 10, 0);
         graph.edge(3, 2).setDistance(10).set(speedEnc, 10, 0);
         graph.edge(2, 4).setDistance(10).set(speedEnc, 10, 0);
-        graph.freeze();
         setRestriction(5, 6, 7);
+
+        graph.freeze();
 
         final IntArrayList expectedPath = IntArrayList.from(5, 6, 1, 4, 0, 3, 2, 4, 1, 6, 7);
         checkPath(expectedPath, 10, 0, 5, 7, new int[]{0, 1, 2, 3, 4, 5, 6, 7});
@@ -635,7 +643,6 @@ public class CHTurnCostTest {
                 }
             }
         }
-        graph.freeze();
         EdgeExplorer inExplorer = graph.createEdgeExplorer();
         EdgeExplorer outExplorer = graph.createEdgeExplorer();
 
@@ -654,6 +661,7 @@ public class CHTurnCostTest {
                 }
             }
         }
+        graph.freeze();
 
         IntArrayList contractionOrder = getRandomIntegerSequence(graph.getNodes(), rnd);
         checkStrict = false;

--- a/core/src/test/java/com/graphhopper/routing/ch/EdgeBasedNodeContractorTest.java
+++ b/core/src/test/java/com/graphhopper/routing/ch/EdgeBasedNodeContractorTest.java
@@ -92,12 +92,10 @@ public class EdgeBasedNodeContractorTest {
         final EdgeIteratorState edge3to2 = graph.edge(3, 2).setDistance(20).set(speedEnc, 10, 0);
         final EdgeIteratorState edge2to7 = graph.edge(2, 7).setDistance(10).set(speedEnc, 10, 0);
         graph.edge(7, 9).setDistance(10).set(speedEnc, 10, 0);
-        freeze();
-        setMaxLevelOnAllNodes();
-
         setRestriction(6, 7, 9);
         setTurnCost(8, 3, 2, 2);
-
+        freeze();
+        setMaxLevelOnAllNodes();
         contractNodes(5, 6, 3, 2, 9, 1, 8, 4, 7, 0);
         checkShortcuts(
                 createShortcut(2, 8, edge8to3, edge3to2, 5, false, true),
@@ -121,9 +119,9 @@ public class EdgeBasedNodeContractorTest {
         final EdgeIteratorState e3to5 = graph.edge(3, 5).setDistance(20).set(speedEnc, 10, 0);
         graph.edge(2, 6).setDistance(10).set(speedEnc, 10, 0);
         graph.edge(5, 4).setDistance(20).set(speedEnc, 10, 0);
+        setRestriction(1, 6, 3);
         freeze();
         setMaxLevelOnAllNodes();
-        setRestriction(1, 6, 3);
         contractAllNodesInOrder();
         checkShortcuts(
                 // from contracting node 0: need a shortcut because of turn restriction
@@ -175,12 +173,12 @@ public class EdgeBasedNodeContractorTest {
         final EdgeIteratorState e3to4 = graph.edge(3, 4).setDistance(10).set(speedEnc, 10, 10);
         final EdgeIteratorState e4to5 = graph.edge(4, 5).setDistance(10).set(speedEnc, 10, 0);
         graph.edge(5, 2).setDistance(20).set(speedEnc, 10, 0);
-        freeze();
 
         // enforce loop (going counter-clockwise)
         setRestriction(0, 4, 5);
         setTurnCost(6, 3, 4, 2);
         setTurnCost(4, 3, 6, 4);
+        freeze();
         setMaxLevelOnAllNodes();
 
         contractAllNodesInOrder();
@@ -469,9 +467,9 @@ public class EdgeBasedNodeContractorTest {
         graph.edge(2, 7).setDistance(10).set(speedEnc, 10, 0);
         graph.edge(5, 6).setDistance(10).set(speedEnc, 10, 0);
         graph.edge(1, 4).setDistance(10).set(speedEnc, 10, 10);
+        setRestriction(7, 3, 5);
         freeze();
         setMaxLevelOnAllNodes();
-        setRestriction(7, 3, 5);
         contractNodes(3, 4, 2, 6, 7, 5, 1);
         checkShortcuts(
                 // from contracting node 3
@@ -1072,13 +1070,13 @@ public class EdgeBasedNodeContractorTest {
         graph.edge(3, 2).setDistance(10).set(speedEnc, 10, 10);
         graph.edge(2, 4).setDistance(10).set(speedEnc, 10, 10);
         graph.edge(4, 1).setDistance(10).set(speedEnc, 10, 0);
-        freeze();
-        setMaxLevelOnAllNodes();
 
         // enforce loop (going counter-clockwise)
         setRestriction(0, 4, 1);
         setTurnCost(4, 2, 3, 4);
         setTurnCost(3, 2, 4, 2);
+        freeze();
+        setMaxLevelOnAllNodes();
         contractNodes(2, 0, 1, 4, 3);
         checkShortcuts(
                 createShortcut(4, 3, 7, 5, 3, 2, 6, true, false),
@@ -1100,12 +1098,12 @@ public class EdgeBasedNodeContractorTest {
         graph.edge(4, 2).setDistance(5000).set(speedEnc, 10, 0);
         graph.edge(2, 3).setDistance(2000).set(speedEnc, 10, 0);
         graph.edge(3, 1).setDistance(1000).set(speedEnc, 10, 0);
+        setRestriction(0, 3, 1);
         freeze();
         chStore = CHStorage.fromGraph(graph, chConfigs.get(1));
         chBuilder = new CHStorageBuilder(chStore);
         weighting = RoutingCHGraphImpl.fromGraph(graph, chStore, chConfigs.get(1)).getWeighting();
         setMaxLevelOnAllNodes();
-        setRestriction(0, 3, 1);
         contractNodes(4, 0, 1, 2, 3);
         checkShortcuts(
                 createShortcut(2, 3, 2, 4, 1, 2, 600, false, true),

--- a/core/src/test/java/com/graphhopper/storage/ShortcutUnpackerTest.java
+++ b/core/src/test/java/com/graphhopper/storage/ShortcutUnpackerTest.java
@@ -274,7 +274,6 @@ public class ShortcutUnpackerTest {
         edge3 = f.graph.edge(3, 4).setDistance(1).set(f.speedEnc, 20, 10);
         edge4 = f.graph.edge(4, 5).setDistance(1).set(f.speedEnc, 20, 10);
         edge5 = f.graph.edge(5, 6).setDistance(1).set(f.speedEnc, 20, 10);
-        f.freeze();
 
         // turn costs ->
         f.setTurnCost(PREV_EDGE, 0, edge0.getEdge(), 2.0);
@@ -292,6 +291,8 @@ public class ShortcutUnpackerTest {
         f.setTurnCost(edge2.getEdge(), 2, edge1.getEdge(), 1.0);
         f.setTurnCost(edge1.getEdge(), 1, edge0.getEdge(), 0.0);
         f.setTurnCost(edge0.getEdge(), 0, PREV_EDGE, 1.0);
+
+        f.freeze();
 
         f.setCHLevels(1, 3, 5, 4, 2, 0, 6);
         f.shortcut(4, 2, 2, 3, 4, 6, true);


### PR DESCRIPTION
When we are done adding turn cost entries we can sort the entries such that no TC_NEXT pointer is required anymore. This saves four bytes per turn cost entry and turns the linked list iteration into a simple loop.

However, since we use this storage only for OSM turn restrictions currently this is no real improvement: The overall memory requirement for turn restrictions is small, so saving memory is not important. Also for the majority of nodes there are no turn cost entries at all such that the linked list iteration is not an issue, either. For nodes without turn cost entries the TC_NEXT pointer is even more efficient since it requires only a single read, while the loop method requires two reads. I could not measure any difference in routing speed between the two methods for an OSM planet import.

Keeping this here only for later reference as it introduces some complexity and might only be an improvement if a significant number of turn cost entries were needed.
