### PR TITLE
Update Dropwizard to 5.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-dependencies</artifactId>
-                <version>5.0.1</version>
+                <version>5.0.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
## Summary

Update Dropwizard from 5.0.1 to 5.0.2.

## Motivation

Dropwizard 5.0.1 depends on a Jetty version affected by CVE-2026-2332.

Dropwizard 5.0.2 updates the Jetty dependencies and includes the fix for this vulnerability.

## Testing

- [x] mvn clean test verify