### PR TITLE
Add street:name as fallback for way names of footways and cycleways

### DIFF
--- a/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
+++ b/core/src/main/java/com/graphhopper/reader/osm/OSMReader.java
@@ -429,6 +429,8 @@ public class OSMReader {
                 name = fixWayName(way.getTag("name"));
             if (name.isEmpty())
                 name = fixWayName(way.getTag("is_sidepath:of:name"));
+            if (name.isEmpty())
+                name = fixWayName(way.getTag("street:name"));
             if (!name.isEmpty())
                 map.put(STREET_NAME, new KValue(name));
 

--- a/core/src/test/java/com/graphhopper/reader/osm/OSMReaderTest.java
+++ b/core/src/test/java/com/graphhopper/reader/osm/OSMReaderTest.java
@@ -993,6 +993,32 @@ public class OSMReaderTest {
     }
 
     @Test
+    public void testStreetNameFallback() throws IOException {
+        // Test that street:name is used as a fallback when name and is_sidepath:of:name are not present
+        EncodingManager em = EncodingManager.start()
+                .add(VehicleSpeed.create("bike", 4, 2, false)).add(VehicleAccess.create("bike"))
+                .build();
+        OSMParsers osmParsers = new OSMParsers();
+        BaseGraph graph = new BaseGraph.Builder(em).create();
+        OSMReader reader = new OSMReader(graph, osmParsers, new OSMReaderConfig());
+        reader.setFile(new File(getClass().getResource("test-osm-street-name.xml").getFile()));
+        reader.readGraph();
+
+        assertEquals(3, graph.getEdges());
+        // way 1: only street:name -> should use street:name
+        EdgeIteratorState edge0 = graph.getEdgeIteratorState(0, Integer.MIN_VALUE);
+        assertEquals("Main Street", edge0.getName());
+
+        // way 2: is_sidepath:of:name and street:name -> is_sidepath:of:name should take priority
+        EdgeIteratorState edge1 = graph.getEdgeIteratorState(1, Integer.MIN_VALUE);
+        assertEquals("Sidepath Road", edge1.getName());
+
+        // way 3: name and street:name -> name should take priority
+        EdgeIteratorState edge2 = graph.getEdgeIteratorState(2, Integer.MIN_VALUE);
+        assertEquals("Explicit Name", edge2.getName());
+    }
+
+    @Test
     public void testCalc2DDistanceWithMixedElevation() {
         // Simulate the scenario where tower nodes have elevation but pillar nodes return NaN
         // (because pillar elevation is deferred to edge creation time).

--- a/core/src/test/resources/com/graphhopper/reader/osm/test-osm-street-name.xml
+++ b/core/src/test/resources/com/graphhopper/reader/osm/test-osm-street-name.xml
@@ -1,0 +1,33 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version="0.6" generator="test">
+    <node id="1" lat="49.0" lon="11.0" version="1"/>
+    <node id="2" lat="49.001" lon="11.001" version="1"/>
+    <node id="3" lat="49.002" lon="11.002" version="1"/>
+    <node id="4" lat="49.003" lon="11.003" version="1"/>
+
+    <!-- way with only street:name tag (no name, no is_sidepath:of:name) -->
+    <way id="1" version="1">
+        <nd ref="1"/>
+        <nd ref="2"/>
+        <tag k="highway" v="cycleway"/>
+        <tag k="street:name" v="Main Street"/>
+    </way>
+
+    <!-- way with is_sidepath:of:name and street:name (is_sidepath:of:name should win) -->
+    <way id="2" version="1">
+        <nd ref="2"/>
+        <nd ref="3"/>
+        <tag k="highway" v="footway"/>
+        <tag k="is_sidepath:of:name" v="Sidepath Road"/>
+        <tag k="street:name" v="Street Name Road"/>
+    </way>
+
+    <!-- way with name and street:name (name should win) -->
+    <way id="3" version="1">
+        <nd ref="3"/>
+        <nd ref="4"/>
+        <tag k="highway" v="cycleway"/>
+        <tag k="name" v="Explicit Name"/>
+        <tag k="street:name" v="Fallback Street"/>
+    </way>
+</osm>


### PR DESCRIPTION
## Summary

Follow-up to #3210 and fixes #3277.

Commit c9207e5 added support for `is_sidepath:of:name` as a fallback when determining way names for footways and cycleways that lack a `name` tag. However, the synonymous `street:name` tag was not included at that time.

This PR adds `street:name` as an additional fallback in the name resolution chain in `OSMReader.preprocessWay()`. The full priority order is now:

1. `name:{preferred_language}` — localized name
2. `name` — standard OSM name
3. `is_sidepath:of:name` — sidepath tag (added in c9207e5)
4. **`street:name`** — synonymous tag, newly added

Each tag is only checked when all previous ones are empty, so existing behavior is fully preserved.

## Why

- [`street:name` usage has grown significantly](https://taginfo.openstreetmap.org/keys/street%3Aname#overview) in recent months in OSM
- `street:name` and `is_sidepath:of:name` are [synonymous tags](https://wiki.openstreetmap.org/wiki/Synonymous_tags) serving the same purpose
- [OSRM already supports both tags](https://github.com/Project-OSRM/osrm-backend/pull/7288) — this brings GraphHopper to parity
- Without this, footways/cycleways tagged only with `street:name` appear unnamed in navigation instructions, degrading the routing experience for pedestrians and cyclists

## Changes

- **`OSMReader.java`**: Added 2-line fallback check for `street:name` after `is_sidepath:of:name`
- **`OSMReaderTest.java`**: Added `testStreetNameFallback` test covering three scenarios:
  - Way with only `street:name` → uses `street:name` as the name
  - Way with both `is_sidepath:of:name` and `street:name` → `is_sidepath:of:name` takes priority
  - Way with both `name` and `street:name` → `name` takes priority
- **`test-osm-street-name.xml`**: Test fixture with the three way variants above