### PR TITLE
bike: fix problem with agricultural

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonAccessParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonAccessParser.java
@@ -71,8 +71,8 @@ public abstract class BikeCommonAccessParser extends AbstractAccessParser implem
         if (!allowedHighways.contains(highwayValue))
             return WayAccess.CAN_SKIP;
 
-        // use the way for pushing
-        if (way.hasTag("bicycle", "dismount"))
+        if (way.hasTag("bicycle", "dismount") // use the way for pushing
+                || "cycleway".equals(highwayValue) && !way.hasTag("bicycle", "no")) // cycleway gets bicycle=yes by default
             return WayAccess.WAY;
 
         int firstIndex = way.getFirstIndex(restrictionKeys);

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/BikeTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/BikeTagParserTest.java
@@ -23,6 +23,7 @@ import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.*;
 import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.routing.util.PriorityCode;
+import com.graphhopper.routing.util.WayAccess;
 import com.graphhopper.util.PMap;
 import org.junit.jupiter.api.Test;
 
@@ -473,7 +474,16 @@ public class BikeTagParserTest extends AbstractBikeTagParserTester {
         way.clearTags();
         way.setTag("highway", "cycleway");
         way.setTag("access", "no");
+        // Tagging mistake and bikes should have access to their cycleway
+        // And if it would be a constructions: should be mapped as highway=construction
+        assertTrue(accessParser.getAccess(way).isWay());
+        way.setTag("bicycle", "no");
         assertTrue(accessParser.getAccess(way).canSkip());
+
+        way.clearTags();
+        way.setTag("highway", "cycleway");
+        way.setTag("access", "agricultural");
+        assertTrue(accessParser.getAccess(way).isWay());
         way.setTag("bicycle", "no");
         assertTrue(accessParser.getAccess(way).canSkip());
 


### PR DESCRIPTION
See [this inaccessible OSM way](https://www.openstreetmap.org/way/89482973) or [this route](https://graphhopper.com/maps/?point=51.19367%2C13.388138&point=51.195114%2C13.390896&point=51.19464%2C13.395275&profile=bike&layer=Omniscale).

Now access restrictions for highway=cycleway have a bit of a history: #870 and #2980 with PR #2981.
From that I can read that highway=cycleway is nothing special regarding access/vehicle=no and so we then assume dismount for all highway=*.
But now for access=agricultural it also restricts access which it should not because `highway=cycleway` should be something special as bicycle=yes by default (even if not tagged) and so access should be allowed. Or WDYT @ratrun ?