### PR TITLE
Slope and curvature calculation must be done after bridge/tunnel interpolation

### DIFF
--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -910,8 +910,25 @@ public class GraphHopper {
         if (hasElevation())
             interpolateBridgesTunnelsAndFerries();
 
+        calculateSlope();
+
+        if (encodingManager.hasEncodedValue(Curvature.KEY))
+            new CurvatureCalculator(encodingManager.getDecimalEncodedValue(Curvature.KEY)).execute(baseGraph.getBaseGraph());
+
         if (sortGraph)
             sortGraphAlongHilbertCurve(baseGraph);
+    }
+
+    private void calculateSlope() {
+        if (encodingManager.hasEncodedValue(AverageSlope.KEY) || encodingManager.hasEncodedValue(MaxSlope.KEY)) {
+            if (!hasElevation())
+                throw new IllegalArgumentException("average_slope and max_slope encoded values require elevation, but no elevation provider is configured");
+            DecimalEncodedValue maxSlopeEnc = encodingManager.hasEncodedValue(MaxSlope.KEY)
+                    ? encodingManager.getDecimalEncodedValue(MaxSlope.KEY) : null;
+            DecimalEncodedValue averageSlopeEnc = encodingManager.hasEncodedValue(AverageSlope.KEY)
+                    ? encodingManager.getDecimalEncodedValue(AverageSlope.KEY) : null;
+            new SlopeCalculator(maxSlopeEnc, averageSlopeEnc).execute(baseGraph.getBaseGraph());
+        }
     }
 
     protected void importOSM() {

--- a/core/src/main/java/com/graphhopper/routing/ev/DefaultImportRegistry.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/DefaultImportRegistry.java
@@ -202,20 +202,11 @@ public class DefaultImportRegistry implements ImportRegistry {
                     (lookup, props) -> new FerrySpeedCalculator(
                             lookup.getDecimalEncodedValue(FerrySpeed.KEY)));
         else if (Curvature.KEY.equals(name))
-            return ImportUnit.create(name, props -> Curvature.create(),
-                    (lookup, props) -> new CurvatureCalculator(
-                            lookup.getDecimalEncodedValue(Curvature.KEY))
-            );
+            return ImportUnit.create(name, props -> Curvature.create(), null);
         else if (AverageSlope.KEY.equals(name))
-            return ImportUnit.create(name, props -> AverageSlope.create(), null, "slope_calculator");
+            return ImportUnit.create(name, props -> AverageSlope.create(), null);
         else if (MaxSlope.KEY.equals(name))
-            return ImportUnit.create(name, props -> MaxSlope.create(), null, "slope_calculator");
-        else if ("slope_calculator".equals(name))
-            return ImportUnit.create(name, null,
-                    (lookup, props) -> new SlopeCalculator(
-                            lookup.hasEncodedValue(MaxSlope.KEY) ? lookup.getDecimalEncodedValue(MaxSlope.KEY) : null,
-                            lookup.hasEncodedValue(AverageSlope.KEY) ? lookup.getDecimalEncodedValue(AverageSlope.KEY) : null
-                    ));
+            return ImportUnit.create(name, props -> MaxSlope.create(), null);
         else if (BikeNetwork.KEY.equals(name) || MtbNetwork.KEY.equals(name) || FootNetwork.KEY.equals(name))
             return ImportUnit.create(name, props -> RouteNetwork.create(name), null);
 

--- a/core/src/main/java/com/graphhopper/routing/util/CurvatureCalculator.java
+++ b/core/src/main/java/com/graphhopper/routing/util/CurvatureCalculator.java
@@ -1,14 +1,12 @@
 package com.graphhopper.routing.util;
 
-import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.DecimalEncodedValue;
-import com.graphhopper.routing.ev.EdgeIntAccess;
-import com.graphhopper.routing.util.parsers.TagParser;
-import com.graphhopper.storage.IntsRef;
+import com.graphhopper.storage.Graph;
 import com.graphhopper.util.DistanceCalcEarth;
+import com.graphhopper.util.FetchMode;
 import com.graphhopper.util.PointList;
 
-public class CurvatureCalculator implements TagParser {
+public class CurvatureCalculator {
 
     private final DecimalEncodedValue curvatureEnc;
 
@@ -16,21 +14,23 @@ public class CurvatureCalculator implements TagParser {
         this.curvatureEnc = curvatureEnc;
     }
 
-    @Override
-    public void handleWayTags(int edgeId, EdgeIntAccess edgeIntAccess, ReaderWay way, IntsRef relationFlags) {
-        PointList pointList = way.getTag("point_list", null);
-        Double edgeDistance = way.getTag("edge_distance", null);
-        if (pointList != null && edgeDistance != null && !pointList.isEmpty()) {
-            double lat0 = pointList.getLat(0), lon0 = pointList.getLon(0);
-            double latEnd = pointList.getLat(pointList.size() - 1), lonEnd = pointList.getLon(pointList.size() - 1);
-            double beeline = pointList.is3D() ? DistanceCalcEarth.DIST_EARTH.calcDist3D(lat0, lon0, pointList.getEle(0), latEnd, lonEnd, pointList.getEle(pointList.size() - 1))
-                    : DistanceCalcEarth.DIST_EARTH.calcDist(lat0, lon0, latEnd, lonEnd);
-            // For now keep the formula simple. Maybe later use quadratic value as it might improve the "resolution"
-            double curvature = beeline / edgeDistance;
-            curvatureEnc.setDecimal(false, edgeId, edgeIntAccess, Math.max(curvatureEnc.getMinStorableDecimal(), Math.min(curvatureEnc.getMaxStorableDecimal(),
-                    curvature)));
-        } else {
-            curvatureEnc.setDecimal(false, edgeId, edgeIntAccess, 1.0);
+    public void execute(Graph graph) {
+        AllEdgesIterator iter = graph.getAllEdges();
+        while (iter.next()) {
+            PointList pointList = iter.fetchWayGeometry(FetchMode.ALL);
+            double edgeDistance = iter.getDistance();
+            if (!pointList.isEmpty() && edgeDistance > 0) {
+                double lat0 = pointList.getLat(0), lon0 = pointList.getLon(0);
+                double latEnd = pointList.getLat(pointList.size() - 1), lonEnd = pointList.getLon(pointList.size() - 1);
+                double beeline = pointList.is3D() ? DistanceCalcEarth.DIST_EARTH.calcDist3D(lat0, lon0, pointList.getEle(0), latEnd, lonEnd, pointList.getEle(pointList.size() - 1))
+                        : DistanceCalcEarth.DIST_EARTH.calcDist(lat0, lon0, latEnd, lonEnd);
+                // For now keep the formula simple. Maybe later use quadratic value as it might improve the "resolution"
+                double curvature = beeline / edgeDistance;
+                iter.set(curvatureEnc, Math.max(curvatureEnc.getMinStorableDecimal(), Math.min(curvatureEnc.getMaxStorableDecimal(),
+                        curvature)));
+            } else {
+                iter.set(curvatureEnc, 1.0);
+            }
         }
     }
 }

--- a/core/src/test/java/com/graphhopper/routing/RoutingAlgorithmWithOSMTest.java
+++ b/core/src/test/java/com/graphhopper/routing/RoutingAlgorithmWithOSMTest.java
@@ -318,7 +318,7 @@ public class RoutingAlgorithmWithOSMTest {
     public void testMonacoBike3D() {
         List<Query> queries = new ArrayList<>();
         // 1. alternative: go over steps 'Rampe Major' => 1.7km vs. around 2.7km
-        queries.add(new Query(43.730864, 7.420771, 43.727687, 7.418737, 2702, 111));
+        queries.add(new Query(43.730864, 7.420771, 43.727687, 7.418737, 2670, 118));
         // 2.
         queries.add(new Query(43.728499, 7.417907, 43.74958, 7.436566, 4220, 233));
         // 3.
@@ -329,7 +329,7 @@ public class RoutingAlgorithmWithOSMTest {
         // try reverse direction
         // 1.
         queries.add(new Query(43.727687, 7.418737, 43.730864, 7.420771, 2598, 115));
-        queries.add(new Query(43.74958, 7.436566, 43.728499, 7.417907, 4250, 165));
+        queries.add(new Query(43.74958, 7.436566, 43.728499, 7.417907, 3977, 181));
         queries.add(new Query(43.739213, 7.427806, 43.728677, 7.41016, 2806, 145));
         // 4. avoid tunnel(s)!
         queries.add(new Query(43.739662, 7.424355, 43.733802, 7.413433, 1901, 116));
@@ -337,6 +337,7 @@ public class RoutingAlgorithmWithOSMTest {
         GraphHopper hopper = createHopper(MONACO,
                 new Profile("bike").setCustomModel(CustomModel.merge(getCustomModel("bike.json"), getCustomModel("bike_elevation.json")).
                         addToPriority(If("!bike_access", MULTIPLY, "0"))));
+        hopper.setEncodedValuesString("average_slope, max_slope, " + hopper.getEncodedValuesString());
         hopper.setElevationProvider(new SRTMProvider(DIR));
         hopper.importOrLoad();
         checkQueries(hopper, queries);
@@ -590,6 +591,7 @@ public class RoutingAlgorithmWithOSMTest {
 
         GraphHopper hopper = createHopper(BAYREUTH, new Profile("bike").setCustomModel(
                 CustomModel.merge(getCustomModel("bike.json"), getCustomModel("bike_elevation.json"))));
+        hopper.setEncodedValuesString("average_slope, max_slope, " + hopper.getEncodedValuesString());
         hopper.setElevationProvider(new SRTMProvider(DIR));
         hopper.importOrLoad();
         checkQueries(hopper, list);
@@ -705,7 +707,7 @@ public class RoutingAlgorithmWithOSMTest {
                 setStoreOnFlush(false).
                 setOSMFile(osmFile).
                 setProfiles(profiles).
-                setEncodedValuesString("average_slope, max_slope, hike_rating, car_access, car_average_speed, " +
+                setEncodedValuesString("hike_rating, car_access, car_average_speed, " +
                         "foot_access, foot_priority, foot_average_speed, foot_network, " +
                         "bike_access, bike_priority, bike_average_speed, bike_network, roundabout, " +
                         "mtb_access, mtb_priority, mtb_average_speed, mtb_rating, " +

--- a/core/src/test/java/com/graphhopper/routing/util/SlopeCalculatorTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/SlopeCalculatorTest.java
@@ -1,12 +1,16 @@
 package com.graphhopper.routing.util;
 
-import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.*;
-import com.graphhopper.storage.IntsRef;
+import com.graphhopper.storage.BaseGraph;
+import com.graphhopper.storage.NodeAccess;
+import com.graphhopper.util.DistanceCalcEarth;
+import com.graphhopper.util.EdgeIteratorState;
+import com.graphhopper.util.FetchMode;
 import com.graphhopper.util.PointList;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class SlopeCalculatorTest {
 
@@ -14,106 +18,99 @@ class SlopeCalculatorTest {
     void simpleElevation() {
         DecimalEncodedValue averageEnc = AverageSlope.create();
         DecimalEncodedValue maxEnc = MaxSlope.create();
-        new EncodingManager.Builder().add(averageEnc).add(maxEnc).build();
-        SlopeCalculator creator = new SlopeCalculator(maxEnc, averageEnc);
-        EdgeIntAccess edgeIntAccess = new ArrayEdgeIntAccess(1);
-        int edgeId = 0;
-        ReaderWay way = new ReaderWay(1L);
-        PointList pointList = new PointList(5, true);
-        pointList.add(51.0, 12.001, 0);
-        pointList.add(51.0, 12.002, 3.5); // ~70m
-        pointList.add(51.0, 12.003, 4); // ~140m
-        pointList.add(51.0, 12.004, 2); // ~210m
-        way.setTag("point_list", pointList);
-        creator.handleWayTags(edgeId, edgeIntAccess, way, IntsRef.EMPTY);
+        EncodingManager em = new EncodingManager.Builder().add(averageEnc).add(maxEnc).build();
+        BaseGraph graph = new BaseGraph.Builder(em).set3D(true).create();
+        NodeAccess na = graph.getNodeAccess();
+        na.setNode(0, 51.0, 12.001, 0);
+        na.setNode(1, 51.0, 12.004, 2);
+        PointList pillarNodes = new PointList(3, true);
+        pillarNodes.add(51.0, 12.002, 3.5);
+        pillarNodes.add(51.0, 12.003, 4);
+        EdgeIteratorState edge = graph.edge(0, 1).setWayGeometry(pillarNodes);
+        edge.setDistance(DistanceCalcEarth.calcDistance(edge.fetchWayGeometry(FetchMode.ALL), false));
 
-        assertEquals(Math.round(2.0 / 210 * 100), averageEnc.getDecimal(false, edgeId, edgeIntAccess), 1e-3);
-        assertEquals(-Math.round(2.0 / 210 * 100), averageEnc.getDecimal(true, edgeId, edgeIntAccess), 1e-3);
+        new SlopeCalculator(maxEnc, averageEnc).execute(graph);
 
-        assertEquals(Math.round(1.75 / 105 * 100), maxEnc.getDecimal(false, edgeId, edgeIntAccess), 1e-3);
-        assertEquals(-Math.round(1.75 / 105 * 100), maxEnc.getDecimal(true, edgeId, edgeIntAccess), 1e-3);
+        assertEquals(Math.round(2.0 / 210 * 100), edge.get(averageEnc), 1e-3);
+        assertEquals(-Math.round(2.0 / 210 * 100), edge.getReverse(averageEnc), 1e-3);
+
+        assertEquals(Math.round(1.75 / 105 * 100), edge.get(maxEnc), 1e-3);
+        assertEquals(-Math.round(1.75 / 105 * 100), edge.getReverse(maxEnc), 1e-3);
     }
 
     @Test
     public void testAveragingOfMaxSlope() {
-        // point=49.977518%2C11.564285&point=49.979878%2C11.563663&profile=bike
         DecimalEncodedValue averageEnc = AverageSlope.create();
         DecimalEncodedValue maxEnc = MaxSlope.create();
-        new EncodingManager.Builder().add(averageEnc).add(maxEnc).build();
-        SlopeCalculator creator = new SlopeCalculator(maxEnc, averageEnc);
-        ArrayEdgeIntAccess intAccess = new ArrayEdgeIntAccess(1);
-        int edgeId = 0;
-        ReaderWay way = new ReaderWay(1L);
-        PointList pointList = new PointList(5, true);
-        pointList.add(51.0, 12.0010, 10);
-        pointList.add(51.0, 12.0014, 8); // 28m
-        pointList.add(51.0, 12.0034, 8); // 140m
-        pointList.add(51.0, 12.0054, 0); // 140m
-        pointList.add(51.0, 12.0070, 7); // 112m
-        way.setTag("point_list", pointList);
-        creator.handleWayTags(edgeId, intAccess, way, IntsRef.EMPTY);
+        EncodingManager em = new EncodingManager.Builder().add(averageEnc).add(maxEnc).build();
+        BaseGraph graph = new BaseGraph.Builder(em).set3D(true).create();
+        NodeAccess na = graph.getNodeAccess();
+        na.setNode(0, 51.0, 12.0010, 10);
+        na.setNode(1, 51.0, 12.0070, 7);
+        PointList pillarNodes = new PointList(3, true);
+        pillarNodes.add(51.0, 12.0014, 8);
+        pillarNodes.add(51.0, 12.0034, 8);
+        pillarNodes.add(51.0, 12.0054, 0);
+        EdgeIteratorState edge = graph.edge(0, 1).setWayGeometry(pillarNodes);
+        edge.setDistance(DistanceCalcEarth.calcDistance(edge.fetchWayGeometry(FetchMode.ALL), false));
 
-        assertEquals(-Math.round(8.0 / 210 * 100), maxEnc.getDecimal(false, edgeId, intAccess), 1e-3);
-        assertEquals(Math.round(8.0 / 210 * 100), maxEnc.getDecimal(true, edgeId, intAccess), 1e-3);
+        new SlopeCalculator(maxEnc, averageEnc).execute(graph);
+
+        assertEquals(-Math.round(8.0 / 210 * 100), edge.get(maxEnc), 1e-3);
+        assertEquals(Math.round(8.0 / 210 * 100), edge.getReverse(maxEnc), 1e-3);
     }
 
     @Test
     public void testMaxSlopeLargerThanMaxStorableDecimal() {
-        PointList pointList = new PointList(5, true);
-        pointList.add(47.7281561, 11.9993135, 1163.0);
-        pointList.add(47.7282782, 11.9991944, 1163.0);
-        pointList.add(47.7283135, 11.9991135, 1178.0);
-        ReaderWay way = new ReaderWay(1);
-        way.setTag("point_list", pointList);
-        ArrayEdgeIntAccess intAccess = new ArrayEdgeIntAccess(1);
-
         DecimalEncodedValue averageEnc = AverageSlope.create();
         DecimalEncodedValue maxEnc = MaxSlope.create();
-        new EncodingManager.Builder().add(averageEnc).add(maxEnc).build();
-        SlopeCalculator creator = new SlopeCalculator(maxEnc, averageEnc);
-        int edgeId = 0;
-        creator.handleWayTags(edgeId, intAccess, way, IntsRef.EMPTY);
-        assertEquals(31, maxEnc.getDecimal(false, edgeId, intAccess), 1e-3);
-        assertEquals(-31, averageEnc.getDecimal(true, edgeId, intAccess), 1e-3);
+        EncodingManager em = new EncodingManager.Builder().add(averageEnc).add(maxEnc).build();
+        BaseGraph graph = new BaseGraph.Builder(em).set3D(true).create();
+        NodeAccess na = graph.getNodeAccess();
+        na.setNode(0, 47.7281561, 11.9993135, 1163.0);
+        na.setNode(1, 47.7283135, 11.9991135, 1178.0);
+        PointList pillarNodes = new PointList(1, true);
+        pillarNodes.add(47.7282782, 11.9991944, 1163.0);
+        EdgeIteratorState edge = graph.edge(0, 1).setWayGeometry(pillarNodes);
+        edge.setDistance(DistanceCalcEarth.calcDistance(edge.fetchWayGeometry(FetchMode.ALL), false));
+
+        new SlopeCalculator(maxEnc, averageEnc).execute(graph);
+
+        assertEquals(31, edge.get(maxEnc), 1e-3);
+        assertEquals(-31, edge.getReverse(averageEnc), 1e-3);
     }
 
     @Test
     public void testMaxSlopeSmallerThanMinStorableDecimal() {
-        PointList pointList = new PointList(5, true);
-        pointList.add(47.7283135, 11.9991135, 1178.0);
-        pointList.add(47.7282782, 11.9991944, 1163.0);
-        pointList.add(47.7281561, 11.9993135, 1163.0);
-
-        ReaderWay way = new ReaderWay(1);
-        way.setTag("point_list", pointList);
-        ArrayEdgeIntAccess intAccess = new ArrayEdgeIntAccess(1);
-
         DecimalEncodedValue averageEnc = AverageSlope.create();
         DecimalEncodedValue maxEnc = MaxSlope.create();
-        new EncodingManager.Builder().add(averageEnc).add(maxEnc).build();
-        SlopeCalculator creator = new SlopeCalculator(maxEnc, averageEnc);
+        EncodingManager em = new EncodingManager.Builder().add(averageEnc).add(maxEnc).build();
+        BaseGraph graph = new BaseGraph.Builder(em).set3D(true).create();
+        NodeAccess na = graph.getNodeAccess();
+        na.setNode(0, 47.7283135, 11.9991135, 1178.0);
+        na.setNode(1, 47.7281561, 11.9993135, 1163.0);
+        PointList pillarNodes = new PointList(1, true);
+        pillarNodes.add(47.7282782, 11.9991944, 1163.0);
+        EdgeIteratorState edge = graph.edge(0, 1).setWayGeometry(pillarNodes);
+        edge.setDistance(DistanceCalcEarth.calcDistance(edge.fetchWayGeometry(FetchMode.ALL), false));
 
-        int edgeId = 0;
-        creator.handleWayTags(edgeId, intAccess, way, IntsRef.EMPTY);
-        assertEquals(-31, maxEnc.getDecimal(false, edgeId, intAccess), 1e-3);
-        assertEquals(31, averageEnc.getDecimal(true, edgeId, intAccess), 1e-3);
+        new SlopeCalculator(maxEnc, averageEnc).execute(graph);
+
+        assertEquals(-31, edge.get(maxEnc), 1e-3);
+        assertEquals(31, edge.getReverse(averageEnc), 1e-3);
     }
 
     @Test
-    public void test2D() {
-        ArrayEdgeIntAccess intAccess = new ArrayEdgeIntAccess(1);
-        int edgeId = 0;
-        PointList pointList = new PointList(5, false);
-        pointList.add(47.7283135, 11.9991135);
-        ReaderWay way = new ReaderWay(1);
-        way.setTag("point_list", pointList);
+    public void testThrowErrorFor2D() {
         DecimalEncodedValue averageEnc = AverageSlope.create();
         DecimalEncodedValue maxEnc = MaxSlope.create();
-        new EncodingManager.Builder().add(averageEnc).add(maxEnc).build();
+        EncodingManager em = new EncodingManager.Builder().add(averageEnc).add(maxEnc).build();
+        BaseGraph graph = new BaseGraph.Builder(em).create();
+        NodeAccess na = graph.getNodeAccess();
+        na.setNode(0, 47.7283135, 11.9991135);
+        na.setNode(1, 47.7281561, 11.9993135);
+        graph.edge(0, 1).setDistance(100);
 
-        SlopeCalculator creator = new SlopeCalculator(maxEnc, averageEnc);
-        creator.handleWayTags(edgeId, intAccess, way, IntsRef.EMPTY);
-        assertEquals(0, maxEnc.getDecimal(false, edgeId, intAccess), 1e-3);
-        assertEquals(0, averageEnc.getDecimal(false, edgeId, intAccess), 1e-3);
+        assertThrows(IllegalArgumentException.class, () -> new SlopeCalculator(maxEnc, averageEnc).execute(graph));
     }
 }

--- a/web/src/test/java/com/graphhopper/application/resources/RouteResourceCustomModelTest.java
+++ b/web/src/test/java/com/graphhopper/application/resources/RouteResourceCustomModelTest.java
@@ -63,6 +63,8 @@ public class RouteResourceCustomModelTest {
                 putObject("prepare.min_network_size", 200).
                 putObject("datareader.file", "../core/files/north-bayreuth.osm.gz").
                 putObject("graph.location", DIR).
+                putObject("graph.elevation.provider", "srtm").
+                putObject("graph.elevation.cache_dir", "../core/files/").
                 putObject("custom_areas.directory", "./src/test/resources/com/graphhopper/application/resources/areas").
                 putObject("import.osm.ignored_highways", "").
                 putObject("graph.encoded_values", "car_access, car_average_speed, road_access, max_speed, " +
@@ -218,7 +220,7 @@ public class RouteResourceCustomModelTest {
     }
 
     @ParameterizedTest
-    @CsvSource(value = {"0.05,3073", "0.5,1498"})
+    @CsvSource(value = {"0.05,3093", "0.5,1498"})
     public void testAvoidArea(double priority, double expectedDistance) {
         String bodyFragment = "\"points\": [[11.58199, 50.0141], [11.5865, 50.0095]], \"profile\": \"car\", \"ch.disable\": true";
         JsonNode path = getPath("{" + bodyFragment + ", \"custom_model\": {}}");
@@ -246,7 +248,7 @@ public class RouteResourceCustomModelTest {
     @Test
     public void testAvoidArea() {
         JsonNode path = getPath("{\"points\": [[11.58199, 50.0141], [11.5865, 50.0095]], \"profile\": \"car_with_area\", \"ch.disable\": true, \"custom_model\": {}}");
-        assertEquals(path.get("distance").asDouble(), 3073, 10);
+        assertEquals(path.get("distance").asDouble(), 3093, 10);
     }
 
     @Test
@@ -290,7 +292,7 @@ public class RouteResourceCustomModelTest {
                 "}";
         JsonNode path = getPath(jsonQuery);
         double expectedDistance = path.get("distance").asDouble();
-        assertEquals(4819, expectedDistance, 10);
+        assertEquals(4833, expectedDistance, 10);
     }
 
     @Test
@@ -313,14 +315,14 @@ public class RouteResourceCustomModelTest {
                 " \"ch.disable\": true" +
                 "}";
         JsonNode path = getPath(body);
-        assertEquals(8754, path.get("distance").asDouble(), 5);
+        assertEquals(8772, path.get("distance").asDouble(), 10);
 
         // CH
         body = "{\"points\": [[11.556416,50.007739], [11.528864,50.021638]]," +
                 " \"profile\": \"car_no_unclassified\"" +
                 "}";
         path = getPath(body);
-        assertEquals(8754, path.get("distance").asDouble(), 5);
+        assertEquals(8772, path.get("distance").asDouble(), 10);
 
         // different profile
         body = "{\"points\": [[11.494446, 50.027814], [11.511483, 49.987628]]," +
@@ -328,7 +330,7 @@ public class RouteResourceCustomModelTest {
                 " \"ch.disable\": true" +
                 "}";
         path = getPath(body);
-        assertEquals(5827, path.get("distance").asDouble(), 5);
+        assertEquals(5838, path.get("distance").asDouble(), 10);
     }
 
     @Test
@@ -373,15 +375,15 @@ public class RouteResourceCustomModelTest {
                 "   \"speed\": [{\"if\":\"true\", \"limit_to\":\"car_average_speed * 0.9\"}], \n" +
                 "   \"priority\": [{\"if\": \"car_access == false || hgv == NO || max_width < 3 || max_height < 4\", \"multiply_by\": \"0\"}]}}";
         JsonNode path = getPath(body);
-        assertEquals(7314, path.get("distance").asDouble(), 10);
-        assertEquals(944 * 1000, path.get("time").asLong(), 1_000);
+        assertEquals(7350, path.get("distance").asDouble(), 10);
+        assertEquals(952 * 1000, path.get("time").asLong(), 1_000);
     }
 
     @Test
     public void testTurnCosts() {
         String body = "{\"points\": [[11.508198,50.015441], [11.505063,50.01737]], \"profile\": \"car_tc_left\", \"ch.disable\":true }";
         JsonNode path = getPath(body);
-        assertEquals(1067, path.get("distance").asDouble(), 10);
+        assertEquals(1083, path.get("distance").asDouble(), 10);
     }
 
     @Test


### PR DESCRIPTION
The SlopeCalculator and CurvatureCalculator no longer implement TagParser and instead run as post-import steps in GraphHopper.postImportOSM(), after elevation interpolation for bridges/tunnels/ferries. Basically fixing the comment in SlopeCalculator:

> Probably we should somehow recalculate even the average_slope after elevation interpolation? See EdgeElevationInterpolator

Previously we explicitly excluded bridges+tunnels from the calculation but now no such workaround has to be done.

Now SlopeCalculator rejects data without elevation.