### PR TITLE
Define HK bike rules separately from UK rules

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMRoadAccessParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMRoadAccessParser.java
@@ -227,9 +227,13 @@ public class OSMRoadAccessParser<T extends Enum> implements TagParser {
                         || roadClass == RoadClass.BRIDLEWAY) return BikeRoadAccess.NO;
                 else if (roadClass == RoadClass.PEDESTRIAN) return BikeRoadAccess.YES;
             }
-            case GRC, GBR, HKG, IRL -> {
+            case GRC, GBR, IRL -> {
                 if (roadClass == RoadClass.PEDESTRIAN
                         || roadClass == RoadClass.FOOTWAY) return BikeRoadAccess.NO;
+            }
+            case HKG -> {
+                if (roadClass == RoadClass.PEDESTRIAN
+                        || roadClass == RoadClass.FOOTWAY) return BikeRoadAccess.DISMOUNT;
             }
             case HUN -> {
                 if (roadClass == RoadClass.TRUNK


### PR DESCRIPTION
This resolves #3289.

This is done by splitting off the Hong Kong bike rules from the UK bike rules. As Hong Kong currently does not have comprehensive signage and legislation around bikes, bikes are allowed to go through regular foot paths on the condition that the cyclists must dismount when going through such foot paths (e.g. dismount when using pedestrian crossings).

This essentially means cyclists may use regular footpaths as low-priority roads, and will still strongly prefer using existing cycling infrastructure.