### PR TITLE
replace PriorityQueue with cache-friendly binary heap

### DIFF
--- a/core/src/main/java/com/graphhopper/coll/BinaryHeapWithDuplicates.java
+++ b/core/src/main/java/com/graphhopper/coll/BinaryHeapWithDuplicates.java
@@ -1,0 +1,83 @@
+package com.graphhopper.coll;
+
+import java.util.Arrays;
+
+/**
+ * A binary min-heap that stores items with parallel double[] weights for cache-friendly comparisons.
+ * Unlike java.util.PriorityQueue which dereferences Object pointers during sift operations,
+ * this heap compares weights from a contiguous double[] array, dramatically reducing cache misses.
+ */
+public class BinaryHeapWithDuplicates<E> {
+    private double[] weights;
+    private Object[] items;
+    private int size;
+
+    public BinaryHeapWithDuplicates() { this(64); }
+    public BinaryHeapWithDuplicates(int initialCapacity) {
+        initialCapacity = Math.max(1, initialCapacity);
+        weights = new double[initialCapacity];
+        items = new Object[initialCapacity];
+    }
+
+    public int size() { return size; }
+    public boolean isEmpty() { return size == 0; }
+
+    public void add(E item, double weight) {
+        if (size == weights.length) grow();
+        weights[size] = weight;
+        items[size] = item;
+        siftUp(size);
+        size++;
+    }
+
+    @SuppressWarnings("unchecked")
+    public E poll() {
+        if (size == 0) return null;
+        E result = (E) items[0];
+        size--;
+        if (size > 0) {
+            weights[0] = weights[size];
+            items[0] = items[size];
+            items[size] = null;
+            siftDown(0);
+        } else {
+            items[0] = null;
+        }
+        return result;
+    }
+
+    @SuppressWarnings("unchecked")
+    public E peek() { return size > 0 ? (E) items[0] : null; }
+
+    public void clear() { Arrays.fill(items, 0, size, null); size = 0; }
+
+    private void siftUp(int pos) {
+        double w = weights[pos]; Object item = items[pos];
+        while (pos > 0) {
+            int parent = (pos - 1) >>> 1;
+            if (w >= weights[parent]) break;
+            weights[pos] = weights[parent]; items[pos] = items[parent];
+            pos = parent;
+        }
+        weights[pos] = w; items[pos] = item;
+    }
+
+    private void siftDown(int pos) {
+        double w = weights[pos]; Object item = items[pos];
+        int half = size >>> 1;
+        while (pos < half) {
+            int child = (pos << 1) + 1, right = child + 1;
+            if (right < size && weights[right] < weights[child]) child = right;
+            if (w <= weights[child]) break;
+            weights[pos] = weights[child]; items[pos] = items[child];
+            pos = child;
+        }
+        weights[pos] = w; items[pos] = item;
+    }
+
+    private void grow() {
+        int nc = weights.length + (weights.length >> 1) + 1;
+        weights = Arrays.copyOf(weights, nc);
+        items = Arrays.copyOf(items, nc);
+    }
+}

--- a/core/src/main/java/com/graphhopper/routing/AbstractBidirAlgo.java
+++ b/core/src/main/java/com/graphhopper/routing/AbstractBidirAlgo.java
@@ -25,6 +25,7 @@ import com.graphhopper.util.EdgeIterator;
 import java.util.Collections;
 import java.util.List;
 import java.util.PriorityQueue;
+import com.graphhopper.coll.BinaryHeapWithDuplicates;
 
 import static com.graphhopper.util.EdgeIterator.ANY_EDGE;
 
