### PR TITLE
Create barrier node copies directly as tower nodes

### DIFF
--- a/core/src/main/java/com/graphhopper/reader/osm/OSMNodeData.java
+++ b/core/src/main/java/com/graphhopper/reader/osm/OSMNodeData.java
@@ -76,8 +76,6 @@ class OSMNodeData {
 
     private int nextTowerId = 0;
     private long nextPillarId = 0;
-    // we use negative ids to create artificial OSM node ids
-    private long nextArtificialOSMNodeId = -Long.MAX_VALUE;
 
     public OSMNodeData(PointAccess nodeAccess, Directory directory) {
         // We use a b-tree that can store as many entries as there are longs. A tree is also more
@@ -181,19 +179,20 @@ class OSMNodeData {
     }
 
     /**
-     * Creates a copy of the coordinates stored for the given node ID
-     *
-     * @return the (artificial) OSM node ID created for the copied node and the associated ID
+     * Creates a copy of the given node as a new tower node. Barrier copies are always at segment
+     * boundaries, so they always become tower nodes — we create them directly as tower nodes
+     * instead of going through the pillar→tower roundtrip.
      */
     SegmentNode addCopyOfNode(SegmentNode node) {
         GHPoint3D point = getCoordinates(node.id);
         if (point == null)
             throw new IllegalStateException("Cannot copy node : " + node.osmNodeId + ", because it is missing");
-        final long newOsmId = nextArtificialOSMNodeId++;
-        if (idsByOsmNodeIds.put(newOsmId, INTERMEDIATE_NODE) != EMPTY_NODE)
-            throw new IllegalStateException("Artificial osm node id already exists: " + newOsmId);
-        long id = addPillarNode(newOsmId, point.getLat(), point.getLon(), point.getEle());
-        return new SegmentNode(newOsmId, id, node.tags);
+        towerNodes.setNode(nextTowerId, point.getLat(), point.getLon(), point.getEle());
+        long id = towerNodeToId(nextTowerId);
+        nextTowerId++;
+        if (nextTowerId == Integer.MAX_VALUE)
+            throw new IllegalStateException("Tower node id overflow, too many tower nodes");
+        return new SegmentNode(node.osmNodeId, id, node.tags);
     }
 
     long convertPillarToTowerNode(long id, long osmNodeId) {

--- a/core/src/test/java/com/graphhopper/reader/osm/OSMReaderTest.java
+++ b/core/src/test/java/com/graphhopper/reader/osm/OSMReaderTest.java
@@ -49,6 +49,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Set;
 
 import static com.graphhopper.json.Statement.Else;
 import static com.graphhopper.json.Statement.If;
@@ -360,18 +361,21 @@ public class OSMReaderTest {
         assertEquals(7, graph.getEdges());
 
         int n10 = AbstractGraphStorageTester.getIdOf(graph, 51);
-        int n20 = AbstractGraphStorageTester.getIdOf(graph, 52);
         int n30 = AbstractGraphStorageTester.getIdOf(graph, 53);
         int n50 = AbstractGraphStorageTester.getIdOf(graph, 55);
 
-        // separate id
-        int new20 = 4;
+        // OSM node 20 was split because of the barrier: the original n20 connects to n10,
+        // the copy (new20) connects to n30
+        Set<Integer> n10Neighbors = GHUtility.getNeighbors(carOutExplorer.setBaseNode(n10));
+        n10Neighbors.remove(n30);
+        int n20 = n10Neighbors.iterator().next();
+        Set<Integer> n30Neighbors = GHUtility.getNeighbors(carOutExplorer.setBaseNode(n30));
+        n30Neighbors.removeAll(Set.of(n10, n50));
+        int new20 = n30Neighbors.iterator().next();
         assertNotEquals(n20, new20);
         NodeAccess na = graph.getNodeAccess();
         assertEquals(na.getLat(n20), na.getLat(new20), 1e-5);
         assertEquals(na.getLon(n20), na.getLon(new20), 1e-5);
-
-        assertEquals(n20, findID(hopper.getLocationIndex(), 52, 9.4));
 
         assertEquals(GHUtility.asSet(n20, n30), GHUtility.getNeighbors(carOutExplorer.setBaseNode(n10)));
         assertEquals(GHUtility.asSet(new20, n10, n50), GHUtility.getNeighbors(carOutExplorer.setBaseNode(n30)));

--- a/web/src/test/java/com/graphhopper/application/resources/RouteResourceLeipzigTest.java
+++ b/web/src/test/java/com/graphhopper/application/resources/RouteResourceLeipzigTest.java
@@ -80,8 +80,8 @@ public class RouteResourceLeipzigTest {
 
     @ParameterizedTest
     @CsvSource(value = {
-            "84,-1,algorithm=" + DIJKSTRA_BI,
-            "89,-1,algorithm=" + ASTAR_BI,
+            "93,-1,algorithm=" + DIJKSTRA_BI,
+            "125,-1,algorithm=" + ASTAR_BI,
             "30743,1,ch.disable=true&algorithm=" + DIJKSTRA,
             "21133,1,ch.disable=true&algorithm=" + ASTAR,
             "14866,1,ch.disable=true&algorithm=" + DIJKSTRA_BI,


### PR DESCRIPTION
Barrier copies always end up as tower nodes at segment boundaries, so create them directly instead of storing them temporarily in idsByOsmNodeIds (from which they ended up as tower nodes too). Also there is no need for artificial OSM ids anymore. The graph topology should stay but the tower node IDs are assigned in a different order (this changed order should still remain even through hilbert ordering as coordinates are identical).