### PR TITLE
Fix roundabout exit name inheritance and prioritize destination tags (#3213, #3215)

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/InstructionsFromEdges.java
+++ b/core/src/main/java/com/graphhopper/routing/InstructionsFromEdges.java
@@ -225,7 +225,7 @@ public class InstructionsFromEdges implements Path.EdgeVisitor {
 
         } else if (prevInRoundabout) //previously in roundabout but not anymore
         {
-            prevInstruction.setName(name);
+            prevInstruction.setName(name == null ? "" : name);
             prevInstruction.setExtraInfo(STREET_REF, ref);
             prevInstruction.setExtraInfo(STREET_DESTINATION, destination);
             prevInstruction.setExtraInfo(STREET_DESTINATION_REF, destinationRef);

--- a/core/src/test/java/com/graphhopper/routing/InstructionsFromEdgesTest.java
+++ b/core/src/test/java/com/graphhopper/routing/InstructionsFromEdgesTest.java
@@ -1,0 +1,64 @@
+package com.graphhopper.routing;
+
+import com.graphhopper.routing.ev.*;
+import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.routing.weighting.SpeedWeighting;
+import com.graphhopper.routing.weighting.Weighting;
+import com.graphhopper.search.KVStorage;
+import com.graphhopper.storage.BaseGraph;
+import com.graphhopper.util.Instruction;
+import com.graphhopper.util.InstructionList;
+import com.graphhopper.util.TranslationMap;
+import org.junit.jupiter.api.Test;
+
+import java.util.Locale;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static com.graphhopper.util.Parameters.Details.STREET_DESTINATION;
+import static com.graphhopper.util.Parameters.Details.STREET_NAME;
+
+public class InstructionsFromEdgesTest {
+
+    @Test
+    public void testRoundaboutWithUnnamedExit() {
+        BooleanEncodedValue accessEnc = new SimpleBooleanEncodedValue("car_access", true);
+        DecimalEncodedValue speedEnc = new DecimalEncodedValueImpl("car_average_speed", 5, 5, true);
+        BooleanEncodedValue roundaboutEnc = new SimpleBooleanEncodedValue("roundabout", true);
+        EnumEncodedValue<RoadEnvironment> roadEnvEnc = new EnumEncodedValue<>("road_environment", RoadEnvironment.class);
+        EnumEncodedValue<RoadClass> roadClassEnc = new EnumEncodedValue<>("road_class", RoadClass.class);
+        BooleanEncodedValue roadClassLinkEnc = new SimpleBooleanEncodedValue("road_class_link", true);
+        DecimalEncodedValue maxSpeedEnc = new DecimalEncodedValueImpl("max_speed", 7, 2, true);
+
+        EncodingManager em = EncodingManager.start()
+                .add(accessEnc).add(speedEnc).add(roundaboutEnc)
+                .add(roadEnvEnc).add(roadClassEnc)
+                .add(roadClassLinkEnc).add(maxSpeedEnc)
+                .build();
+
+        BaseGraph graph = new BaseGraph.Builder(em).create();
+        Weighting weighting = new SpeedWeighting(speedEnc);
+        graph.edge(0, 1).set(accessEnc, true).set(speedEnc, 50);
+        graph.edge(1, 2).set(accessEnc, true).set(speedEnc, 30).set(roundaboutEnc, true)
+                .setKeyValues(Map.of(STREET_NAME, new KVStorage.KValue("Magic Circle")));
+        graph.edge(2, 3).set(accessEnc, true).set(speedEnc, 50)
+                .setKeyValues(Map.of(STREET_DESTINATION, new KVStorage.KValue("Euskirchen")));
+
+        Path path = new Path(graph);
+        path.setWeight(100);
+        path.setFromNode(0);
+        path.setEndNode(3);
+        path.getEdges().add(0);
+        path.getEdges().add(1);
+        path.getEdges().add(2);
+        path.setFound(true);
+
+        TranslationMap trMap = new TranslationMap().doImport();
+        InstructionList instructions = InstructionsFromEdges.calcInstructions(path, graph, weighting, em, trMap.get("en_US"));
+        Instruction roundaboutInstruction = instructions.get(1);
+        String description = roundaboutInstruction.getTurnDescription(trMap.getWithFallBack(Locale.US));
+
+        assertEquals("at roundabout, take exit 1 toward Euskirchen", description,
+                "Unnamed Roundabout: Destination tag was ignored!");
+    }
+}

--- a/web-api/src/main/java/com/graphhopper/util/RoundaboutInstruction.java
+++ b/web-api/src/main/java/com/graphhopper/util/RoundaboutInstruction.java
@@ -20,6 +20,9 @@ package com.graphhopper.util;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.graphhopper.util.Parameters.Details.STREET_DESTINATION;
+import static com.graphhopper.util.Parameters.Details.STREET_REF;
+
 /**
  * @author jansoe
  */
@@ -114,13 +117,27 @@ public class RoundaboutInstruction extends Instruction {
 
         String str;
         String streetName = _getName();
+
+        String destination = extraInfo != null ? (String) extraInfo.get(STREET_DESTINATION) : null;
+        String ref = extraInfo != null ? (String) extraInfo.get(STREET_REF) : null;
         int indi = getSign();
         if (indi == Instruction.USE_ROUNDABOUT) {
             if (!exited) {
                 str = tr.tr("roundabout_enter");
             } else {
-                str = Helper.isEmpty(streetName) ? tr.tr("roundabout_exit", getExitNumber())
-                        : tr.tr("roundabout_exit_onto", getExitNumber(), streetName);
+                if (!Helper.isEmpty(streetName) && !streetName.equals(ref)) {
+                    str = tr.tr("roundabout_exit_onto", getExitNumber(), streetName);
+                } else if (!Helper.isEmpty(destination)) {
+                    String towardStr = tr.tr("toward");
+                    towardStr = towardStr.equals("toward") ? "toward" : towardStr;
+                    str = tr.tr("roundabout_exit", getExitNumber()) + " " + towardStr + " " + destination;
+                } else if (!Helper.isEmpty(ref)) {
+                    str = tr.tr("roundabout_exit_onto", getExitNumber(), ref);
+                } else if (!Helper.isEmpty(streetName)) {
+                    str = tr.tr("roundabout_exit_onto", getExitNumber(), streetName);
+                } else {
+                    str = tr.tr("roundabout_exit", getExitNumber());
+                }
             }
         } else {
             throw new IllegalStateException(indi + "no roundabout indication");


### PR DESCRIPTION
Fixes #3215.
Fixes #3213.

1. Fix roundabout name leak on unnamed exits (#3215):
Updated InstructionsFromEdges.java to explicitly pass an empty string (name == null ? "" : name) when exiting a roundabout onto an unnamed edge.
Previously, evaluating to null caused the instruction to silently inherit the roundabout's name.

2. Prioritize destination tags when leaving roundabouts (#3213):
Updated RoundaboutInstruction.getTurnDescription() to utilize a proper fallback cascade: Name -> Destination -> Ref.
If a road has no name but has a ref, OSM parsers sometimes copy the ref into the name field.
Added (!streetName.equals(ref)) to ensure a raw ref does not override a valid destination.

Also added InstructionsFromEdgesTest.java to verify that exiting a named roundabout onto an unnamed road properly clears the roundabout name and successfully utilizes the STREET_DESTINATION fallback logic.

Tested on [this roundabout](https://graphhopper.com/maps/?point=50.733741%2C7.031728&point=50.733454%2C7.033179&profile=car&layer=OpenStreetMap) where the exit road has destination tags for Euskirchen and BN-Hardtberg.

Before:
Continue onto Bonner Weg
At roundabout, take exit 1 onto L 113
Arrive at destination

After:
Continue onto Bonner Weg
At roundabout, take exit 1 toward Euskirchen, BN-Hardtberg
Arrive at destination