### PR TITLE
make navigation mode config more customizable

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -49,7 +49,7 @@ Here is an overview:
  * jessLryan, max elevation can now be negative
  * joe-akeem, improvements like #2158
  * JohannesPelzer, improved GPX information and various other things
- * karololszacki, introduce `navigation_transportation_mode` option for Profiles to easily set which Voice Guidance distances to use
+ * karololszacki, introduce `navigation_mode` option for Profiles to easily set which Voice Guidance distances to use
  * karussell, one of the core developers
  * khuebner, initial turn costs support
  * kodonnell, adding support for CH and other algorithms (#60) and penalizing inner-link U-turns (#88)

--- a/config-example.yml
+++ b/config-example.yml
@@ -30,7 +30,6 @@ graphhopper:
 
   profiles:
    - name: car
-#     navigation_transportation_mode: "car"
 #     turn_costs:
 #       vehicle_types: [motorcar, motor_vehicle]
 #       u_turn_costs: 60
@@ -40,20 +39,23 @@ graphhopper:
 #   You can use the following in-built profiles. After you start GraphHopper it will print which encoded values you'll have to add to graph.encoded_values in this config file.
 #
 #    - name: foot
-#      navigation_transportation_mode: "foot"
 #      custom_model_files: [foot.json, foot_elevation.json]
 #
 #    - name: bike
-#      navigation_transportation_mode: "bike"
 #      custom_model_files: [bike.json, bike_elevation.json]
 #
 #    - name: racingbike
-#      navigation_transportation_mode: "bike"
 #      custom_model_files: [racingbike.json, bike_elevation.json]
 #
 #    - name: mtb
-#      navigation_transportation_mode: "bike"
 #      custom_model_files: [mtb.json, bike_elevation.json]
+#
+#    - name: custom_profile
+#      navigation_mode: bike
+#      turn_costs:
+#        vehicle_types: [bicycle]
+#        u_turn_costs: 10
+#      custom_model_files: [your_custom_model.json]
 #
 #    # See the bus.json for more details.
 #    - name: bus

--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -298,6 +298,16 @@ public class GraphHopper {
         return profilesByName.get(profileName);
     }
 
+    public TransportationMode getNavigationMode(String profileName) {
+        Profile profile = profilesByName.get(profileName);
+        if (profile == null) return TransportationMode.CAR;
+        try {
+            return TransportationMode.valueOf(profile.getHints().getString("navigation_mode", profileName).toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            return TransportationMode.CAR;
+        }
+    }
+
     /**
      * @return true if storing and fetching elevation data is enabled. Default is false
      */

--- a/navigation/src/main/java/com/graphhopper/navigation/DistanceConfig.java
+++ b/navigation/src/main/java/com/graphhopper/navigation/DistanceConfig.java
@@ -33,10 +33,6 @@ public class DistanceConfig {
     final List<VoiceInstructionConfig> voiceInstructions;
     final DistanceUtils.Unit unit;
 
-    public DistanceConfig(DistanceUtils.Unit unit, TranslationMap translationMap, Locale locale, Profile profile) {
-        this(unit, translationMap, locale, profile.getHints().getString("navigation_transportation_mode", ""));
-    }
-
     public DistanceConfig(DistanceUtils.Unit unit, TranslationMap translationMap, Locale locale, TransportationMode mode) {
         this(unit, translationMap, locale, mode.name());
     }

--- a/navigation/src/main/java/com/graphhopper/navigation/NavigateResource.java
+++ b/navigation/src/main/java/com/graphhopper/navigation/NavigateResource.java
@@ -144,7 +144,7 @@ public class NavigateResource {
         } else {
             DistanceUtils.Unit unit = voiceUnits.equals("metric") ? DistanceUtils.Unit.METRIC : DistanceUtils.Unit.IMPERIAL;
             Locale locale = Helper.getLocale(localeStr);
-            DistanceConfig config = new DistanceConfig(unit, translationMap, locale, graphHopper.getProfile(ghProfile));
+            DistanceConfig config = new DistanceConfig(unit, translationMap, locale, graphHopper.getNavigationMode(ghProfile));
             logger.info(logStr);
             return Response.ok(NavigateResponseConverter.convertFromGHResponse(ghResponse, translationMap, locale, config)).
                     header("X-GH-Took", "" + Math.round(took * 1000)).
@@ -214,7 +214,7 @@ public class NavigateResource {
                 unit = DistanceUtils.Unit.IMPERIAL;
             }
 
-            DistanceConfig config = new DistanceConfig(unit, translationMap, request.getLocale(), graphHopper.getProfile(request.getProfile()));
+            DistanceConfig config = new DistanceConfig(unit, translationMap, request.getLocale(), graphHopper.getNavigationMode(request.getProfile()));
             logger.info(logStr);
             return Response.ok(NavigateResponseConverter.convertFromGHResponse(ghResponse, translationMap, request.getLocale(), config)).
                     header("X-GH-Took", "" + Math.round(took * 1000)).

--- a/navigation/src/test/java/com/graphhopper/navigation/DistanceConfigTest.java
+++ b/navigation/src/test/java/com/graphhopper/navigation/DistanceConfigTest.java
@@ -1,5 +1,6 @@
 package com.graphhopper.navigation;
 
+import com.graphhopper.GraphHopper;
 import com.graphhopper.config.Profile;
 import com.graphhopper.routing.util.TransportationMode;
 import org.junit.jupiter.api.Test;
@@ -20,24 +21,15 @@ public class DistanceConfigTest {
         DistanceConfig bus = new DistanceConfig(DistanceUtils.Unit.METRIC, null, null, TransportationMode.BUS);
         assertEquals(4, bus.voiceInstructions.size());
 
-
         // from Profile
-        Profile awesomeProfile = new Profile("my_awesome_profile").putHint("navigation_transportation_mode", "car");
-        DistanceConfig carFromProfile = new DistanceConfig(DistanceUtils.Unit.METRIC, null, null, awesomeProfile);
-        assertEquals(4, carFromProfile.voiceInstructions.size());
-
-        Profile fastWalkProfile = new Profile("my_fast_walk_profile").putHint("navigation_transportation_mode", "foot");
-        DistanceConfig footFromProfile = new DistanceConfig(DistanceUtils.Unit.METRIC, null, null, fastWalkProfile);
-        assertEquals(1, footFromProfile.voiceInstructions.size());
-
-        Profile crazyMtbProfile = new Profile("my_crazy_mtb").putHint("navigation_transportation_mode", "bike");
-        DistanceConfig bikeFromProfile = new DistanceConfig(DistanceUtils.Unit.METRIC, null, null, crazyMtbProfile);
-        assertEquals(1, bikeFromProfile.voiceInstructions.size());
-
-        Profile truckProfile = new Profile("my_truck"); // no hint set, so defaults to car
-        DistanceConfig truckCfg = new DistanceConfig(DistanceUtils.Unit.METRIC, null, null, truckProfile);
-        assertEquals(4, truckCfg.voiceInstructions.size());
-
+        GraphHopper hopper = new GraphHopper().setProfiles(
+                new Profile("my_truck"),
+                new Profile("foot"),
+                new Profile("ebike").putHint("navigation_mode", "bike"));
+        assertEquals(TransportationMode.CAR, hopper.getNavigationMode("unknown"));
+        assertEquals(TransportationMode.CAR, hopper.getNavigationMode("my_truck"));
+        assertEquals(TransportationMode.FOOT, hopper.getNavigationMode("foot"));
+        assertEquals(TransportationMode.BIKE, hopper.getNavigationMode("ebike"));
 
         // from String
         DistanceConfig driving = new DistanceConfig(DistanceUtils.Unit.METRIC, null, null, "driving");


### PR DESCRIPTION
It seems for #3165 we need a bit more flexibility and default profiles like `foot` shouldn't need an extra config.

Also I would prefer to change the name (once again). In #3165 there was a typo and in master it is too long and so I would prefer just `navigation_mode` :)

(/cc @OlafFlebbeBosch @boldtrn)