### PR TITLE
Bike: priority "multiplier" instead of "set" for lane

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonPriorityParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonPriorityParser.java
@@ -25,7 +25,6 @@ public abstract class BikeCommonPriorityParser implements TagParser {
     protected final HashSet<String> pushingSectionsHighways = new HashSet<>();
     protected final Set<String> preferHighwayTags = new HashSet<>();
     protected final Map<String, PriorityCode> avoidHighwayTags = new HashMap<>();
-    protected final DecimalEncodedValue avgSpeedEnc;
     protected final DecimalEncodedValue priorityEnc;
     // Car speed limit which switches the preference from UNCHANGED to AVOID_IF_POSSIBLE
     int avoidSpeedLimit;
@@ -34,9 +33,8 @@ public abstract class BikeCommonPriorityParser implements TagParser {
     // This is the specific bicycle class
     private String classBicycleKey;
 
-    protected BikeCommonPriorityParser(DecimalEncodedValue priorityEnc, DecimalEncodedValue avgSpeedEnc) {
+    protected BikeCommonPriorityParser(DecimalEncodedValue priorityEnc) {
         this.priorityEnc = priorityEnc;
-        this.avgSpeedEnc = avgSpeedEnc;
 
         addPushingSection("footway");
         addPushingSection("pedestrian");
@@ -63,9 +61,7 @@ public abstract class BikeCommonPriorityParser implements TagParser {
 
         TreeMap<Double, PriorityCode> weightToPrioMap = new TreeMap<>();
         weightToPrioMap.put(0d, UNCHANGED);
-        double maxSpeed = Math.max(avgSpeedEnc.getDecimal(false, edgeId, edgeIntAccess),
-                avgSpeedEnc.getDecimal(true, edgeId, edgeIntAccess));
-        collect(way, maxSpeed, isBikeDesignated(way), weightToPrioMap);
+        collect(way, isBikeDesignated(way), weightToPrioMap);
 
         // pick priority with the biggest order value
         double prio = PriorityCode.getValue(weightToPrioMap.lastEntry().getValue().getValue());
@@ -93,7 +89,7 @@ public abstract class BikeCommonPriorityParser implements TagParser {
      * @param weightToPrioMap associate a weight with every priority. This sorted map allows
      *                        subclasses to 'insert' more important priorities as well as overwrite determined priorities.
      */
-    void collect(ReaderWay way, double wayTypeSpeed, boolean bikeDesignated, TreeMap<Double, PriorityCode> weightToPrioMap) {
+    void collect(ReaderWay way, boolean bikeDesignated, TreeMap<Double, PriorityCode> weightToPrioMap) {
         String highway = way.getTag("highway");
         if (bikeDesignated) {
             boolean isGoodSurface = way.getTag("tracktype", "").equals("grade1") || goodSurface.contains(way.getTag("surface", ""));
@@ -113,7 +109,7 @@ public abstract class BikeCommonPriorityParser implements TagParser {
         double maxSpeed = Math.max(OSMMaxSpeedParser.parseMaxSpeed(way, false), OSMMaxSpeedParser.parseMaxSpeed(way, true));
         if (preferHighwayTags.contains(highway) || maxSpeed <= 30) {
             if (maxSpeed == MaxSpeed.MAXSPEED_MISSING || maxSpeed < avoidSpeedLimit) {
-                weightToPrioMap.put(40d, PREFER);
+                weightToPrioMap.put(40d, SLIGHT_PREFER);
                 if (way.hasTag("tunnel", INTENDED))
                     weightToPrioMap.put(40d, UNCHANGED);
             }
@@ -135,9 +131,11 @@ public abstract class BikeCommonPriorityParser implements TagParser {
 
         Set<String> cyclewayValues = Stream.of("cycleway", "cycleway:left", "cycleway:both", "cycleway:right").map(key -> way.getTag(key, "")).collect(Collectors.toSet());
         if (cyclewayValues.contains("track")) {
-            weightToPrioMap.put(100d, PREFER);
+            weightToPrioMap.put(100d, VERY_NICE);
         } else if (Stream.of("lane", "opposite_track", "shared_lane", "share_busway", "shoulder").anyMatch(cyclewayValues::contains)) {
-            weightToPrioMap.put(100d, SLIGHT_PREFER);
+            PriorityCode current = weightToPrioMap.lastEntry().getValue();
+            if (current.getValue() < PREFER.getValue())
+                weightToPrioMap.put(100d, current.better());
         } else if (pushingSectionsHighways.contains(highway) || "parking_aisle".equals(way.getTag("service"))) {
             PriorityCode pushingSectionPrio = SLIGHT_AVOID;
             if (way.hasTag("highway", "steps"))
@@ -166,13 +164,6 @@ public abstract class BikeCommonPriorityParser implements TagParser {
             weightToPrioMap.compute(100d, (key, existing) ->
                     existing == null || existing.getValue() < prio.getValue() ? prio : existing
             );
-        }
-
-        // Increase priority in case that maxspeed limits our average speed as compensation. See #630
-        if (maxSpeed > 0 && maxSpeed <= wayTypeSpeed) {
-            PriorityCode lastEntryValue = weightToPrioMap.lastEntry().getValue();
-            if (lastEntryValue.getValue() < BEST.getValue())
-                weightToPrioMap.put(110d, lastEntryValue.better());
         }
     }
 

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/BikePriorityParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/BikePriorityParser.java
@@ -3,17 +3,15 @@ package com.graphhopper.routing.util.parsers;
 import com.graphhopper.routing.ev.DecimalEncodedValue;
 import com.graphhopper.routing.ev.EncodedValueLookup;
 import com.graphhopper.routing.ev.VehiclePriority;
-import com.graphhopper.routing.ev.VehicleSpeed;
 
 public class BikePriorityParser extends BikeCommonPriorityParser {
 
     public BikePriorityParser(EncodedValueLookup lookup) {
-        this(lookup.getDecimalEncodedValue(VehiclePriority.key("bike")),
-                lookup.getDecimalEncodedValue(VehicleSpeed.key("bike")));
+        this(lookup.getDecimalEncodedValue(VehiclePriority.key("bike")));
     }
 
-    public BikePriorityParser(DecimalEncodedValue priorityEnc, DecimalEncodedValue speedEnc) {
-        super(priorityEnc, speedEnc);
+    public BikePriorityParser(DecimalEncodedValue priorityEnc) {
+        super(priorityEnc);
 
         addPushingSection("path");
 

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/MountainBikePriorityParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/MountainBikePriorityParser.java
@@ -12,12 +12,11 @@ import static com.graphhopper.routing.util.PriorityCode.*;
 public class MountainBikePriorityParser extends BikeCommonPriorityParser {
 
     public MountainBikePriorityParser(EncodedValueLookup lookup) {
-        this(lookup.getDecimalEncodedValue(VehicleSpeed.key("mtb")),
-                lookup.getDecimalEncodedValue(VehiclePriority.key("mtb")));
+        this(lookup.getDecimalEncodedValue(VehiclePriority.key("mtb")));
     }
 
-    protected MountainBikePriorityParser(DecimalEncodedValue speedEnc, DecimalEncodedValue priorityEnc) {
-        super(priorityEnc, speedEnc);
+    protected MountainBikePriorityParser(DecimalEncodedValue priorityEnc) {
+        super(priorityEnc);
 
         preferHighwayTags.add("road");
         preferHighwayTags.add("track");
@@ -32,8 +31,8 @@ public class MountainBikePriorityParser extends BikeCommonPriorityParser {
     }
 
     @Override
-    void collect(ReaderWay way, double wayTypeSpeed, boolean bikeDesignated, TreeMap<Double, PriorityCode> weightToPrioMap) {
-        super.collect(way, wayTypeSpeed, bikeDesignated, weightToPrioMap);
+    void collect(ReaderWay way, boolean bikeDesignated, TreeMap<Double, PriorityCode> weightToPrioMap) {
+        super.collect(way, bikeDesignated, weightToPrioMap);
 
         String highway = way.getTag("highway");
         if ("track".equals(highway)) {

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikePriorityParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikePriorityParser.java
@@ -11,12 +11,11 @@ import static com.graphhopper.routing.util.PriorityCode.*;
 public class RacingBikePriorityParser extends BikeCommonPriorityParser {
 
     public RacingBikePriorityParser(EncodedValueLookup lookup) {
-        this(lookup.getDecimalEncodedValue(VehiclePriority.key("racingbike")),
-                lookup.getDecimalEncodedValue(VehicleSpeed.key("racingbike")));
+        this(lookup.getDecimalEncodedValue(VehiclePriority.key("racingbike")));
     }
 
-    protected RacingBikePriorityParser(DecimalEncodedValue priorityEnc, DecimalEncodedValue speedEnc) {
-        super(priorityEnc, speedEnc);
+    protected RacingBikePriorityParser(DecimalEncodedValue priorityEnc) {
+        super(priorityEnc);
 
         addPushingSection("path");
 
@@ -40,8 +39,8 @@ public class RacingBikePriorityParser extends BikeCommonPriorityParser {
     }
 
     @Override
-    void collect(ReaderWay way, double wayTypeSpeed, boolean bikeDesignated, TreeMap<Double, PriorityCode> weightToPrioMap) {
-        super.collect(way, wayTypeSpeed, bikeDesignated, weightToPrioMap);
+    void collect(ReaderWay way, boolean bikeDesignated, TreeMap<Double, PriorityCode> weightToPrioMap) {
+        super.collect(way, bikeDesignated, weightToPrioMap);
 
         String highway = way.getTag("highway");
         if ("service".equals(highway) || "residential".equals(highway)) {

--- a/core/src/test/java/com/graphhopper/GraphHopperTest.java
+++ b/core/src/test/java/com/graphhopper/GraphHopperTest.java
@@ -462,9 +462,9 @@ public class GraphHopperTest {
         // via obergräfenthal
         assertEquals(2651, rsp.getAll().get(0).getTime() / 1000);
         // via ramsenthal
-        assertEquals(2782, rsp.getAll().get(1).getTime() / 1000);
+        assertEquals(2776, rsp.getAll().get(1).getTime() / 1000);
         // via unterwaiz
-        assertEquals(2872, rsp.getAll().get(2).getTime() / 1000);
+        assertEquals(2667, rsp.getAll().get(2).getTime() / 1000);
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/routing/RoutingAlgorithmWithOSMTest.java
+++ b/core/src/test/java/com/graphhopper/routing/RoutingAlgorithmWithOSMTest.java
@@ -433,8 +433,8 @@ public class RoutingAlgorithmWithOSMTest {
     @Test
     public void testKremsBikeRelation() {
         List<Query> queries = new ArrayList<>();
-        queries.add(new Query(48.409523, 15.602394, 48.375466, 15.72916, 12493, 159));
-        queries.add(new Query(48.410061, 15.63951, 48.411386, 15.604899, 3091, 92));
+        queries.add(new Query(48.409523, 15.602394, 48.375466, 15.72916, 12574, 169));
+        queries.add(new Query(48.410061, 15.63951, 48.411386, 15.604899, 3103, 95));
         queries.add(new Query(48.412294, 15.62007, 48.398306, 15.609667, 3965, 95));
 
         Profile bikeProfile = new Profile("bike").setCustomModel(new CustomModel().
@@ -458,8 +458,8 @@ public class RoutingAlgorithmWithOSMTest {
     @Test
     public void testKremsMountainBikeRelation() {
         List<Query> queries = new ArrayList<>();
-        queries.add(new Query(48.409523, 15.602394, 48.375466, 15.72916, 12493, 159));
-        queries.add(new Query(48.410061, 15.63951, 48.411386, 15.604899, 3091, 92));
+        queries.add(new Query(48.409523, 15.602394, 48.375466, 15.72916, 12574, 169));
+        queries.add(new Query(48.410061, 15.63951, 48.411386, 15.604899, 3103, 95));
         queries.add(new Query(48.412294, 15.62007, 48.398306, 15.609667, 3965, 95));
 
         Profile mtbProfile = new Profile("mtb").setCustomModel(new CustomModel().

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/AbstractBikeTagParserTester.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/AbstractBikeTagParserTester.java
@@ -315,7 +315,7 @@ public abstract class AbstractBikeTagParserTester {
     public void testAvoidTunnel() {
         ReaderWay osmWay = new ReaderWay(1);
         osmWay.setTag("highway", "residential");
-        assertPriority(PREFER, osmWay);
+        assertPriority(SLIGHT_PREFER, osmWay);
 
         osmWay.setTag("tunnel", "yes");
         assertPriority(UNCHANGED, osmWay);
@@ -345,7 +345,7 @@ public abstract class AbstractBikeTagParserTester {
     public void testService() {
         ReaderWay way = new ReaderWay(1);
         way.setTag("highway", "service");
-        assertPriorityAndSpeed(PREFER, 12, way);
+        assertPriorityAndSpeed(SLIGHT_PREFER, 12, way);
 
         way.setTag("service", "parking_aisle");
         assertPriorityAndSpeed(SLIGHT_AVOID, 8, way);
@@ -355,7 +355,7 @@ public abstract class AbstractBikeTagParserTester {
         way.clearTags();
         way.setTag("highway", "residential");
         way.setTag("service", "alley");
-        assertPriorityAndSpeed(PREFER, 18, way);
+        assertPriorityAndSpeed(SLIGHT_PREFER, 18, way);
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/BikeCustomModelTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/BikeCustomModelTest.java
@@ -159,16 +159,16 @@ public class BikeCustomModelTest {
         way.setTag("surface", "ground"); // bad surface means slow speed for mtb too
         EdgeIteratorState edge = createEdge(way);
         CustomWeighting.Parameters p = CustomModelParser.createWeightingParameters(cm, em);
-        assertEquals(1.2, p.getEdgeToPriorityMapping().get(edge, false), 0.01);
+        assertEquals(1.1, p.getEdgeToPriorityMapping().get(edge, false), 0.01);
         assertEquals(10.0, p.getEdgeToSpeedMapping().get(edge, false), 0.01);
 
         way.setTag("mtb:scale", "3");
         edge = createEdge(way);
-        assertEquals(0.6, p.getEdgeToPriorityMapping().get(edge, false), 0.01);
+        assertEquals(0.55, p.getEdgeToPriorityMapping().get(edge, false), 0.01);
 
         way.setTag("mtb:scale", "5");
         edge = createEdge(way);
-        assertEquals(0.6, p.getEdgeToPriorityMapping().get(edge, false), 0.01);
+        assertEquals(0.55, p.getEdgeToPriorityMapping().get(edge, false), 0.01);
         assertEquals(4.0, p.getEdgeToSpeedMapping().get(edge, false), 0.01);
 
         way.setTag("mtb:scale", "6");
@@ -178,15 +178,15 @@ public class BikeCustomModelTest {
         way.removeTag("mtb:scale");
         way.setTag("sac_scale", "hiking");
         edge = createEdge(way);
-        assertEquals(1.2, p.getEdgeToPriorityMapping().get(edge, false), 0.01);
+        assertEquals(1.1, p.getEdgeToPriorityMapping().get(edge, false), 0.01);
 
         way.setTag("sac_scale", "mountain_hiking");
         edge = createEdge(way);
-        assertEquals(1.2, p.getEdgeToPriorityMapping().get(edge, false), 0.01);
+        assertEquals(1.1, p.getEdgeToPriorityMapping().get(edge, false), 0.01);
 
         way.setTag("sac_scale", "alpine_hiking");
         edge = createEdge(way);
-        assertEquals(1.2, p.getEdgeToPriorityMapping().get(edge, false), 0.01);
+        assertEquals(1.1, p.getEdgeToPriorityMapping().get(edge, false), 0.01);
 
         way.setTag("sac_scale", "demanding_alpine_hiking");
         edge = createEdge(way);
@@ -357,7 +357,7 @@ public class BikeCustomModelTest {
         rel.setTag("route", "bicycle");
         rel.setTag("network", "lcn");
         edge = createEdge(way, rel);
-        assertEquals(1.56, p.getEdgeToPriorityMapping().get(edge, false), 0.01);
+        assertEquals(1.43, p.getEdgeToPriorityMapping().get(edge, false), 0.01);
         assertEquals(18, p.getEdgeToSpeedMapping().get(edge, false), 0.01);
 
         way.clearTags();
@@ -389,7 +389,7 @@ public class BikeCustomModelTest {
         rel.setTag("route", "mtb");
         rel.setTag("network", "lcn");
         edge = createEdge(way, rel);
-        assertEquals(1.56, p.getEdgeToPriorityMapping().get(edge, false), 0.01);
+        assertEquals(1.43, p.getEdgeToPriorityMapping().get(edge, false), 0.01);
         assertEquals(18, p.getEdgeToSpeedMapping().get(edge, false), 0.01);
     }
 

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/BikeTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/BikeTagParserTest.java
@@ -124,7 +124,7 @@ public class BikeTagParserTest extends AbstractBikeTagParserTester {
         way.clearTags();
         way.setTag("highway", "residential");
         way.setTag("surface", "asphalt");
-        assertPriorityAndSpeed(PREFER, 18, way);
+        assertPriorityAndSpeed(SLIGHT_PREFER, 18, way);
 
         way.clearTags();
         way.setTag("highway", "motorway");
@@ -404,24 +404,24 @@ public class BikeTagParserTest extends AbstractBikeTagParserTester {
         way.setTag("surface", "paved");
         assertPriority(BAD, way);
         way.setTag("cycleway", "track");
-        assertPriority(PREFER, way);
+        assertPriority(VERY_NICE, way);
 
         way.clearTags();
         way.setTag("highway", "primary");
         way.setTag("cycleway:left", "lane");
-        assertPriority(SLIGHT_PREFER, way);
+        assertPriority(AVOID_MORE, way);
 
         way.clearTags();
         way.setTag("highway", "primary");
         way.setTag("cycleway:right", "lane");
-        assertPriority(SLIGHT_PREFER, way);
+        assertPriority(AVOID_MORE, way);
         way.setTag("cycleway:left", "no");
-        assertPriority(SLIGHT_PREFER, way);
+        assertPriority(AVOID_MORE, way);
 
         way.clearTags();
         way.setTag("highway", "primary");
         way.setTag("cycleway:both", "lane");
-        assertPriority(SLIGHT_PREFER, way);
+        assertPriority(AVOID_MORE, way);
 
         way.clearTags();
         way.setTag("highway", "primary");
@@ -433,7 +433,7 @@ public class BikeTagParserTest extends AbstractBikeTagParserTester {
         way.setTag("highway", "primary");
         way.setTag("oneway", "yes");
         way.setTag("cycleway", "opposite_track");
-        assertPriority(SLIGHT_PREFER, way);
+        assertPriority(AVOID_MORE, way);
 
         way.clearTags();
         way.setTag("highway", "primary");
@@ -454,7 +454,7 @@ public class BikeTagParserTest extends AbstractBikeTagParserTester {
         way.setTag("highway", "secondary");
         way.setTag("cycleway", "lane");
         way.setTag("cycleway:lane", "advisory");
-        assertPriority(SLIGHT_PREFER, way);
+        assertPriority(SLIGHT_AVOID, way);
     }
 
     @Test
@@ -548,13 +548,13 @@ public class BikeTagParserTest extends AbstractBikeTagParserTester {
         way = new ReaderWay(1);
         way.setTag("highway", "secondary");
         way.setTag("maxspeed", "10");
-        assertPriorityAndSpeed(VERY_NICE, 10, way);
+        assertPriorityAndSpeed(SLIGHT_PREFER, 10, way);
 
         way = new ReaderWay(1);
         way.setTag("highway", "residential");
         way.setTag("maxspeed", "15");
         // todo: speed is larger than maxspeed tag due to rounding and storable max speed is 30
-        assertPriorityAndSpeed(VERY_NICE, 16, way);
+        assertPriorityAndSpeed(SLIGHT_PREFER, 16, way);
     }
 
     // Issue 407 : Always block kissing_gate except for mountainbikes
@@ -615,7 +615,7 @@ public class BikeTagParserTest extends AbstractBikeTagParserTester {
         assertPriority(VERY_NICE, way);
 
         way.setTag("maxspeed", "15");
-        assertPriority(BEST, way);
+        assertPriority(VERY_NICE, way);
 
         // do not overwrite better priority
         way = new ReaderWay(1);
@@ -700,9 +700,9 @@ public class BikeTagParserTest extends AbstractBikeTagParserTester {
         way.clearTags();
         way.setTag("highway", "pedestrian");
         way.setTag("cycleway:right", "track");
-        assertPriorityAndSpeed(PREFER, 18, way);
+        assertPriorityAndSpeed(VERY_NICE, 18, way);
         way.setTag("bicycle", "yes");
-        assertPriorityAndSpeed(PREFER, 18, way);
+        assertPriorityAndSpeed(VERY_NICE, 18, way);
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/MountainBikeTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/MountainBikeTagParserTest.java
@@ -67,7 +67,7 @@ public class MountainBikeTagParserTest extends AbstractBikeTagParserTester {
         assertPriorityAndSpeed(BAD, 18, way);
 
         way.setTag("highway", "residential");
-        assertPriorityAndSpeed(PREFER, 18, way);
+        assertPriorityAndSpeed(SLIGHT_PREFER, 18, way);
 
         // Test pushing section speeds
         way.setTag("highway", "footway");
@@ -92,7 +92,7 @@ public class MountainBikeTagParserTest extends AbstractBikeTagParserTester {
         way.clearTags();
         way.setTag("highway", "path");
         way.setTag("surface", "ground");
-        assertPriorityAndSpeed(PREFER, 10, way);
+        assertPriorityAndSpeed(SLIGHT_PREFER, 10, way);
     }
 
     @Test
@@ -159,6 +159,6 @@ public class MountainBikeTagParserTest extends AbstractBikeTagParserTester {
     public void testPreferenceForSlowSpeed() {
         ReaderWay osmWay = new ReaderWay(1);
         osmWay.setTag("highway", "tertiary");
-        assertPriority(PREFER, osmWay);
+        assertPriority(SLIGHT_PREFER, osmWay);
     }
 }

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/RacingBikeTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/RacingBikeTagParserTest.java
@@ -244,13 +244,13 @@ public class RacingBikeTagParserTest extends AbstractBikeTagParserTester {
         ReaderWay osmWay = new ReaderWay(1);
         osmWay.setTag("highway", "tertiary");
         osmWay.setTag("maxspeed", "50");
-        assertPriorityAndSpeed(encodingManager, priorityEnc, speedEnc, parsers, PREFER, 24, osmWay);
+        assertPriorityAndSpeed(encodingManager, priorityEnc, speedEnc, parsers, SLIGHT_PREFER, 24, osmWay);
 
         osmWay.setTag("maxspeed", "60");
-        assertPriorityAndSpeed(encodingManager, priorityEnc, speedEnc, parsers, PREFER, 24, osmWay);
+        assertPriorityAndSpeed(encodingManager, priorityEnc, speedEnc, parsers, SLIGHT_PREFER, 24, osmWay);
 
         osmWay.setTag("maxspeed", "80");
-        assertPriorityAndSpeed(encodingManager, priorityEnc, speedEnc, parsers, PREFER, 24, osmWay);
+        assertPriorityAndSpeed(encodingManager, priorityEnc, speedEnc, parsers, SLIGHT_PREFER, 24, osmWay);
 
         osmWay.setTag("maxspeed", "90");
         assertPriorityAndSpeed(encodingManager, priorityEnc, speedEnc, parsers, UNCHANGED, 24, osmWay);
@@ -312,6 +312,6 @@ public class RacingBikeTagParserTest extends AbstractBikeTagParserTester {
     public void testPreferenceForSlowSpeed() {
         ReaderWay osmWay = new ReaderWay(1);
         osmWay.setTag("highway", "tertiary");
-        assertPriority(PREFER, osmWay);
+        assertPriority(SLIGHT_PREFER, osmWay);
     }
 }

--- a/web-bundle/src/main/resources/com/graphhopper/maps/config.js
+++ b/web-bundle/src/main/resources/com/graphhopper/maps/config.js
@@ -19,9 +19,5 @@ const config = {
         ],
         snapPreventions: ['ferry'],
     },
-    profiles: {
-        bike:   { details: ['cycleway', 'bike_network'] },
-        foot:   { details: ['sidewalk', 'foot_network'] },
-    },
     profile_group_mapping: {},
 }

--- a/web-bundle/src/main/resources/com/graphhopper/maps/config.js
+++ b/web-bundle/src/main/resources/com/graphhopper/maps/config.js
@@ -19,5 +19,9 @@ const config = {
         ],
         snapPreventions: ['ferry'],
     },
+    profiles: {
+        bike:   { details: ['cycleway', 'bike_network'] },
+        foot:   { details: ['sidewalk', 'foot_network'] },
+    },
     profile_group_mapping: {},
 }

--- a/web/src/test/java/com/graphhopper/application/resources/RouteResourceClientHCTest.java
+++ b/web/src/test/java/com/graphhopper/application/resources/RouteResourceClientHCTest.java
@@ -407,7 +407,7 @@ public class RouteResourceClientHCTest {
 
         GHResponse response = gh.route(req);
         ResponsePath path = response.getBest();
-        assertEquals(5158, path.getDistance(), 5);
+        assertEquals(5038, path.getDistance(), 5);
         assertEquals(11, path.getWaypoints().size());
 
         assertEquals(path.getTime(), path.getPathDetails().get("leg_time").stream().mapToLong(d -> (long) d.getValue()).sum(), 1);

--- a/web/src/test/java/com/graphhopper/application/resources/RouteResourceCustomModelTest.java
+++ b/web/src/test/java/com/graphhopper/application/resources/RouteResourceCustomModelTest.java
@@ -331,7 +331,7 @@ public class RouteResourceCustomModelTest {
                 " \"ch.disable\": true" +
                 "}";
         path = getPath(body);
-        assertEquals(5838, path.get("distance").asDouble(), 10);
+        assertEquals(5542, path.get("distance").asDouble(), 10);
     }
 
     @Test


### PR DESCRIPTION
This PR boosts the priority for "lane" slightly (and removes the cycleway=track inconsistency and the speed-compensation block) and fixes the inconsistencies discussed in #3219 (and does this for all bike classes) but without removing preferHighwayTags (would lead to unrelated changes for [routes like this](https://graphhopper.com/maps/?point=51.156885%2C13.006289&point=51.162289%2C13.209058&profile=bike&layer=TF+Cycle)). The maximum priority is 1.2 (PREFER) i.e. it can never get as good as cycleway=track. This leads to fewer route changes compared to #3336 (draft) and #3327.

Also the [the original route](https://graphhopper.com/maps/?point=-3.753787%2C-38.586304&point=-3.774791%2C-38.57886&profile=bike&layer=Cyclosm) is fixed and now follows the initial laned residential:

<img width="300" alt="image" src="https://github.com/user-attachments/assets/74800446-cc48-487e-a9fa-1dd76afa4c3f" />

I also deleted the speed-compensate block as @michaz said - it makes the priority calculation unnecessary complex.

AI generated summary table:

 ### Original issue                                                                                                                                            
                                                                                                                                                                     
  | Tags | Before | After |
  |---|---|---|                                                                                                                                                      
  | `highway=residential` | 1.2 | **1.1** |                 
  | `highway=residential` + `cycleway=lane` | 1.1 X | **1.2** |                                                                                                      
  | `highway=residential` + `cycleway=track` | 1.2 | **1.3** |
  | `highway=cycleway` | 1.3 | 1.3 |                                                                                                                                 
                                                            
  ### Hierarchy preservation                                                                                                                                         
                                                            
  | Tags | Before | After |
  |---|---|---|
  | `highway=tertiary` (not in preferHwy) | 1.0 | 1.0 |
  | `highway=residential` | 1.2 | **1.1** |                                                                                                                          
  | `highway=residential` + `cycleway=lane` | 1.1 X | **1.2** |
  | `highway=secondary` | 0.8 | 0.8 |                                                                                                                                
  | `highway=secondary` + `cycleway=lane` | 1.1 X | **0.9** |
  | `highway=primary` | 0.5 | 0.5 |                                                                                                                                  
  | `highway=primary` + `cycleway=lane` | 1.1 X | **0.6** | 
  | `highway=primary` + `cycleway=track` | 1.2 | **1.3** |                                                                                                           
  | `highway=secondary` + `cycleway=track` | 1.2 | **1.3** |
                                                                                                                                                                     
  ### `maxspeed≤30` (now "1.1 like residential")            
                                                                                                                                                                     
  | Tags | Before | After |                                 
  |---|---|---|
  | `highway=secondary` + `maxspeed=30` | 1.2 | **1.1** |
  | `highway=secondary` + `maxspeed=30` + `cycleway=lane` | 1.1 X | **1.2** |                                                                                        
  | `highway=primary` + `maxspeed=30` | 1.2 | **1.1** |                                                                                                              
                                                                                                                                                                     
  ### Speed-compensation block removed                                                                                                                               
                                                            
  | Tags | Before | After |                                                                                                                                          
  |---|---|---|
  | `highway=secondary` + `maxspeed=10` | 1.3 | **1.1** |                                                                                                            
  | `highway=residential` + `maxspeed=15` | 1.3 | **1.1** | 
  | `residential` + `bicycle=designated` + `class:bicycle:touring=2` + `maxspeed=15` | 1.5 | **1.3** |                                                               
                                                                                                                                                                     
  ### `bikeDesignated` no longer downgraded by `cycleway=track`                                                                                                      
                                                                                                                                                                     
  | Tags | Before | After |                                 
  |---|---|---|
  | `highway=path` + `bicycle=designated` (good surface) | 1.3 | 1.3 |
  | `highway=path` + `bicycle=designated` + `cycleway=track` | 1.2 X | **1.3** |  