### PR TITLE
remove npm from build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,20 +20,6 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - name: Cache node
-        uses: actions/cache@v4
-        with:
-          path: web-bundle/node
-          key: ${{ runner.os }}-node-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os}}-node-
-      - name: Cache node_modules
-        uses: actions/cache@v4
-        with:
-          path: web-bundle/node_modules
-          key: ${{ runner.os }}-node-${{ hashFiles('**/pom.xml', '**/package.json') }}
-          restore-keys: |
-            ${{ runner.os}}-node_modules-
       - name: Build ${{ matrix.java-version }}
         run: mvn -B clean test
 

--- a/web-bundle/pom.xml
+++ b/web-bundle/pom.xml
@@ -119,46 +119,17 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.github.eirslett</groupId>
-                <artifactId>frontend-maven-plugin</artifactId>
-                <version>1.12.1</version>
-                <executions>
-                    <execution>
-                        <id>install node and npm</id>
-                        <goals>
-                            <goal>install-node-and-npm</goal>
-                        </goals>
-                        <configuration>
-                            <nodeVersion>v20.14.0</nodeVersion>
-                            <npmVersion>10.7.0</npmVersion>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>download graphhopper maps</id>
-                        <phase>generate-resources</phase>
-                        <goals>
-                            <goal>npm</goal>
-                        </goals>
-                        <configuration>
-                            <!--suppress UnresolvedMavenProperty (IntelliJ shows an error otherwise...)-->
-                            <arguments>
-                                pack --pack-destination=${basedir}/target
-                                @graphhopper/graphhopper-maps-bundle@${graphhopper-maps.version}
-                            </arguments>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <artifactId>maven-antrun-plugin</artifactId>
                 <executions>
                     <execution>
-                        <!-- this is needed because we want to download the maps bundle to the target folder -->
-                        <id>create target directory</id>
-                        <phase>initialize</phase>
+                        <id>download graphhopper maps</id>
+                        <phase>generate-resources</phase>
                         <configuration>
                             <target>
                                 <mkdir dir="${basedir}/target"/>
+                                <get src="https://registry.npmjs.org/@graphhopper/graphhopper-maps-bundle/-/graphhopper-maps-bundle-${graphhopper-maps.version}.tgz"
+                                     dest="${basedir}/target/graphhopper-maps-bundle-${graphhopper-maps.version}.tgz"
+                                     skipexisting="true"/>
                             </target>
                         </configuration>
                         <goals>
@@ -171,7 +142,7 @@
                         <configuration>
                             <target>
                                 <untar compression="gzip"
-                                       src="${basedir}/target/graphhopper-graphhopper-maps-bundle-${graphhopper-maps.version}.tgz"
+                                       src="${basedir}/target/graphhopper-maps-bundle-${graphhopper-maps.version}.tgz"
                                        dest="${basedir}/target/classes/com/graphhopper/maps">
                                     <patternset>
                                         <include name="package/dist/**"/>


### PR DESCRIPTION
This works and does not require npm (and updating it). Not sure yet what the downsides are.