### PR TITLE
Limit weight increase caused by priority factors

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/weighting/custom/CustomWeighting.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/custom/CustomWeighting.java
@@ -124,7 +124,10 @@ public final class CustomWeighting implements Weighting {
         if (edgeState.get(EdgeIteratorState.UNFAVORED_EDGE)) seconds += headingPenaltySeconds;
         double distanceCosts = distance * distanceInfluence;
         if (Double.isInfinite(distanceCosts)) return Double.POSITIVE_INFINITY;
-        return roundWeight(10 * (seconds / priority + distanceCosts));
+        double costs = seconds / priority;
+        // we limit the weight increase due to priority to 1M (i.e. ~28h). this guards against
+        // tiny priority factors (for example applying 0.001 multiple times to the same edge)
+        return roundWeight(10 * (Math.min(costs, seconds + 100_000) + distanceCosts));
     }
 
     double calcSeconds(double distance, EdgeIteratorState edgeState, boolean reverse) {

--- a/core/src/main/java/com/graphhopper/routing/weighting/custom/CustomWeighting.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/custom/CustomWeighting.java
@@ -124,10 +124,9 @@ public final class CustomWeighting implements Weighting {
         if (edgeState.get(EdgeIteratorState.UNFAVORED_EDGE)) seconds += headingPenaltySeconds;
         double distanceCosts = distance * distanceInfluence;
         if (Double.isInfinite(distanceCosts)) return Double.POSITIVE_INFINITY;
-        double costs = seconds / priority;
         // we limit the weight increase due to priority to 1M (i.e. ~28h). this guards against
         // tiny priority factors (for example applying 0.001 multiple times to the same edge)
-        return roundWeight(10 * (Math.min(costs, seconds + 100_000) + distanceCosts));
+        return roundWeight(10 * (Math.min(seconds / priority, seconds + 100_000) + distanceCosts));
     }
 
     double calcSeconds(double distance, EdgeIteratorState edgeState, boolean reverse) {


### PR DESCRIPTION
Custom model allows setting arbitrarily small (but non-zero) priority factors. And even multiple ones can be applied to the same edge via different rules, making them even smaller. This increases weights to arbitrarily large values, even ones exceeding our (large limit) (#3297). At the same time these factors have no practical meaning: For example it makes no sense to accept a three day detour to avoid a bridge, but still use the bridge in case the detour is three days an half an hour.

Here I have limited the maximum weight penalty that can be applied by the priority factor to one million. That is the equivalent to ~28h (100k seconds). I cant think of any useful scenario where it would be required to increase the weight of a single edge more than that.

Performance seems unaffected by this change.