### PR TITLE
Adding support for Sonny's LiDAR 1" elevation provider

### DIFF
--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -723,6 +723,10 @@ public class GraphHopper {
             elevationProvider = new MultiSourceElevationProvider(cacheDirStr);
         } else if (eleProviderStr.equalsIgnoreCase("skadi")) {
             elevationProvider = new SkadiProvider(cacheDirStr);
+        } else if (eleProviderStr.equalsIgnoreCase("sonny")) {
+            elevationProvider = new SonnyProvider(cacheDirStr);
+        } else if (eleProviderStr.equalsIgnoreCase("multi3")) {
+            elevationProvider = new MultiSource3ElevationProvider(cacheDirStr);
         }
 
         if (elevationProvider instanceof TileBasedElevationProvider) {

--- a/core/src/main/java/com/graphhopper/reader/dem/MultiSource3ElevationProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/MultiSource3ElevationProvider.java
@@ -1,0 +1,127 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.reader.dem;
+
+import com.graphhopper.storage.DAType;
+
+/**
+ * The MultiSource3ElevationProvider mixes different elevation providers to provide the best available elevation data
+ * for the whole world.
+ *
+ * @author ratrun
+ */
+public class MultiSource3ElevationProvider extends TileBasedElevationProvider {
+
+    // The  provider that provides elevation data for Europe
+    private final TileBasedElevationProvider sonnyProvider;
+    // Usually a high resolution provider in the SRTM area
+    private final TileBasedElevationProvider srtmProvider;
+    // The fallback provider that provides elevation data globally
+    private final TileBasedElevationProvider globalProvider;
+
+    public MultiSource3ElevationProvider(TileBasedElevationProvider srtmProvider, TileBasedElevationProvider globalProvider, TileBasedElevationProvider sonnyProvider) {
+        super(srtmProvider.cacheDir.getAbsolutePath());
+        this.srtmProvider = srtmProvider;
+        this.globalProvider = globalProvider;
+        this.sonnyProvider = sonnyProvider;
+    }
+
+    public MultiSource3ElevationProvider() {
+        this(new CGIARProvider(), new GMTEDProvider(), new SonnyProvider());
+    }
+
+    public MultiSource3ElevationProvider(String cacheDir) {
+        this(new CGIARProvider(cacheDir), new GMTEDProvider(cacheDir), new SonnyProvider(cacheDir));
+    }
+
+    @Override
+    public double getEle(double lat, double lon) {
+        try {
+            return sonnyProvider.getEle(lat, lon);
+        } catch ( Exception ex) {
+            // Sometimes the cgiar data north of 59.999 equals 0
+            if (lat < 59.999 && lat > -56) {
+                double ele = srtmProvider.getEle(lat, lon);
+                if (Double.isNaN(ele))  {
+                    // If the SRTM data is not available, use the global provider
+                    ele = globalProvider.getEle(lat, lon);
+                }
+                return ele;
+            }
+            return globalProvider.getEle(lat, lon);
+        }
+    }
+
+    /**
+     * For the MultiSource3ElevationProvider you have to specify the base URL separated by a ';'.
+     * The first for cgiar, the second for gmted, the third for sonny
+     */
+    @Override
+    public MultiSource3ElevationProvider setBaseURL(String baseURL) {
+        String[] urls = baseURL.split(";");
+        if (urls.length != 3) {
+            throw new IllegalArgumentException("The base url must consist of three urls separated by a ';'. The first for cgiar, the second for gmted");
+        }
+        srtmProvider.setBaseURL(urls[0]);
+        globalProvider.setBaseURL(urls[1]);
+        sonnyProvider.setBaseURL(urls[2]);
+        return this;
+    }
+
+    @Override
+    public MultiSource3ElevationProvider setDAType(DAType daType) {
+        srtmProvider.setDAType(daType);
+        globalProvider.setDAType(daType);
+        sonnyProvider.setDAType(daType);
+        return this;
+    }
+
+    @Override
+    public MultiSource3ElevationProvider setInterpolate(boolean interpolate) {
+        srtmProvider.setInterpolate(interpolate);
+        globalProvider.setInterpolate(interpolate);
+        sonnyProvider.setInterpolate(interpolate);
+        return this;
+    }
+
+    @Override
+    public boolean canInterpolate() {
+        return srtmProvider.canInterpolate() && globalProvider.canInterpolate() && sonnyProvider.canInterpolate();
+    }
+
+    @Override
+    public void release() {
+        srtmProvider.release();
+        globalProvider.release();
+        sonnyProvider.release();
+    }
+
+    @Override
+    public MultiSource3ElevationProvider setAutoRemoveTemporaryFiles(boolean autoRemoveTemporary) {
+        srtmProvider.setAutoRemoveTemporaryFiles(autoRemoveTemporary);
+        globalProvider.setAutoRemoveTemporaryFiles(autoRemoveTemporary);
+        sonnyProvider.setAutoRemoveTemporaryFiles(autoRemoveTemporary);
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return "multi3";
+    }
+
+}

--- a/core/src/main/java/com/graphhopper/reader/dem/MultiSourceElevationProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/MultiSourceElevationProvider.java
@@ -50,7 +50,12 @@ public class MultiSourceElevationProvider extends TileBasedElevationProvider {
     public double getEle(double lat, double lon) {
         // Sometimes the cgiar data north of 59.999 equals 0
         if (lat < 59.999 && lat > -56) {
-            return srtmProvider.getEle(lat, lon);
+            double ele = srtmProvider.getEle(lat, lon);
+            if (Double.isNaN(ele))  {
+                // If the SRTM data is not available, use the global provider
+                ele = globalProvider.getEle(lat, lon);
+            }
+            return ele;
         }
         return globalProvider.getEle(lat, lon);
     }

--- a/core/src/main/java/com/graphhopper/reader/dem/SonnyProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/SonnyProvider.java
@@ -1,0 +1,133 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.reader.dem;
+
+import java.io.*;
+
+import static com.graphhopper.util.Helper.close;
+
+/**
+ * Sonny's LiDAR Digital Terrain Models contains elevation data for Europe with 1 arc second (~30m) accuracy.
+ * The description is available at https://sonny.4lima.de/. Unfortunately the data is provided on a Google Drive
+ * https://drive.google.com/drive/folders/0BxphPoRgwhnoWkRoTFhMbTM3RDA?resourcekey=0-wRe5bWl96pwvQ9tAfI9cQg
+ * Therefore, the data is not available via a direct URL and you have to download it manually. After downloading,
+ * the data has to be unzipped and placed in the cache directory. The cache directory is expected to contain DTM
+ * data files with the naming convention like "N49E011.hgt" for the area around 49°N and 11°E.
+ * <p>
+ * Please note that the data cannot be used for public hosting or redistribution due to the terms of use of the data. See
+ * https://github.com/graphhopper/graphhopper/issues/2823
+ * <p>
+ *
+ * @author ratrun
+ */
+public class SonnyProvider extends AbstractSRTMElevationProvider {
+
+    public SonnyProvider() {
+        this("");
+    }
+
+    public SonnyProvider(String cacheDir) {
+        super("https://drive.google.com/drive/folders/0BxphPoRgwhnoWkRoTFhMbTM3RDA?resourcekey=0-wRe5bWl96pwvQ9tAfI9cQg/", // This base URL cannot be used, as the data is not available via a direct URL
+                cacheDir.isEmpty() ? "/tmp/sonny" : cacheDir,
+                "GraphHopper SonnyReader",
+                -56,
+                90,
+                3601
+        );
+    }
+
+    public static void main(String[] args) throws IOException {
+        SonnyProvider provider = new SonnyProvider();
+        // 338
+        System.out.println(provider.getEle(49.949784, 11.57517));
+        // 462
+        System.out.println(provider.getEle(49.968668, 11.575127));
+        // 462
+        System.out.println(provider.getEle(49.968682, 11.574842));
+        // 982
+        System.out.println(provider.getEle(47.468668, 14.575127));
+        // 1094
+        System.out.println(provider.getEle(47.467753, 14.573911));
+        // 1925
+        System.out.println(provider.getEle(46.468835, 12.578777));
+        // 834
+        System.out.println(provider.getEle(48.469123, 9.576393));
+        // Out of area
+        try {
+            System.out.println(provider.getEle(37.5969196, 23.0706507));
+        } catch (Exception e) {
+            System.out.println("Error: Out of area! " + e.getMessage());
+        }
+
+    }
+
+    @Override
+    byte[] readFile(File file) throws IOException {
+        InputStream is = new FileInputStream(file);
+        BufferedInputStream buff = new BufferedInputStream(is);
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        byte[] buffer = new byte[0xFFFF];
+        int len;
+        while ((len = buff.read(buffer)) > 0) {
+            os.write(buffer, 0, len);
+        }
+        os.flush();
+        close(buff);
+        return os.toByteArray();
+    }
+
+    @Override
+    String getFileName(double lat, double lon) {
+        String str = "";
+
+        int minLat = Math.abs(down(lat));
+        int minLon = Math.abs(down(lon));
+
+        if (lat >= 0)
+            str += "N";
+        else
+            str += "S";
+
+        if (minLat < 10)
+            str += "0";
+        str += minLat;
+
+        if (lon >= 0)
+            str += "E";
+        else
+            str += "W";
+
+        if (minLon < 10)
+            str += "0";
+        if (minLon < 100)
+            str += "0";
+        str += minLon;
+        return str;
+    }
+
+    @Override
+    String getDownloadURL(double lat, double lon) {
+        return getFileName(lat, lon) + ".hgt";
+    }
+
+    @Override
+    public String toString() {
+        return "sonny";
+    }
+
+}

--- a/core/src/test/java/com/graphhopper/reader/dem/MultiSource3ElevationProviderTest.java
+++ b/core/src/test/java/com/graphhopper/reader/dem/MultiSource3ElevationProviderTest.java
@@ -26,8 +26,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 /**
  * @author Robin Boldt
  */
-public class MultiSourceElevationProviderTest {
-    MultiSourceElevationProvider instance;
+public class MultiSource3ElevationProviderTest {
+    MultiSource3ElevationProvider instance;
 
     @AfterEach
     public void tearDown() {
@@ -36,7 +36,7 @@ public class MultiSourceElevationProviderTest {
 
     @Test
     public void testGetEleMocked() {
-        instance = new MultiSourceElevationProvider(
+        instance = new MultiSource3ElevationProvider(
                 new CGIARProvider() {
                     @Override
                     public double getEle(double lat, double lon) {
@@ -48,43 +48,50 @@ public class MultiSourceElevationProviderTest {
                     public double getEle(double lat, double lon) {
                         return 2;
                     }
+                },
+                new SonnyProvider() {
+                    @Override
+                    public double getEle(double lat, double lon) {
+                        return 3;
+                    }
                 }
         );
 
-        assertEquals(1, instance.getEle(0, 0), .1);
-        assertEquals(2, instance.getEle(60.0001, 0), .1);
-        assertEquals(2, instance.getEle(-56.0001, 0), .1);
+        assertEquals(3, instance.getEle(0, 0), .1);
+        assertEquals(3, instance.getEle(60.0001, 0), .1);
+        assertEquals(3, instance.getEle(-56.0001, 0), .1);
     }
 
     /*
     Enabling this test requires you to change the pom.xml and increase the memory limit for running tests.
     Change to: <argLine>-Xmx500m -Xms500m</argLine>
+    Additionally, the Sonny DTM 1" data files need to manually installed into the cache directory /tmp/sonny!
     */
     @Disabled
     @Test
     public void testGetEle() {
-        instance = new MultiSourceElevationProvider();
+        instance = new MultiSource3ElevationProvider();
         double precision = .1;
         // The first part is copied from the SRTMGL1ProviderTest
         assertEquals(338, instance.getEle(49.949784, 11.57517), precision);
-        assertEquals(456, instance.getEle(49.968668, 11.575127), precision);
-        assertEquals(450, instance.getEle(49.968682, 11.574842), precision);
+        assertEquals(462, instance.getEle(49.968668, 11.575127), precision);
+        assertEquals(462, instance.getEle(49.968682, 11.574842), precision);
         assertEquals(3130, instance.getEle(-22.532854, -65.110474), precision);
         assertEquals(123, instance.getEle(38.065392, -87.099609), precision);
         assertEquals(1616, instance.getEle(40, -105.2277023), precision);
         assertEquals(1616, instance.getEle(39.99999999, -105.2277023), precision);
         assertEquals(1616, instance.getEle(39.9999999, -105.2277023), precision);
         assertEquals(1616, instance.getEle(39.999999, -105.2277023), precision);
-        assertEquals(1046, instance.getEle(47.468668, 14.575127), precision);
-        assertEquals(1131, instance.getEle(47.467753, 14.573911), precision);
-        assertEquals(1915, instance.getEle(46.468835, 12.578777), precision);
-        assertEquals(841, instance.getEle(48.469123, 9.576393), precision);
+        assertEquals(982, instance.getEle(47.468668, 14.575127), precision);
+        assertEquals(1094, instance.getEle(47.467753, 14.573911), precision);
+        assertEquals(1925, instance.getEle(46.468835, 12.578777), precision);
+        assertEquals(834, instance.getEle(48.469123, 9.576393), precision);
         // The file for this coordinate does not exist, but there is a ferry tagged in OSM
         assertEquals(0, instance.getEle(56.4787319, 17.6118363), precision);
         assertEquals(0, instance.getEle(56.4787319, 17.6118363), precision);
         // The second part is copied from the GMTEDProviderTest
         // Outside of SRTM covered area
-        assertEquals(108, instance.getEle(60.0000001, 16), precision);
+        assertEquals(118, instance.getEle(60.0000001, 16), precision);
         assertEquals(0, instance.getEle(60.0000001, 19), precision);
         // Stor Roten
         assertEquals(4, instance.getEle(60.251, 18.805), precision);

--- a/docs/core/elevation.md
+++ b/docs/core/elevation.md
@@ -1,11 +1,11 @@
 # Elevation
 
 Per default elevation is disabled. But you can easily enable it e.g. via
-`graph.elevation.provider: cgiar`. Or use other possibilities `srtm`, `gmted`
-or `multi` (combined cgiar and gmted).
+`graph.elevation.provider: cgiar`. Or use other possibilities `srtm`, `gmted`, `sonny`, 
+`multi` (combined cgiar and gmted), or `multi3` (combined cgiar, gmted and sonny).
 
 Then GraphHopper will automatically download the necessary data for the area and include elevation 
-for all vehicles - making also the distances a bit more precise. 
+for all vehicles except when using `sonny` - making also the distances a bit more precise. 
 
 The default cache directory `/tmp/<provider name>` will be used. For large areas it is highly recommended to 
 use a SSD disc, thus you need to specify the cache directory:
@@ -19,7 +19,7 @@ change. See the [custom model](custom-models.md) feature.
 
 ## What to download and where to store it?
 
-All should work automatically but you can tune certain settings like the location where the files are 
+Except when using `sonny` all should work automatically, but you can tune certain settings like the location where the files are 
 downloaded and e.g. if the servers are not reachable, then you set:
 `graph.elevation.base_url`
 
@@ -35,6 +35,19 @@ The CGIAR data is preferred because of the quality but is in general not public 
 But we got a license for our and our users' usage: https://graphhopper.com/public/license/CGIAR.txt
 
 Using SRTM instead CGIAR has the minor advantage of a faster download, especially for smaller areas.
+
+## Sonny's LiDAR Digital Terrain Models
+Sonny's LiDAR Digital Terrain Models are available for Europe only, see https://sonny.4lima.de/. 
+It is a very high resolution elevation data set, but it is **not free** to use! See the discussion at
+https://github.com/graphhopper/graphhopper/issues/2823.
+The DTM 1" data is provided on a Google Drive https://drive.google.com/drive/folders/0BxphPoRgwhnoWkRoTFhMbTM3RDA?resourcekey=0-wRe5bWl96pwvQ9tAfI9cQg. 
+From there it needs to be manually downloaded and extracted into a persistent cache directory. Automatic download
+is not supported due to Google Drive not providing support for hyperlinks on to the DTM data files.
+The cache directory is expected to contain the DTM data files with the naming convention like 
+"N49E011.hgt" for the area around 49°N and 11°E.
+Sonny's LiDAR Digital Terrain Model `sonny` only works for countries in Europe, which are fully covered 
+by the Sonny DTM 1" data. See https://sonny.4lima.de/map.png for coverage. In case the covered sonny 
+data area does not match your graphhopper coverage area, make sure to use the `multi3` elevation provider.
 
 ## Custom Elevation Data
 


### PR DESCRIPTION
For the use-case of a not public graphhopper instance, I added support for [Sonny's LiDAR Digital Terrain Models of Europe](https://sonny.4lima.de/) as elevation provider. The advantage is that for the covered area in Europe the DTM data is much better compared to CGIAR data. The disadvantage is that the data is [**not free** to use](https://github.com/graphhopper/graphhopper/issues/2823)!

Although I expect that this won't get merged due to the licensing issues and because the data does not get automatically fetched, I decided to create this public pull request such that this work does not get lost. It still could be useful for certain scenarios.
