### PR TITLE
consider bicycle=optional_sidepath

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonPriorityParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonPriorityParser.java
@@ -129,6 +129,8 @@ public abstract class BikeCommonPriorityParser implements TagParser {
 
         if (way.hasTag("bicycle", "use_sidepath")) {
             weightToPrioMap.put(100d, REACH_DESTINATION);
+        } else if (way.hasTag("bicycle", "optional_sidepath")) {
+            weightToPrioMap.put(100d, AVOID);
         }
 
         Set<String> cyclewayValues = Stream.of("cycleway", "cycleway:left", "cycleway:both", "cycleway:right").map(key -> way.getTag(key, "")).collect(Collectors.toSet());

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/BikeTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/BikeTagParserTest.java
@@ -95,6 +95,9 @@ public class BikeTagParserTest extends AbstractBikeTagParserTester {
         way.setTag("bicycle", "use_sidepath");
         assertPriorityAndSpeed(REACH_DESTINATION, 18, way);
 
+        way.setTag("bicycle", "optional_sidepath");
+        assertPriorityAndSpeed(AVOID, 18.0, way);
+
         way.clearTags();
         way.setTag("highway", "secondary");
         way.setTag("bicycle", "dismount");


### PR DESCRIPTION
For example [this route](https://graphhopper.com/maps/?point=52.506919%2C13.476185&point=52.502923%2C13.4739&profile=bike&layer=OpenStreetMap) prefers the residential because [the cycleway](https://www.openstreetmap.org/way/892641895) has surface=paving_stones (16km/h) and smoothness=intermediate (0.9=>14km/h). The intermediate tagging is questionable in this case according to mapillary but if we consider bicycle=optional_sidepath the route is as intended and should be useful for other cases.