### PR TITLE
Custom modes: Add property for direction of edge

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/weighting/custom/CustomModelParser.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/custom/CustomModelParser.java
@@ -48,6 +48,7 @@ public class CustomModelParser {
     static final String PREV_PREFIX = "prev_";
     static final String CHANGE_ANGLE = "change_angle";
     static final String STREET_NAME = "street_name";
+    static final String IS_FORWARD = "is_forward";
     private static final boolean JANINO_DEBUG = Boolean.getBoolean(Scanner.SYSTEM_PROPERTY_SOURCE_DEBUGGING_ENABLE);
     private static final String SCRIPT_FILE_DIR = System.getProperty(Scanner.SYSTEM_PROPERTY_SOURCE_DEBUGGING_DIR, "./src/main/java/com/graphhopper/routing/weighting/custom");
 
@@ -185,7 +186,7 @@ public class CustomModelParser {
             // some literals are no variables and would throw an exception (encoded value not found)
             if (Character.isUpperCase(s.charAt(0)) || s.startsWith(IN_AREA_PREFIX))
                 return true;
-            if (nameValidator.isValid(s)) {
+            if (nameValidator.isValid(s) || s.equals(IS_FORWARD)) {
                 variables.add(s);
                 return true;
             }
@@ -343,6 +344,11 @@ public class CustomModelParser {
             } else {
                 throw new IllegalArgumentException("Not supported for backward: " + argSubstr);
             }
+        } else if (arg.equals(IS_FORWARD)) {
+            // If edge key is even, the EdgeIteratorState is points in the same direction as the edge in the graph.
+            // We also have to take the "reverse" argument into account because it is true the weight of an edge
+            // is calcuated as part of the reverse search starting at the destination node.
+            return "boolean is_forward = (edge.getEdgeKey() % 2 == 0) ^ reverse;";
         } else if (arg.startsWith(IN_AREA_PREFIX)) {
             return "";
         } else {
@@ -486,7 +492,7 @@ public class CustomModelParser {
             } else if (arg.equals(STREET_NAME)) {
                 // street_name is resolved at runtime from graph KV storage, no class field needed
             } else {
-                if (!arg.startsWith(IN_AREA_PREFIX))
+                if (!arg.startsWith(IN_AREA_PREFIX) && !arg.equals(IS_FORWARD))
                     throw new IllegalArgumentException("Variable not supported: " + arg);
             }
         }
@@ -533,6 +539,7 @@ public class CustomModelParser {
         NameValidator nameInConditionValidator = name -> lookup.hasEncodedValue(name)
                 || name.toUpperCase(Locale.ROOT).equals(name) || name.startsWith(IN_AREA_PREFIX) || name.equals(CHANGE_ANGLE)
                 || name.equals(STREET_NAME) || name.equals(PREV_PREFIX + STREET_NAME)
+                || name.equals(IS_FORWARD)
                 || name.startsWith(BACKWARD_PREFIX) && lookup.hasEncodedValue(name.substring(BACKWARD_PREFIX.length()))
                 || name.startsWith(PREV_PREFIX) && lookup.hasEncodedValue(name.substring(PREV_PREFIX.length()));
         Function<String, EncodedValue> fct = createSimplifiedLookup(lookup);
@@ -541,7 +548,6 @@ public class CustomModelParser {
             if (ev == null) throw new IllegalArgumentException("Couldn't find class for " + key);
             return getReturnType(ev);
         };
-
         parseExpressions(expressions, nameInConditionValidator, info, createObjects, list, helper, "");
         expressions.append("return value;\n");
         return new Parser(new org.codehaus.janino.Scanner(info, new StringReader(expressions.toString()))).

--- a/core/src/test/java/com/graphhopper/GraphHopperTest.java
+++ b/core/src/test/java/com/graphhopper/GraphHopperTest.java
@@ -690,6 +690,29 @@ public class GraphHopperTest {
         assertTrue(rsp.hasErrors(), "expected errors");
         assertEquals(1, rsp.getErrors().size());
         assertTrue(rsp.getErrors().get(0) instanceof ConnectionNotFoundException);
+
+        // Block a road in one direction only
+        CustomModel customModelDirected = new CustomModel().addToPriority(If("in_blocked_circle && !is_forward", MULTIPLY, "0"));
+        customModelDirected.getAreas().getFeatures().add(createCircle("blocked_circle", 50.0138917, 11.4895574, 5));
+        req = new GHRequest(50.006347,11.49674, 50.027614,11.49716).
+                        setProfile(profile);
+        // route without custom model
+        rsp = hopper.route(req);
+        assertFalse(rsp.hasErrors(), rsp.getErrors().toString());
+        assertEquals(2684.275, rsp.getBest().getDistance(), 10);
+        assertEquals(114663, rsp.getBest().getTime(), 10);
+        // with custom model
+        req.setCustomModel(customModelDirected);
+        rsp = hopper.route(req);
+        assertFalse(rsp.hasErrors(), rsp.getErrors().toString());
+        assertEquals(2787.087, rsp.getBest().getDistance(), 10);
+        assertEquals(201875, rsp.getBest().getTime(), 10);
+        // reverse direction should not use the detour
+        Collections.reverse(req.getPoints());
+        rsp = hopper.route(req);
+        assertFalse(rsp.hasErrors(), rsp.getErrors().toString());
+        assertEquals(2684.275, rsp.getBest().getDistance(), 10);
+        assertEquals(114663, rsp.getBest().getTime(), 10);
     }
 
     @Test

--- a/docs/core/custom-models.md
+++ b/docs/core/custom-models.md
@@ -122,6 +122,7 @@ There are also some that take on a numeric value, like:
 Special expressions:
 
  - `backward_*`: this expression allows to access the reverse direction of the current edge
+ - `is_forward`: is true if the edge is passed in the direction it is stored in the graph (useful to change speed/priority of an edge in one direction only)
  - `in_*`: see `areas` for more information about this expression
  - `prev_*`: this expression allows to access the previous edge; can only be used in statements of `turn_penalty`.
  - `country.isRightHandTraffic()`: returns true if right-hand traffic is the standard in the country of the current edge; `false` otherwise


### PR DESCRIPTION
I added this feature in a GraphHopper fork I maintain for a client (they use GraphHopper with HERE data). I thought that it might be useful for the public.

This pull request adds support for `is_forward` in custom models. This property allows you to block an edge in one direction only.

For example, if you import OSM data with the encoded value `osm_way_id`, you can send route requests like this:

```json
{
  "points": [
    [8.483888, 48.944448],
    [8.480776, 48.944547]
  ],
  "profile": "car",
  "custom_model": {
    "distance_influence": 15,
    "priority": [
      {
        "if": "osm_way_id == 1091253952 && is_forward",
        "multiply_by": "0.0"
      }
    ]
  }
}

```

This will make OSM way 1091253952 unpassable in the direction of the edge from base to adjacent node (which is the direction of the OSM way). Note: OSM way IDs are not stable. If a way is split, parts of the way get a new ID.

It can be also used to block a road in one direction only with a tiny no-go area (example see GraphHopperTest) in order to model a temporary traffic restriction.

I am happy to add more tests if this feature is appreciated by you.