### PR TITLE
fix: OSRM response when a legs'has no intermediate steps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ local.properties
 .DS_Store
 /graph-cache
 package-lock.json
+.vscode/

--- a/navigation/src/main/java/com/graphhopper/navigation/NavigateResponseConverter.java
+++ b/navigation/src/main/java/com/graphhopper/navigation/NavigateResponseConverter.java
@@ -121,6 +121,10 @@ public class NavigateResponseConverter {
             if (isDepartInstruction) {
                 maneuverType = ManeuverType.DEPART;
                 fixDepartIntersectionDetail(intersectionDetails, i);
+                // if the depart is on a REACHED_VIA or FINISH node, add the summary
+                if (instruction.getSign() == Instruction.REACHED_VIA || instruction.getSign() == Instruction.FINISH) {
+                    putLegInformation(legJson, path, routeNr, time, distance);
+                }
             } else {
                 switch (instruction.getSign()) {
                     case Instruction.REACHED_VIA, Instruction.FINISH:

--- a/navigation/src/test/java/com/graphhopper/navigation/NavigateResponseConverterTest.java
+++ b/navigation/src/test/java/com/graphhopper/navigation/NavigateResponseConverterTest.java
@@ -614,6 +614,36 @@ public class NavigateResponseConverterTest {
         assertEquals(route.get("distance").asDouble(), distance, 1);
     }
 
+
+    @Test
+    public void testMultipleWaypointsAndLastDuplicate() {
+
+        GHRequest request = new GHRequest();
+        request.addPoint(new GHPoint(42.505144, 1.526113));
+        request.addPoint(new GHPoint(42.50529, 1.527218));
+        request.addPoint(new GHPoint(42.50529, 1.527218));
+        request.setProfile(profile).setPathDetails(Collections.singletonList("intersection"));
+
+        GHResponse rsp = hopper.route(request);
+
+        ObjectNode json = NavigateResponseConverter.convertFromGHResponse(rsp, trMap, Locale.ENGLISH, distanceConfig);
+
+        // Check that all waypoints are there and in the right order
+        JsonNode waypointsJson = json.get("waypoints");
+        assertEquals(3, waypointsJson.size());
+
+        // Check that there are 2 legs
+        JsonNode route = json.get("routes").get(0);
+        JsonNode legs = route.get("legs");
+        assertEquals(2, legs.size());
+
+        // check last leg
+        JsonNode leg = legs.get(1);
+
+        JsonNode summary = leg.get("summary");
+        assertNotNull(summary);
+    }
+
     @Test
     public void testError() {
         GHResponse rsp = hopper.route(new GHRequest(42.554851, 111.536198, 42.510071, 1.548128).setProfile(profile));


### PR DESCRIPTION
Fix the edge case that part of the necessary fields (like "summary") is missing in case a leg has no intermediate routing instructions.