### PR TITLE
Handle partial downloads

### DIFF
--- a/core/src/main/java/com/graphhopper/reader/dem/AbstractSRTMElevationProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/AbstractSRTMElevationProvider.java
@@ -46,7 +46,7 @@ public abstract class AbstractSRTMElevationProvider extends TileBasedElevationPr
     public AbstractSRTMElevationProvider(String baseUrl, String cacheDir, String downloaderName, int minLat, int maxLat, int defaultWidth) {
         super(cacheDir);
         this.baseUrl = baseUrl;
-        downloader = new Downloader(downloaderName).setTimeout(10000);
+        downloader = new Downloader().setTimeout(10000);
         this.DEFAULT_WIDTH = defaultWidth;
         this.MIN_LAT = minLat;
         this.MAX_LAT = maxLat;

--- a/core/src/main/java/com/graphhopper/reader/dem/AbstractTiffElevationProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/AbstractTiffElevationProvider.java
@@ -45,10 +45,10 @@ public abstract class AbstractTiffElevationProvider extends TileBasedElevationPr
     // Degrees of longitude covered by this tile
     final int LON_DEGREE;
 
-    public AbstractTiffElevationProvider(String baseUrl, String cacheDir, String downloaderName, int width, int height, int latDegree, int lonDegree) {
+    public AbstractTiffElevationProvider(String baseUrl, String cacheDir, int width, int height, int latDegree, int lonDegree) {
         super(cacheDir);
         this.baseUrl = baseUrl;
-        this.downloader = new Downloader(downloaderName).setTimeout(10000);
+        this.downloader = new Downloader().setTimeout(10000);
         this.WIDTH = width;
         this.HEIGHT = height;
         this.LAT_DEGREE = latDegree;

--- a/core/src/main/java/com/graphhopper/reader/dem/CGIARProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/CGIARProvider.java
@@ -56,7 +56,6 @@ public class CGIARProvider extends AbstractTiffElevationProvider {
         // Alternative URLs for the CGIAR data can be found in #346
         super("https://srtm.csi.cgiar.org/wp-content/uploads/files/srtm_5x5/TIFF/",
                 cacheDir.isEmpty() ? "/tmp/cgiar" : cacheDir,
-                "GraphHopper CGIARReader",
                 6000, 6000,
                 5, 5);
     }

--- a/core/src/main/java/com/graphhopper/reader/dem/GMTEDProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/GMTEDProvider.java
@@ -88,7 +88,6 @@ public class GMTEDProvider extends AbstractTiffElevationProvider {
     public GMTEDProvider(String cacheDir) {
         super("https://edcintl.cr.usgs.gov/downloads/sciweb1/shared/topo/downloads/GMTED/Global_tiles_GMTED/075darcsec/mea/",
                 cacheDir.isEmpty() ? "/tmp/gmted" : cacheDir,
-                "GraphHopper GMTEDReader",
                 14400, 9600,
                 20, 30);
     }

--- a/core/src/main/java/com/graphhopper/util/Downloader.java
+++ b/core/src/main/java/com/graphhopper/util/Downloader.java
@@ -34,17 +34,13 @@ import java.util.zip.InflaterInputStream;
  */
 public class Downloader {
     private static final int BUFFER_SIZE = 8 * 1024;
-    private final String userAgent;
+    private static final String USER_AGENT = "graphhopper/" + Constants.VERSION;
     private String referrer = "http://graphhopper.com";
     private String acceptEncoding = "gzip, deflate";
     private int timeout = 4000;
 
-    public Downloader(String userAgent) {
-        this.userAgent = userAgent;
-    }
-
     public static void main(String[] args) throws IOException {
-        new Downloader("GraphHopper Downloader").downloadAndUnzip("http://graphhopper.com/public/maps/0.1/europe_germany_berlin.ghz", "somefolder",
+        new Downloader().downloadAndUnzip("http://graphhopper.com/public/maps/0.1/europe_germany_berlin.ghz", "somefolder",
                 val -> System.out.println("progress:" + val));
     }
 
@@ -101,7 +97,7 @@ public class Downloader {
         conn.setDoInput(true);
         conn.setUseCaches(true);
         conn.setRequestProperty("Referrer", referrer);
-        conn.setRequestProperty("User-Agent", userAgent);
+        conn.setRequestProperty("User-Agent", USER_AGENT);
         // suggest respond to be gzipped or deflated (which is just another compression)
         // http://stackoverflow.com/q/3932117
         conn.setRequestProperty("Accept-Encoding", acceptEncoding);

--- a/core/src/test/java/com/graphhopper/reader/dem/CGIARProviderTest.java
+++ b/core/src/test/java/com/graphhopper/reader/dem/CGIARProviderTest.java
@@ -81,7 +81,7 @@ public class CGIARProviderTest {
         file.delete();
         zipFile.delete();
 
-        instance.setDownloader(new Downloader("test GH") {
+        instance.setDownloader(new Downloader() {
             @Override
             public void downloadFile(String url, String toFile) throws IOException {
                 throw new FileNotFoundException("xyz");
@@ -93,7 +93,7 @@ public class CGIARProviderTest {
         assertTrue(file.exists());
         assertEquals(1048676, file.length());
 
-        instance.setDownloader(new Downloader("test GH") {
+        instance.setDownloader(new Downloader() {
             @Override
             public void downloadFile(String url, String toFile) throws IOException {
                 throw new SocketTimeoutException("xyz");

--- a/core/src/test/java/com/graphhopper/reader/dem/GMTEDProviderTest.java
+++ b/core/src/test/java/com/graphhopper/reader/dem/GMTEDProviderTest.java
@@ -88,7 +88,7 @@ public class GMTEDProviderTest {
         file.delete();
         zipFile.delete();
 
-        instance.setDownloader(new Downloader("test GH") {
+        instance.setDownloader(new Downloader() {
             @Override
             public void downloadFile(String url, String toFile) throws IOException {
                 throw new FileNotFoundException("xyz");
@@ -100,7 +100,7 @@ public class GMTEDProviderTest {
         assertTrue(file.exists());
         assertEquals(1048676, file.length());
 
-        instance.setDownloader(new Downloader("test GH") {
+        instance.setDownloader(new Downloader() {
             @Override
             public void downloadFile(String url, String toFile) throws IOException {
                 throw new SocketTimeoutException("xyz");


### PR DESCRIPTION
This is a subset of the changes proposed in #3143:

* handle partial downloads
* use a proper User-Agent e.g `graphhopper/12.0`