### PR TITLE
Fix: use pushing speed for bicycle:backward=dismount on oneways

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -93,6 +93,7 @@ Here is an overview:
  * stefanholder, Stefan Holder, BMW AG, creating and integrating the hmm-lib (#49, #66, #69) and penalizing inner-link U-turns (#88, #91), refactored unfavoring of virtual edges #885
  * stevensnoeijen, fixes like #1568 
  * Svantulden, improved documentation and nearest API
+* suhanikhanna31, fix wrong speed for bicycle:backward=dismount on oneways #3354
  * taulinger, hopefully more to come 
  * thehereward, code cleanups like #620
  * tyrasd, improved toll road handling in Austria #3190

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonAverageSpeedParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonAverageSpeedParser.java
@@ -180,8 +180,13 @@ public abstract class BikeCommonAverageSpeedParser extends AbstractAverageSpeedP
         }
 
         setSpeed(false, edgeId, edgeIntAccess, applyMaxSpeed(way, speed, false));
-        if (avgSpeedEnc.isStoreTwoDirections())
-            setSpeed(true, edgeId, edgeIntAccess, applyMaxSpeed(way, speed, true));
+if (avgSpeedEnc.isStoreTwoDirections()) {
+    // If bicycle:backward=dismount, the cyclist must push in reverse direction
+    // regardless of what speed was calculated above
+    String bicycleBackward = way.getTag("bicycle:backward");
+    double backwardSpeed = "dismount".equals(bicycleBackward) ? PUSHING_SECTION_SPEED : speed;
+    setSpeed(true, edgeId, edgeIntAccess, applyMaxSpeed(way, backwardSpeed, true));
+}
     }
 
     void setHighwaySpeed(String highway, int speed) {


### PR DESCRIPTION
Fixes #3354

The handleWayTags method in BikeCommonAverageSpeedParser applied the same 
computed speed to both directions without checking bicycle:backward=dismount. 

This fix checks for that tag before setting backward speed and uses 
PUSHING_SECTION_SPEED (4 km/h) when present.
