### PR TITLE
Disable elevation sampling for ferries

### DIFF
--- a/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
+++ b/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
@@ -331,7 +331,7 @@ public class OSMReader {
 
         if (pointList.is3D()) {
             // sample points along long edges
-            if (config.getLongEdgeSamplingDistance() < Double.MAX_VALUE)
+            if (config.getLongEdgeSamplingDistance() < Double.MAX_VALUE && !isFerry(way))
                 pointList = EdgeSampling.sample(pointList, config.getLongEdgeSamplingDistance(), distCalc, eleProvider);
 
             // smooth the elevation before calculating the distance because the distance will be incorrect if calculated afterwards


### PR DESCRIPTION
Here is the PR title and description for your second pull request.

**Title:** Disable elevation sampling for ferries

**Description:**
This PR disables elevation sampling for edges identified as ferries.

Long-distance ferry routes (e.g., 1,300 km) generate massive amounts of artificial geometry points when `graph.elevation.long_edge_sampling_distance` is set to a low value (e.g., 40m). This significantly increases graph size and memory usage during import while adding no value, as ferry routes are effectively flat.

**Changes:**
* Added a check for `!isFerry(way)` in `OSMReader.addEdge` before triggering `EdgeSampling`.

**Fixes:** #3234 