### PR TITLE
allow skipping instructions for via points (#3299)

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/Router.java
+++ b/core/src/main/java/com/graphhopper/routing/Router.java
@@ -294,6 +294,7 @@ public class Router {
     private PathMerger createPathMerger(GHRequest request, Weighting weighting, Graph graph) {
         boolean enableInstructions = request.getHints().getBool(Parameters.Routing.INSTRUCTIONS, routerConfig.isInstructionsEnabled());
         boolean calcPoints = request.getHints().getBool(Parameters.Routing.CALC_POINTS, routerConfig.isCalcPoints());
+        boolean skipViaInstructions = request.getHints().getBool(Parameters.Routing.SKIP_VIA_INSTRUCTIONS, false);
         double wayPointMaxDistance = request.getHints().getDouble(Parameters.Routing.WAY_POINT_MAX_DISTANCE, 0.5);
         double elevationWayPointMaxDistance = request.getHints().getDouble(ELEVATION_WAY_POINT_MAX_DISTANCE, routerConfig.getElevationWayPointMaxDistance());
 
@@ -304,6 +305,7 @@ public class Router {
                 setCalcPoints(calcPoints).
                 setRamerDouglasPeucker(peucker).
                 setEnableInstructions(enableInstructions).
+                setSkipViaInstructions(skipViaInstructions).
                 setPathDetailsBuilders(pathDetailsBuilderFactory, request.getPathDetails()).
                 setSimplifyResponse(routerConfig.isSimplifyResponse() && wayPointMaxDistance > 0);
 

--- a/core/src/main/java/com/graphhopper/util/PathMerger.java
+++ b/core/src/main/java/com/graphhopper/util/PathMerger.java
@@ -53,6 +53,7 @@ public class PathMerger {
     private boolean simplifyResponse = true;
     private RamerDouglasPeucker ramerDouglasPeucker = RDP;
     private boolean calcPoints = true;
+    private boolean skipViaInstructions = false;
     private PathDetailsBuilderFactory pathBuilderFactory;
     private List<String> requestedPathDetails = Collections.emptyList();
     private double favoredHeading = Double.NaN;
@@ -85,6 +86,11 @@ public class PathMerger {
 
     public PathMerger setEnableInstructions(boolean enableInstructions) {
         this.enableInstructions = enableInstructions;
+        return this;
+    }
+
+    public PathMerger setSkipViaInstructions(boolean skipViaInstructions) {
+        this.skipViaInstructions = skipViaInstructions;
         return this;
     }
 
@@ -151,6 +157,8 @@ public class PathMerger {
 
         if (enableInstructions) {
             fullInstructions = updateInstructionsWithContext(fullInstructions);
+            if (skipViaInstructions)
+                fullInstructions = removeViaInstructions(fullInstructions);
             responsePath.setInstructions(fullInstructions);
         }
 
@@ -179,6 +187,15 @@ public class PathMerger {
             PathSimplification.simplify(responsePath, ramerDouglasPeucker, enableInstructions);
         }
         return responsePath;
+    }
+
+    private static InstructionList removeViaInstructions(InstructionList instructions) {
+        InstructionList result = new InstructionList(instructions.size(), instructions.getTr());
+        for (Instruction instruction : instructions) {
+            if (instruction.getSign() != Instruction.REACHED_VIA)
+                result.add(instruction);
+        }
+        return result;
     }
 
     /**

--- a/core/src/test/java/com/graphhopper/reader/osm/GraphHopperOSMTest.java
+++ b/core/src/test/java/com/graphhopper/reader/osm/GraphHopperOSMTest.java
@@ -629,6 +629,18 @@ public class GraphHopperOSMTest {
         assertEquals(4, rsp.getPoints().size());
         assertEquals(5, rsp.getInstructions().size());
         assertEquals(Instruction.REACHED_VIA, rsp.getInstructions().get(1).getSign());
+
+        GHRequest skipViaRequest = new GHRequest(Arrays.asList(first, second, third))
+                .setProfile(profile);
+        skipViaRequest.getHints().putObject(Parameters.Routing.SKIP_VIA_INSTRUCTIONS, true);
+        GHResponse skipViaResponse = instance.route(skipViaRequest);
+        assertFalse(skipViaResponse.hasErrors(), "should find 1->2->3 with skip_via_instructions");
+        ResponsePath skipViaPath = skipViaResponse.getBest();
+        assertEquals(4, skipViaPath.getPoints().size());
+        assertEquals(4, skipViaPath.getInstructions().size());
+        for (Instruction instruction : skipViaPath.getInstructions()) {
+            assertNotEquals(Instruction.REACHED_VIA, instruction.getSign());
+        }
     }
 
     @Test

--- a/docs/web/api-doc.md
+++ b/docs/web/api-doc.md
@@ -74,6 +74,7 @@ algorithm        |`astarbi`   | The algorithm to calculate the route. Other opti
 heading          | NaN        | Favour a heading direction for a certain point. Specify either one heading for the start point or as many as there are points. In this case headings are associated by their order to the specific points. Headings are given as north based clockwise angle between 0 and 360 degree. This parameter also influences the tour generated with `algorithm=round_trip` and forces the initial direction.
 heading_penalty  | 300        | Penalty for omitting a specified heading. The penalty corresponds to the accepted time delay in seconds in comparison to the route without a heading.
 pass_through     | `false`    | If `true` u-turns are avoided at via-points with regard to the `heading_penalty`.
+ skip_via_instructions | `false` | If `true` the response instructions will not contain entries with `sign=REACHED_VIA` (via-point/stopover instructions).
 round_trip.distance                 | 10000 | If `algorithm=round_trip` this parameter configures approximative length of the resulting round trip
 round_trip.seed                     | 0     | If `algorithm=round_trip` this parameter introduces randomness if e.g. the first try wasn't good.
 alternative_route.max_paths         | 2     | If `algorithm=alternative_route` this parameter sets the number of maximum paths which should be calculated. Increasing can lead to worse alternatives.

--- a/navigation/src/main/java/com/graphhopper/navigation/NavigateResource.java
+++ b/navigation/src/main/java/com/graphhopper/navigation/NavigateResource.java
@@ -94,6 +94,7 @@ public class NavigateResource {
             @QueryParam("overview") @DefaultValue("simplified") String overview,
             @QueryParam("geometries") @DefaultValue("polyline") String geometries,
             @QueryParam("bearings") @DefaultValue("") String bearings,
+            @QueryParam(Parameters.Routing.SKIP_VIA_INSTRUCTIONS) @DefaultValue("false") boolean skipViaInstructions,
             @QueryParam("language") @DefaultValue("en") String localeStr,
             @PathParam("profile") String mapboxProfile) {
 
@@ -120,11 +121,11 @@ public class NavigateResource {
             throw new IllegalArgumentException("Number of bearings and waypoints did not match");
         }
 
-        GHResponse ghResponse = calcRouteForGET(favoredHeadings, requestPoints, ghProfile, localeStr, enableInstructions, minPathPrecision);
+        GHResponse ghResponse = calcRouteForGET(favoredHeadings, requestPoints, ghProfile, localeStr, enableInstructions, minPathPrecision, skipViaInstructions);
 
         // Only do this, when there are more than 2 points, otherwise we use alternative routes
         if (!ghResponse.hasErrors() && !favoredHeadings.isEmpty()) {
-            GHResponse noHeadingResponse = calcRouteForGET(Collections.emptyList(), requestPoints, ghProfile, localeStr, enableInstructions, minPathPrecision);
+            GHResponse noHeadingResponse = calcRouteForGET(Collections.emptyList(), requestPoints, ghProfile, localeStr, enableInstructions, minPathPrecision, skipViaInstructions);
             if (ghResponse.getBest().getDistance() != noHeadingResponse.getBest().getDistance()) {
                 ghResponse.getAll().add(noHeadingResponse.getBest());
             }
@@ -223,7 +224,7 @@ public class NavigateResource {
     }
 
     private GHResponse calcRouteForGET(List<Double> headings, List<GHPoint> requestPoints, String profileStr,
-                                       String localeStr, boolean enableInstructions, double minPathPrecision) {
+                                       String localeStr, boolean enableInstructions, double minPathPrecision, boolean skipViaInstructions) {
         GHRequest request = new GHRequest(requestPoints);
         if (!headings.isEmpty())
             request.setHeadings(headings);
@@ -234,6 +235,7 @@ public class NavigateResource {
                 setPathDetails(List.of(INTERSECTION)).
                 putHint(CALC_POINTS, true).
                 putHint(INSTRUCTIONS, enableInstructions).
+                putHint(Parameters.Routing.SKIP_VIA_INSTRUCTIONS, skipViaInstructions).
                 putHint(WAY_POINT_MAX_DISTANCE, minPathPrecision);
 
         if (requestPoints.size() > 2 || !headings.isEmpty()) {

--- a/web-api/src/main/java/com/graphhopper/util/Parameters.java
+++ b/web-api/src/main/java/com/graphhopper/util/Parameters.java
@@ -109,6 +109,10 @@ public class Parameters {
          */
         public static final String CALC_POINTS = "calc_points";
         /**
+         * If true the response instructions will not contain via-point instructions (Instruction.REACHED_VIA).
+         */
+        public static final String SKIP_VIA_INSTRUCTIONS = "skip_via_instructions";
+        /**
          * configure simplification of returned point list
          */
         public static final String WAY_POINT_MAX_DISTANCE = "way_point_max_distance";

--- a/web/src/test/java/com/graphhopper/application/resources/RouteResourceTest.java
+++ b/web/src/test/java/com/graphhopper/application/resources/RouteResourceTest.java
@@ -256,6 +256,20 @@ public class RouteResourceTest {
     }
 
     @Test
+    public void testSkipViaInstructions() {
+        JsonNode json = clientTarget(app, "/route?profile=my_car&" +
+                "point=42.554851,1.536198&point=42.531896,1.553278&point=42.510071,1.548128&skip_via_instructions=true")
+                .request()
+                .get(JsonNode.class);
+        JsonNode path = json.get("paths").get(0);
+        JsonNode instructions = path.get("instructions");
+        assertTrue(instructions.size() > 0);
+        for (int i = 0; i < instructions.size(); i++) {
+            assertNotEquals(REACHED_VIA, instructions.get(i).get("sign").asInt());
+        }
+    }
+
+    @Test
     public void testPathDetailsRoadClass() {
         GraphHopperWeb client = new GraphHopperWeb(clientUrl(app, "/route"));
         GHRequest request = new GHRequest(42.546757, 1.528645, 42.520573, 1.557999).setProfile("my_car");


### PR DESCRIPTION
## Summary
- Add `skip_via_instructions` request flag to suppress `REACHED_VIA` (via-point) instructions while keeping other maneuver instructions intact.
- Wire the flag from request hints through `Router` to `PathMerger` and support it in the navigation GET endpoint.

Fixes #3299

## Tests
- Added/updated tests covering `skip_via_instructions=true` (core `GraphHopperOSMTest#testVia` and web `RouteResourceTest#testSkipViaInstructions`).
- `mvn clean test`