### PR TITLE
MapMatchingResource: Reduce log verbosity of map matching, log ms instead of ns

### DIFF
--- a/web-bundle/src/main/java/com/graphhopper/resources/MapMatchingResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/MapMatchingResource.java
@@ -136,10 +136,11 @@ public class MapMatchingResource {
 
         sw.stop();
         logger.info(objectMapper.createObjectNode()
-                .put("duration", sw.getNanos())
+                .put("took", sw.getMillisDouble())
                 .put("profile", profile)
                 .put("observations", measurements.size())
-                .putPOJO("mapmatching", matching.getStatistics()).toString());
+                .put("original_distance", matchResult.getGpxEntriesLength())
+                .put("distance", matchResult.getMatchLength()).toString());
 
         if (debugMode) {
             return Response.ok(matching.getDebugInfo()).


### PR DESCRIPTION
This pull request reduces the verbosity of logging of MapMatchingResource. Changes:

* The processing time will not be written in millisecons like it is implemented in RouteResource.
* "duration" is replaced by "took" (like RouteResource)
* Dropping all `mapmatching`.

Prior to this commit, each request is written like this to the log (all examples copied from Systemd journal, line breaks added for better rendering on github.com).

```
May 23 02:17:47 myhostname42 java[3506533]: 2026-05-23 02:17:47.084 [pool-2-thread-2242 - POST /matc
h?profile=all_edges&type=json&points_encoded=false&locale=en&elevation=true&gps_accuracy=20] INFO  c
.g.resources.MapMatchingResource - {"duration":185752771,"profile":"all_edges","observations":70,"ma
pmatching":{"snapsPerObservation":[1,2,1,4,1,3,5,1,4,4,3,3,3,2,3,3,3,1,1,2,1,3,4,4,9,6,3,4,11,11,8,5
,2,2,3,2,2,3,2,2,9,4,12,8,3,1,2,3,2,3,2,1,3,1],"snapDistanceRanks":[0,0,0,0,0,1,1,0,0,1,2,0,0,0,0,0,
0,0,0,0,0,0,1,0,0,1,0,0,0,7,4,1,1,1,0,0,0,0,0,0,4,0,0,1,0,0,0,0,0,0,0,0,0,0],"maxSnapDistances":[0.0
17091533986574085,15.86605399321331,0.043564826638646366,23.71106438879341,0.03426389666822854,0.860
6174839624832,6.334911585071413,1.2525502153737738,20.332972554365334,17.620772183652164,2.873217840
5402786,6.536923894180684,2.8990235046328663,20.33306628383344,13.893233948060224,10.419402975393695
,2.952733088446325,0.03499863453768705,0.03653429200921441,2.7838170218088223,0.02953516589870086,3.
386269207316973,3.1613233249505646,13.283553339141559,19.67159565633287,10.200640378378685,10.355714
977311948,12.878031134530833,21.075169697802924,24.61138626505137,18.58869555585336,20.6216864986970
7,7.536791677207637,10.503463540682064,9.001226850547878,7.922938913147305,13.849732214847652,16.427
932990269372,11.524732121197097,10.544020249237153,19.234571323603024,16.336124968985665,19.63104285
3022745,18.12260875046366,4.716040553413121,0.06422533643252432,16.693604270457207,18.55977490675160
3,12.944023574651617,7.786817150516735,12.399303701814473,0.05923468279474062,21.02723624447948,0.39
914681670945845],"filteredObservations":54,"visitedNodes":0,"snapDistances":[0.017091533986574085,0.
030363785128045204,0.043564826638646366,0.06264674199562457,0.03426389666822854,0.6787816268433331,0
.38351672170884143,1.2525502153737738,0.08662460021721062,2.537967717209008,2.8732178405402786,0.459
04146041897054,0.5758180705693213,0.3706932734061342,0.0781266772933942,0.05795386973353649,0.202160
13190931129,0.03499863453768705,0.03653429200921441,0.03587044033651194,0.02953516589870086,0.361345
21099756345,0.9152160778789529,0.3410133489553635,0.018259896415099324,0.5893692376953943,0.05363857
02551597,0.03443780029457387,0.046957729444581014,13.836943529662234,9.496137431114967,6.74426826189
8301,7.536791677207637,10.503463540682064,0.056058330643464674,0.01905670096711738,0.057391881420227
345,0.06643908973117624,0.49881660373081016,0.9499917100057341,3.646573350176179,0.9899000817003818,
0.27809234125808463,0.30902502637038276,0.06841885244576393,0.06422533643252432,0.44483773488126327,
0.3737712803906646,0.05190393847496911,0.10889643676556421,0.036348008061996916,0.05923468279474062,
0.002673200478648401,0.39914681670945845],"transitionDistances":[130,143,193,141,106,156,90,66,41,91
,193,44,100,131,71,276,124,101,279,104,52,76,67,108,92,82,74,44,49,97,334,569,168,70,169,722,155,435
,73,848,48,95,50,41,182,74,118,160,55,55,81,60,106]}}
```

If the submitted track is longer, the log is spammed with matching results and difficult to read.

After the change, it looks like this:

```
May 26 15:01:26 myhostname42 java[3252851]: 2026-05-26 15:01:26.765 [pool-2-thread-78 - POST /match?
calc_junctions=true&profile=all_edges&type=json&points_encoded=false&locale=en&elevation=true&gps_ac
curacy=5] INFO  c.g.resources.MapMatchingResource - {"took":384.332385,"profile":"all_edges","observ
ations":2401,"original_distance":48449.604319685655,"distance":49281.44005270316}

```

I compared it the with the RouteResource class. That logs for GET requests:

```
May 23 02:13:43 myhostname42 java[3506533]: 2026-05-23 02:13:43.488 [pool-2-thread-2015 - GET /route
?point=49.638757025823%2C18.667345521971583&point=49.5276%2C18.754282&locale=cs&elevation=true&point
s_encoded=false&optimize=true&debug=false&heading=133&heading_penalty=300&profile=bike&ch.disable=tr
ue] INFO  c.g.resources.RouteResource - 127.0.0.1 en_US my_clients_user_agent [49.638757025823,18.66
7345521971583, 49.5276,18.754282], took: 44.8ms, algo: , profile: bike, alternatives: 1, distance0: 
17915.63091726408, weight0: 3025.0316055154776, time0: 61min, points0: 403, debugInfo: idLookup:2.25
598E-4s; , algoInit:854 μs, astarbi|beeline-routing:42 ms, path extraction: 67 μs, visited nodes sum
: 5092

```

and for POST requests:

```
May 23 02:24:46 myhostname42 java[3506533]: 2026-05-23 02:24:46.386 [pool-2-thread-1936 - POST /rout
e] INFO  c.g.resources.RouteResource - 127.0.0.1 en_US my_clients_user_agent 2, took: 0.9 ms, algo: 
, profile: racingbike, custom_model: null, alternatives: 1, distance0: 1320.4727426380982, weight0: 
631.3805639571474, time0: 7min, points0: 50, debugInfo: idLookup:1.46178E-4s; , algoInit:242 μs, ast
arbi|ch|edge_based|no_sod-routing:0 ms, path extraction: 18 μs, visited nodes sum: 40
```

If desired, I am happy to adapt the logging of MapMatchingResource even more to RouteResource to make it possible to extract processing times from both with the same regular expression for monitoring purposes.