### PR TITLE
bike dismount should ignore surface+smoothness

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonAverageSpeedParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonAverageSpeedParser.java
@@ -170,14 +170,15 @@ public abstract class BikeCommonAverageSpeedParser extends AbstractAverageSpeedP
                         // if explicitly allowed then allow speeds above limit to get more realistic routes and ETAs
                         speed = bikeDesignated ? Math.max(speed, 12) : Math.max(speed, 10);
             }
+
+            // speed reduction if bad surface
+            if (surfaceSpeed != null)
+                speed = Math.min(surfaceSpeed, speed);
+
+            Smoothness smoothness = smoothnessEnc.getEnum(false, edgeId, edgeIntAccess);
+            speed = Math.max(MIN_SPEED, smoothnessFactor.get(smoothness) * speed);
         }
 
-        // speed reduction if bad surface
-        if (surfaceSpeed != null)
-            speed = Math.min(surfaceSpeed, speed);
-
-        Smoothness smoothness = smoothnessEnc.getEnum(false, edgeId, edgeIntAccess);
-        speed = Math.max(MIN_SPEED, smoothnessFactor.get(smoothness) * speed);
         setSpeed(false, edgeId, edgeIntAccess, applyMaxSpeed(way, speed, false));
         if (avgSpeedEnc.isStoreTwoDirections())
             setSpeed(true, edgeId, edgeIntAccess, applyMaxSpeed(way, speed, true));

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/AbstractBikeTagParserTester.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/AbstractBikeTagParserTester.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static com.graphhopper.routing.util.PriorityCode.*;
+import static com.graphhopper.routing.util.parsers.BikeCommonAverageSpeedParser.PUSHING_SECTION_SPEED;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -288,7 +289,7 @@ public abstract class AbstractBikeTagParserTester {
         int edgeId = 0;
         accessParser.handleWayTags(edgeId, intAccess, way, null);
         speedParser.handleWayTags(edgeId, intAccess, way, null);
-        assertEquals(4.0, avgSpeedEnc.getDecimal(false, edgeId, intAccess));
+        assertEquals(PUSHING_SECTION_SPEED, avgSpeedEnc.getDecimal(false, edgeId, intAccess));
         assertTrue(accessEnc.getBool(false, edgeId, intAccess));
 
         way = new ReaderWay(1);
@@ -298,7 +299,7 @@ public abstract class AbstractBikeTagParserTester {
         assertTrue(accessEnc.getBool(false, edgeId, intAccess));
 
         speedParser.handleWayTags(edgeId, intAccess, way, null);
-        assertEquals(4, avgSpeedEnc.getDecimal(false, edgeId, intAccess));
+        assertEquals(PUSHING_SECTION_SPEED, avgSpeedEnc.getDecimal(false, edgeId, intAccess));
 
         way = new ReaderWay(1);
         way.setTag("highway", "track");
@@ -348,7 +349,7 @@ public abstract class AbstractBikeTagParserTester {
         assertPriorityAndSpeed(PREFER, 12, way);
 
         way.setTag("service", "parking_aisle");
-        assertPriorityAndSpeed(SLIGHT_AVOID, 4, way);
+        assertPriorityAndSpeed(SLIGHT_AVOID, PUSHING_SECTION_SPEED, way);
         way.setTag("bicycle", "designated");
         assertPriorityAndSpeed(VERY_NICE, 12, way);
     }

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/BikeTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/BikeTagParserTest.java
@@ -106,6 +106,14 @@ public class BikeTagParserTest extends AbstractBikeTagParserTester {
         way.setTag("bicycle", "dismount");
         assertPriorityAndSpeed(AVOID, PUSHING_SECTION_SPEED, way);
 
+        // if already pushing the bike the surface should not matter much
+        way.clearTags();
+        way.setTag("highway", "path");
+        way.setTag("bicycle", "dismount");
+        way.setTag("smoothness", "bad");
+        way.setTag("surface", "fine_gravel");
+        assertPriorityAndSpeed(SLIGHT_AVOID, PUSHING_SECTION_SPEED, way);
+
         way.clearTags();
         way.setTag("highway", "primary");
         way.setTag("surface", "fine_gravel");
@@ -377,7 +385,7 @@ public class BikeTagParserTest extends AbstractBikeTagParserTester {
         way.clearTags();
         way.setTag("highway", "track");
         way.setTag("tracktype", "grade5");
-        assertEquals(4, getSpeedFromFlags(way), 0.01);
+        assertEquals(PUSHING_SECTION_SPEED, getSpeedFromFlags(way), 0.01);
 
         way.setTag("smoothness", "bad");
         assertEquals(2, getSpeedFromFlags(way), 0.01);

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/RacingBikeTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/RacingBikeTagParserTest.java
@@ -91,7 +91,7 @@ public class RacingBikeTagParserTest extends AbstractBikeTagParserTester {
         assertPriorityAndSpeed(SLIGHT_AVOID, 12, way);
 
         way.setTag("service", "parking_aisle");
-        assertPriorityAndSpeed(SLIGHT_AVOID, 4, way);
+        assertPriorityAndSpeed(SLIGHT_AVOID, PUSHING_SECTION_SPEED, way);
     }
 
     @Test
@@ -123,11 +123,11 @@ public class RacingBikeTagParserTest extends AbstractBikeTagParserTester {
         way.setTag("highway", "track");
         way.setTag("tracktype", "grade3");
         // use pushing section
-        assertEquals(4, getSpeedFromFlags(way), 1e-1);
+        assertEquals(PUSHING_SECTION_SPEED, getSpeedFromFlags(way), 1e-1);
 
         // Even if it is part of a cycle way
         way.setTag("bicycle", "yes");
-        assertEquals(4, getSpeedFromFlags(way), 1e-1);
+        assertEquals(PUSHING_SECTION_SPEED, getSpeedFromFlags(way), 1e-1);
 
         way.clearTags();
         way.setTag("highway", "steps");
@@ -177,10 +177,10 @@ public class RacingBikeTagParserTest extends AbstractBikeTagParserTester {
         way.clearTags();
         way.setTag("highway", "track");
         way.setTag("tracktype", "grade5");
-        assertEquals(4, getSpeedFromFlags(way), 0.01);
+        assertEquals(PUSHING_SECTION_SPEED, getSpeedFromFlags(way), 0.01);
 
         way.setTag("smoothness", "bad");
-        assertEquals(MIN_SPEED, getSpeedFromFlags(way), 0.01);
+        assertEquals(2, getSpeedFromFlags(way), 0.01);
 
         way.setTag("smoothness", "impassable");
         assertEquals(MIN_SPEED, getSpeedFromFlags(way), 0.01);
@@ -223,7 +223,7 @@ public class RacingBikeTagParserTest extends AbstractBikeTagParserTester {
         osmWay.clearTags();
         osmWay.setTag("highway", "track");
         osmWay.setTag("tracktype", "grade3");
-        assertPriorityAndSpeed(AVOID_MORE, 4, osmWay);
+        assertPriorityAndSpeed(AVOID_MORE, PUSHING_SECTION_SPEED, osmWay);
     }
 
     @Test


### PR DESCRIPTION
[Our current route choice here](https://graphhopper.com/maps/?point=51.193154%2C13.362408&point=51.195171%2C13.374167&profile=bike&layer=TF+Cycle) is a detour and more dangerous:

<img width="1030" height="428" alt="image" src="https://github.com/user-attachments/assets/8236c6af-1fc0-4480-9ae1-48ce80be3385" />

than how the bike network was intended.

The problem is the double penalty we give to [this way](https://www.openstreetmap.org/way/229899458) because of the dismount and bad smoothness etc. If we are already pushing the surface shouldn't have a (big) impact how slow it is.