### PR TITLE
Allow bike_road_access==PRIVATE for foot and bicycle profiles

### DIFF
--- a/config-example.yml
+++ b/config-example.yml
@@ -64,7 +64,7 @@ graphhopper:
 #
 #   Other custom models not listed here are: car4wd.json, motorcycle.json, truck.json or cargo-bike.json. You might need to modify and test them before production usage.
 #   See ./core/src/main/resources/com/graphhopper/custom_models and let us know if you customize them, improve them or create new onces!
-#   Also there is the curvature.json custom model which might be useful for a motorcyle profile or the opposite for a truck profile.
+#   Also, there is the curvature.json custom model which might be useful for a motorcycle profile or the opposite for a truck profile.
 #   Then specify a folder where to find your own custom model files:
 #  custom_models.directory: custom_models
 
@@ -80,7 +80,7 @@ graphhopper:
 
   # Hybrid mode:
   # Similar to speed mode, the hybrid mode (Landmarks, LM) also speeds up routing by doing calculating auxiliary data
-  # in advance. Its not as fast as speed mode, but more flexible.
+  # in advance. It is not as fast as speed mode, but more flexible.
   #
   # Advanced usage: It is possible to use the same preparation for multiple profiles which saves memory and preparation
   # time. To do this use e.g. `preparation_profile: my_other_profile` where `my_other_profile` is the name of another
@@ -97,6 +97,10 @@ graphhopper:
   #   surface,smoothness,max_width,max_height,max_weight,max_weight_except,hgv,max_axle_load,max_length,
   #   hazmat,hazmat_tunnel,hazmat_water,lanes,osm_way_id,toll,track_type,mtb_rating,hike_rating,horse_rating,
   #   country,curvature,average_slope,max_slope,car_temporal_access,bike_temporal_access,foot_temporal_access
+  #   To unblock "access=private" tagged ways, the following encoded values can be parameterized with block_private=false:
+  #      car_access, foot_access, bus_access, bike_access, racingbike_access, mtb_access
+  #   like this:
+  #   car_access|block_private=false
   graph.encoded_values: car_access, car_average_speed, road_access
 
   #### Speed, hybrid and flexible mode ####

