### PR TITLE
bike: consider implicit access via highway=cycleway

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonAccessParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonAccessParser.java
@@ -75,6 +75,10 @@ public abstract class BikeCommonAccessParser extends AbstractAccessParser implem
         if (way.hasTag("bicycle", "dismount"))
             return WayAccess.WAY;
 
+        // if bicycle=* is missing we assume access
+        if ((way.hasTag("bicycle_road", "yes") || way.hasTag("highway", "cycleway")) && !way.hasTag("bicycle"))
+            return WayAccess.WAY;
+
         int firstIndex = way.getFirstIndex(restrictionKeys);
         if (firstIndex >= 0) {
             String firstValue = way.getTag(restrictionKeys.get(firstIndex), "");

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/BikeTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/BikeTagParserTest.java
@@ -473,7 +473,9 @@ public class BikeTagParserTest extends AbstractBikeTagParserTester {
         way.clearTags();
         way.setTag("highway", "cycleway");
         way.setTag("access", "no");
-        assertTrue(accessParser.getAccess(way).canSkip());
+        // assume tagging mistake (if highway=cycleway)
+        assertTrue(accessParser.getAccess(way).isWay());
+        // only if explicitly forbidden we follow
         way.setTag("bicycle", "no");
         assertTrue(accessParser.getAccess(way).canSkip());
 
@@ -501,6 +503,26 @@ public class BikeTagParserTest extends AbstractBikeTagParserTester {
         way.setTag("vehicle", "forestry");
         assertTrue(accessParser.getAccess(way).isWay());
         way.setTag("vehicle", "agricultural;forestry");
+        assertTrue(accessParser.getAccess(way).isWay());
+
+        // with access=agricultural we are rather strict (with vehicle=agricultural we can push the bike)
+        way.clearTags();
+        way.setTag("highway", "tertiary");
+        way.setTag("access", "agricultural");
+        assertFalse(accessParser.getAccess(way).isWay());
+        way.setTag("bicycle", "yes");
+        assertTrue(accessParser.getAccess(way).isWay());
+
+        way.clearTags();
+        way.setTag("highway", "tertiary");
+        way.setTag("access", "agricultural");
+        way.setTag("bicycle_road", "yes");
+        assertTrue(accessParser.getAccess(way).isWay());
+
+        // ignore access restriction for highway=cycleway
+        way.clearTags();
+        way.setTag("highway", "cycleway");
+        way.setTag("access", "agricultural");
         assertTrue(accessParser.getAccess(way).isWay());
     }
 


### PR DESCRIPTION
[Here](https://www.openstreetmap.org/way/89482973) is a real world example which we currently exclude.

Or maybe we are a bit too strict regarding access=agricultural? See e.g. [this way](https://www.openstreetmap.org/way/34540645) which we currently exclude but e.g. komoot allows.