### PR TITLE
bike: allow higher speed for living_street if explicitly allowed

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonAverageSpeedParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonAverageSpeedParser.java
@@ -41,7 +41,7 @@ public abstract class BikeCommonAverageSpeedParser extends AbstractAverageSpeedP
         setSurfaceSpeed("asphalt", 18);
         setSurfaceSpeed("cobblestone", 8);
         setSurfaceSpeed("cobblestone:flattened", 10);
-        setSurfaceSpeed("sett", 10);
+        setSurfaceSpeed("sett", 12);
         setSurfaceSpeed("concrete", 18);
         setSurfaceSpeed("concrete:lanes", 16);
         setSurfaceSpeed("concrete:plates", 16);
@@ -172,6 +172,10 @@ public abstract class BikeCommonAverageSpeedParser extends AbstractAverageSpeedP
                         speed = Math.max(speed, highwaySpeeds.get("cycleway"));
                     else if (bikeAllowed)
                         speed = Math.max(speed, 12);
+                case "living_street":
+                    if(bikeAllowed)
+                        // if explicitly allowed then allow speeds above limit to get more realistic routes and ETAs
+                        speed = bikeDesignated ? Math.max(speed, 12) : Math.max(speed, 10);
             }
         }
 

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/BikeTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/BikeTagParserTest.java
@@ -80,6 +80,10 @@ public class BikeTagParserTest extends AbstractBikeTagParserTester {
         way.clearTags();
         way.setTag("highway", "living_street");
         assertPriorityAndSpeed(UNCHANGED, 6, way);
+        way.setTag("bicycle", "yes");
+        assertPriorityAndSpeed(UNCHANGED, 10, way);
+        way.setTag("bicycle", "designated");
+        assertPriorityAndSpeed(PREFER, 12, way);
 
         // Pushing section: this is fine as we obey the law!
         way.clearTags();


### PR DESCRIPTION
We had a similar issue here #3029.

But still currently we make unnecessary detours for living_street like [here](https://graphhopper.com/maps/?point=51.099724%2C13.679337&point=51.102439%2C13.681118&profile=bike) (420 vs 820m). Increasing priority while keeping the speed is not a good solution as in other cases the living_street should not be overly preferred.