### PR TITLE
Fix missing instructions at forks where side road is slower

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/InstructionsFromEdges.java
+++ b/core/src/main/java/com/graphhopper/routing/InstructionsFromEdges.java
@@ -468,6 +468,21 @@ public class InstructionsFromEdges implements Path.EdgeVisitor {
             return sign;
         }
 
+        if (outgoingEdgesAreSlower) {
+            EdgeIterator iter = allExplorer.setBaseNode(baseNode);
+            while (iter.next()) {
+                if (iter.getEdge() == edge.getEdge())
+                    continue;
+                if (iter.getAdjNode() == prevNode)
+                    continue;
+                GHPoint tmpPoint = InstructionsHelper.getPointForOrientationCalculation(iter, nodeAccess);
+                double otherDelta = InstructionsHelper.calculateOrientationDelta(prevLat, prevLon, tmpPoint.getLat(), tmpPoint.getLon(), prevOrientation);
+                if (Math.abs(otherDelta) < 1.3) {
+                    return sign;
+                }
+            }
+        }
+
         return Instruction.IGNORE;
     }
 


### PR DESCRIPTION
Fixes missing instructions at splits (Y-forks) where the side road is significantly slower.

Added a fallback check using EdgeIterator. If the instruction is about to be suppressed due to speed, we check the geometry of the outgoing edges. If we find a valid edge with a shallow angle (< 1.3 rad), we force the instruction to be generated.

I tested this on [this road](https://graphhopper.com/maps/?point=51.302192%2C14.315739&point=51.300985%2C14.3134&profile=car) and it works. The turn angle there is 1.19, which is captured by the 1.3 threshold, correctly returning a "Turn slight right".

<img width="1024" height="522" alt="Image" src="https://github.com/user-attachments/assets/b9ac4b4c-b0a5-43e1-a979-61156f0ca3c7" />