### PR TITLE
allow shorter conditions in custom model statement

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/weighting/custom/ConditionalExpressionVisitor.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/custom/ConditionalExpressionVisitor.java
@@ -71,7 +71,7 @@ class ConditionalExpressionVisitor implements Visitor.AtomVisitor<Boolean, Excep
                     result.guessedVariables.add(arg);
                     return true;
                 } else {
-                    // e.g. like road_class
+                    // arg is e.g. "road_class" or "MOTORWAY"
                     if (isValidIdentifier(arg)) {
                         int start = rv.getLocation().getColumnNumber() - 1;
                         if (lhsOpForVarInclude != null)
@@ -122,6 +122,7 @@ class ConditionalExpressionVisitor implements Visitor.AtomVisitor<Boolean, Excep
             return false;
         } else if (rv instanceof Java.ParenthesizedExpression) {
             lhsOpForVarInclude = null;
+            opForTypeInclude = null;
             return ((Java.ParenthesizedExpression) rv).value.accept(this);
         } else if (rv instanceof Java.BinaryOperation binOp) {
             // Handle "type includes": for expressions like "road_class == MOTORWAY", store the operation

--- a/core/src/test/java/com/graphhopper/routing/weighting/custom/ConditionalExpressionVisitorTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/custom/ConditionalExpressionVisitorTest.java
@@ -160,7 +160,7 @@ public class ConditionalExpressionVisitorTest {
         assertTrue(result.ok);
         assertEquals("road_class == RoadClass.SECONDARY && road_class == RoadClass.PRIMARY && road_class == RoadClass.TERTIARY || road_class == RoadClass.RESIDENTIAL", result.converted.toString());
 
-        // but no variable inclusion outside of parenthesis
+        // but no variable inclusion outside of parenthesis (parsing here works but later compiling obviously not)
         result = parse("(road_class == SECONDARY && PRIMARY) && TERTIARY || RESIDENTIAL", validVariable, helper);
         assertTrue(result.ok);
         assertEquals("(road_class == RoadClass.SECONDARY && road_class == RoadClass.PRIMARY) && TERTIARY || RESIDENTIAL", result.converted.toString());
@@ -168,7 +168,7 @@ public class ConditionalExpressionVisitorTest {
         // also such mixed constructs won't work
         result = parse("road_class == SECONDARY || PRIMARY && road_environment == TUNNEL || BRIDGE || ROAD", validVariable, helper);
         assertTrue(result.ok);
-//        assertEquals("road_class == RoadClass.SECONDARY || road_class == RoadClass.PRIMARY && road_environment == RoadEnvironment.TUNNEL || road_environment == RoadEnvironment.BRIDGE || road_environment == RoadEnvironment.ROAD", result.converted.toString());
+        assertEquals("road_class == RoadClass.SECONDARY || PRIMARY && road_environment == RoadEnvironment.TUNNEL || BRIDGE || ROAD", result.converted.toString());
 
         // when combining multiple conditions with different variables you need to put brackets around them ...
         result = parse("(road_class == SECONDARY || PRIMARY) && (road_environment == TUNNEL || BRIDGE || ROAD)", validVariable, helper);
@@ -180,10 +180,18 @@ public class ConditionalExpressionVisitorTest {
         assertTrue(result.ok);
         assertEquals("road_class == RoadClass.SECONDARY && road_class == RoadClass.PRIMARY || road_environment == RoadEnvironment.TUNNEL && road_environment == RoadEnvironment.BRIDGE && road_environment == RoadEnvironment.ROAD", result.converted.toString());
 
-        // 'variable include' currently won't work for numbers yet (Java.Literal), but has no practical relevance at the moment
+        // no automatic bracket placement => no working replacement mechanism
+        result = parse("road_environment == TUNNEL && road_class == SECONDARY || PRIMARY", validVariable, helper);
+        assertTrue(result.ok);
+        assertEquals("road_environment == RoadEnvironment.TUNNEL && road_class == RoadClass.SECONDARY || PRIMARY", result.converted.toString());
+        result = parse("road_environment == TUNNEL && (road_class == SECONDARY || PRIMARY)", validVariable, helper);
+        assertTrue(result.ok);
+        assertEquals("road_environment == RoadEnvironment.TUNNEL && (road_class == RoadClass.SECONDARY || road_class == RoadClass.PRIMARY)", result.converted.toString());
+
+        // 'variable include' currently won't work for numbers, but has no practical relevance at the moment
         result = parse("max_speed == 90 || 100", validVariable, helper);
         assertTrue(result.ok);
-//        assertEquals("max_speed == 90 || max_speed == 100", result.converted.toString());
+        assertEquals("max_speed == 90 || 100", result.converted.toString());
 
         result = parse("prev_bike_road_access != bike_road_access && (bike_road_access == DESTINATION || PRIVATE)", validVariable, helper);
         assertTrue(result.ok);


### PR DESCRIPTION
Allow more compact conditions like
`road_class == PRIMARY || SECONDARY || TERTIARY`
additionally to the longer form
`road_class == PRIMARY || road_class == SECONDARY || road_class == TERTIARY`. 

TODOs:

 - [ ] Should we use a more readable (but still Java-parsable) approach like `set(...).contains(road_class)`? When caching the set it should not be slower than multiple if's (at least for several values). Especially when we need the negation `! set(...).contains(road_class)` would be more readable than `road_class != PRIMARY && SECONDARY && TERTIARY`. We could also keep the implementation of `set(A,B,C).contains(var)` as `var == A || var == B || var == C`. Then we could easily use a shorter method name like `set(...).in(var)` or `set(...).has(var)`. On the other hand no one forces us to write `road_class != PRIMARY && SECONDARY && TERTIARY` and we could just use the again readable expression `!(road_class == PRIMARY || SECONDARY || TERTIARY)`.
 - [ ] custom model editor

Fixes #2808. 

Internal note: this change slightly rewrites how the "type includes" are happening (like `road_class==PRIMARY` -> `road_class==RoadClass.PRIMARY`) but is a necessary change to make string replacement working in order with the new "variable includes".