@@ -45,8 +46,8 @@ public abstract class AbstractBidirAlgo implements EdgeToEdgeRoutingAlgorithm {
     protected int maxVisitedNodes = Integer.MAX_VALUE;
     protected long timeoutMillis = Long.MAX_VALUE;
     private long finishTimeMillis = Long.MAX_VALUE;
-    PriorityQueue<SPTEntry> pqOpenSetFrom;
-    PriorityQueue<SPTEntry> pqOpenSetTo;
+    BinaryHeapWithDuplicates<SPTEntry> pqOpenSetFrom;
+    BinaryHeapWithDuplicates<SPTEntry> pqOpenSetTo;
     protected boolean updateBestPath = true;
     protected boolean finishedFrom;
     protected boolean finishedTo;
@@ -61,10 +62,10 @@ public abstract class AbstractBidirAlgo implements EdgeToEdgeRoutingAlgorithm {
     }
 
     protected void initCollections(int size) {
-        pqOpenSetFrom = new PriorityQueue<>(size);
+        pqOpenSetFrom = new BinaryHeapWithDuplicates<>(size);
         bestWeightMapFrom = new GHIntObjectHashMap<>(size);
 
-        pqOpenSetTo = new PriorityQueue<>(size);
+        pqOpenSetTo = new BinaryHeapWithDuplicates<>(size);
         bestWeightMapTo = new GHIntObjectHashMap<>(size);
     }
 
@@ -106,7 +107,7 @@ public abstract class AbstractBidirAlgo implements EdgeToEdgeRoutingAlgorithm {
     protected void initFrom(int from, double weight) {
         this.from = from;
         currFrom = createStartEntry(from, weight, false);
-        pqOpenSetFrom.add(currFrom);
+        pqOpenSetFrom.add(currFrom, currFrom.weight);
         if (!traversalMode.isEdgeBased()) {
             bestWeightMapFrom.put(from, currFrom);
         }
@@ -115,7 +116,7 @@ public abstract class AbstractBidirAlgo implements EdgeToEdgeRoutingAlgorithm {
     protected void initTo(int to, double weight) {
         this.to = to;
         currTo = createStartEntry(to, weight, true);
-        pqOpenSetTo.add(currTo);
+        pqOpenSetTo.add(currTo, currTo.weight);
         if (!traversalMode.isEdgeBased()) {
             bestWeightMapTo.put(to, currTo);
         }

--- a/core/src/main/java/com/graphhopper/routing/AbstractBidirCHAlgo.java
+++ b/core/src/main/java/com/graphhopper/routing/AbstractBidirCHAlgo.java
@@ -24,6 +24,7 @@ import com.graphhopper.storage.*;
 import com.graphhopper.util.GHUtility;
 
 import java.util.PriorityQueue;
+import com.graphhopper.coll.BinaryHeapWithDuplicates;
 import java.util.function.Supplier;
 
 import static com.graphhopper.util.EdgeIterator.ANY_EDGE;
@@ -174,7 +175,7 @@ public abstract class AbstractBidirCHAlgo extends AbstractBidirAlgo implements E
         return true;
     }
 
-    private void fillEdges(SPTEntry currEdge, PriorityQueue<SPTEntry> prioQueue,
+    private void fillEdges(SPTEntry currEdge, BinaryHeapWithDuplicates<SPTEntry> prioQueue,
                            IntObjectMap<SPTEntry> bestWeightMap, RoutingCHEdgeExplorer explorer, boolean reverse) {
         RoutingCHEdgeIterator iter = explorer.setBaseNode(currEdge.adjNode);
         while (iter.next()) {
@@ -191,7 +192,7 @@ public abstract class AbstractBidirCHAlgo extends AbstractBidirAlgo implements E
             if (entry == null) {
                 entry = createEntry(iter.getEdge(), iter.getAdjNode(), origEdgeId, weight, currEdge, reverse);
                 bestWeightMap.put(traversalId, entry);
-                prioQueue.add(entry);
+                prioQueue.add(entry, entry.weight);
             } else if (entry.getWeightOfVisitedPath() > weight) {
                 // flagging this entry, so it will be ignored when it is polled the next time
                 // this is faster than removing the entry from the queue and adding again, but for CH it does not really
@@ -200,7 +201,7 @@ public abstract class AbstractBidirCHAlgo extends AbstractBidirAlgo implements E
                 boolean isBestEntry = reverse ? (entry == bestBwdEntry) : (entry == bestFwdEntry);
                 entry = createEntry(iter.getEdge(), iter.getAdjNode(), origEdgeId, weight, currEdge, reverse);
                 bestWeightMap.put(traversalId, entry);
-                prioQueue.add(entry);
+                prioQueue.add(entry, entry.weight);
                 // if this is the best entry we need to update the best reference as well
                 if (isBestEntry)
                     if (reverse)

--- a/core/src/main/java/com/graphhopper/routing/AbstractNonCHBidirAlgo.java
+++ b/core/src/main/java/com/graphhopper/routing/AbstractNonCHBidirAlgo.java
@@ -30,7 +30,7 @@ import com.graphhopper.util.EdgeIterator;
 import com.graphhopper.util.EdgeIteratorState;
 import com.graphhopper.util.GHUtility;
 
-import java.util.PriorityQueue;
+import com.graphhopper.coll.BinaryHeapWithDuplicates;
 
 import static com.graphhopper.util.EdgeIterator.ANY_EDGE;
 
@@ -153,7 +153,7 @@ public abstract class AbstractNonCHBidirAlgo extends AbstractBidirAlgo implement
         return true;
     }
 
-    private void fillEdges(SPTEntry currEdge, PriorityQueue<SPTEntry> prioQueue, IntObjectMap<SPTEntry> bestWeightMap, boolean reverse) {
+    private void fillEdges(SPTEntry currEdge, BinaryHeapWithDuplicates<SPTEntry> prioQueue, IntObjectMap<SPTEntry> bestWeightMap, boolean reverse) {
         EdgeIterator iter = edgeExplorer.setBaseNode(currEdge.adjNode);
         while (iter.next()) {
             if (!accept(iter, currEdge.edge))
@@ -168,14 +168,14 @@ public abstract class AbstractNonCHBidirAlgo extends AbstractBidirAlgo implement
             if (entry == null) {
                 entry = createEntry(iter, weight, currEdge, reverse);
                 bestWeightMap.put(traversalId, entry);
-                prioQueue.add(entry);
+                prioQueue.add(entry, entry.weight);
             } else if (entry.getWeightOfVisitedPath() > weight) {
                 // flagging this entry, so it will be ignored when it is polled the next time
                 entry.setDeleted();
                 boolean isBestEntry = reverse ? (entry == bestBwdEntry) : (entry == bestFwdEntry);
                 entry = createEntry(iter, weight, currEdge, reverse);
                 bestWeightMap.put(traversalId, entry);
-                prioQueue.add(entry);
+                prioQueue.add(entry, entry.weight);
                 // if this is the best entry we need to update the best reference as well
                 if (isBestEntry)
                     if (reverse)


### PR DESCRIPTION
I gave the AI the task to find performance improvements and this was one of the results which gives a >10% query speed improvement but not for CH routing queries.

This should use slightly more memory as it is one array more.

(Here is [a similar change](https://github.com/graphhopper/graphhopper/tree/try_pq_replace_4ary)).

