### PR TITLE
Increase used JTS version to 1.20.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
             <dependency>
                 <groupId>org.locationtech.jts</groupId>
                 <artifactId>jts-core</artifactId>
-                <version>1.19.0</version>
+                <version>1.20.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
See https://github.com/locationtech/jts/re…leases/tag/1.20.0
In my testing this improves the graph preparation performance by about 6%.