### PR TITLE
remove scenic=yes

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonPriorityParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonPriorityParser.java
@@ -166,8 +166,8 @@ public abstract class BikeCommonPriorityParser implements TagParser {
             );
         }
 
-        // Increase the priority for scenic routes or in case that maxspeed limits our average speed as compensation. See #630
-        if (way.hasTag("scenic", "yes") || maxSpeed > 0 && maxSpeed <= wayTypeSpeed) {
+        // Increase priority in case that maxspeed limits our average speed as compensation. See #630
+        if (maxSpeed > 0 && maxSpeed <= wayTypeSpeed) {
             PriorityCode lastEntryValue = weightToPrioMap.lastEntry().getValue();
             if (lastEntryValue.getValue() < BEST.getValue())
                 weightToPrioMap.put(110d, lastEntryValue.better());

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/BikeTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/BikeTagParserTest.java
@@ -73,8 +73,9 @@ public class BikeTagParserTest extends AbstractBikeTagParserTester {
         way.setTag("highway", "primary");
         assertPriorityAndSpeed(BAD, 18, way);
 
+        // ignore scenic as it is a too generic indication and not for bike and can therefor lead to wrong suggestions
         way.setTag("scenic", "yes");
-        assertPriorityAndSpeed(AVOID_MORE, 18, way);
+        assertPriorityAndSpeed(BAD, 18, way);
 
         way.clearTags();
         way.setTag("highway", "living_street");


### PR DESCRIPTION
`scenic=yes` might be "nice" but not necessarily "nice" for bikes. See the [wiki page](https://wiki.openstreetmap.org/wiki/Key:scenic)? 

E.g. see [this OSM way](https://www.openstreetmap.org/way/169798802) which explicitly lists `class:bicycle=-2` and [we choose the secondary](https://graphhopper.com/maps/?point=48.059781%2C11.376165&point=48.016933%2C11.351414&profile=bike) because of that. With this fix everything is fine (at least locally)

<img width="1046" height="815" alt="image" src="https://github.com/user-attachments/assets/04636fd2-33ed-4ea8-ad12-e2d83892de67" />