--- a/core/src/main/resources/com/graphhopper/custom_models/bike.json
+++ b/core/src/main/resources/com/graphhopper/custom_models/bike.json
@@ -8,7 +8,7 @@
 {
   "priority": [
     { "if": "true",  "multiply_by": "bike_priority" },
-    { "if": "bike_road_access == PRIVATE && foot_road_access != YES", "multiply_by": "0" },
+    { "if": "bike_road_access == PRIVATE", "multiply_by": "0.1" },
     { "if": "mtb_rating > 2",  "multiply_by": "0" },
     { "if": "hike_rating > 1",  "multiply_by": "0" },
     { "if": "country == DEU && road_class == BRIDLEWAY && bike_road_access != YES", "multiply_by": "0" },
@@ -18,6 +18,6 @@
   "speed": [
     { "if": "true", "limit_to": "bike_average_speed" },
     { "if": "!bike_access && backward_bike_access", "limit_to": "5" },
-    { "if": "bike_road_access == PRIVATE && foot_road_access == YES", "limit_to": "5" }
+    { "if": "bike_road_access == PRIVATE", "limit_to": "5" }
   ]
 }

--- a/core/src/main/resources/com/graphhopper/custom_models/bike_tc.json
+++ b/core/src/main/resources/com/graphhopper/custom_models/bike_tc.json
@@ -19,12 +19,13 @@
 {
   "priority": [
     { "if": "true",  "multiply_by": "bike_priority" },
-    { "if": "bike_road_access == PRIVATE", "multiply_by": "0" },
+    { "if": "bike_road_access == PRIVATE", "multiply_by": "0.1" },
     { "if": "!bike_access && (!backward_bike_access || roundabout)",  "multiply_by": "0" },
     { "else_if": "!bike_access && backward_bike_access",  "multiply_by": "0.2" }
   ],
   "speed": [
     { "if": "true", "limit_to": "bike_average_speed" },
-    { "if": "!bike_access && backward_bike_access", "limit_to": "5" }
+    { "if": "!bike_access && backward_bike_access", "limit_to": "5" },
+    { "if": "bike_road_access == PRIVATE", "limit_to": "5" }
   ]
 }

--- a/core/src/main/resources/com/graphhopper/custom_models/cargo_bike.json
+++ b/core/src/main/resources/com/graphhopper/custom_models/cargo_bike.json
@@ -3,7 +3,7 @@
 
 {
   "priority": [
-    { "if": "bike_road_access == PRIVATE",  "multiply_by": "0" },
+    { "if": "bike_road_access == PRIVATE",  "multiply_by": "0.1" },
     { "if": "road_class == STEPS", "multiply_by": 0 },
     { "if": "surface == SAND", "multiply_by": 0.5 },
     { "if": "track_type != MISSING && track_type != GRADE1", "multiply_by": 0.9 },
@@ -13,6 +13,7 @@
   ],
   "speed": [
     { "if": "road_class == PRIMARY", "limit_to": 28 },
-    { "else": "", "limit_to": 25 }
+    { "else": "", "limit_to": 25 },
+    { "if": "bike_road_access == PRIVATE", "limit_to": "5" }
   ]
 }

--- a/core/src/main/resources/com/graphhopper/custom_models/foot.json
+++ b/core/src/main/resources/com/graphhopper/custom_models/foot.json
@@ -10,7 +10,7 @@
     { "if": "!foot_access || hike_rating >= 2 || mtb_rating > 2", "multiply_by": "0" },
     { "else": "", "multiply_by": "foot_priority"},
     { "if": "country == DEU && road_class == BRIDLEWAY && foot_road_access != YES", "multiply_by": "0" },
-    { "if": "foot_road_access == PRIVATE", "multiply_by": "0" }
+    { "if": "foot_road_access == PRIVATE", "multiply_by": "0.1" }
   ],
   "speed": [
     { "if": "true", "limit_to": "foot_average_speed" }

--- a/core/src/main/resources/com/graphhopper/custom_models/hike.json
+++ b/core/src/main/resources/com/graphhopper/custom_models/hike.json
@@ -9,7 +9,7 @@
   "priority": [
     { "if": "!foot_access || hike_rating >= 5", "multiply_by": "0"},
     { "else": "", "multiply_by": "foot_priority"},
-    { "if": "foot_road_access == PRIVATE", "multiply_by": "0" },
+    { "if": "foot_road_access == PRIVATE", "multiply_by": "0.1" },
     { "if": "foot_network == INTERNATIONAL || foot_network == NATIONAL", "multiply_by": "1.7"},
     { "else_if": "foot_network == REGIONAL || foot_network == LOCAL", "multiply_by": "1.5"}
   ],

--- a/core/src/main/resources/com/graphhopper/custom_models/mtb.json
+++ b/core/src/main/resources/com/graphhopper/custom_models/mtb.json
@@ -14,11 +14,12 @@
     { "if": "country == DEU && road_class == BRIDLEWAY && bike_road_access != YES", "multiply_by": "0" },
     { "if": "!mtb_access && (!backward_mtb_access || roundabout)",  "multiply_by": "0" },
     { "else_if": "!mtb_access && backward_mtb_access",  "multiply_by": "0.2" },
-    { "if": "bike_road_access == PRIVATE",  "multiply_by": "0" }
+    { "if": "bike_road_access == PRIVATE",  "multiply_by": "0.1" }
   ],
   "speed": [
     { "if": "true", "limit_to": "mtb_average_speed" },
     { "if": "mtb_rating > 3",  "limit_to": "4" },
-    { "if": "!mtb_access && backward_mtb_access", "limit_to": "5" }
+    { "if": "!mtb_access && backward_mtb_access", "limit_to": "5" },
+    { "if": "bike_road_access == PRIVATE", "limit_to": "5" }
   ]
 }

--- a/core/src/main/resources/com/graphhopper/custom_models/racingbike.json
+++ b/core/src/main/resources/com/graphhopper/custom_models/racingbike.json
@@ -8,7 +8,7 @@
 {
   "priority": [
     { "if": "true",  "multiply_by": "racingbike_priority" },
-    { "if": "bike_road_access == PRIVATE", "multiply_by": "0" },
+    { "if": "bike_road_access == PRIVATE", "multiply_by": "0.1" },
     { "if": "mtb_rating > 2",  "multiply_by": "0" },
     { "if": "mtb_rating == 2",  "multiply_by": "0.5" },
     { "if": "hike_rating > 1",  "multiply_by": "0" },
@@ -18,6 +18,7 @@
   ],
   "speed": [
     { "if": "true", "limit_to": "racingbike_average_speed" },
-    { "if": "!racingbike_access && backward_racingbike_access", "limit_to": "5" }
+    { "if": "!racingbike_access && backward_racingbike_access", "limit_to": "5" },
+    { "if": "bike_road_access == PRIVATE", "limit_to": "5" }
   ]
 }


### PR DESCRIPTION
The result of the [discussion in the forum](https://discuss.graphhopper.com/t/correct-ferry-terminal-access-tagging/9655/1) was that we should not block ways tagged as `access=customers` by default as this may block access to ferries for example. 

As `access=customers` currently gets turned into a `bike_road_access=PRIVATE` encoded value we need to prevent assigning priority=0 in the custom models as this blocks such ways completely. This PR changes the priority for `bike_road_access=PRIVATE` into the lowest possible value together with assigning walking speed instead.

Additionally, this PR improves the documentation about the currently undocumented  `block_private=false` encoding value option.

By explicitly configuring `block_private=false` in the config.yml it is possible to allow access additionally also for private roads. If this parameter is missing in the config, access is only provided to ways with `access` tags set to `delivery`, `customer` or `permit`.