### PR TITLE
Netherlands HGV toll

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMTollParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMTollParser.java
@@ -112,7 +112,7 @@ public class OSMTollParser implements TagParser {
                 else
                     return Toll.NO;
             }
-            case BEL, BLR, LUX, POL, SWE -> {
+            case BEL, BLR, LUX, NLD, POL, SWE -> {
                 RoadClass roadClass = RoadClass.find(readerWay.getTag("highway", ""));
                 if (roadClass == RoadClass.MOTORWAY)
                     return Toll.HGV;


### PR DESCRIPTION
The Netherlands is rolling out an HGV toll, which will come into effect on 01.07. With this change, by default, motorways will be classified as `Toll.HGV` if no tagging is present in OSM. While some provincial and municipal roads are affected too, the proportion is too low to include them by default, IMHO. This should rather be handled by explicit tagging.

[<img width="1920" height="2364" alt="image" src="https://github.com/user-attachments/assets/1d87607a-6150-489e-b487-2a8a3d3efcff" />](https://www.vrachtwagenheffing.nl/-/media/trucktol/website/hier-gaat-u-vrachtwagenheffing-betalen/nieuwe-wegenkaarten/truck-toll-road-map.pdf?rev=45d521bfce0143aba12f41a55de66f11&hash=0F5F2417BD636E9B34A516DF59A982F7)