### PR TITLE
fix #3337 (instructions): propagate major road names for unnamed link instructions 

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -36,6 +36,7 @@ Here is an overview:
  * fredao, translations 
  * gberaudo, improvements regarding elevation
  * GProbo, fixes like #2241
+ * gulbalasalamov, fix for instruction generation when unnamed link roads continue onto named major roads (#3337) 
  * HarelM, improvements regarding elevation
  * HelgeKrueger, modularization of javascript, #590
  * henningvs, doc improvements

--- a/core/src/main/java/com/graphhopper/routing/InstructionsFromEdges.java
+++ b/core/src/main/java/com/graphhopper/routing/InstructionsFromEdges.java
@@ -48,6 +48,13 @@ public class InstructionsFromEdges implements Path.EdgeVisitor {
     private final IntEncodedValue lanesEnc;
     private final DecimalEncodedValue maxSpeedEnc;
 
+    /**
+     * True when the current instruction started on an unnamed link road and we want to
+     * replace its blank name later with the first suitable named non-link major road
+     * encountered on the actual routed continuation of the same instruction.
+     */
+    private boolean prevInstructionNeedsNameFallback;
+
     /*
      * We need three points to make directions
      *
@@ -99,6 +106,7 @@ public class InstructionsFromEdges implements Path.EdgeVisitor {
         prevInRoundabout = false;
         prevName = null;
         prevRoadEnv = null;
+        prevInstructionNeedsNameFallback = false;
 
         BooleanEncodedValue carAccessEnc = evLookup.getBooleanEncodedValue(VehicleAccess.key("car"));
         outEdgeExplorer = graph.createEdgeExplorer(edge -> edge.get(carAccessEnc));
@@ -170,6 +178,10 @@ public class InstructionsFromEdges implements Path.EdgeVisitor {
             double heading = AngleCalc.ANGLE_CALC.calcAzimuth(startLat, startLon, latitude, longitude);
             prevInstruction.setExtraInfo("heading", Helper.round(heading, 2));
             ways.add(prevInstruction);
+
+            // If the route starts on an unnamed link road, keep a deferred fallback pending.
+            prevInstructionNeedsNameFallback = isBlank(name) && isLinkRoad(edge);
+
             prevName = name;
             prevRoadEnv = roadEnv;
             prevDestinationAndRef = destination + destinationRef;
@@ -213,6 +225,9 @@ public class InstructionsFromEdges implements Path.EdgeVisitor {
                 ways.add(prevInstruction);
             }
 
+            // once in roundabout, deferred fallback should not leak into roundabout instructions
+            prevInstructionNeedsNameFallback = false;
+
             // Add passed exits to instruction. A node is counted if there is at least one outgoing edge
             // out of the roundabout
             EdgeIterator edgeIter = outEdgeExplorer.setBaseNode(edge.getAdjNode());
@@ -248,6 +263,9 @@ public class InstructionsFromEdges implements Path.EdgeVisitor {
                     .setDirOfRotation(deltaOut)
                     .setExited();
 
+            // exiting roundabout: no deferred fallback from previous instruction
+            prevInstructionNeedsNameFallback = false;
+
             prevInstructionName = prevName;
             prevName = name;
             prevRoadEnv = roadEnv;
@@ -255,6 +273,18 @@ public class InstructionsFromEdges implements Path.EdgeVisitor {
 
         } else {
             int sign = getTurn(edge, baseNode, prevNode, adjNode, name, destination + destinationRef);
+
+            if (prevInstructionNeedsNameFallback
+                    && sign == Instruction.IGNORE
+                    && isMajorNonLinkRoad(edge)
+                    && hasUsableRoadLabel(name, ref)
+                    && !hasDestinationInfo(prevInstruction)) {
+
+                prevInstruction.setName(buildRoadLabel(name, ref));
+                prevInstruction.setExtraInfo(STREET_REF, ref);
+                prevInstructionNeedsNameFallback = false;
+            }
+
             if (sign != Instruction.IGNORE) {
                 /*
                     Check if the next instruction is likely to only be a short connector to execute a u-turn
@@ -297,12 +327,18 @@ public class InstructionsFromEdges implements Path.EdgeVisitor {
                 if (isUTurn) {
                     prevInstruction.setSign(uTurnType);
                     prevInstruction.setName(name);
+                    prevInstructionNeedsNameFallback = false;
                 } else {
+                    boolean needsDeferredFallback = isBlank(name) && isLinkRoad(edge);
+
                     prevInstruction = new Instruction(sign, name, new PointList(10, nodeAccess.is3D()));
                     // Remember the Orientation and name of the road, before doing this maneuver
                     prevInstructionPrevOrientation = prevOrientation;
                     prevInstructionName = prevName;
                     ways.add(prevInstruction);
+
+                    prevInstruction.setExtraInfo(STREET_REF, ref);
+                    prevInstructionNeedsNameFallback = needsDeferredFallback;
                 }
                 prevInstruction.setExtraInfo(STREET_REF, ref);
                 prevInstruction.setExtraInfo(STREET_DESTINATION, destination);
@@ -479,6 +515,47 @@ public class InstructionsFromEdges implements Path.EdgeVisitor {
             prevInstruction.setTime(GHUtility.calcMillisWithTurnMillis(weighting, edge, false, prevEdge.getEdge()) + prevInstruction.getTime());
         else
             prevInstruction.setTime(weighting.calcEdgeMillis(edge, false) + prevInstruction.getTime());
+    }
+
+    private String buildRoadLabel(String name, String ref) {
+        boolean hasName = name != null && !name.isBlank();
+        boolean hasRef = ref != null && !ref.isBlank();
+
+        if (hasName && hasRef) return name + " (" + ref + ")";
+        if (hasRef) return ref;
+        if (hasName) return name;
+        return "";
+    }
+
+    private boolean isLinkRoad(EdgeIteratorState edge) {
+        return edge.get(roadClassLinkEnc);
+    }
+
+    private boolean hasUsableRoadLabel(String name, String ref) {
+        return !isBlank(name) || !isBlank(ref);
+    }
+
+    private boolean isMajorNonLinkRoad(EdgeIteratorState edge) {
+        if (edge.get(roadClassLinkEnc)) return false;
+
+        RoadClass rc = edge.get(roadClassEnc);
+        return rc == RoadClass.MOTORWAY
+                || rc == RoadClass.TRUNK
+                || rc == RoadClass.PRIMARY
+                || rc == RoadClass.SECONDARY
+                || rc == RoadClass.TERTIARY;
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+
+    private boolean hasDestinationInfo(Instruction instruction) {
+        String destination = (String) instruction.getExtraInfoJSON().get(STREET_DESTINATION);
+        String destinationRef = (String) instruction.getExtraInfoJSON().get(STREET_DESTINATION_REF);
+        String motorwayJunction = (String) instruction.getExtraInfoJSON().get(MOTORWAY_JUNCTION);
+
+        return !isBlank(destination) || !isBlank(destinationRef) || !isBlank(motorwayJunction);
     }
 
 }

--- a/core/src/test/java/com/graphhopper/util/InstructionListTest.java
+++ b/core/src/test/java/com/graphhopper/util/InstructionListTest.java
@@ -40,6 +40,7 @@ import java.util.*;
 import static com.graphhopper.json.Statement.If;
 import static com.graphhopper.search.KVStorage.KValue;
 import static com.graphhopper.util.Parameters.Details.STREET_NAME;
+import static com.graphhopper.util.Parameters.Details.STREET_REF;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -427,6 +428,81 @@ public class InstructionListTest {
         assertEquals(Arrays.asList("continue onto myroad", "keep left onto myroad", "arrive at destination"), tmpList);
         assertEquals(3, wayList.size());
         assertEquals(20, wayList.get(1).getDistance());
+    }
+
+    @Test
+    public void testUnnamedLinkInstructionUsesFollowingMajorRoadName() {
+        EnumEncodedValue<RoadClass> roadClassEnc = carManager.getEnumEncodedValue(RoadClass.KEY, RoadClass.class);
+        BooleanEncodedValue roadClassLinkEnc = carManager.getBooleanEncodedValue(RoadClassLink.KEY);
+
+        BaseGraph g = new BaseGraph.Builder(carManager).create();
+        NodeAccess na = g.getNodeAccess();
+
+        // 0 ---- 1 ---- 4
+        //        |
+        //        2
+        //        |
+        //        3
+        //
+        // Path: 0 -> 1 -> 2 -> 3
+        //
+        // 0-1: named local road
+        // 1-2: unnamed motorway_link
+        // 2-3: named motorway "Purple Heart Trail" ref "I-40"
+        //
+        // The important part is:
+        // - a turn instruction is created at 1
+        // - no new instruction is created at 2
+        // - therefore the same instruction should pick up the following motorway name/ref
+
+        na.setNode(0, 0.0000, 0.0000);
+        na.setNode(1, 0.0000, 0.0010);
+        na.setNode(2, 0.0010, 0.0010);
+        na.setNode(3, 0.0100, 0.0010);
+        na.setNode(4, 0.0000, 0.0020);
+
+        g.edge(0, 1)
+                .setDistance(100)
+                .set(speedEnc, 60, 60)
+                .set(roadClassEnc, RoadClass.PRIMARY)
+                .setKeyValues(Map.of(STREET_NAME, new KValue("West Beale Street")));
+
+        g.edge(1, 4)
+                .setDistance(100)
+                .set(speedEnc, 60, 60)
+                .set(roadClassEnc, RoadClass.PRIMARY)
+                .setKeyValues(Map.of(STREET_NAME, new KValue("West Beale Street")));
+
+        g.edge(1, 2)
+                .setDistance(80)
+                .set(speedEnc, 60, 60)
+                .set(roadClassEnc, RoadClass.MOTORWAY)
+                .set(roadClassLinkEnc, true);
+
+        g.edge(2, 3)
+                .setDistance(500)
+                .set(speedEnc, 90, 90)
+                .set(roadClassEnc, RoadClass.MOTORWAY)
+                .setKeyValues(Map.of(
+                        STREET_NAME, new KValue("Purple Heart Trail"),
+                        STREET_REF, new KValue("I-40")
+                ));
+
+        Weighting weighting = new SpeedWeighting(speedEnc);
+        Path p = new Dijkstra(g, weighting, tMode).calcPath(0, 3);
+
+        assertEquals(IntArrayList.from(0, 1, 2, 3), p.calcNodes());
+
+        InstructionList wayList = InstructionsFromEdges.calcInstructions(p, g, weighting, carManager, usTR);
+        List<String> descriptions = getTurnDescriptions(wayList);
+
+        assertEquals(3, wayList.size());
+        assertEquals("Purple Heart Trail (I-40)", wayList.get(1).getName());
+        assertEquals(Arrays.asList(
+                "continue onto West Beale Street",
+                "turn left onto Purple Heart Trail (I-40)",
+                "arrive at destination"
+        ), descriptions);
     }
 
     @Test


### PR DESCRIPTION
Fixes [#3337](https://github.com/graphhopper/graphhopper/issues/3337)

## Summary

This PR fixes missing road names for instructions that start on unnamed link roads and continue onto named major roads.

Previously, GraphHopper could generate instructions like:

* `Turn left`

even though the merged instruction actually continued onto a named road such as:

* `Purple Heart Trail (I-40)`

## Root cause

The unnamed link and following major road were merged into a single instruction, but the major road name/ref was not propagated into the merged instruction.

## Fix

Instead of guessing from neighboring graph edges, this change performs deferred name fallback on the actual routed continuation:

* if an instruction starts on an unnamed link road,
* and the next edges remain part of the same instruction,
* and a named non-link major road is encountered,
* the instruction name is updated using that road's name/ref.

To avoid regressions for motorway destination-style instructions, the fallback is not applied when the instruction already carries destination-related information.

## Result

The instruction now changes from:

* `Turn left`

to:

* `Turn left onto Purple Heart Trail (I-40)`

for this class of cases.

## Testing

* Added a regression test in `InstructionListTest` for unnamed link -> named major road instruction generation.
* Verified the change with local test runs, including a full successful Maven build/test run.
