### PR TITLE
Fix #3211: Ignore car 'oneway' tag in FootAccessParser

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -8,6 +8,7 @@ Here is an overview:
  * AnahitaS, docs for Android, Android, Tomcat
  * andreaswolf, flag encoder versioning and more
  * andreylh, polygon for blocked area #1306
+ * modhtom, fixes like #3211
  * Anvoker, fixes like #1614 and helped with JUnit 5 migration #1632 
  * b3nn0, Android improvements
  * baumboi, path detail and landmark improvements

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/FootAccessParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/FootAccessParser.java
@@ -144,17 +144,25 @@ public class FootAccessParser extends AbstractAccessParser implements TagParser 
         return WayAccess.WAY;
     }
 
+
     @Override
     public void handleWayTags(int edgeId, EdgeIntAccess edgeIntAccess, ReaderWay way) {
         WayAccess access = getAccess(way);
         if (access.canSkip())
             return;
 
-        if (way.hasTag("oneway:foot", ONEWAYS) || way.hasTag("foot:backward") || way.hasTag("foot:forward")
-                || way.hasTag("oneway", ONEWAYS) && way.hasTag("highway", "steps") // outdated mapping style
-        ) {
+        if (way.hasTag("oneway:foot", ONEWAYS) || way.hasTag("foot:backward") || way.hasTag("foot:forward")) {
+
             boolean reverse = way.hasTag("oneway:foot", "-1") || way.hasTag("foot:backward", "yes") || way.hasTag("foot:forward", "no");
-            accessEnc.setBool(reverse, edgeId, edgeIntAccess, true);
+
+            if (reverse) {
+                accessEnc.setBool(false, edgeId, edgeIntAccess, false);
+                accessEnc.setBool(true, edgeId, edgeIntAccess, true);
+            } else {
+                accessEnc.setBool(false, edgeId, edgeIntAccess, true);
+                accessEnc.setBool(true, edgeId, edgeIntAccess, false);
+            }
+
         } else {
             accessEnc.setBool(false, edgeId, edgeIntAccess, true);
             accessEnc.setBool(true, edgeId, edgeIntAccess, true);

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/FootTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/FootTagParserTest.java
@@ -287,6 +287,26 @@ public class FootTagParserTest {
     }
 
     @Test
+    public void testCarOneWayIsIgnored() {
+        // This test simulates the bug #3211
+        // A road with a 'oneway=yes' tag (for cars) should be ignored by the foot parser
+        // and allow pedestrian access in BOTH directions.
+
+        ReaderWay way = new ReaderWay(1);
+        way.setTag("highway", "residential");
+        way.setTag("oneway", "yes");
+
+        EdgeIntAccess edgeIntAccess = ArrayEdgeIntAccess.createFromBytes(encodingManager.getBytesForFlags());
+        int edgeId = 0;
+
+        accessParser.handleWayTags(edgeId, edgeIntAccess, way);
+
+        // We expect BOTH forward (false) and backward (true) access to be allowed
+        assertTrue(footAccessEnc.getBool(false, edgeId, edgeIntAccess), "Forward access should be allowed");
+        assertTrue(footAccessEnc.getBool(true, edgeId, edgeIntAccess), "Backward access should be allowed");
+    }
+
+    @Test
     public void testMixSpeedAndSafe() {
         ReaderWay way = new ReaderWay(1);
         way.setTag("highway", "motorway");


### PR DESCRIPTION
Hi, this PR fixes issue #3211.

I found an asymmetrical behavior (the route from A->B failed, but B->A worked). This was because the FootAccessParser was not ignoring the generic oneway tag meant for cars, blocking pedestrian access in one direction.

My fix changes the logic in handleWayTags to only apply one-way rules for specific pedestrian tags (like oneway:foot), and to treat all other roads as bidirectional for pedestrians.

I have tested this on my local server and it now produces the correct route. I've also added a new unit test to FootTagParserTest to confirm this fix and prevent future regressions.
