### PR TITLE
Avoid unnecessary detours for racingbike

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonPriorityParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonPriorityParser.java
@@ -26,8 +26,7 @@ public abstract class BikeCommonPriorityParser implements TagParser {
     protected final Set<String> preferHighwayTags = new HashSet<>();
     protected final Map<String, PriorityCode> avoidHighwayTags = new HashMap<>();
     protected final DecimalEncodedValue priorityEnc;
-    // Car speed limit which switches the preference from UNCHANGED to AVOID_IF_POSSIBLE
-    int avoidSpeedLimit;
+    double avoidSpeedLimit = 71;
     protected final Set<String> goodSurface = Set.of("paved", "asphalt", "concrete");
 
     // This is the specific bicycle class
@@ -48,8 +47,6 @@ public abstract class BikeCommonPriorityParser implements TagParser {
         avoidHighwayTags.put("secondary", AVOID);
         avoidHighwayTags.put("secondary_link", AVOID);
         avoidHighwayTags.put("bridleway", AVOID);
-
-        avoidSpeedLimit = 71;
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonPriorityParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonPriorityParser.java
@@ -45,8 +45,6 @@ public abstract class BikeCommonPriorityParser implements TagParser {
         avoidHighwayTags.put("motorway_link", REACH_DESTINATION);
         avoidHighwayTags.put("trunk", REACH_DESTINATION);
         avoidHighwayTags.put("trunk_link", REACH_DESTINATION);
-        avoidHighwayTags.put("primary", BAD);
-        avoidHighwayTags.put("primary_link", BAD);
         avoidHighwayTags.put("secondary", AVOID);
         avoidHighwayTags.put("secondary_link", AVOID);
         avoidHighwayTags.put("bridleway", AVOID);
@@ -99,15 +97,13 @@ public abstract class BikeCommonPriorityParser implements TagParser {
                 weightToPrioMap.put(100d, PREFER);
         }
 
-        if ("cycleway".equals(highway)) {
+        double maxSpeed = Math.max(OSMMaxSpeedParser.parseMaxSpeed(way, false), OSMMaxSpeedParser.parseMaxSpeed(way, true));
+        if ("cycleway".equals(highway) && preferHighwayTags.contains(highway)) {
             if (way.hasTag("foot", INTENDED) && !way.hasTag("segregated", "yes"))
                 weightToPrioMap.put(100d, PREFER);
             else
                 weightToPrioMap.put(100d, VERY_NICE);
-        }
-
-        double maxSpeed = Math.max(OSMMaxSpeedParser.parseMaxSpeed(way, false), OSMMaxSpeedParser.parseMaxSpeed(way, true));
-        if (preferHighwayTags.contains(highway) || maxSpeed <= 30) {
+        } else if (preferHighwayTags.contains(highway) || maxSpeed <= 30) {
             if (maxSpeed == MaxSpeed.MAXSPEED_MISSING || maxSpeed < avoidSpeedLimit) {
                 weightToPrioMap.put(40d, SLIGHT_PREFER);
                 if (way.hasTag("tunnel", INTENDED))

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/BikePriorityParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/BikePriorityParser.java
@@ -4,6 +4,8 @@ import com.graphhopper.routing.ev.DecimalEncodedValue;
 import com.graphhopper.routing.ev.EncodedValueLookup;
 import com.graphhopper.routing.ev.VehiclePriority;
 
+import static com.graphhopper.routing.util.PriorityCode.BAD;
+
 public class BikePriorityParser extends BikeCommonPriorityParser {
 
     public BikePriorityParser(EncodedValueLookup lookup) {
@@ -15,9 +17,13 @@ public class BikePriorityParser extends BikeCommonPriorityParser {
 
         addPushingSection("path");
 
+        avoidHighwayTags.put("primary", BAD);
+        avoidHighwayTags.put("primary_link", BAD);
+
         preferHighwayTags.add("service");
         preferHighwayTags.add("residential");
         preferHighwayTags.add("unclassified");
+        preferHighwayTags.add("cycleway");
 
         setSpecificClassBicycle("touring");
     }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/MountainBikePriorityParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/MountainBikePriorityParser.java
@@ -18,6 +18,9 @@ public class MountainBikePriorityParser extends BikeCommonPriorityParser {
     protected MountainBikePriorityParser(DecimalEncodedValue priorityEnc) {
         super(priorityEnc);
 
+        avoidHighwayTags.put("primary", BAD);
+        avoidHighwayTags.put("primary_link", BAD);
+
         preferHighwayTags.add("road");
         preferHighwayTags.add("track");
         preferHighwayTags.add("path");
@@ -26,6 +29,7 @@ public class MountainBikePriorityParser extends BikeCommonPriorityParser {
         preferHighwayTags.add("tertiary_link");
         preferHighwayTags.add("residential");
         preferHighwayTags.add("unclassified");
+        preferHighwayTags.add("cycleway");
 
         setSpecificClassBicycle("mtb");
     }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikeAverageSpeedParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikeAverageSpeedParser.java
@@ -54,6 +54,8 @@ public class RacingBikeAverageSpeedParser extends BikeCommonAverageSpeedParser {
         setHighwaySpeed("tertiary", 24);
         setHighwaySpeed("tertiary_link", 24);
         setHighwaySpeed("cycleway", 24);
+        setHighwaySpeed("residential", 24);
+        setHighwaySpeed("unclassified", 24);
 
         // overwrite map from BikeCommon
         setSmoothnessSpeedFactor(Smoothness.EXCELLENT, 1.2d);

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikePriorityParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikePriorityParser.java
@@ -33,7 +33,7 @@ public class RacingBikePriorityParser extends BikeCommonPriorityParser {
 
         setSpecificClassBicycle("roadcycling");
 
-        avoidSpeedLimit = 81;
+        avoidSpeedLimit = Double.POSITIVE_INFINITY;
     }
 
     @Override
@@ -41,14 +41,14 @@ public class RacingBikePriorityParser extends BikeCommonPriorityParser {
         super.collect(way, bikeDesignated, weightToPrioMap);
 
         String highway = way.getTag("highway");
-        if (way.hasTag("foot", INTENDED) && !way.hasTag("segregated", "yes")) {
+        if (way.hasTag("foot", INTENDED)) {
             weightToPrioMap.put(100d, AVOID);
-        } else if ("service".equals(highway) || "residential".equals(highway)) {
+        } else if ("service".equals(highway) || "residential".equals(highway) || "unclassified".equals(highway)) {
             weightToPrioMap.put(40d, SLIGHT_AVOID);
         } else if ("track".equals(highway)) {
             String trackType = way.getTag("tracktype");
             if ("grade1".equals(trackType) || goodSurface.contains(way.getTag("surface", "")))
-                weightToPrioMap.put(110d, PREFER);
+                weightToPrioMap.put(110d, UNCHANGED);
             else if (trackType == null || trackType.startsWith("grade"))
                 weightToPrioMap.put(110d, AVOID_MORE);
         }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikePriorityParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikePriorityParser.java
@@ -25,7 +25,6 @@ public class RacingBikePriorityParser extends BikeCommonPriorityParser {
         preferHighwayTags.add("secondary_link");
         preferHighwayTags.add("tertiary");
         preferHighwayTags.add("tertiary_link");
-        preferHighwayTags.add("residential"); // TODO NOW: remove as conflict with collect method
 
         avoidHighwayTags.put("motorway", BAD);
         avoidHighwayTags.put("motorway_link", BAD);

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikePriorityParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikePriorityParser.java
@@ -7,6 +7,7 @@ import com.graphhopper.routing.util.PriorityCode;
 import java.util.TreeMap;
 
 import static com.graphhopper.routing.util.PriorityCode.*;
+import static com.graphhopper.routing.util.parsers.AbstractAccessParser.INTENDED;
 
 public class RacingBikePriorityParser extends BikeCommonPriorityParser {
 
@@ -24,7 +25,7 @@ public class RacingBikePriorityParser extends BikeCommonPriorityParser {
         preferHighwayTags.add("secondary_link");
         preferHighwayTags.add("tertiary");
         preferHighwayTags.add("tertiary_link");
-        preferHighwayTags.add("residential");
+        preferHighwayTags.add("residential"); // TODO NOW: remove as conflict with collect method
 
         avoidHighwayTags.put("motorway", BAD);
         avoidHighwayTags.put("motorway_link", BAD);
@@ -41,12 +42,14 @@ public class RacingBikePriorityParser extends BikeCommonPriorityParser {
         super.collect(way, bikeDesignated, weightToPrioMap);
 
         String highway = way.getTag("highway");
-        if ("service".equals(highway) || "residential".equals(highway)) {
+        if (way.hasTag("foot", INTENDED) && !way.hasTag("segregated", "yes")) {
+            weightToPrioMap.put(100d, AVOID);
+        } else if ("service".equals(highway) || "residential".equals(highway)) {
             weightToPrioMap.put(40d, SLIGHT_AVOID);
         } else if ("track".equals(highway)) {
             String trackType = way.getTag("tracktype");
             if ("grade1".equals(trackType) || goodSurface.contains(way.getTag("surface", "")))
-                weightToPrioMap.put(110d, VERY_NICE);
+                weightToPrioMap.put(110d, PREFER);
             else if (trackType == null || trackType.startsWith("grade"))
                 weightToPrioMap.put(110d, AVOID_MORE);
         }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikePriorityParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikePriorityParser.java
@@ -30,8 +30,6 @@ public class RacingBikePriorityParser extends BikeCommonPriorityParser {
         avoidHighwayTags.put("motorway_link", BAD);
         avoidHighwayTags.put("trunk", BAD);
         avoidHighwayTags.put("trunk_link", BAD);
-        avoidHighwayTags.put("primary", AVOID_MORE);
-        avoidHighwayTags.put("primary_link", AVOID_MORE);
 
         setSpecificClassBicycle("roadcycling");
 

--- a/core/src/test/java/com/graphhopper/routing/RoutingAlgorithmWithOSMTest.java
+++ b/core/src/test/java/com/graphhopper/routing/RoutingAlgorithmWithOSMTest.java
@@ -412,9 +412,9 @@ public class RoutingAlgorithmWithOSMTest {
     public void testMonacoRacingBike() {
         List<Query> queries = new ArrayList<>();
         queries.add(new Query(43.730864, 7.420771, 43.727687, 7.418737, 2597, 118)); // watch out, this route has an alternative that looks very different but has almost identical weight
-        queries.add(new Query(43.727687, 7.418737, 43.74958, 7.436566, 3615, 184));
-        queries.add(new Query(43.728677, 7.41016, 43.739213, 7.427806, 2651, 167));
-        queries.add(new Query(43.733802, 7.413433, 43.739662, 7.424355, 1516, 86));
+        queries.add(new Query(43.727687, 7.418737, 43.74958, 7.436566, 3588, 170));
+        queries.add(new Query(43.728677, 7.41016, 43.739213, 7.427806, 2568, 134));
+        queries.add(new Query(43.733802, 7.413433, 43.739662, 7.424355, 1491, 84));
 
         GraphHopper hopper = createHopper(MONACO, TestProfiles.accessSpeedAndPriority("racingbike"));
         hopper.importOrLoad();

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/AbstractBikeTagParserTester.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/AbstractBikeTagParserTester.java
@@ -201,7 +201,6 @@ public abstract class AbstractBikeTagParserTester {
         way.setTag("bicycle", "no");
         assertTrue(accessParser.getAccess(way).canSkip());
 
-
         way.clearTags();
         way.setTag("highway", "cycleway");
         way.setTag("cycleway", "track");
@@ -371,7 +370,7 @@ public abstract class AbstractBikeTagParserTester {
     }
 
     @Test
-    public void testHandleWayTagsCallsHandlePriority() {
+    public void testCycleway() {
         ReaderWay osmWay = new ReaderWay(1);
         osmWay.setTag("highway", "cycleway");
 

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/RacingBikeTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/RacingBikeTagParserTest.java
@@ -78,7 +78,7 @@ public class RacingBikeTagParserTest extends AbstractBikeTagParserTester {
         ReaderWay osmWay = new ReaderWay(1);
         osmWay.setTag("highway", "residential");
         osmWay.setTag("tunnel", "yes");
-        assertPriorityAndSpeed(SLIGHT_AVOID, 18, osmWay);
+        assertPriorityAndSpeed(SLIGHT_AVOID, 24, osmWay);
 
         osmWay.setTag("highway", "secondary");
         osmWay.setTag("tunnel", "yes");
@@ -106,7 +106,7 @@ public class RacingBikeTagParserTest extends AbstractBikeTagParserTester {
         way.setTag("bicycle", "yes");
         assertPriorityAndSpeed(AVOID_MORE, 2, way);
         way.setTag("surface", "asphalt");
-        assertPriorityAndSpeed(VERY_NICE, 24, way);
+        assertPriorityAndSpeed(PREFER, 24, way);
 
         way.clearTags();
         way.setTag("highway", "track");
@@ -114,9 +114,9 @@ public class RacingBikeTagParserTest extends AbstractBikeTagParserTester {
         way.setTag("segregated","no");
         assertPriorityAndSpeed(AVOID_MORE, 2, way);
         way.setTag("surface", "asphalt");
-        assertPriorityAndSpeed(VERY_NICE, 24, way);
+        assertPriorityAndSpeed(PREFER, 24, way);
         way.setTag("tracktype","grade1");
-        assertPriorityAndSpeed(VERY_NICE, 24, way);
+        assertPriorityAndSpeed(PREFER, 24, way);
     }
 
     @Test
@@ -157,19 +157,19 @@ public class RacingBikeTagParserTest extends AbstractBikeTagParserTester {
     public void testSmoothness() {
         ReaderWay way = new ReaderWay(1);
         way.setTag("highway", "residential");
-        assertEquals(18, getSpeedFromFlags(way), 0.01);
+        assertEquals(24, getSpeedFromFlags(way), 0.01);
 
         way.setTag("smoothness", "excellent");
-        assertEquals(22, getSpeedFromFlags(way), 0.01);
+        assertEquals(28, getSpeedFromFlags(way), 0.01);
 
         way.setTag("smoothness", "bad");
-        assertEquals(12, getSpeedFromFlags(way), 0.01);
+        assertEquals(16, getSpeedFromFlags(way), 0.01);
 
         way.setTag("smoothness", "impassable");
         assertEquals(MIN_SPEED, getSpeedFromFlags(way), 0.01);
 
         way.setTag("smoothness", "unknown");
-        assertEquals(12, getSpeedFromFlags(way), 0.01);
+        assertEquals(16, getSpeedFromFlags(way), 0.01);
 
         way.clearTags();
         way.setTag("highway", "residential");
@@ -209,7 +209,7 @@ public class RacingBikeTagParserTest extends AbstractBikeTagParserTester {
 
         // Now we assume bicycle=yes, and paved
         osmWay.setTag("tracktype", "grade1");
-        assertPriorityAndSpeed(VERY_NICE, 24, osmWay, osmRel);
+        assertPriorityAndSpeed(PREFER, 24, osmWay, osmRel);
 
         // Now we assume bicycle=yes, and unpaved and as part of a cycle relation
         osmWay.setTag("tracktype", "grade2");
@@ -220,7 +220,7 @@ public class RacingBikeTagParserTest extends AbstractBikeTagParserTester {
         osmWay.clearTags();
         osmWay.setTag("highway", "track");
         osmWay.setTag("surface", "asphalt");
-        assertPriorityAndSpeed(VERY_NICE, 24, osmWay, osmRel);
+        assertPriorityAndSpeed(PREFER, 24, osmWay, osmRel);
 
         // Now we assume bicycle=yes, and unpaved and not part of a cycle relation
         osmWay.clearTags();

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/RacingBikeTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/RacingBikeTagParserTest.java
@@ -106,7 +106,7 @@ public class RacingBikeTagParserTest extends AbstractBikeTagParserTester {
         way.setTag("bicycle", "yes");
         assertPriorityAndSpeed(AVOID_MORE, 2, way);
         way.setTag("surface", "asphalt");
-        assertPriorityAndSpeed(PREFER, 24, way);
+        assertPriorityAndSpeed(UNCHANGED, 24, way);
 
         way.clearTags();
         way.setTag("highway", "track");
@@ -114,9 +114,9 @@ public class RacingBikeTagParserTest extends AbstractBikeTagParserTester {
         way.setTag("segregated","no");
         assertPriorityAndSpeed(AVOID_MORE, 2, way);
         way.setTag("surface", "asphalt");
-        assertPriorityAndSpeed(PREFER, 24, way);
+        assertPriorityAndSpeed(UNCHANGED, 24, way);
         way.setTag("tracktype","grade1");
-        assertPriorityAndSpeed(PREFER, 24, way);
+        assertPriorityAndSpeed(UNCHANGED, 24, way);
     }
 
     @Test
@@ -209,7 +209,7 @@ public class RacingBikeTagParserTest extends AbstractBikeTagParserTester {
 
         // Now we assume bicycle=yes, and paved
         osmWay.setTag("tracktype", "grade1");
-        assertPriorityAndSpeed(PREFER, 24, osmWay, osmRel);
+        assertPriorityAndSpeed(UNCHANGED, 24, osmWay, osmRel);
 
         // Now we assume bicycle=yes, and unpaved and as part of a cycle relation
         osmWay.setTag("tracktype", "grade2");
@@ -220,7 +220,7 @@ public class RacingBikeTagParserTest extends AbstractBikeTagParserTester {
         osmWay.clearTags();
         osmWay.setTag("highway", "track");
         osmWay.setTag("surface", "asphalt");
-        assertPriorityAndSpeed(PREFER, 24, osmWay, osmRel);
+        assertPriorityAndSpeed(UNCHANGED, 24, osmWay, osmRel);
 
         // Now we assume bicycle=yes, and unpaved and not part of a cycle relation
         osmWay.clearTags();
@@ -258,10 +258,10 @@ public class RacingBikeTagParserTest extends AbstractBikeTagParserTester {
         assertPriorityAndSpeed(encodingManager, priorityEnc, speedEnc, parsers, SLIGHT_PREFER, 24, osmWay);
 
         osmWay.setTag("maxspeed", "90");
-        assertPriorityAndSpeed(encodingManager, priorityEnc, speedEnc, parsers, UNCHANGED, 24, osmWay);
+        assertPriorityAndSpeed(encodingManager, priorityEnc, speedEnc, parsers, SLIGHT_PREFER, 24, osmWay);
 
         osmWay.setTag("maxspeed", "120");
-        assertPriorityAndSpeed(encodingManager, priorityEnc, speedEnc, parsers, UNCHANGED, 24, osmWay);
+        assertPriorityAndSpeed(encodingManager, priorityEnc, speedEnc, parsers, SLIGHT_PREFER, 24, osmWay);
 
         osmWay.setTag("highway", "motorway");
         assertPriorityAndSpeed(encodingManager, priorityEnc, speedEnc, parsers, BAD, 18, osmWay);
@@ -285,7 +285,7 @@ public class RacingBikeTagParserTest extends AbstractBikeTagParserTester {
         osmWay.setTag("highway", "notdefined");
         osmWay.setTag("tunnel", "yes");
         osmWay.setTag("maxspeed", "120");
-        assertPriorityAndSpeed(encodingManager, priorityEnc, speedEnc, parsers, BAD, PUSHING_SECTION_SPEED, osmWay);
+        assertPriorityAndSpeed(encodingManager, priorityEnc, speedEnc, parsers, UNCHANGED, PUSHING_SECTION_SPEED, osmWay);
 
         osmWay.clearTags();
         osmWay.setTag("highway", "notdefined");

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/RacingBikeTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/RacingBikeTagParserTest.java
@@ -66,6 +66,11 @@ public class RacingBikeTagParserTest extends AbstractBikeTagParserTester {
         return new RacingBikePriorityParser(lookup);
     }
 
+    @Override
+    @Test
+    public void testCycleway() {
+    }
+
     @Test
     @Override
     public void testAvoidTunnel() {


### PR DESCRIPTION
This is based on feedback from [racingbike enthusiasts](https://github.com/gpxstudio/gpx.studio/issues/325).

 * removes the penalty for primary roads
 * removes the preference for cycleway
 * removes inconsistencies (not adding residential to preferHighwayTags and no longer different speeds for unclassified+residential)
 * avoids roads with foot=yes (even if segregated)

/cc @ratrun 

Do later:

 * create separate collect method for racingbike to make things easier to understand and avoid still existing inconsistencies like with `if(way.hasTag("bicycle", "optional_sidepath"))` or pushing bike handling and also generic `class:bicycle` handling should be removed and the avoidSpeedLimit is no longer used too for racingbike.
 * lower penalty for reverse one-way roads (especially for France, Belgium and Netherlands where it is allowed by default for slow roads)
 * increase penalty for cycleways on the wrong side of the road