### PR TITLE
fix: prevent conditional tags from overriding implicit pedestrian roa…

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -75,6 +75,7 @@ Here is an overview:
  * otbutz, added multiple EncodedValues
  * PabloaRuiz, pt_BR 1i8n improvements
  * pantsleftinwash, speed parsing improvements
+ * pgrigolli, pedestrian roads conditional accesses fix
  * PGWelch, shapefile reader #874
  * rafaelstelles, fix deserializer web-api
  * rajanski, script to do routing via PostGIS

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/CarAccessParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/CarAccessParser.java
@@ -27,6 +27,7 @@ import com.graphhopper.util.PMap;
 import java.util.*;
 
 import static com.graphhopper.routing.util.parsers.OSMTemporalAccessParser.hasPermissiveTemporalRestriction;
+import static com.graphhopper.routing.util.parsers.OSMTemporalAccessParser.hasPermissiveTemporalRestrictionForPedestrian;
 
 public class CarAccessParser extends AbstractAccessParser implements TagParser {
 
@@ -94,7 +95,7 @@ public class CarAccessParser extends AbstractAccessParser implements TagParser {
 
         if ("pedestrian".equals(highwayValue)
                 && !allowedValues.contains(firstValue)
-                && !hasPermissiveTemporalRestriction(way, restrictionKeys.size() - 1, restrictionKeys, allowedValues)) {
+                && !hasPermissiveTemporalRestrictionForPedestrian(way, restrictionKeys.size() - 1, restrictionKeys, allowedValues)) {
             // allow pedestrian if explicitly tagged
             return WayAccess.CAN_SKIP;
         }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMTemporalAccessParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMTemporalAccessParser.java
@@ -100,6 +100,14 @@ public class OSMTemporalAccessParser implements TagParser {
         return null;
     }
 
+    public static boolean hasPermissiveTemporalRestrictionForPedestrian(ReaderWay way, int firstIndex,
+                                                                List<String> restrictionKeys, Collection<String> allowedValues) {
+        // only consider conditional tags if there is an explicit restriction
+        String access = way.getTag("access");
+        String motorVehicle = way.getTag("motor_vehicle");
+        if (!"no".equals(access) && !"no".equals(motorVehicle)) return false;
+        return hasPermissiveTemporalRestriction(way, firstIndex, restrictionKeys, allowedValues);
+    }
     /**
      * This method checks the conditional restrictions starting from firstIndex and returns
      * true if the access value is in the "accepted" collection AND the conditional value describes
@@ -107,6 +115,7 @@ public class OSMTemporalAccessParser implements TagParser {
      */
     public static boolean hasPermissiveTemporalRestriction(ReaderWay way, int firstIndex,
                                                            List<String> restrictionKeys, Collection<String> accepted) {
+
         for (int i = firstIndex; i >= 0; i--) {
             String value = way.getTag(restrictionKeys.get(i) + ":conditional");
             if (acceptedAndInRange(value, accepted)) return true;

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/CarTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/CarTagParserTest.java
@@ -752,7 +752,13 @@ public class CarTagParserTest {
         way.clearTags();
         way.setTag("highway", "pedestrian");
         way.setTag("motor_vehicle:conditional", "destination @ ( 8:00 - 10:00 )");
-        assertTrue(parser.getAccess(way).isWay());
+        assertTrue(parser.getAccess(way).canSkip());
+
+        way.clearTags();
+        way.setTag("highway", "pedestrian");
+        way.setTag("motor_vehicle:conditional", "delivery @ (Mo-Fr 06:00-11:00, 19:00-21:00; Sa 06:00-09:30; PH off)");
+        way.setTag("bicycle", "yes");
+        assertTrue(parser.getAccess(way).canSkip());
 
         way.clearTags();
         way.setTag("highway", "pedestrian");


### PR DESCRIPTION
Fixes #3308 
highway=pedestrian roads were being routed for cars when a motor_vehicle:conditional tag was present, even without any explicit access tag. For example, a road tagged with:
```
highway = pedestrian
motor_vehicle:conditional = delivery @ (Mo-Fr 06:00-11:00, 19:00-21:00; Sa 06:00-09:30; PH off)
bicycle = yes
```
was being treated as accessible for cars, causing the router to send vehicles through pedestrian areas instead of calculating a detour.
### Root cause
The if block responsible for blocking cars on pedestrian roads calls hasPermissiveTemporalRestriction as its third condition. This method was returning true whenever a conditional tag contained a value present in allowedValues (such as delivery) and a time range — regardless of whether the restriction on the road was explicit (access=no) or implicit (derived from highway=pedestrian). This caused the CAN_SKIP return to be skipped, leaving the road accessible for cars.
### Fix
Added a private method hasPermissiveTemporalRestrictionForPedestrian in CarAccessParser that adds a guard before calling hasPermissiveTemporalRestriction — only considering conditional tags if an explicit restriction (access=no or motor_vehicle=no) is present on the way. The original hasPermissiveTemporalRestriction method was left untouched to avoid breaking other parsers that depend on it (bike, temporal access).