### PR TITLE
Allow custom scoring of transition route length in map-matching

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -48,6 +48,7 @@ Here is an overview:
  * Janekdererste, GUI for public transit
  * jansoe, many improvements regarding A* algorithm, forcing direction, roundabouts etc
  * jansonhanson, general host config
+ * JerzyJerzu, TransitionRouteLengthFunction strategy hook for map-matching transition scoring
  * jessLryan, max elevation can now be negative
  * joe-akeem, improvements like #2158
  * JohannesPelzer, improved GPX information and various other things

--- a/map-matching/src/main/java/com/graphhopper/matching/MapMatching.java
+++ b/map-matching/src/main/java/com/graphhopper/matching/MapMatching.java
@@ -72,6 +72,8 @@ public class MapMatching {
     private double measurementErrorSigma = 10.0;
     private double transitionProbabilityBeta = 2.0;
     private double uTurnCost = 40.0;
+    private static final TransitionRouteLengthFunction GEOMETRIC_ROUTE_LENGTH = (distance, timeMillis, weight) -> distance;
+    private TransitionRouteLengthFunction transitionRouteLengthFunction = GEOMETRIC_ROUTE_LENGTH;
     private final DistanceCalc distanceCalc = new DistancePlaneProjection();
     private QueryGraph queryGraph;
     private boolean collectDebugInfo = false;
@@ -202,6 +204,10 @@ public class MapMatching {
         this.transitionProbabilityBeta = transitionProbabilityBeta;
     }
 
+    public double getTransitionProbabilityBeta() {
+        return transitionProbabilityBeta;
+    }
+
     /**
      * Standard deviation of the normal distribution [m] used for modeling the
      * GPS error.
@@ -210,8 +216,26 @@ public class MapMatching {
         this.measurementErrorSigma = measurementErrorSigma;
     }
 
+    public double getMeasurementErrorSigma() {
+        return measurementErrorSigma;
+    }
+
     public void setUTurnCost(double uTurnCost) {
         this.uTurnCost = uTurnCost;
+    }
+
+    /**
+     * Sets the strategy used to compute the effective route length passed to
+     * transition probability scoring. The default returns the raw geometric
+     * distance, matching the Newson &amp; Krumm HMM model.
+     * <p>
+     * Does not affect U-turn transitions, which use the fixed
+     * {@link #setUTurnCost(double) U-turn cost} mechanism.
+     *
+     * @param function the scoring strategy, or {@code null} to restore the default
+     */
+    public void setTransitionRouteLengthFunction(TransitionRouteLengthFunction function) {
+        this.transitionRouteLengthFunction = (function != null) ? function : GEOMETRIC_ROUTE_LENGTH;
     }
 
     public void setCollectDebugInfo(boolean collectDebugInfo) {
@@ -629,7 +653,8 @@ public class MapMatching {
                 State to = nextTimeStep.candidates.get(i);
                 Path path = paths.get(i);
                 if (path.isFound()) {
-                    double transitionLogProbability = probabilities.transitionLogProbability(path.getDistance(), linearDistance);
+                    double effectiveRouteLength = transitionRouteLengthFunction.apply(path.getDistance(), path.getTime(), path.getWeight());
+                    double transitionLogProbability = probabilities.transitionLogProbability(effectiveRouteLength, linearDistance);
                     Transition<State> transition = new Transition<>(from, to);
                     roadPaths.put(transition, path);
                     double minusLogProbability = qe.minusLogProbability - probabilities.emissionLogProbability(to.getSnap().getQueryDistance()) - transitionLogProbability;
@@ -767,6 +792,23 @@ public class MapMatching {
 
     public Map<String, Object> getStatistics() {
         return statistics;
+    }
+
+    /**
+     * Strategy for computing the effective route length used in transition
+     * probability scoring. See
+     * {@link MapMatching#setTransitionRouteLengthFunction(TransitionRouteLengthFunction)}.
+     */
+    @FunctionalInterface
+    public interface TransitionRouteLengthFunction {
+        /**
+         * @param distanceMeters geometric distance of the routed path in metres
+         * @param timeMillis     travel time of the routed path in milliseconds
+         * @param weight         weighted cost of the routed path (custom_model units)
+         * @return effective length to be passed to transition probability scoring;
+         *         must be non-negative and comparable to the chord (linear) distance
+         */
+        double apply(double distanceMeters, long timeMillis, double weight);
     }
 
     private static class MapMatchedPath extends Path {

--- a/web/src/test/java/com/graphhopper/application/MapMatchingTest.java
+++ b/web/src/test/java/com/graphhopper/application/MapMatchingTest.java
@@ -42,6 +42,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -292,6 +293,59 @@ public class MapMatchingTest {
         mr = mapMatching.match(GpxConversions.getEntries(gpx.trk.get(0)));
         assertEquals(Arrays.asList("Gustav-Adolf-Straße", "Funkenburgstraße"), fetchStreets(mr.getEdgeMatches()));
         assertEquals(445.0, mr.getMatchLength(), 1.0);
+    }
+
+    /**
+     * Verifies that a custom TransitionRouteLengthFunction is invoked during matching.
+     */
+    @ParameterizedTest
+    @ArgumentsSource(FixtureProvider.class)
+    public void testCustomTransitionRouteLengthFunctionIsInvoked(PMap hints) {
+        MapMatching mapMatching = MapMatching.fromGraphHopper(graphHopper, hints);
+        ResponsePath route = graphHopper.route(new GHRequest(
+                new GHPoint(51.358735, 12.360574),
+                new GHPoint(51.358594, 12.360032))
+                .setProfile("my_profile")).getBest();
+        List<Observation> inputGPXEntries = createRandomGPXEntriesAlongRoute(route);
+
+        AtomicInteger callCount = new AtomicInteger();
+        mapMatching.setTransitionRouteLengthFunction((distance, timeMillis, weight) -> {
+            callCount.incrementAndGet();
+            return distance;
+        });
+        mapMatching.match(inputGPXEntries);
+
+        assertTrue(callCount.get() > 0, "Custom strategy should be invoked at least once");
+    }
+
+    /**
+     * Verifies that passing null to setTransitionRouteLengthFunction stops the
+     * previously-installed custom strategy from being invoked on subsequent matches.
+     */
+    @ParameterizedTest
+    @ArgumentsSource(FixtureProvider.class)
+    public void testNullClearsPreviouslyInstalledStrategy(PMap hints) {
+        MapMatching mapMatching = MapMatching.fromGraphHopper(graphHopper, hints);
+        ResponsePath route = graphHopper.route(new GHRequest(
+                new GHPoint(51.358735, 12.360574),
+                new GHPoint(51.358594, 12.360032))
+                .setProfile("my_profile")).getBest();
+        List<Observation> inputGPXEntries = createRandomGPXEntriesAlongRoute(route);
+
+        AtomicInteger callCount = new AtomicInteger();
+        mapMatching.setTransitionRouteLengthFunction((distance, timeMillis, weight) -> {
+            callCount.incrementAndGet();
+            return distance;
+        });
+        mapMatching.match(inputGPXEntries);
+        int countAfterFirstMatch = callCount.get();
+        assertTrue(countAfterFirstMatch > 0, "Sanity: the custom strategy should run on the first match");
+
+        mapMatching.setTransitionRouteLengthFunction(null);
+        mapMatching.match(inputGPXEntries);
+
+        assertEquals(countAfterFirstMatch, callCount.get(),
+                "After null reset, the previously-installed strategy must not run again");
     }
 
     static List<String> fetchStreets(List<EdgeMatch> emList) {


### PR DESCRIPTION
## Summary

Allows callers to customize how the route length is computed for comparison with linear distance in `MapMatching`'s transition probability scoring. Users can plug in a function via `setTransitionRouteLengthFunction(...)` which can respect the route weight and time; the default keeps the existing geometric scoring (raw `path.getDistance()`), so behaviour is unchanged byte-for-byte for users who don't opt in. 

  ## Motivation

Today, the transition probability for each candidate-pair is computed purely from geometric route distance:
``` java
  double transitionLogProbability = probabilities.transitionLogProbability(path.getDistance(), linearDistance);
```
This works well when candidate edges differ geometrically - but it breaks down when two candidates are geometrically similar, or when we want to add custom priorites.
For example:
Parallel tracks in a rail/tram network. In many rail networks tracks may hold `preferred_direction` tag rather than strict directional prohibitions (see https://wiki.openstreetmap.org/wiki/Key:railway:preferred_direction). This preferences could be recognized by a custom_model's priority multiplier, but a current map matching code would not respect that and in this case may very often return routes which use a wrong opposite track

Letting a caller plug in a function that incorporates routing metadata (weight, time) into the effective length passed to the HMM solves this, biasing the matcher toward preferred candidates without changing the underlying HMM machinery.

  ## Usage example
``` java
  mapMatching.setTransitionRouteLengthFunction((distance, timeMillis, weight) -> {
      if (timeMillis <= 0) return distance;
      return distance * weight / (timeMillis / 1000.0);
  });
```
For a custom_model with `distance_influence = 0` and `multiply_by: 0.5` on against-direction edges (rail's `preferred_direction` pattern), `weight/time = 2.0`, so the effective length is doubled and Viterbi prefers the preferred direction.

A similar gap exists for road profiles with prioritised road classes — e.g., a bus profile down-weighting service roads relative to tertiary ones, or a cyclist profile preferring cycle paths over shared lanes. The router uses these preferences to find paths, but the matcher discards them, so when geometrically similar candidates exist, it may snap to a deprioritised class even though the router would have avoided it. The same strategy hook applies; the formula shown below is rail-specific (assumes distance_influence = 0), but other formulas can be plugged in to fit each

License
This contribution is made under the Apache License 2.0, as outlined in CONTRIBUTING.md (https://github.com/graphhopper/graphhopper/blob/master/CONTRIBUTING.md). I've added myself to CONTRIBUTORS.md as required for first-time contributors.