### PR TITLE
Add missing encoded value in config-example.yml

### DIFF
--- a/config-example.yml
+++ b/config-example.yml
@@ -110,7 +110,7 @@ graphhopper:
   #   car_access|block_private=false, bike_access|block_private=false
   # By default we add the necessary encoded values for car.json, bike.json and foot.json (remove them if you do not need them)
   graph.encoded_values: |
-    car_access, car_average_speed, country, road_class, roundabout, max_speed,
+    car_access, car_average_speed, country, road_class, roundabout, max_speed, road_environment,
     foot_access, foot_average_speed, foot_priority, foot_road_access, hike_rating, average_slope,
     bike_access, bike_average_speed, bike_priority, bike_road_access, bike_network, mtb_rating, ferry_speed
 


### PR DESCRIPTION
config-example.yml is currently a broken example of a GraphHopper configuration file. This pull request adds the encoded value `road_environment` in order to make it work.

If the current master branch (commit bde93df2c130504eb979356ff653e2ac5e4b143d) is built without this patch, one will get following exception:

```
2026-04-27 16:30:30.173 [main] INFO  org.eclipse.jetty.server.Server - Shutdown oejs.Server@6dcc40f5{STOPPING}[12.1.5,sto=30000]
java.lang.IllegalArgumentException: Encoded values missing: road_environment.
To avoid that certain encoded values are automatically removed when you change the custom model later, you need to set the encoded values manually:
graph.encoded_values: car_access, car_average_speed, country, road_class, roundabout, max_speed, foot_access, foot_average_speed, foot_priority, foot_road_access, hike_rating, average_slope, bike_access, bike_average_speed, bike_priority, bike_road_access, bike_network, mtb_rating, ferry_speed, road_environment
```

How to reproduce:

```
mvn clean install
mkdir -p graph-cache
java -Ddw.graphhopper.datareader.file=/home/michael/Downloads/osm/karlsruhe-regbez.osm.pbf -Ddw.graphhopper.graph.location=graph-cache -jar web/target/graphhopper-web-12.0-SNAPSHOT.jar server config-example.yml
```