### PR TITLE
smoother elevation for tunnels and bridges

### DIFF
--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -1412,6 +1412,10 @@ public class GraphHopper {
         if (encodingManager.hasEncodedValue(RoadEnvironment.KEY)) {
             EnumEncodedValue<RoadEnvironment> roadEnvEnc = encodingManager.getEnumEncodedValue(RoadEnvironment.KEY, RoadEnvironment.class);
             StopWatch sw = new StopWatch().start();
+            // first step: fix the tower-end elevation values using the surrounding road network
+            new BridgeTunnelTowerCorrection(baseGraph.getBaseGraph(), roadEnvEnc).execute();
+            float towerCorrection = sw.stop().getSeconds();
+            sw = new StopWatch().start();
             new EdgeElevationInterpolator(baseGraph.getBaseGraph(), roadEnvEnc, RoadEnvironment.TUNNEL).execute();
             float tunnel = sw.stop().getSeconds();
             sw = new StopWatch().start();
@@ -1421,7 +1425,7 @@ public class GraphHopper {
             // See #2098 for mor information
             sw = new StopWatch().start();
             new EdgeElevationInterpolator(baseGraph.getBaseGraph(), roadEnvEnc, RoadEnvironment.FERRY).execute();
-            logger.info("Bridge interpolation " + (int) bridge + "s, " + "tunnel interpolation " + (int) tunnel + "s, ferry interpolation " + (int) sw.stop().getSeconds() + "s");
+            logger.info("Tower correction " + (int) towerCorrection + "s, bridge interpolation " + (int) bridge + "s, tunnel interpolation " + (int) tunnel + "s, ferry interpolation " + (int) sw.stop().getSeconds() + "s");
         }
     }
 

--- a/core/src/main/java/com/graphhopper/reader/dem/BridgeTunnelTowerCorrection.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/BridgeTunnelTowerCorrection.java
@@ -1,0 +1,266 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.reader.dem;
+
+import  com.carrotsearch.hppc.DoubleArrayList;
+import com.carrotsearch.hppc.IntDoubleHashMap;
+import com.graphhopper.coll.GHBitSet;
+import com.graphhopper.coll.GHIntHashSet;
+import com.graphhopper.coll.GHTBitSet;
+import com.graphhopper.routing.ev.EnumEncodedValue;
+import com.graphhopper.routing.ev.RoadEnvironment;
+import com.graphhopper.storage.BaseGraph;
+import com.graphhopper.storage.NodeAccess;
+import com.graphhopper.util.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Corrects elevations of bridge/tunnel/ferry tower-end nodes from the surrounding road
+ * network, then re-interpolates pillars on the adjacent ramp edges so the slope at the
+ * structure end is smoothed.
+ * <p>
+ * DEM at a bridge end often samples the valley/river below the deck (too low); at a tunnel
+ * end the surface above (too high). The surrounding road is on solid ground at the right
+ * level, so its elevations are the correct anchor. For each structure-touching tower we
+ * BFS outward (≤ {@link #BFS_MAX_DIST_M}) over non-structure edges, sample only pure-ground
+ * nodes (no structure incidence) — walking *past* other structure-touching nodes so that
+ * parallel bridges/tunnels sharing the tower don't terminate the BFS — and replace the
+ * tower's elevation with the inverse-distance-weighted mean of the samples (Shepard's IDW).
+ * If a single edge would overshoot the budget, we sample along its way-geometry at the
+ * cutoff so sparse graphs still produce a representative sample.
+ * <p>
+ * After tower correction, we re-interpolate the pillar nodes on each adjacent ramp edge
+ * linearly between the two endpoints — this kills the slope artifact at the approach when
+ * ramp pillars had bad DEM.
+ * <p>
+ * {@link EdgeElevationInterpolator} should run AFTER this class — it interpolates the
+ * structure interior (bridge/tunnel pillars, inner tower nodes) from the now-correct
+ * outer values.
+ */
+public class BridgeTunnelTowerCorrection {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(BridgeTunnelTowerCorrection.class);
+
+    // How far outward to search via BFS (in meter).
+    private static final double BFS_MAX_DIST_M = 50.0;
+    // Minimum number of pure-ground samples required before we trust the inferred elevation.
+    private static final int MIN_ROAD_SAMPLES = 1;
+
+    private final BaseGraph graph;
+    private final EnumEncodedValue<RoadEnvironment> roadEnvEnc;
+
+    public BridgeTunnelTowerCorrection(BaseGraph graph, EnumEncodedValue<RoadEnvironment> roadEnvEnc) {
+        this.graph = graph;
+        this.roadEnvEnc = roadEnvEnc;
+    }
+
+    public void execute() {
+        final NodeAccess nodeAccess = graph.getNodeAccess();
+        final EdgeExplorer explorer = graph.createEdgeExplorer();
+        // Second explorer used purely for the touchesStructure check — keeps its iterator
+        // state independent of the BFS / pillar-loop explorer.
+        final EdgeExplorer touchExplorer = graph.createEdgeExplorer();
+        final int numNodes = graph.getNodes();
+
+        // For every structure-touching tower, collect elevation samples via BFS and decide
+        // the corrected elevation. Apply in place — the BFS only samples pure-ground nodes
+        // (those that do not touch any structure edge), so already-corrected neighbouring
+        // towers cannot contaminate later BFS results.
+        int corrected = 0, skipped = 0;
+        for (int n = 0; n < numNodes; n++) {
+            if (!touchesStructure(n, touchExplorer)) continue;
+            DoubleArrayList sampleEles = new DoubleArrayList();
+            DoubleArrayList sampleDists = new DoubleArrayList();
+            bfsCollectRoadSamples(n, nodeAccess, explorer, sampleEles, sampleDists);
+            if (sampleEles.size() < MIN_ROAD_SAMPLES) {
+                skipped++;
+                continue;
+            }
+            // Fully replace the DEM value (no soft-trust dampening). If DEM is already
+            // consistent with surroundings, IDW ≈ obs and nothing visibly moves anyway;
+            // a smaller threshold previously let ~1 m underbias slip through.
+            double newZ = inverseDistanceWeightedMean(sampleEles, sampleDists);
+            double obs = nodeAccess.getEle(n);
+            if (Math.abs(newZ - obs) > 1e-6) {
+                nodeAccess.setNode(n, nodeAccess.getLat(n), nodeAccess.getLon(n), newZ);
+                corrected++;
+            }
+        }
+
+        // Run for ALL structure-touching towers, not only the corrected ones — a ramp
+        // pillar can have bad DEM even when its tower endpoints don't.
+        ElevationInterpolator elevationInterpolator = new ElevationInterpolator();
+        GHIntHashSet processedEdges = new GHIntHashSet();
+        for (int n = 0; n < numNodes; n++) {
+            if (!touchesStructure(n, touchExplorer)) continue;
+            EdgeIterator it = explorer.setBaseNode(n);
+            while (it.next()) {
+                if (isStructureEdge(it)) continue;
+                if (processedEdges.contains(it.getEdge())) continue;
+                processedEdges.add(it.getEdge());
+                reinterpolatePillars(it, nodeAccess, elevationInterpolator);
+            }
+        }
+
+        LOGGER.info("BridgeTunnelTowerCorrection: corrected {} towers, skipped {} (insufficient road samples)",
+                corrected, skipped);
+    }
+
+    private boolean touchesStructure(int node, EdgeExplorer explorer) {
+        EdgeIterator it = explorer.setBaseNode(node);
+        while (it.next()) {
+            if (isStructureEdge(it)) return true;
+        }
+        return false;
+    }
+
+    /** Sample pure-ground node elevations via BFS — see class doc. The
+     *  "n touches structure" check is done inline at dequeue time, so no
+     *  precomputed array is needed. */
+    private void bfsCollectRoadSamples(int startTower,
+                                       NodeAccess nodeAccess, EdgeExplorer explorer,
+                                       DoubleArrayList sampleEles, DoubleArrayList sampleDists) {
+        GHBitSet visited = new GHTBitSet();
+        visited.add(startTower);
+        SimpleIntDeque fifo = new SimpleIntDeque();
+        fifo.push(startTower);
+
+        IntDoubleHashMap distFromStart = new IntDoubleHashMap();
+        distFromStart.put(startTower, 0.0);
+
+        while (!fifo.isEmpty()) {
+            int n = fifo.pop();
+            double dN = distFromStart.get(n);
+            EdgeIterator it = explorer.setBaseNode(n);
+            boolean nodeTouchesStructure = false;
+            while (it.next()) {
+                if (isStructureEdge(it)) {
+                    nodeTouchesStructure = true;
+                    continue;
+                }
+                int adj = it.getAdjNode();
+                double edgeDist = it.getDistance();
+                if (dN + edgeDist > BFS_MAX_DIST_M) {
+                    // Edge overshoots — sample along way-geometry at the budget cutoff.
+                    double remaining = BFS_MAX_DIST_M - dN;
+                    if (remaining > 0) {
+                        double virtualEle = sampleEleAlongEdge(it, remaining);
+                        if (!Double.isNaN(virtualEle)) {
+                            sampleEles.add(virtualEle);
+                            sampleDists.add(dN + remaining);
+                        }
+                    }
+                    continue;
+                }
+                if (visited.contains(adj)) continue;
+                visited.add(adj);
+                distFromStart.put(adj, dN + edgeDist);
+                // Always queue (= walk past), so that structure-touching nodes — outers of
+                // PARALLEL bridges/tunnels sharing this node, common on multi-way bridges
+                // like the Albertbrücke — don't terminate the BFS. Whether they get sampled
+                // is decided when they themselves are dequeued.
+                fifo.push(adj);
+            }
+            // Sample the elevation of current node n only if it's pure ground. The start tower is itself
+            // structure-touching by construction, so it's naturally excluded.
+            if (!nodeTouchesStructure) {
+                sampleEles.add(nodeAccess.getEle(n));
+                sampleDists.add(dN);
+            }
+        }
+    }
+
+    /** Inverse-distance-squared weighting. Closer neighbours dominate the result —
+     *  important on terrain that climbs or descends steadily through the BFS window,
+     *  where a plain 1/d would still let far samples drag the answer away from the
+     *  road that is immediately adjacent to the bridge end. */
+    private static double inverseDistanceWeightedMean(DoubleArrayList eles, DoubleArrayList dists) {
+        double weightedSum = 0, totalWeight = 0;
+        for (int i = 0; i < eles.size(); i++) {
+            double d = Math.max(dists.get(i), 1.0);
+            double w = 1.0 / (d * d);
+            weightedSum += w * eles.get(i);
+            totalWeight += w;
+        }
+        return weightedSum / totalWeight;
+    }
+
+    /** Sample the elevation at a given distance along an edge's way-geometry,
+     *  linearly interpolating between the two surrounding pillar/tower points.
+     *  Returns NaN if the edge geometry is unusable. */
+    private double sampleEleAlongEdge(EdgeIteratorState edge, double distAlongEdge) {
+        PointList pl = edge.fetchWayGeometry(FetchMode.ALL);
+        if (pl.size() < 2) return Double.NaN;
+        double cum = 0;
+        for (int i = 0; i < pl.size() - 1; i++) {
+            double segLen = DistancePlaneProjection.DIST_PLANE.calcDist(
+                    pl.getLat(i), pl.getLon(i), pl.getLat(i + 1), pl.getLon(i + 1));
+            if (cum + segLen >= distAlongEdge) {
+                double frac = segLen > 0 ? (distAlongEdge - cum) / segLen : 0;
+                return pl.getEle(i) + frac * (pl.getEle(i + 1) - pl.getEle(i));
+            }
+            cum += segLen;
+        }
+        return pl.getEle(pl.size() - 1);
+    }
+
+    /** Re-interpolate pillar nodes on a non-structure edge linearly between its two
+     *  tower endpoints. Mirrors {@link EdgeElevationInterpolator}'s Phase 2 for
+     *  bridge/tunnel edges. Also recomputes the edge distance. We build a fresh mutable
+     *  PointList because the one returned by {@code fetchWayGeometry} via an EdgeExplorer
+     *  iterator is immutable. */
+    private void reinterpolatePillars(EdgeIteratorState edge, NodeAccess nodeAccess,
+                                      ElevationInterpolator elevationInterpolator) {
+        int firstNodeId = edge.getBaseNode();
+        int secondNodeId = edge.getAdjNode();
+        double lat0 = nodeAccess.getLat(firstNodeId);
+        double lon0 = nodeAccess.getLon(firstNodeId);
+        double ele0 = nodeAccess.getEle(firstNodeId);
+        double lat1 = nodeAccess.getLat(secondNodeId);
+        double lon1 = nodeAccess.getLon(secondNodeId);
+        double ele1 = nodeAccess.getEle(secondNodeId);
+
+        PointList original = edge.fetchWayGeometry(FetchMode.ALL);
+        int count = original.size();
+        if (count <= 2) return;
+        // Build a fresh mutable PointList of the new pillar elevations to hand to
+        // setWayGeometry (which expects pillars only, no tower endpoints).
+        PointList newPillars = new PointList(count - 2, true);
+        // Also keep a full geometry list (tower + pillars + tower) for the distance recompute.
+        PointList full = new PointList(count, true);
+        full.add(lat0, lon0, ele0);
+        for (int index = 1; index < count - 1; index++) {
+            double lat = original.getLat(index);
+            double lon = original.getLon(index);
+            double ele = elevationInterpolator.calculateElevationBasedOnTwoPoints(lat, lon,
+                    lat0, lon0, ele0, lat1, lon1, ele1);
+            newPillars.add(lat, lon, ele);
+            full.add(lat, lon, ele);
+        }
+        full.add(lat1, lon1, ele1);
+        edge.setWayGeometry(newPillars);
+        edge.setDistance(DistanceCalcEarth.DIST_EARTH.calcDistance(full));
+    }
+
+    private boolean isStructureEdge(EdgeIteratorState edge) {
+        RoadEnvironment re = edge.get(roadEnvEnc);
+        return re == RoadEnvironment.BRIDGE || re == RoadEnvironment.TUNNEL || re == RoadEnvironment.FERRY;
+    }
+
+}

--- a/core/src/main/java/com/graphhopper/reader/dem/BridgeTunnelTowerCorrection.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/BridgeTunnelTowerCorrection.java
@@ -21,7 +21,6 @@ import com.carrotsearch.hppc.DoubleArrayList;
 import com.carrotsearch.hppc.IntArrayDeque;
 import com.carrotsearch.hppc.IntDoubleHashMap;
 import com.graphhopper.coll.GHBitSet;
-import com.graphhopper.coll.GHIntHashSet;
 import com.graphhopper.coll.GHTBitSet;
 import com.graphhopper.routing.ev.EnumEncodedValue;
 import com.graphhopper.routing.ev.RoadEnvironment;

--- a/core/src/main/java/com/graphhopper/reader/dem/BridgeTunnelTowerCorrection.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/BridgeTunnelTowerCorrection.java
@@ -18,7 +18,6 @@
 package com.graphhopper.reader.dem;
 
 import com.carrotsearch.hppc.DoubleArrayList;
-import com.carrotsearch.hppc.IntArrayDeque;
 import com.carrotsearch.hppc.IntDoubleHashMap;
 import com.graphhopper.coll.GHBitSet;
 import com.graphhopper.coll.GHTBitSet;
@@ -32,6 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.BitSet;
+import java.util.PriorityQueue;
 
 /**
  * Corrects elevations of bridge/tunnel/ferry tower-end nodes from the surrounding road
@@ -41,10 +41,12 @@ import java.util.BitSet;
  * DEM at a bridge end often samples the valley/river below the deck (too low); at a tunnel
  * end the surface above (too high). The surrounding road is on solid ground at the right
  * level, so its elevations are the correct anchor. For each structure-touching tower we
- * BFS outward (≤ {@link #BFS_MAX_DIST_M}) over non-structure edges, sample only pure-ground
- * nodes (no structure incidence) — walking *past* other structure-touching nodes so that
- * parallel bridges/tunnels sharing the tower don't terminate the BFS — and replace the
- * tower's elevation with the inverse-distance-weighted mean of the samples (Shepard's IDW).
+ * run Dijkstra outward (≤ {@link #BFS_MAX_DIST_M}) over non-structure edges, sample only
+ * pure-ground nodes (no structure incidence) — walking *past* other structure-touching
+ * nodes so that parallel bridges/tunnels sharing the tower don't terminate the traversal —
+ * and replace the tower's elevation with the inverse-distance-weighted mean of the samples
+ * (Shepard's IDW). Using shortest-path distances ensures the distance budget and IDW weights
+ * are always correct regardless of traversal order.
  * If a single edge would overshoot the budget, we sample along its way-geometry at the
  * cutoff so sparse graphs still produce a representative sample.
  * <p>
@@ -60,7 +62,7 @@ public class BridgeTunnelTowerCorrection {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(BridgeTunnelTowerCorrection.class);
 
-    // How far outward to search via BFS (in meter).
+    // How far outward to search via Dijkstra (in meter).
     private static final double BFS_MAX_DIST_M = 50.0;
     // Minimum number of pure-ground samples required before we trust the inferred elevation.
     private static final int MIN_ROAD_SAMPLES = 1;
@@ -96,27 +98,27 @@ public class BridgeTunnelTowerCorrection {
         float initTime = sw.stop().getSeconds();
         sw = new StopWatch().start();
 
-        // For every structure-touching tower, collect elevation samples via BFS and decide
-        // the corrected elevation. Apply in place — the BFS only samples pure-ground nodes
+        // For every structure-touching tower, collect elevation samples via Dijkstra and decide
+        // the corrected elevation. Apply in place — the traversal only samples pure-ground nodes
         // (those that do not touch any structure edge), so already-corrected neighbouring
-        // towers cannot contaminate later BFS results.
-        // Scratch buffers allocated once and clear()ed per BFS — saves ~5 allocations per
+        // towers cannot contaminate later results.
+        // Scratch buffers allocated once and clear()ed per run — saves ~5 allocations per
         // candidate tower (hundreds of thousands on a country graph).
         DoubleArrayList sampleEles = new DoubleArrayList();
         DoubleArrayList sampleDists = new DoubleArrayList();
-        GHBitSet visited = new GHTBitSet();
+        GHBitSet settled = new GHTBitSet();
         IntDoubleHashMap distFromStart = new IntDoubleHashMap();
-        IntArrayDeque fifo = new IntArrayDeque();
+        PriorityQueue<double[]> pq = new PriorityQueue<>((a, b) -> Double.compare(a[0], b[0]));
         int corrected = 0, skipped = 0;
         for (int n = 0; n < numNodes; n++) {
             if (!pendingNodes.get(n)) continue;
             sampleEles.clear();
             sampleDists.clear();
-            visited.clear();
+            settled.clear();
             distFromStart.clear();
-            fifo.clear();
-            bfsCollectRoadSamples(n, nodeAccess, explorer, sampleEles, sampleDists,
-                    visited, distFromStart, fifo);
+            pq.clear();
+            dijkstraCollectRoadSamples(n, nodeAccess, explorer, sampleEles, sampleDists,
+                    settled, distFromStart, pq);
             if (sampleEles.size() < MIN_ROAD_SAMPLES) {
                 pendingNodes.clear(n);
                 skipped++;
@@ -151,27 +153,34 @@ public class BridgeTunnelTowerCorrection {
         }
 
         LOGGER.info("BridgeTunnelTowerCorrection: corrected {} towers, skipped {} (insufficient road samples). " +
-                        "init {}s, bfs {}s, interpolate {}s",
+                        "init {}s, dijkstra {}s, interpolate {}s",
                 corrected, skipped, (int) initTime, (int) bfsTime, (int) sw.stop().getSeconds());
     }
 
     /**
-     * Sample pure-ground node elevations via BFS — see class doc. The
-     * "n touches structure" check is done inline at dequeue time, so no
+     * Sample pure-ground node elevations via Dijkstra — see class doc. Using a
+     * priority queue ordered by accumulated distance guarantees that {@code distFromStart}
+     * holds the true shortest-path distances, so the IDW weights and the
+     * {@link #BFS_MAX_DIST_M} cutoff are always based on the nearest approach to each node.
+     * The "n touches structure" check is done inline at settle time, so no
      * precomputed array is needed.
      */
-    private void bfsCollectRoadSamples(int startTower,
-                                       NodeAccess nodeAccess, EdgeExplorer explorer,
-                                       DoubleArrayList sampleEles, DoubleArrayList sampleDists,
-                                       GHBitSet visited, IntDoubleHashMap distFromStart,
-                                       IntArrayDeque fifo) {
-        visited.add(startTower);
-        fifo.addLast(startTower);
+    private void dijkstraCollectRoadSamples(int startTower,
+                                            NodeAccess nodeAccess, EdgeExplorer explorer,
+                                            DoubleArrayList sampleEles, DoubleArrayList sampleDists,
+                                            GHBitSet settled, IntDoubleHashMap distFromStart,
+                                            PriorityQueue<double[]> pq) {
         distFromStart.put(startTower, 0.0);
+        pq.offer(new double[]{0.0, startTower});
 
-        while (!fifo.isEmpty()) {
-            int n = fifo.removeFirst();
-            double dN = distFromStart.get(n);
+        while (!pq.isEmpty()) {
+            double[] top = pq.poll();
+            double dN = top[0];
+            int n = (int) top[1];
+
+            if (settled.contains(n)) continue; // stale entry — a shorter path was found later
+            settled.add(n);
+
             EdgeIterator it = explorer.setBaseNode(n);
             boolean nodeTouchesStructure = false;
             while (it.next()) {
@@ -181,7 +190,8 @@ public class BridgeTunnelTowerCorrection {
                 }
                 int adj = it.getAdjNode();
                 double edgeDist = it.getDistance();
-                if (dN + edgeDist > BFS_MAX_DIST_M) {
+                double newDist = dN + edgeDist;
+                if (newDist > BFS_MAX_DIST_M) {
                     // Edge overshoots — sample along way-geometry at the budget cutoff.
                     double remaining = BFS_MAX_DIST_M - dN;
                     if (remaining > 0) {
@@ -193,14 +203,15 @@ public class BridgeTunnelTowerCorrection {
                     }
                     continue;
                 }
-                if (visited.contains(adj)) continue;
-                visited.add(adj);
-                distFromStart.put(adj, dN + edgeDist);
-                // Always queue (= walk past), so that structure-touching nodes — outers of
-                // PARALLEL bridges/tunnels sharing this node, common on multi-way bridges
-                // like the Albertbrücke — don't terminate the BFS. Whether they get sampled
-                // is decided when they themselves are dequeued.
-                fifo.addLast(adj);
+                if (!settled.contains(adj)
+                        && (!distFromStart.containsKey(adj) || newDist < distFromStart.get(adj))) {
+                    distFromStart.put(adj, newDist);
+                    // Always enqueue (= walk past), so that structure-touching nodes — outers of
+                    // PARALLEL bridges/tunnels sharing this node, common on multi-way bridges
+                    // like the Albertbrücke — don't terminate the traversal. Whether they get
+                    // sampled is decided when they themselves are settled.
+                    pq.offer(new double[]{newDist, adj});
+                }
             }
             // Sample the elevation of current node n only if it's pure ground. The start tower is itself
             // structure-touching by construction, so it's naturally excluded.

--- a/core/src/main/java/com/graphhopper/reader/dem/BridgeTunnelTowerCorrection.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/BridgeTunnelTowerCorrection.java
@@ -81,17 +81,20 @@ public class BridgeTunnelTowerCorrection {
 
         StopWatch sw = new StopWatch().start();
 
-        BitSet isEdgeStructuredBitSet = new BitSet(numNodes);
+        // pendingNodes starts as the set of structure-touching towers, i.e. candidates where we
+        // might correct the elevation. During the correction loop, we clear() any candidate that
+        // ended up not actually corrected (skipped or IDW ≈ obs). After the loop, a set bit means
+        // "this node's elevation was changed", which is what the pillar loop needs.
+        BitSet pendingNodes = new BitSet(numNodes);
         AllEdgesIterator allIter = graph.getAllEdges();
         while (allIter.next()) {
-            boolean isStructureEdge = isStructureEdge(allIter);
-            if (isStructureEdge) {
-                isEdgeStructuredBitSet.set(allIter.getBaseNode(), true);
-                isEdgeStructuredBitSet.set(allIter.getAdjNode(), true);
+            if (isStructureEdge(allIter)) {
+                pendingNodes.set(allIter.getBaseNode());
+                pendingNodes.set(allIter.getAdjNode());
             }
         }
 
-        float init = sw.stop().getSeconds();
+        float initTime = sw.stop().getSeconds();
         sw = new StopWatch().start();
 
         // For every structure-touching tower, collect elevation samples via BFS and decide
@@ -105,14 +108,9 @@ public class BridgeTunnelTowerCorrection {
         GHBitSet visited = new GHTBitSet();
         IntDoubleHashMap distFromStart = new IntDoubleHashMap();
         IntArrayDeque fifo = new IntArrayDeque();
-        // Important performance tweak: track which nodes actually had their elevation changed
-        // => only re-interpolate ramps whose endpoints moved.
-        // We could misuse isEdgeStructuredBitSet for this information too, but it might be too
-        // confusing and not worth the memory savings.
-        BitSet correctedNodes = new BitSet(numNodes);
         int corrected = 0, skipped = 0;
         for (int n = 0; n < numNodes; n++) {
-            if (!isEdgeStructuredBitSet.get(n)) continue;
+            if (!pendingNodes.get(n)) continue;
             sampleEles.clear();
             sampleDists.clear();
             visited.clear();
@@ -121,6 +119,7 @@ public class BridgeTunnelTowerCorrection {
             bfsCollectRoadSamples(n, nodeAccess, explorer, sampleEles, sampleDists,
                     visited, distFromStart, fifo);
             if (sampleEles.size() < MIN_ROAD_SAMPLES) {
+                pendingNodes.clear(n);
                 skipped++;
                 continue;
             }
@@ -131,12 +130,13 @@ public class BridgeTunnelTowerCorrection {
             double obs = nodeAccess.getEle(n);
             if (Math.abs(newZ - obs) > 1e-6) {
                 nodeAccess.setNode(n, nodeAccess.getLat(n), nodeAccess.getLon(n), newZ);
-                correctedNodes.set(n);
                 corrected++;
+            } else {
+                pendingNodes.clear(n);
             }
         }
 
-        float whileLoop = sw.stop().getSeconds();
+        float bfsTime = sw.stop().getSeconds();
         sw = new StopWatch().start();
 
         // Re-interpolate pillars only on ramp edges whose tower endpoints actually moved.
@@ -146,14 +146,14 @@ public class BridgeTunnelTowerCorrection {
         AllEdgesIterator edgeIter = graph.getAllEdges();
         while (edgeIter.next()) {
             if (isStructureEdge(edgeIter)) continue;
-            if (correctedNodes.get(edgeIter.getBaseNode())
-                    || correctedNodes.get(edgeIter.getAdjNode()))
+            if (pendingNodes.get(edgeIter.getBaseNode())
+                    || pendingNodes.get(edgeIter.getAdjNode()))
                 reinterpolatePillars(edgeIter, nodeAccess, elevationInterpolator);
         }
 
         LOGGER.info("BridgeTunnelTowerCorrection: corrected {} towers, skipped {} (insufficient road samples). " +
-                        "init {}s, while loop {}s, interpolate {}s",
-                corrected, skipped, (int) init, (int) whileLoop, (int) sw.stop().getSeconds());
+                        "init {}s, bfs {}s, interpolate {}s",
+                corrected, skipped, (int) initTime, (int) bfsTime, (int) sw.stop().getSeconds());
     }
 
     /**

--- a/core/src/main/java/com/graphhopper/reader/dem/BridgeTunnelTowerCorrection.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/BridgeTunnelTowerCorrection.java
@@ -41,7 +41,7 @@ import java.util.PriorityQueue;
  * DEM at a bridge end often samples the valley/river below the deck (too low); at a tunnel
  * end the surface above (too high). The surrounding road is on solid ground at the right
  * level, so its elevations are the correct anchor. For each structure-touching tower we
- * run Dijkstra outward (≤ {@link #BFS_MAX_DIST_M}) over non-structure edges, sample only
+ * run Dijkstra outward (≤ {@link #MAX_DIST_M}) over non-structure edges, sample only
  * pure-ground nodes (no structure incidence) — walking *past* other structure-touching
  * nodes so that parallel bridges/tunnels sharing the tower don't terminate the traversal —
  * and replace the tower's elevation with the inverse-distance-weighted mean of the samples
@@ -63,7 +63,7 @@ public class BridgeTunnelTowerCorrection {
     private static final Logger LOGGER = LoggerFactory.getLogger(BridgeTunnelTowerCorrection.class);
 
     // How far outward to search via Dijkstra (in meter).
-    private static final double BFS_MAX_DIST_M = 50.0;
+    private static final double MAX_DIST_M = 50.0;
     // Minimum number of pure-ground samples required before we trust the inferred elevation.
     private static final int MIN_ROAD_SAMPLES = 1;
 
@@ -137,7 +137,7 @@ public class BridgeTunnelTowerCorrection {
             }
         }
 
-        float bfsTime = sw.stop().getSeconds();
+        float dijkstraTime = sw.stop().getSeconds();
         sw = new StopWatch().start();
 
         // Re-interpolate pillars only on ramp edges whose tower endpoints actually moved.
@@ -154,14 +154,14 @@ public class BridgeTunnelTowerCorrection {
 
         LOGGER.info("BridgeTunnelTowerCorrection: corrected {} towers, skipped {} (insufficient road samples). " +
                         "init {}s, dijkstra {}s, interpolate {}s",
-                corrected, skipped, (int) initTime, (int) bfsTime, (int) sw.stop().getSeconds());
+                corrected, skipped, (int) initTime, (int) dijkstraTime, (int) sw.stop().getSeconds());
     }
 
     /**
-     * Sample pure-ground node elevations via Dijkstra — see class doc. Using a
+     * Sample pure-ground node elevations via Dijkstra. Using a
      * priority queue ordered by accumulated distance guarantees that {@code distFromStart}
      * holds the true shortest-path distances, so the IDW weights and the
-     * {@link #BFS_MAX_DIST_M} cutoff are always based on the nearest approach to each node.
+     * {@link #MAX_DIST_M} cutoff are always based on the nearest approach to each node.
      * The "n touches structure" check is done inline at settle time, so no
      * precomputed array is needed.
      */
@@ -191,9 +191,9 @@ public class BridgeTunnelTowerCorrection {
                 int adj = it.getAdjNode();
                 double edgeDist = it.getDistance();
                 double newDist = dN + edgeDist;
-                if (newDist > BFS_MAX_DIST_M) {
+                if (newDist > MAX_DIST_M) {
                     // Edge overshoots — sample along way-geometry at the budget cutoff.
-                    double remaining = BFS_MAX_DIST_M - dN;
+                    double remaining = MAX_DIST_M - dN;
                     if (remaining > 0) {
                         double virtualEle = sampleEleAlongEdge(it, remaining);
                         if (!Double.isNaN(virtualEle)) {
@@ -224,7 +224,7 @@ public class BridgeTunnelTowerCorrection {
 
     /**
      * Inverse-distance-squared weighting. Closer neighbours dominate the result —
-     * important on terrain that climbs or descends steadily through the BFS window,
+     * important on terrain that climbs or descends steadily through the Dijkstra window,
      * where a plain 1/d would still let far samples drag the answer away from the
      * road that is immediately adjacent to the bridge end.
      */

--- a/core/src/main/java/com/graphhopper/reader/dem/BridgeTunnelTowerCorrection.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/BridgeTunnelTowerCorrection.java
@@ -17,18 +17,22 @@
  */
 package com.graphhopper.reader.dem;
 
-import  com.carrotsearch.hppc.DoubleArrayList;
+import com.carrotsearch.hppc.DoubleArrayList;
+import com.carrotsearch.hppc.IntArrayDeque;
 import com.carrotsearch.hppc.IntDoubleHashMap;
 import com.graphhopper.coll.GHBitSet;
 import com.graphhopper.coll.GHIntHashSet;
 import com.graphhopper.coll.GHTBitSet;
 import com.graphhopper.routing.ev.EnumEncodedValue;
 import com.graphhopper.routing.ev.RoadEnvironment;
+import com.graphhopper.routing.util.AllEdgesIterator;
 import com.graphhopper.storage.BaseGraph;
 import com.graphhopper.storage.NodeAccess;
 import com.graphhopper.util.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.BitSet;
 
 /**
  * Corrects elevations of bridge/tunnel/ferry tower-end nodes from the surrounding road
@@ -73,21 +77,49 @@ public class BridgeTunnelTowerCorrection {
     public void execute() {
         final NodeAccess nodeAccess = graph.getNodeAccess();
         final EdgeExplorer explorer = graph.createEdgeExplorer();
-        // Second explorer used purely for the touchesStructure check — keeps its iterator
-        // state independent of the BFS / pillar-loop explorer.
-        final EdgeExplorer touchExplorer = graph.createEdgeExplorer();
         final int numNodes = graph.getNodes();
+
+        StopWatch sw = new StopWatch().start();
+
+        BitSet isEdgeStructuredBitSet = new BitSet(numNodes);
+        AllEdgesIterator allIter = graph.getAllEdges();
+        while (allIter.next()) {
+            boolean isStructureEdge = isStructureEdge(allIter);
+            if (isStructureEdge) {
+                isEdgeStructuredBitSet.set(allIter.getBaseNode(), true);
+                isEdgeStructuredBitSet.set(allIter.getAdjNode(), true);
+            }
+        }
+
+        float init = sw.stop().getSeconds();
+        sw = new StopWatch().start();
 
         // For every structure-touching tower, collect elevation samples via BFS and decide
         // the corrected elevation. Apply in place — the BFS only samples pure-ground nodes
         // (those that do not touch any structure edge), so already-corrected neighbouring
         // towers cannot contaminate later BFS results.
+        // Scratch buffers allocated once and clear()ed per BFS — saves ~5 allocations per
+        // candidate tower (hundreds of thousands on a country graph).
+        DoubleArrayList sampleEles = new DoubleArrayList();
+        DoubleArrayList sampleDists = new DoubleArrayList();
+        GHBitSet visited = new GHTBitSet();
+        IntDoubleHashMap distFromStart = new IntDoubleHashMap();
+        IntArrayDeque fifo = new IntArrayDeque();
+        // Important performance tweak: track which nodes actually had their elevation changed
+        // => only re-interpolate ramps whose endpoints moved.
+        // We could misuse isEdgeStructuredBitSet for this information too, but it might be too
+        // confusing and not worth the memory savings.
+        BitSet correctedNodes = new BitSet(numNodes);
         int corrected = 0, skipped = 0;
         for (int n = 0; n < numNodes; n++) {
-            if (!touchesStructure(n, touchExplorer)) continue;
-            DoubleArrayList sampleEles = new DoubleArrayList();
-            DoubleArrayList sampleDists = new DoubleArrayList();
-            bfsCollectRoadSamples(n, nodeAccess, explorer, sampleEles, sampleDists);
+            if (!isEdgeStructuredBitSet.get(n)) continue;
+            sampleEles.clear();
+            sampleDists.clear();
+            visited.clear();
+            distFromStart.clear();
+            fifo.clear();
+            bfsCollectRoadSamples(n, nodeAccess, explorer, sampleEles, sampleDists,
+                    visited, distFromStart, fifo);
             if (sampleEles.size() < MIN_ROAD_SAMPLES) {
                 skipped++;
                 continue;
@@ -99,53 +131,47 @@ public class BridgeTunnelTowerCorrection {
             double obs = nodeAccess.getEle(n);
             if (Math.abs(newZ - obs) > 1e-6) {
                 nodeAccess.setNode(n, nodeAccess.getLat(n), nodeAccess.getLon(n), newZ);
+                correctedNodes.set(n);
                 corrected++;
             }
         }
 
-        // Run for ALL structure-touching towers, not only the corrected ones — a ramp
-        // pillar can have bad DEM even when its tower endpoints don't.
+        float whileLoop = sw.stop().getSeconds();
+        sw = new StopWatch().start();
+
+        // Re-interpolate pillars only on ramp edges whose tower endpoints actually moved.
+        // If neither endpoint changed, the stored geometry is still consistent — re-running
+        // linear interpolation would just destroy any real DEM variation along the ramp.
         ElevationInterpolator elevationInterpolator = new ElevationInterpolator();
-        GHIntHashSet processedEdges = new GHIntHashSet();
-        for (int n = 0; n < numNodes; n++) {
-            if (!touchesStructure(n, touchExplorer)) continue;
-            EdgeIterator it = explorer.setBaseNode(n);
-            while (it.next()) {
-                if (isStructureEdge(it)) continue;
-                if (processedEdges.contains(it.getEdge())) continue;
-                processedEdges.add(it.getEdge());
-                reinterpolatePillars(it, nodeAccess, elevationInterpolator);
-            }
+        AllEdgesIterator edgeIter = graph.getAllEdges();
+        while (edgeIter.next()) {
+            if (isStructureEdge(edgeIter)) continue;
+            if (correctedNodes.get(edgeIter.getBaseNode())
+                    || correctedNodes.get(edgeIter.getAdjNode()))
+                reinterpolatePillars(edgeIter, nodeAccess, elevationInterpolator);
         }
 
-        LOGGER.info("BridgeTunnelTowerCorrection: corrected {} towers, skipped {} (insufficient road samples)",
-                corrected, skipped);
+        LOGGER.info("BridgeTunnelTowerCorrection: corrected {} towers, skipped {} (insufficient road samples). " +
+                        "init {}s, while loop {}s, interpolate {}s",
+                corrected, skipped, (int) init, (int) whileLoop, (int) sw.stop().getSeconds());
     }
 
-    private boolean touchesStructure(int node, EdgeExplorer explorer) {
-        EdgeIterator it = explorer.setBaseNode(node);
-        while (it.next()) {
-            if (isStructureEdge(it)) return true;
-        }
-        return false;
-    }
-
-    /** Sample pure-ground node elevations via BFS — see class doc. The
-     *  "n touches structure" check is done inline at dequeue time, so no
-     *  precomputed array is needed. */
+    /**
+     * Sample pure-ground node elevations via BFS — see class doc. The
+     * "n touches structure" check is done inline at dequeue time, so no
+     * precomputed array is needed.
+     */
     private void bfsCollectRoadSamples(int startTower,
                                        NodeAccess nodeAccess, EdgeExplorer explorer,
-                                       DoubleArrayList sampleEles, DoubleArrayList sampleDists) {
-        GHBitSet visited = new GHTBitSet();
+                                       DoubleArrayList sampleEles, DoubleArrayList sampleDists,
+                                       GHBitSet visited, IntDoubleHashMap distFromStart,
+                                       IntArrayDeque fifo) {
         visited.add(startTower);
-        SimpleIntDeque fifo = new SimpleIntDeque();
-        fifo.push(startTower);
-
-        IntDoubleHashMap distFromStart = new IntDoubleHashMap();
+        fifo.addLast(startTower);
         distFromStart.put(startTower, 0.0);
 
         while (!fifo.isEmpty()) {
-            int n = fifo.pop();
+            int n = fifo.removeFirst();
             double dN = distFromStart.get(n);
             EdgeIterator it = explorer.setBaseNode(n);
             boolean nodeTouchesStructure = false;
@@ -175,7 +201,7 @@ public class BridgeTunnelTowerCorrection {
                 // PARALLEL bridges/tunnels sharing this node, common on multi-way bridges
                 // like the Albertbrücke — don't terminate the BFS. Whether they get sampled
                 // is decided when they themselves are dequeued.
-                fifo.push(adj);
+                fifo.addLast(adj);
             }
             // Sample the elevation of current node n only if it's pure ground. The start tower is itself
             // structure-touching by construction, so it's naturally excluded.
@@ -186,10 +212,12 @@ public class BridgeTunnelTowerCorrection {
         }
     }
 
-    /** Inverse-distance-squared weighting. Closer neighbours dominate the result —
-     *  important on terrain that climbs or descends steadily through the BFS window,
-     *  where a plain 1/d would still let far samples drag the answer away from the
-     *  road that is immediately adjacent to the bridge end. */
+    /**
+     * Inverse-distance-squared weighting. Closer neighbours dominate the result —
+     * important on terrain that climbs or descends steadily through the BFS window,
+     * where a plain 1/d would still let far samples drag the answer away from the
+     * road that is immediately adjacent to the bridge end.
+     */
     private static double inverseDistanceWeightedMean(DoubleArrayList eles, DoubleArrayList dists) {
         double weightedSum = 0, totalWeight = 0;
         for (int i = 0; i < eles.size(); i++) {
@@ -201,9 +229,11 @@ public class BridgeTunnelTowerCorrection {
         return weightedSum / totalWeight;
     }
 
-    /** Sample the elevation at a given distance along an edge's way-geometry,
-     *  linearly interpolating between the two surrounding pillar/tower points.
-     *  Returns NaN if the edge geometry is unusable. */
+    /**
+     * Sample the elevation at a given distance along an edge's way-geometry,
+     * linearly interpolating between the two surrounding pillar/tower points.
+     * Returns NaN if the edge geometry is unusable.
+     */
     private double sampleEleAlongEdge(EdgeIteratorState edge, double distAlongEdge) {
         PointList pl = edge.fetchWayGeometry(FetchMode.ALL);
         if (pl.size() < 2) return Double.NaN;
@@ -220,11 +250,13 @@ public class BridgeTunnelTowerCorrection {
         return pl.getEle(pl.size() - 1);
     }
 
-    /** Re-interpolate pillar nodes on a non-structure edge linearly between its two
-     *  tower endpoints. Mirrors {@link EdgeElevationInterpolator}'s Phase 2 for
-     *  bridge/tunnel edges. Also recomputes the edge distance. We build a fresh mutable
-     *  PointList because the one returned by {@code fetchWayGeometry} via an EdgeExplorer
-     *  iterator is immutable. */
+    /**
+     * Re-interpolate pillar nodes on a non-structure edge linearly between its two
+     * tower endpoints. Mirrors {@link EdgeElevationInterpolator}'s Phase 2 for
+     * bridge/tunnel edges. Also recomputes the edge distance. We build a fresh mutable
+     * PointList because the one returned by {@code fetchWayGeometry} via an EdgeExplorer
+     * iterator is immutable.
+     */
     private void reinterpolatePillars(EdgeIteratorState edge, NodeAccess nodeAccess,
                                       ElevationInterpolator elevationInterpolator) {
         int firstNodeId = edge.getBaseNode();
@@ -236,26 +268,21 @@ public class BridgeTunnelTowerCorrection {
         double lon1 = nodeAccess.getLon(secondNodeId);
         double ele1 = nodeAccess.getEle(secondNodeId);
 
-        PointList original = edge.fetchWayGeometry(FetchMode.ALL);
-        int count = original.size();
-        if (count <= 2) return;
-        // Build a fresh mutable PointList of the new pillar elevations to hand to
-        // setWayGeometry (which expects pillars only, no tower endpoints).
-        PointList newPillars = new PointList(count - 2, true);
-        // Also keep a full geometry list (tower + pillars + tower) for the distance recompute.
-        PointList full = new PointList(count, true);
-        full.add(lat0, lon0, ele0);
+        // Mutate the fetched PointList in place (mirrors EdgeElevationInterpolator).
+        // The distance is always recomputed (even on a 2-point edge with no pillars),
+        // because a tower endpoint's elevation may have changed in the correction pass and needs an update.
+        PointList pointList = edge.fetchWayGeometry(FetchMode.ALL);
+        int count = pointList.size();
         for (int index = 1; index < count - 1; index++) {
-            double lat = original.getLat(index);
-            double lon = original.getLon(index);
+            double lat = pointList.getLat(index);
+            double lon = pointList.getLon(index);
             double ele = elevationInterpolator.calculateElevationBasedOnTwoPoints(lat, lon,
                     lat0, lon0, ele0, lat1, lon1, ele1);
-            newPillars.add(lat, lon, ele);
-            full.add(lat, lon, ele);
+            pointList.set(index, lat, lon, ele);
         }
-        full.add(lat1, lon1, ele1);
-        edge.setWayGeometry(newPillars);
-        edge.setDistance(DistanceCalcEarth.DIST_EARTH.calcDistance(full));
+        if (count > 2)
+            edge.setWayGeometry(pointList.shallowCopy(1, count - 1, false));
+        edge.setDistance(DistanceCalcEarth.DIST_EARTH.calcDistance(pointList));
     }
 
     private boolean isStructureEdge(EdgeIteratorState edge) {

--- a/core/src/main/java/com/graphhopper/reader/dem/BridgeTunnelTowerCorrection.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/BridgeTunnelTowerCorrection.java
@@ -252,9 +252,7 @@ public class BridgeTunnelTowerCorrection {
     /**
      * Re-interpolate pillar nodes on a non-structure edge linearly between its two
      * tower endpoints. Mirrors {@link EdgeElevationInterpolator}'s Phase 2 for
-     * bridge/tunnel edges. Also recomputes the edge distance. We build a fresh mutable
-     * PointList because the one returned by {@code fetchWayGeometry} via an EdgeExplorer
-     * iterator is immutable.
+     * bridge/tunnel edges. Also recomputes the edge distance.
      */
     private void reinterpolatePillars(EdgeIteratorState edge, NodeAccess nodeAccess,
                                       ElevationInterpolator elevationInterpolator) {

--- a/core/src/main/java/com/graphhopper/reader/dem/BridgeTunnelTowerCorrection.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/BridgeTunnelTowerCorrection.java
@@ -49,12 +49,7 @@ import java.util.PriorityQueue;
  * are always correct regardless of traversal order.
  * If a single edge would overshoot the budget, we sample along its way-geometry at the
  * cutoff so sparse graphs still produce a representative sample.
- * <p>
- * After tower correction, we re-interpolate the pillar nodes on each adjacent ramp edge
- * linearly between the two endpoints — this kills the slope artifact at the approach when
- * ramp pillars had bad DEM.
- * <p>
- * {@link EdgeElevationInterpolator} should run AFTER this class — it interpolates the
+ * {@link EdgeElevationInterpolator} should run AFTER this class as it interpolates the
  * structure interior (bridge/tunnel pillars, inner tower nodes) from the now-correct
  * outer values.
  */
@@ -99,11 +94,10 @@ public class BridgeTunnelTowerCorrection {
         sw = new StopWatch().start();
 
         // For every structure-touching tower, collect elevation samples via Dijkstra and decide
-        // the corrected elevation. Apply in place — the traversal only samples pure-ground nodes
-        // (those that do not touch any structure edge), so already-corrected neighbouring
-        // towers cannot contaminate later results.
-        // Scratch buffers allocated once and clear()ed per run — saves ~5 allocations per
-        // candidate tower (hundreds of thousands on a country graph).
+        // the corrected elevation. Apply in place to reduce memory usage and as the traversal only
+        // samples pure-ground nodes (those that do not touch any structure edge) the
+        // already-corrected neighboring towers cannot contaminate later results.
+        // Scratch buffers allocated once and clear()ed per run to reduce GC pressure.
         DoubleArrayList sampleEles = new DoubleArrayList();
         DoubleArrayList sampleDists = new DoubleArrayList();
         GHBitSet settled = new GHTBitSet();
@@ -140,9 +134,7 @@ public class BridgeTunnelTowerCorrection {
         float dijkstraTime = sw.stop().getSeconds();
         sw = new StopWatch().start();
 
-        // Re-interpolate pillars only on ramp edges whose tower endpoints actually moved.
-        // If neither endpoint changed, the stored geometry is still consistent — re-running
-        // linear interpolation would just destroy any real DEM variation along the ramp.
+        // Re-interpolate pillars only on ramp edges whose tower endpoints actually moved (very important filter for performance).
         ElevationInterpolator elevationInterpolator = new ElevationInterpolator();
         AllEdgesIterator edgeIter = graph.getAllEdges();
         while (edgeIter.next()) {
@@ -158,10 +150,10 @@ public class BridgeTunnelTowerCorrection {
     }
 
     /**
-     * Sample pure-ground node elevations via Dijkstra. Using a
-     * priority queue ordered by accumulated distance guarantees that {@code distFromStart}
-     * holds the true shortest-path distances, so the IDW weights and the
-     * {@link #MAX_DIST_M} cutoff are always based on the nearest approach to each node.
+     * Sample pure-ground node elevations via Dijkstra. BFS us also possible but Dijkstra leads
+     * to slightly more correct result as the {@code distFromStart} holds the true shortest-path
+     * distances and so the IDW weights and the {@link #MAX_DIST_M} cutoff are always based on
+     * the nearest approach to each node.
      * The "n touches structure" check is done inline at settle time, so no
      * precomputed array is needed.
      */
@@ -178,7 +170,7 @@ public class BridgeTunnelTowerCorrection {
             double dN = top[0];
             int n = (int) top[1];
 
-            if (settled.contains(n)) continue; // stale entry — a shorter path was found later
+            if (settled.contains(n)) continue; // stale entry — n was already settled via a shorter path
             settled.add(n);
 
             EdgeIterator it = explorer.setBaseNode(n);
@@ -192,7 +184,7 @@ public class BridgeTunnelTowerCorrection {
                 double edgeDist = it.getDistance();
                 double newDist = dN + edgeDist;
                 if (newDist > MAX_DIST_M) {
-                    // Edge overshoots — sample along way-geometry at the budget cutoff.
+                    // Edge overshoots: sample along way-geometry at the budget cutoff.
                     double remaining = MAX_DIST_M - dN;
                     if (remaining > 0) {
                         double virtualEle = sampleEleAlongEdge(it, remaining);
@@ -208,7 +200,7 @@ public class BridgeTunnelTowerCorrection {
                     distFromStart.put(adj, newDist);
                     // Always enqueue (= walk past), so that structure-touching nodes — outers of
                     // PARALLEL bridges/tunnels sharing this node, common on multi-way bridges
-                    // like the Albertbrücke — don't terminate the traversal. Whether they get
+                    // like the Albertbrücke (Dresden) — don't terminate the traversal. Whether they get
                     // sampled is decided when they themselves are settled.
                     pq.offer(new double[]{newDist, adj});
                 }
@@ -223,7 +215,7 @@ public class BridgeTunnelTowerCorrection {
     }
 
     /**
-     * Inverse-distance-squared weighting. Closer neighbours dominate the result —
+     * Inverse-distance-squared weighting. Closer neighbors dominate the result —
      * important on terrain that climbs or descends steadily through the Dijkstra window,
      * where a plain 1/d would still let far samples drag the answer away from the
      * road that is immediately adjacent to the bridge end.

--- a/core/src/main/java/com/graphhopper/reader/dem/EdgeElevationInterpolator.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/EdgeElevationInterpolator.java
@@ -76,11 +76,11 @@ public class EdgeElevationInterpolator {
     }
 
     public void execute() {
-        interpolateElevationsOfTowerNodes();
+        interpolateElevationsOfInnerTowerNodes();
         interpolateElevationsOfPillarNodes();
     }
 
-    private void interpolateElevationsOfTowerNodes() {
+    private void interpolateElevationsOfInnerTowerNodes() {
         final AllEdgesIterator edge = graph.getAllEdges();
         final GHBitSet visitedEdgeIds = new GHBitSetImpl(edge.length());
         final EdgeExplorer edgeExplorer = graph.createEdgeExplorer();

--- a/core/src/test/java/com/graphhopper/GraphHopperTest.java
+++ b/core/src/test/java/com/graphhopper/GraphHopperTest.java
@@ -1086,7 +1086,7 @@ public class GraphHopperTest {
                 setAlgorithm(ASTAR).setProfile(profile));
 
         ResponsePath res = rsp.getBest();
-        assertEquals(1616.8, res.getDistance(), .1);
+        assertEquals(1601.7, res.getDistance(), .1);
         assertEquals(68, res.getPoints().size());
         assertTrue(res.getPoints().is3D());
 
@@ -1103,20 +1103,20 @@ public class GraphHopperTest {
                 43.7319676, 7.4206159, 19.0, 43.732038, 7.4203936, 20.0, 43.732173, 7.4198886, 20.0, 43.7322266, 7.4196414, 26.0,
                 43.732266, 7.4194654, 26.0, 43.7323236, 7.4192656, 26.0, 43.7323374, 7.4191503, 26.0, 43.7323374, 7.4190461, 26.0,
                 43.7323875, 7.4189195, 26.0, 43.7323444, 7.4188579, 26.0, 43.731974, 7.4181688, 29.0, 43.7316421, 7.4173042, 23.0,
-                43.7315686, 7.4170356, 31.0, 43.7314269, 7.4166815, 31.0, 43.7312401, 7.4163184, 49.0, 43.7308286, 7.4157613, 29.4000244140625,
-                43.730662, 7.4155599, 22.0, 43.7303643, 7.4151193, 51.0, 43.729579, 7.4137274, 40.0, 43.7295167, 7.4137244, 40.0, 43.7294669, 7.4137725, 40.0,
+                43.7315686, 7.4170356, 25.0899658203125, 43.7314269, 7.4166815, 27.93994140625, 43.7312401, 7.4163184, 31.0, 43.7308286, 7.4157613, 45.4300537109375,
+                43.730662, 7.4155599, 50.8759765625, 43.7303643, 7.4151193, 48.0799560546875, 43.729579, 7.4137274, 40.0, 43.7295167, 7.4137244, 40.0, 43.7294669, 7.4137725, 40.0,
                 43.7285987, 7.4149068, 23.0, 43.7285167, 7.4149272, 22.0, 43.7283974, 7.4148646, 22.0, 43.7285619, 7.4151365, 23.0, 43.7285774, 7.4152444, 23.0,
                 43.7285863, 7.4157656, 21.0, 43.7285763, 7.4159759, 21.0, 43.7285238, 7.4161982, 20.0, 43.7284592, 7.4163655, 18.0, 43.72838, 7.4165003, 18.0,
                 43.7281669, 7.4168192, 18.0, 43.7281442, 7.4169449, 18.0, 43.7281477, 7.4170695, 18.0, 43.7281684, 7.4172435, 14.0, 43.7282784, 7.4179606, 14.0,
                 43.7282757, 7.418175, 11.0, 43.7282319, 7.4183683, 11.0, 43.7281482, 7.4185473, 11.0, 43.7280654, 7.4186535, 11.0, 43.727926, 7.418748, 11.0,
-                43.7278398, 7.4187697, 11.0, 43.727779, 7.4187731, 11.0, 43.7276825, 7.4190072, 11.0, 43.72767974015672, 7.419198523220426, 11.0), res.getPoints());
+                43.7278398, 7.4187697, 11.0, 43.727779, 7.4187731, 11.0, 43.7276825, 7.4190072, 11.0, 43.72767974015672, 7.419198523220426, 11.416705816245472), res.getPoints());
 
-        assertEquals(82.3, res.getAscend(), 1e-1);
-        assertEquals(135, res.getDescend(), 1e-1);
+        assertEquals(55.5, res.getAscend(), 1e-1);
+        assertEquals(107.9, res.getDescend(), 1e-1);
 
         assertEquals(68, res.getPoints().size());
         assertEquals(new GHPoint3D(43.73068455771767, 7.421283689825812, 63.74379211), res.getPoints().get(0));
-        assertEquals(new GHPoint3D(43.727679637988224, 7.419198521975086, 11.0), res.getPoints().get(res.getPoints().size() - 1));
+        assertEquals(new GHPoint3D(43.72767974015672, 7.419198523220426, 11.416705816245472), res.getPoints().get(res.getPoints().size() - 1));
 
         assertEquals(63.74, res.getPoints().get(0).getEle(), 1e-2);
         assertEquals(66, res.getPoints().get(1).getEle(), 1e-2);
@@ -1171,13 +1171,13 @@ public class GraphHopperTest {
         assertTrue(pointList.is3D());
 
         if (withTunnelInterpolation) {
-            assertEquals(351.8, res.getDistance(), .1);
+            assertEquals(351.5, res.getDistance(), .1);
             assertEquals(17, pointList.getEle(0), .1);
-            assertEquals(19.04, pointList.getEle(1), .1);
-            assertEquals(21.67, pointList.getEle(2), .1);
-            assertEquals(25.03, pointList.getEle(3), .1);
-            assertEquals(28.65, pointList.getEle(4), .1);
-            assertEquals(34.00, pointList.getEle(5), .1);
+            assertEquals(17.44, pointList.getEle(1), .1);
+            assertEquals(18.01, pointList.getEle(2), .1);
+            assertEquals(18.73, pointList.getEle(3), .1);
+            assertEquals(19.51, pointList.getEle(4), .1);
+            assertEquals(20.66, pointList.getEle(5), .1);
         } else {
             assertEquals(358.3, res.getDistance(), .1);
             assertEquals(17.0, pointList.getEle(0), .1);
@@ -1214,19 +1214,19 @@ public class GraphHopperTest {
 
         ResponsePath arsp = rsp.getBest();
         assertEquals(1570, arsp.getDistance(), 1);
-        assertEquals(74, arsp.getPoints().size());
+        assertEquals(70, arsp.getPoints().size());
         assertTrue(arsp.getPoints().is3D());
 
         InstructionList il = arsp.getInstructions();
         assertEquals(12, il.size());
         assertTrue(il.get(0).getPoints().is3D());
 
-        assertEquals(22.8, arsp.getAscend(), 1e-1);
-        assertEquals(67.4, arsp.getDescend(), 1e-1);
+        assertEquals(16.3, arsp.getAscend(), 1e-1);
+        assertEquals(61.2, arsp.getDescend(), 1e-1);
 
-        assertEquals(74, arsp.getPoints().size());
+        assertEquals(70, arsp.getPoints().size());
         assertEquals(new GHPoint3D(43.73068455771767, 7.421283689825812, 56.68), arsp.getPoints().get(0));
-        assertEquals(new GHPoint3D(43.727679637988224, 7.419198521975086, 12.11), arsp.getPoints().get(arsp.getPoints().size() - 1));
+        assertEquals(new GHPoint3D(43.72767974015672, 7.419198523220426, 11.79), arsp.getPoints().get(arsp.getPoints().size() - 1));
 
         assertEquals(56.68, arsp.getPoints().get(0).getEle(), 1e-2);
         assertEquals(57.78, arsp.getPoints().get(1).getEle(), 1e-2);

--- a/core/src/test/java/com/graphhopper/reader/dem/BridgeTunnelTowerCorrectionTest.java
+++ b/core/src/test/java/com/graphhopper/reader/dem/BridgeTunnelTowerCorrectionTest.java
@@ -99,7 +99,7 @@ public class BridgeTunnelTowerCorrectionTest {
         na.setNode(1, 1, 0, 100);
         na.setNode(2, 2, 0, 100);
         na.setNode(3, 3, 0, 100);  // ramp tower right before the bridge
-        na.setNode(4, 4, 0, 100);  // bridge outer (correct)
+        na.setNode(4, 4, 0, 80);   // bridge outer with bad DEM — gets lifted to 100
         na.setNode(5, 5, 0, 100);
         na.setNode(6, 6, 0, 100);
 
@@ -124,8 +124,9 @@ public class BridgeTunnelTowerCorrectionTest {
 
         new BridgeTunnelTowerCorrection(graph, roadEnvEnc).execute();
 
-        // The ramp edge connects tower 3 (= bridge outer, was already correct at 100)
-        // and tower 4 — so its pillar should be re-interpolated between 100 and 100.
+        // Tower 4 was corrected from 80 to ~100 via IDW, so the ramp edge (3-4) gets
+        // its pillar re-interpolated linearly between 100 and ~100 → pillar at ~100
+        // instead of its original bad DEM value of 85.
         PointList pl = e34.fetchWayGeometry(FetchMode.ALL);
         assertEquals(3, pl.size());
         assertEquals(100, pl.getEle(1), 0.5);

--- a/core/src/test/java/com/graphhopper/reader/dem/BridgeTunnelTowerCorrectionTest.java
+++ b/core/src/test/java/com/graphhopper/reader/dem/BridgeTunnelTowerCorrectionTest.java
@@ -144,7 +144,7 @@ public class BridgeTunnelTowerCorrectionTest {
     }
 
     /** A bridge tower whose DEM is already consistent with nearby road must not be moved
-     *  (median ≈ tower's own elevation). Real terrain at the bridge level. */
+     *  (IDW mean ≈ tower's own elevation). Real terrain at the bridge level. */
     @Test
     public void doesNotMoveTowerWhenAlreadyConsistent() {
         NodeAccess na = graph.getNodeAccess();

--- a/core/src/test/java/com/graphhopper/reader/dem/BridgeTunnelTowerCorrectionTest.java
+++ b/core/src/test/java/com/graphhopper/reader/dem/BridgeTunnelTowerCorrectionTest.java
@@ -1,0 +1,248 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.reader.dem;
+
+import com.graphhopper.routing.ev.*;
+import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.storage.BaseGraph;
+import com.graphhopper.storage.NodeAccess;
+import com.graphhopper.util.EdgeIteratorState;
+import com.graphhopper.util.FetchMode;
+import com.graphhopper.util.GHUtility;
+import com.graphhopper.util.Helper;
+import com.graphhopper.util.PointList;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class BridgeTunnelTowerCorrectionTest {
+
+    private BaseGraph graph;
+    private EnumEncodedValue<RoadEnvironment> roadEnvEnc;
+    private BooleanEncodedValue accessEnc;
+    private DecimalEncodedValue speedEnc;
+
+    @BeforeEach
+    void setUp() {
+        accessEnc = new SimpleBooleanEncodedValue("access", true);
+        speedEnc = new DecimalEncodedValueImpl("speed", 5, 5, false);
+        EncodingManager em = EncodingManager.start().add(accessEnc).add(speedEnc).add(RoadEnvironment.create()).build();
+        graph = new BaseGraph.Builder(em).set3D(true).create();
+        roadEnvEnc = em.getEnumEncodedValue(RoadEnvironment.KEY, RoadEnvironment.class);
+    }
+
+    /** Bridge tower-end has bad DEM (way too low). Surrounding road is at the correct
+     *  deck level. The tower must be lifted to ~the road's elevation. */
+    @Test
+    public void liftsBridgeTowerFromValleyDemToSurroundingRoad() {
+        NodeAccess na = graph.getNodeAccess();
+        na.setNode(0, 0, 0, 100);
+        na.setNode(1, 1, 0, 100);
+        na.setNode(2, 2, 0, 100);
+        na.setNode(3, 3, 0, 80);   // BRIDGE outer, bad DEM (valley below deck)
+        na.setNode(4, 4, 0, 100);  // bridge outer (good)
+        na.setNode(5, 5, 0, 100);
+        na.setNode(6, 6, 0, 100);
+
+        EdgeIteratorState e01, e12, e23, e34, e45, e56;
+        GHUtility.setSpeed(60, 60, accessEnc, speedEnc,
+                e01 = graph.edge(0, 1).setDistance(15),
+                e12 = graph.edge(1, 2).setDistance(15),
+                e23 = graph.edge(2, 3).setDistance(15),
+                e34 = graph.edge(3, 4).setDistance(15), // BRIDGE
+                e45 = graph.edge(4, 5).setDistance(15),
+                e56 = graph.edge(5, 6).setDistance(15));
+
+        e01.set(roadEnvEnc, RoadEnvironment.ROAD);
+        e12.set(roadEnvEnc, RoadEnvironment.ROAD);
+        e23.set(roadEnvEnc, RoadEnvironment.ROAD);
+        e34.set(roadEnvEnc, RoadEnvironment.BRIDGE);
+        e45.set(roadEnvEnc, RoadEnvironment.ROAD);
+        e56.set(roadEnvEnc, RoadEnvironment.ROAD);
+
+        new BridgeTunnelTowerCorrection(graph, roadEnvEnc).execute();
+
+        // Tower 3 should now be the median of nearby road nodes — 100.
+        assertEquals(100, na.getEle(3), 0.5);
+        // Tower 4 has plenty of good neighbours too, stays at 100.
+        assertEquals(100, na.getEle(4), 0.5);
+        // Ground untouched.
+        assertEquals(100, na.getEle(0), 1e-9);
+        assertEquals(100, na.getEle(6), 1e-9);
+    }
+
+    /** Pillar on the ramp edge immediately before the bridge has bad DEM. After
+     *  the tower is corrected, the pillar must be re-interpolated linearly between
+     *  the two endpoints of that ramp edge (mirroring how bridge interior pillars
+     *  are interpolated). */
+    @Test
+    public void reinterpolatesRampPillarAfterTowerCorrection() {
+        NodeAccess na = graph.getNodeAccess();
+        na.setNode(0, 0, 0, 100);
+        na.setNode(1, 1, 0, 100);
+        na.setNode(2, 2, 0, 100);
+        na.setNode(3, 3, 0, 100);  // ramp tower right before the bridge
+        na.setNode(4, 4, 0, 100);  // bridge outer (correct)
+        na.setNode(5, 5, 0, 100);
+        na.setNode(6, 6, 0, 100);
+
+        EdgeIteratorState e01, e12, e23, e34, e45, e56;
+        GHUtility.setSpeed(60, 60, accessEnc, speedEnc,
+                e01 = graph.edge(0, 1).setDistance(15),
+                e12 = graph.edge(1, 2).setDistance(15),
+                e23 = graph.edge(2, 3).setDistance(15),
+                e34 = graph.edge(3, 4).setDistance(15), // ramp edge with bad pillar
+                e45 = graph.edge(4, 5).setDistance(15), // BRIDGE
+                e56 = graph.edge(5, 6).setDistance(15));
+
+        // Pillar mid-ramp at bad DEM 85.
+        e34.setWayGeometry(Helper.createPointList3D(3.5, 0, 85));
+
+        e01.set(roadEnvEnc, RoadEnvironment.ROAD);
+        e12.set(roadEnvEnc, RoadEnvironment.ROAD);
+        e23.set(roadEnvEnc, RoadEnvironment.ROAD);
+        e34.set(roadEnvEnc, RoadEnvironment.ROAD);
+        e45.set(roadEnvEnc, RoadEnvironment.BRIDGE);
+        e56.set(roadEnvEnc, RoadEnvironment.ROAD);
+
+        new BridgeTunnelTowerCorrection(graph, roadEnvEnc).execute();
+
+        // The ramp edge connects tower 3 (= bridge outer, was already correct at 100)
+        // and tower 4 — so its pillar should be re-interpolated between 100 and 100.
+        PointList pl = e34.fetchWayGeometry(FetchMode.ALL);
+        assertEquals(3, pl.size());
+        assertEquals(100, pl.getEle(1), 0.5);
+    }
+
+    /** Tunnel-end has bad DEM (high, sampling surface above). Surrounding road is at
+     *  the correct road level. The tunnel-end must be pulled down to the road level. */
+    @Test
+    public void pullsTunnelEndDownFromSurfaceAbove() {
+        NodeAccess na = graph.getNodeAccess();
+        na.setNode(0, 0, 0, 100);
+        na.setNode(1, 1, 0, 100);
+        na.setNode(2, 2, 0, 100);
+        na.setNode(3, 3, 0, 500); // tunnel outer, bad DEM (ridge above)
+        na.setNode(4, 4, 0, 100); // tunnel outer
+        na.setNode(5, 5, 0, 100);
+        na.setNode(6, 6, 0, 100);
+
+        EdgeIteratorState e01, e12, e23, e34, e45, e56;
+        GHUtility.setSpeed(60, 60, accessEnc, speedEnc,
+                e01 = graph.edge(0, 1).setDistance(15),
+                e12 = graph.edge(1, 2).setDistance(15),
+                e23 = graph.edge(2, 3).setDistance(15),
+                e34 = graph.edge(3, 4).setDistance(15), // TUNNEL
+                e45 = graph.edge(4, 5).setDistance(15),
+                e56 = graph.edge(5, 6).setDistance(15));
+
+        e01.set(roadEnvEnc, RoadEnvironment.ROAD);
+        e12.set(roadEnvEnc, RoadEnvironment.ROAD);
+        e23.set(roadEnvEnc, RoadEnvironment.ROAD);
+        e34.set(roadEnvEnc, RoadEnvironment.TUNNEL);
+        e45.set(roadEnvEnc, RoadEnvironment.ROAD);
+        e56.set(roadEnvEnc, RoadEnvironment.ROAD);
+
+        new BridgeTunnelTowerCorrection(graph, roadEnvEnc).execute();
+
+        assertEquals(100, na.getEle(3), 0.5);
+    }
+
+    /** A bridge tower whose DEM is already consistent with nearby road must not be moved
+     *  (median ≈ tower's own elevation). Real terrain at the bridge level. */
+    @Test
+    public void doesNotMoveTowerWhenAlreadyConsistent() {
+        NodeAccess na = graph.getNodeAccess();
+        na.setNode(0, 0, 0, 100);
+        na.setNode(1, 1, 0, 100);
+        na.setNode(2, 2, 0, 100);
+        na.setNode(3, 3, 0, 100); // bridge tower at correct elevation
+        na.setNode(4, 4, 0, 100);
+        na.setNode(5, 5, 0, 100);
+        na.setNode(6, 6, 0, 100);
+
+        EdgeIteratorState e01, e12, e23, e34, e45, e56;
+        GHUtility.setSpeed(60, 60, accessEnc, speedEnc,
+                e01 = graph.edge(0, 1).setDistance(15),
+                e12 = graph.edge(1, 2).setDistance(15),
+                e23 = graph.edge(2, 3).setDistance(15),
+                e34 = graph.edge(3, 4).setDistance(15),
+                e45 = graph.edge(4, 5).setDistance(15),
+                e56 = graph.edge(5, 6).setDistance(15));
+
+        e01.set(roadEnvEnc, RoadEnvironment.ROAD);
+        e12.set(roadEnvEnc, RoadEnvironment.ROAD);
+        e23.set(roadEnvEnc, RoadEnvironment.ROAD);
+        e34.set(roadEnvEnc, RoadEnvironment.BRIDGE);
+        e45.set(roadEnvEnc, RoadEnvironment.ROAD);
+        e56.set(roadEnvEnc, RoadEnvironment.ROAD);
+
+        new BridgeTunnelTowerCorrection(graph, roadEnvEnc).execute();
+
+        assertEquals(100, na.getEle(3), 0.5);
+        assertEquals(100, na.getEle(4), 0.5);
+    }
+
+    /** Tower with fewer than MIN_ROAD_SAMPLES pure-ground neighbours (deep inside a
+     *  combined structure chain) is left at its DEM value — this is the
+     *  tunnel→bridge→tunnel boundary case. */
+    @Test
+    public void leavesTowerAloneWhenNoRoadNeighbourReachable() {
+        NodeAccess na = graph.getNodeAccess();
+        na.setNode(0, 0, 0, 200); // road
+        na.setNode(1, 1, 0, 200); // tunnel outer
+        na.setNode(2, 2, 0, 1000); // tunnel inner — touches only tunnel
+        na.setNode(3, 3, 0, 1000); // tunnel→bridge boundary — touches only structures
+        na.setNode(4, 4, 0, 1000); // bridge→tunnel boundary
+        na.setNode(5, 5, 0, 1000); // tunnel inner
+        na.setNode(6, 6, 0, 100); // tunnel outer
+        na.setNode(7, 7, 0, 100); // road
+
+        EdgeIteratorState e01, e12, e23, e34, e45, e56, e67;
+        GHUtility.setSpeed(60, 60, accessEnc, speedEnc,
+                e01 = graph.edge(0, 1).setDistance(50),
+                e12 = graph.edge(1, 2).setDistance(50),
+                e23 = graph.edge(2, 3).setDistance(50),
+                e34 = graph.edge(3, 4).setDistance(50), // BRIDGE
+                e45 = graph.edge(4, 5).setDistance(50),
+                e56 = graph.edge(5, 6).setDistance(50),
+                e67 = graph.edge(6, 7).setDistance(50));
+
+        e01.set(roadEnvEnc, RoadEnvironment.ROAD);
+        e12.set(roadEnvEnc, RoadEnvironment.TUNNEL);
+        e23.set(roadEnvEnc, RoadEnvironment.TUNNEL);
+        e34.set(roadEnvEnc, RoadEnvironment.BRIDGE);
+        e45.set(roadEnvEnc, RoadEnvironment.TUNNEL);
+        e56.set(roadEnvEnc, RoadEnvironment.TUNNEL);
+        e67.set(roadEnvEnc, RoadEnvironment.ROAD);
+
+        new BridgeTunnelTowerCorrection(graph, roadEnvEnc).execute();
+
+        // Boundary nodes 3 and 4 have no road neighbours within 50 m via non-structure
+        // edges (every path goes through tunnel/bridge). They stay at DEM.
+        assertEquals(1000, na.getEle(3), 0.5);
+        assertEquals(1000, na.getEle(4), 0.5);
+        // Tunnel outer 1 IS reachable from road (one non-structure edge to road tower 0,
+        // which is itself pure ground). But MIN_ROAD_SAMPLES=3 — only one road sample,
+        // so left at DEM.
+        assertEquals(200, na.getEle(1), 0.5);
+    }
+
+}

--- a/core/src/test/java/com/graphhopper/reader/dem/BridgeTunnelTowerCorrectionTest.java
+++ b/core/src/test/java/com/graphhopper/reader/dem/BridgeTunnelTowerCorrectionTest.java
@@ -71,7 +71,7 @@ public class BridgeTunnelTowerCorrectionTest {
 
         new BridgeTunnelTowerCorrection(graph, roadEnvEnc).execute();
 
-        // Tower 3 should now be the median of nearby road nodes — 100.
+        // Tower 3 should now be close to the inverse-distance-weighted mean (IDW) of nearby road nodes — 100.
         assertEquals(100, na.getEle(3), 0.5);
         // Tower 4 has plenty of good neighbours too, stays at 100.
         assertEquals(100, na.getEle(4), 0.5);

--- a/core/src/test/java/com/graphhopper/reader/dem/BridgeTunnelTowerCorrectionTest.java
+++ b/core/src/test/java/com/graphhopper/reader/dem/BridgeTunnelTowerCorrectionTest.java
@@ -201,8 +201,8 @@ public class BridgeTunnelTowerCorrectionTest {
         assertEquals(1000, na.getEle(3), 0.5);
         assertEquals(1000, na.getEle(4), 0.5);
         // Tunnel outer 1 IS reachable from road (one non-structure edge to road tower 0,
-        // which is itself pure ground). But MIN_ROAD_SAMPLES=3 — only one road sample,
-        // so left at DEM.
+        // which is itself pure ground). With MIN_ROAD_SAMPLES=1 there is enough data, but
+        // the inferred elevation equals the current value, so it remains unchanged.
         assertEquals(200, na.getEle(1), 0.5);
     }
 

--- a/core/src/test/java/com/graphhopper/reader/dem/BridgeTunnelTowerCorrectionTest.java
+++ b/core/src/test/java/com/graphhopper/reader/dem/BridgeTunnelTowerCorrectionTest.java
@@ -29,8 +29,8 @@ import com.graphhopper.util.PointList;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static com.graphhopper.routing.ev.RoadEnvironment.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BridgeTunnelTowerCorrectionTest {
 
@@ -61,21 +61,13 @@ public class BridgeTunnelTowerCorrectionTest {
         na.setNode(5, 5, 0, 100);
         na.setNode(6, 6, 0, 100);
 
-        EdgeIteratorState e01, e12, e23, e34, e45, e56;
         GHUtility.setSpeed(60, 60, accessEnc, speedEnc,
-                e01 = graph.edge(0, 1).setDistance(15),
-                e12 = graph.edge(1, 2).setDistance(15),
-                e23 = graph.edge(2, 3).setDistance(15),
-                e34 = graph.edge(3, 4).setDistance(15), // BRIDGE
-                e45 = graph.edge(4, 5).setDistance(15),
-                e56 = graph.edge(5, 6).setDistance(15));
-
-        e01.set(roadEnvEnc, RoadEnvironment.ROAD);
-        e12.set(roadEnvEnc, RoadEnvironment.ROAD);
-        e23.set(roadEnvEnc, RoadEnvironment.ROAD);
-        e34.set(roadEnvEnc, RoadEnvironment.BRIDGE);
-        e45.set(roadEnvEnc, RoadEnvironment.ROAD);
-        e56.set(roadEnvEnc, RoadEnvironment.ROAD);
+                graph.edge(0, 1).setDistance(15).set(roadEnvEnc, ROAD),
+                graph.edge(1, 2).setDistance(15).set(roadEnvEnc, ROAD),
+                graph.edge(2, 3).setDistance(15).set(roadEnvEnc, ROAD),
+                graph.edge(3, 4).setDistance(15).set(roadEnvEnc, BRIDGE),
+                graph.edge(4, 5).setDistance(15).set(roadEnvEnc, ROAD),
+                graph.edge(5, 6).setDistance(15).set(roadEnvEnc, ROAD));
 
         new BridgeTunnelTowerCorrection(graph, roadEnvEnc).execute();
 
@@ -103,24 +95,17 @@ public class BridgeTunnelTowerCorrectionTest {
         na.setNode(5, 5, 0, 100);
         na.setNode(6, 6, 0, 100);
 
-        EdgeIteratorState e01, e12, e23, e34, e45, e56;
+        EdgeIteratorState e34;
         GHUtility.setSpeed(60, 60, accessEnc, speedEnc,
-                e01 = graph.edge(0, 1).setDistance(15),
-                e12 = graph.edge(1, 2).setDistance(15),
-                e23 = graph.edge(2, 3).setDistance(15),
-                e34 = graph.edge(3, 4).setDistance(15), // ramp edge with bad pillar
-                e45 = graph.edge(4, 5).setDistance(15), // BRIDGE
-                e56 = graph.edge(5, 6).setDistance(15));
+                graph.edge(0, 1).setDistance(15).set(roadEnvEnc, ROAD),
+                graph.edge(1, 2).setDistance(15).set(roadEnvEnc, ROAD),
+                graph.edge(2, 3).setDistance(15).set(roadEnvEnc, ROAD),
+                e34 = graph.edge(3, 4).setDistance(15).set(roadEnvEnc, ROAD), // ramp edge with bad pillar
+                graph.edge(4, 5).setDistance(15).set(roadEnvEnc, BRIDGE),
+                graph.edge(5, 6).setDistance(15).set(roadEnvEnc, ROAD));
 
         // Pillar mid-ramp at bad DEM 85.
         e34.setWayGeometry(Helper.createPointList3D(3.5, 0, 85));
-
-        e01.set(roadEnvEnc, RoadEnvironment.ROAD);
-        e12.set(roadEnvEnc, RoadEnvironment.ROAD);
-        e23.set(roadEnvEnc, RoadEnvironment.ROAD);
-        e34.set(roadEnvEnc, RoadEnvironment.ROAD);
-        e45.set(roadEnvEnc, RoadEnvironment.BRIDGE);
-        e56.set(roadEnvEnc, RoadEnvironment.ROAD);
 
         new BridgeTunnelTowerCorrection(graph, roadEnvEnc).execute();
 
@@ -145,21 +130,13 @@ public class BridgeTunnelTowerCorrectionTest {
         na.setNode(5, 5, 0, 100);
         na.setNode(6, 6, 0, 100);
 
-        EdgeIteratorState e01, e12, e23, e34, e45, e56;
         GHUtility.setSpeed(60, 60, accessEnc, speedEnc,
-                e01 = graph.edge(0, 1).setDistance(15),
-                e12 = graph.edge(1, 2).setDistance(15),
-                e23 = graph.edge(2, 3).setDistance(15),
-                e34 = graph.edge(3, 4).setDistance(15), // TUNNEL
-                e45 = graph.edge(4, 5).setDistance(15),
-                e56 = graph.edge(5, 6).setDistance(15));
-
-        e01.set(roadEnvEnc, RoadEnvironment.ROAD);
-        e12.set(roadEnvEnc, RoadEnvironment.ROAD);
-        e23.set(roadEnvEnc, RoadEnvironment.ROAD);
-        e34.set(roadEnvEnc, RoadEnvironment.TUNNEL);
-        e45.set(roadEnvEnc, RoadEnvironment.ROAD);
-        e56.set(roadEnvEnc, RoadEnvironment.ROAD);
+                graph.edge(0, 1).setDistance(15).set(roadEnvEnc, ROAD),
+                graph.edge(1, 2).setDistance(15).set(roadEnvEnc, ROAD),
+                graph.edge(2, 3).setDistance(15).set(roadEnvEnc, ROAD),
+                graph.edge(3, 4).setDistance(15).set(roadEnvEnc, TUNNEL),
+                graph.edge(4, 5).setDistance(15).set(roadEnvEnc, ROAD),
+                graph.edge(5, 6).setDistance(15).set(roadEnvEnc, ROAD));
 
         new BridgeTunnelTowerCorrection(graph, roadEnvEnc).execute();
 
@@ -179,21 +156,13 @@ public class BridgeTunnelTowerCorrectionTest {
         na.setNode(5, 5, 0, 100);
         na.setNode(6, 6, 0, 100);
 
-        EdgeIteratorState e01, e12, e23, e34, e45, e56;
         GHUtility.setSpeed(60, 60, accessEnc, speedEnc,
-                e01 = graph.edge(0, 1).setDistance(15),
-                e12 = graph.edge(1, 2).setDistance(15),
-                e23 = graph.edge(2, 3).setDistance(15),
-                e34 = graph.edge(3, 4).setDistance(15),
-                e45 = graph.edge(4, 5).setDistance(15),
-                e56 = graph.edge(5, 6).setDistance(15));
-
-        e01.set(roadEnvEnc, RoadEnvironment.ROAD);
-        e12.set(roadEnvEnc, RoadEnvironment.ROAD);
-        e23.set(roadEnvEnc, RoadEnvironment.ROAD);
-        e34.set(roadEnvEnc, RoadEnvironment.BRIDGE);
-        e45.set(roadEnvEnc, RoadEnvironment.ROAD);
-        e56.set(roadEnvEnc, RoadEnvironment.ROAD);
+                graph.edge(0, 1).setDistance(15).set(roadEnvEnc, ROAD),
+                graph.edge(1, 2).setDistance(15).set(roadEnvEnc, ROAD),
+                graph.edge(2, 3).setDistance(15).set(roadEnvEnc, ROAD),
+                graph.edge(3, 4).setDistance(15).set(roadEnvEnc, BRIDGE),
+                graph.edge(4, 5).setDistance(15).set(roadEnvEnc, ROAD),
+                graph.edge(5, 6).setDistance(15).set(roadEnvEnc, ROAD));
 
         new BridgeTunnelTowerCorrection(graph, roadEnvEnc).execute();
 
@@ -216,23 +185,14 @@ public class BridgeTunnelTowerCorrectionTest {
         na.setNode(6, 6, 0, 100); // tunnel outer
         na.setNode(7, 7, 0, 100); // road
 
-        EdgeIteratorState e01, e12, e23, e34, e45, e56, e67;
         GHUtility.setSpeed(60, 60, accessEnc, speedEnc,
-                e01 = graph.edge(0, 1).setDistance(50),
-                e12 = graph.edge(1, 2).setDistance(50),
-                e23 = graph.edge(2, 3).setDistance(50),
-                e34 = graph.edge(3, 4).setDistance(50), // BRIDGE
-                e45 = graph.edge(4, 5).setDistance(50),
-                e56 = graph.edge(5, 6).setDistance(50),
-                e67 = graph.edge(6, 7).setDistance(50));
-
-        e01.set(roadEnvEnc, RoadEnvironment.ROAD);
-        e12.set(roadEnvEnc, RoadEnvironment.TUNNEL);
-        e23.set(roadEnvEnc, RoadEnvironment.TUNNEL);
-        e34.set(roadEnvEnc, RoadEnvironment.BRIDGE);
-        e45.set(roadEnvEnc, RoadEnvironment.TUNNEL);
-        e56.set(roadEnvEnc, RoadEnvironment.TUNNEL);
-        e67.set(roadEnvEnc, RoadEnvironment.ROAD);
+                graph.edge(0, 1).setDistance(50).set(roadEnvEnc, ROAD),
+                graph.edge(1, 2).setDistance(50).set(roadEnvEnc, TUNNEL),
+                graph.edge(2, 3).setDistance(50).set(roadEnvEnc, TUNNEL),
+                graph.edge(3, 4).setDistance(50).set(roadEnvEnc, BRIDGE),
+                graph.edge(4, 5).setDistance(50).set(roadEnvEnc, TUNNEL),
+                graph.edge(5, 6).setDistance(50).set(roadEnvEnc, TUNNEL),
+                graph.edge(6, 7).setDistance(50).set(roadEnvEnc, ROAD));
 
         new BridgeTunnelTowerCorrection(graph, roadEnvEnc).execute();
 

--- a/core/src/test/java/com/graphhopper/routing/RoutingAlgorithmWithOSMTest.java
+++ b/core/src/test/java/com/graphhopper/routing/RoutingAlgorithmWithOSMTest.java
@@ -110,11 +110,11 @@ public class RoutingAlgorithmWithOSMTest {
     @Test
     public void testMonacoMotorcycleCurvature() {
         List<Query> queries = new ArrayList<>();
-        queries.add(new Query(43.730729, 7.42135, 43.727697, 7.419199, 2675, 117));
+        queries.add(new Query(43.730729, 7.42135, 43.727697, 7.419199, 2669, 117));
         queries.add(new Query(43.727687, 7.418737, 43.74958, 7.436566, 3730, 170));
-        queries.add(new Query(43.728677, 7.41016, 43.739213, 7.4277, 2769, 167));
-        queries.add(new Query(43.733802, 7.413433, 43.739662, 7.424355, 2373, 137));
-        queries.add(new Query(43.730949, 7.412338, 43.739643, 7.424542, 2203, 116));
+        queries.add(new Query(43.728677, 7.41016, 43.739213, 7.4277, 2732, 167));
+        queries.add(new Query(43.733802, 7.413433, 43.739662, 7.424355, 2368, 137));
+        queries.add(new Query(43.730949, 7.412338, 43.739643, 7.424542, 2198, 116));
         queries.add(new Query(43.727592, 7.419333, 43.727712, 7.419333, 0, 1));
         GraphHopper hopper = createHopper(MONACO, new Profile("car").setCustomModel(
                 CustomModel.merge(getCustomModel("motorcycle.json"), getCustomModel("curvature.json"))));
@@ -265,9 +265,9 @@ public class RoutingAlgorithmWithOSMTest {
     public void testMonacoFoot3D() {
         // most routes have same number of points as testMonaceFoot results but longer distance due to elevation difference
         List<Query> queries = createMonacoFoot();
-        queries.get(0).getPoints().get(1).expectedDistance = 1624;
-        queries.get(2).getPoints().get(1).expectedDistance = 2250;
-        queries.get(3).getPoints().get(1).expectedDistance = 1482;
+        queries.get(0).getPoints().get(1).expectedDistance = 1603;
+        queries.get(2).getPoints().get(1).expectedDistance = 2234;
+        queries.get(3).getPoints().get(1).expectedDistance = 1478;
 
         // or slightly longer tour with less nodes: list.get(1).setDistance(1, 3610);
         queries.get(1).getPoints().get(1).expectedDistance = 3576;
@@ -317,20 +317,20 @@ public class RoutingAlgorithmWithOSMTest {
     @Test
     public void testMonacoBike3D() {
         List<Query> queries = new ArrayList<>();
-        // 1. alternative: go over steps 'Rampe Major' => 1.7km vs. around 2.7km
-        queries.add(new Query(43.730864, 7.420771, 43.727687, 7.418737, 2670, 118));
+        // 1. alternative: go over steps 'Rampe Major' => 1.7km vs. around 2.4km after BridgeTunnelTowerCorrection
+        queries.add(new Query(43.730864, 7.420771, 43.727687, 7.418737, 2373, 111));
         // 2.
-        queries.add(new Query(43.728499, 7.417907, 43.74958, 7.436566, 4223, 233));
+        queries.add(new Query(43.728499, 7.417907, 43.74958, 7.436566, 4224, 233));
         // 3.
-        queries.add(new Query(43.728677, 7.41016, 43.739213, 7.427806, 2776, 167));
+        queries.add(new Query(43.728677, 7.41016, 43.739213, 7.427806, 2739, 167));
         // 4.
-        queries.add(new Query(43.733802, 7.413433, 43.739662, 7.424355, 1593, 85));
+        queries.add(new Query(43.733802, 7.413433, 43.739662, 7.424355, 1589, 85));
 
         // try reverse direction
         // 1.
-        queries.add(new Query(43.727687, 7.418737, 43.730864, 7.420771, 2598, 115));
-        queries.add(new Query(43.74958, 7.436566, 43.728499, 7.417907, 3982, 181));
-        queries.add(new Query(43.739213, 7.427806, 43.728677, 7.41016, 2806, 145));
+        queries.add(new Query(43.727687, 7.418737, 43.730864, 7.420771, 2585, 115));
+        queries.add(new Query(43.74958, 7.436566, 43.728499, 7.417907, 3976, 181));
+        queries.add(new Query(43.739213, 7.427806, 43.728677, 7.41016, 2773, 145));
         // 4. avoid tunnel(s)!
         queries.add(new Query(43.739662, 7.424355, 43.733802, 7.413433, 1901, 116));
         // tests here still assert that reverse oneways are excluded
@@ -569,7 +569,7 @@ public class RoutingAlgorithmWithOSMTest {
     public void testNeudrossenfeld() {
         List<Query> list = new ArrayList<>();
         // choose cycleway (Dreschenauer Straße)
-        list.add(new Query(49.987132, 11.510496, 50.018839, 11.505024, 3985, 106));
+        list.add(new Query(49.987132, 11.510496, 50.018839, 11.505024, 3983, 106));
 
         GraphHopper hopper = createHopper(BAYREUTH, TestProfiles.accessSpeedAndPriority("bike"));
         hopper.setElevationProvider(new SRTMProvider(DIR));


### PR DESCRIPTION
The elevation for the "entry nodes" of a bridge (or tunnel or ferry) is often disturbed because the elevation data already starts deviating from the true road level before the OSM bridge tag begins. And so the tower node needs some lifting, including the neighboring ramp. AI helped me implementing 3 different approaches and I picked this one because of its simplicity and overall good results.

There are several examples:

1. [tunnel-bridge complex in Cotta](https://graphhopper.com/maps/?point=51.05702%2C13.687498&point=51.06831%2C13.689663&profile=car) (before/after)
<img width="400" src="https://github.com/user-attachments/assets/25f156ab-7ca9-4fe3-87a4-5f33855f4a13" /> <img width="400" src="https://github.com/user-attachments/assets/9d1ed060-92d0-4b04-97d6-852458d56304" />

2. [Bähnle-Radweg bridge](https://graphhopper.com/maps/?point=47.860933%2C8.240499&point=47.86162%2C8.23785&profile=bike) (before/after):
<img width="400" src="https://github.com/user-attachments/assets/c6550be3-90c3-48c3-a9d6-b2381c4a5b8a" /> <img width="400" src="https://github.com/user-attachments/assets/b41d57d1-ac68-4f98-85db-0c6e53c15478" />

3. [Thiergarten tunnel](https://graphhopper.com/maps/?point=48.091615%2C9.108302&point=48.093812%2C9.107311&profile=car) (before/after):
<img width="400" src="https://github.com/user-attachments/assets/be581241-2f83-4569-b0fb-2e3ca9d50889" /> <img width="400" src="https://github.com/user-attachments/assets/1cadd408-2f0f-4f63-a1a1-4bde1041d664" />

4. [Neudorf bridge](https://graphhopper.com/maps/?point=51.311405%2C14.545808&point=51.308449%2C14.544617&profile=bike) (before/after):
<img width="400" alt="image" src="https://github.com/user-attachments/assets/36a681b1-47b8-46fd-b70d-45a32cd535bf" /> <img width="400" alt="image" src="https://github.com/user-attachments/assets/284df7ca-060a-4061-b81a-83a1b5c6554c" />

5. [An inclined bridge in Daun](https://graphhopper.com/maps/?point=50.194635%2C6.839442&point=50.19535%2C6.844305&profile=car) also works (before/after):
<img width="400" alt="image" src="https://github.com/user-attachments/assets/9ced9e4e-f3bf-4b09-b3d8-5acf0241effe" /> <img width="400" alt="image" src="https://github.com/user-attachments/assets/25ac8aa2-a3b4-4af9-baa4-0c66ae3d0b14" />

6. Tricky bridge structure for [Marienbrücke](https://graphhopper.com/maps/?point=51.057896%2C13.727394&point=51.062119%2C13.735592&profile=bike) and although total incline/decline stays the same you see that it got smoother:
<img width="400" src="https://github.com/user-attachments/assets/4e6b5f7a-4529-474d-8350-1f6455cfafc3" /> <img width="400" src="https://github.com/user-attachments/assets/df05930e-164d-4e7b-9dff-e261ead37310" /> 

7. [Another bridge structure with multiple parallel ways](https://graphhopper.com/maps/?point=47.70992%2C10.980028&point=47.711846%2C10.973925&profile=car)
<img width="400" src="https://github.com/user-attachments/assets/81c9bdec-9017-4214-8a0d-4eb94a4810b8" /> <img width="400" src="https://github.com/user-attachments/assets/ef5a541d-5213-4061-a6a3-068b11cc4a9f" />

8. [Similar improvements for motorway bridges](https://graphhopper.com/maps/?point=49.181316%2C9.756685&point=49.174858%2C9.797098&profile=car)
<img width="400" src="https://github.com/user-attachments/assets/42c68afa-1dba-4476-ac6e-7f061db2cbe4" /> <img width="400" src="https://github.com/user-attachments/assets/433b6e27-da3f-4f0a-a854-d99f6e783c84" />

Unsolved challenges:

 * the [bridge structure in Dresden (Albertbrücke)](https://graphhopper.com/maps/?point=51.055692%2C13.756456&point=51.058528%2C13.751834&profile=car) with multiple parallel ways (bike, car) has only slightly improved from 4m/5m to 4m/3m.
 * the tricky [inclined bridges in Flöha](https://graphhopper.com/maps/?point=50.854344%2C13.113826&point=50.856442%2C13.112572&profile=bike) has improved from 4m/14m to only 1m/12m but is still not nicely smooth.
 * [Bridges near Ortrand](https://graphhopper.com/maps/?point=51.378768%2C13.747259&point=51.365188%2C13.74153&profile=car)
 * [And strange elevation obstacles (strong+short slopes) without bridge/tunnel](https://graphhopper.com/maps/?point=50.847083%2C13.775275&point=50.849703%2C13.781905&profile=car).