### PR TITLE
Racingbike priority refactoring

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonPriorityParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonPriorityParser.java
@@ -94,23 +94,23 @@ public abstract class BikeCommonPriorityParser implements TagParser {
         }
 
         double maxSpeed = Math.max(OSMMaxSpeedParser.parseMaxSpeed(way, false), OSMMaxSpeedParser.parseMaxSpeed(way, true));
-        if ("cycleway".equals(highway) && preferHighwayTags.contains(highway)) {
+        boolean highSpeed = maxSpeed != MaxSpeed.MAXSPEED_MISSING && maxSpeed >= 71;
+        if ("cycleway".equals(highway)) {
             if (way.hasTag("foot", INTENDED) && !way.hasTag("segregated", "yes"))
                 weightToPrioMap.put(100d, PREFER);
             else
                 weightToPrioMap.put(100d, VERY_NICE);
         } else if (preferHighwayTags.contains(highway) || maxSpeed <= 30) {
-            if (maxSpeed == MaxSpeed.MAXSPEED_MISSING || maxSpeed < 71) {
+            if (!highSpeed) {
                 weightToPrioMap.put(40d, SLIGHT_PREFER);
                 if (way.hasTag("tunnel", INTENDED))
                     weightToPrioMap.put(40d, UNCHANGED);
             }
-        } else if (avoidHighwayTags.containsKey(highway)
-                || (maxSpeed != MaxSpeed.MAXSPEED_MISSING && maxSpeed >= 71 && !"track".equals(highway))) {
-            PriorityCode priorityCode = avoidHighwayTags.get(highway);
-            weightToPrioMap.put(50d, priorityCode == null ? AVOID : priorityCode);
+        } else if (avoidHighwayTags.containsKey(highway) || highSpeed && !"track".equals(highway)) {
+            PriorityCode priorityCode = avoidHighwayTags.getOrDefault(highway, AVOID);
+            weightToPrioMap.put(50d, priorityCode);
             if (way.hasTag("tunnel", INTENDED)) {
-                PriorityCode worse = priorityCode == null ? BAD : priorityCode.worse().worse();
+                PriorityCode worse = priorityCode.worse().worse();
                 weightToPrioMap.put(50d, worse == EXCLUDE ? REACH_DESTINATION : worse);
             }
         }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonPriorityParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonPriorityParser.java
@@ -26,7 +26,6 @@ public abstract class BikeCommonPriorityParser implements TagParser {
     protected final Set<String> preferHighwayTags = new HashSet<>();
     protected final Map<String, PriorityCode> avoidHighwayTags = new HashMap<>();
     protected final DecimalEncodedValue priorityEnc;
-    double avoidSpeedLimit = 71;
     protected final Set<String> goodSurface = Set.of("paved", "asphalt", "concrete");
 
     // This is the specific bicycle class
@@ -101,13 +100,13 @@ public abstract class BikeCommonPriorityParser implements TagParser {
             else
                 weightToPrioMap.put(100d, VERY_NICE);
         } else if (preferHighwayTags.contains(highway) || maxSpeed <= 30) {
-            if (maxSpeed == MaxSpeed.MAXSPEED_MISSING || maxSpeed < avoidSpeedLimit) {
+            if (maxSpeed == MaxSpeed.MAXSPEED_MISSING || maxSpeed < 71) {
                 weightToPrioMap.put(40d, SLIGHT_PREFER);
                 if (way.hasTag("tunnel", INTENDED))
                     weightToPrioMap.put(40d, UNCHANGED);
             }
         } else if (avoidHighwayTags.containsKey(highway)
-                || (maxSpeed != MaxSpeed.MAXSPEED_MISSING && maxSpeed >= avoidSpeedLimit && !"track".equals(highway))) {
+                || (maxSpeed != MaxSpeed.MAXSPEED_MISSING && maxSpeed >= 71 && !"track".equals(highway))) {
             PriorityCode priorityCode = avoidHighwayTags.get(highway);
             weightToPrioMap.put(50d, priorityCode == null ? AVOID : priorityCode);
             if (way.hasTag("tunnel", INTENDED)) {

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonPriorityParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonPriorityParser.java
@@ -64,7 +64,7 @@ public abstract class BikeCommonPriorityParser implements TagParser {
     }
 
     // Conversion of class value to priority. See http://wiki.openstreetmap.org/wiki/Class:bicycle
-    private PriorityCode convertClassValueToPriority(String tagvalue) {
+    PriorityCode convertClassValueToPriority(String tagvalue) {
         try {
             return switch (Integer.parseInt(tagvalue)) {
                 case 3 -> BEST;

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikePriorityParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikePriorityParser.java
@@ -4,7 +4,10 @@ import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.*;
 import com.graphhopper.routing.util.PriorityCode;
 
+import java.util.Set;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.graphhopper.routing.util.PriorityCode.*;
 import static com.graphhopper.routing.util.parsers.AbstractAccessParser.INTENDED;
@@ -38,9 +41,80 @@ public class RacingBikePriorityParser extends BikeCommonPriorityParser {
 
     @Override
     void collect(ReaderWay way, boolean bikeDesignated, TreeMap<Double, PriorityCode> weightToPrioMap) {
-        super.collect(way, bikeDesignated, weightToPrioMap);
-
         String highway = way.getTag("highway");
+        if (bikeDesignated) {
+            boolean isGoodSurface = way.getTag("tracktype", "").equals("grade1") || goodSurface.contains(way.getTag("surface", ""));
+            if ("path".equals(highway) || "track".equals(highway) && isGoodSurface)
+                weightToPrioMap.put(100d, VERY_NICE);
+            else
+                weightToPrioMap.put(100d, PREFER);
+        }
+
+        double maxSpeed = Math.max(OSMMaxSpeedParser.parseMaxSpeed(way, false), OSMMaxSpeedParser.parseMaxSpeed(way, true));
+        if ("cycleway".equals(highway) && preferHighwayTags.contains(highway)) {
+            if (way.hasTag("foot", INTENDED) && !way.hasTag("segregated", "yes"))
+                weightToPrioMap.put(100d, PREFER);
+            else
+                weightToPrioMap.put(100d, VERY_NICE);
+        } else if (preferHighwayTags.contains(highway) || maxSpeed <= 30) {
+            if (maxSpeed == MaxSpeed.MAXSPEED_MISSING || maxSpeed < avoidSpeedLimit) {
+                weightToPrioMap.put(40d, SLIGHT_PREFER);
+                if (way.hasTag("tunnel", INTENDED))
+                    weightToPrioMap.put(40d, UNCHANGED);
+            }
+        } else if (avoidHighwayTags.containsKey(highway)
+                || (maxSpeed != MaxSpeed.MAXSPEED_MISSING && maxSpeed >= avoidSpeedLimit && !"track".equals(highway))) {
+            PriorityCode priorityCode = avoidHighwayTags.get(highway);
+            weightToPrioMap.put(50d, priorityCode == null ? AVOID : priorityCode);
+            if (way.hasTag("tunnel", INTENDED)) {
+                PriorityCode worse = priorityCode == null ? BAD : priorityCode.worse().worse();
+                weightToPrioMap.put(50d, worse == EXCLUDE ? REACH_DESTINATION : worse);
+            }
+        }
+
+        if (way.hasTag("bicycle", "use_sidepath")) {
+            weightToPrioMap.put(100d, REACH_DESTINATION);
+        } else if (way.hasTag("bicycle", "optional_sidepath")) {
+            weightToPrioMap.put(100d, AVOID);
+        }
+
+        Set<String> cyclewayValues = Stream.of("cycleway", "cycleway:left", "cycleway:both", "cycleway:right").map(key -> way.getTag(key, "")).collect(Collectors.toSet());
+        if (cyclewayValues.contains("track")) {
+            weightToPrioMap.put(100d, VERY_NICE);
+        } else if (Stream.of("lane", "opposite_track", "shared_lane", "share_busway", "shoulder").anyMatch(cyclewayValues::contains)) {
+            PriorityCode current = weightToPrioMap.lastEntry().getValue();
+            if (current.getValue() < PREFER.getValue())
+                weightToPrioMap.put(100d, current.better());
+        } else if (pushingSectionsHighways.contains(highway) || "parking_aisle".equals(way.getTag("service"))) {
+            PriorityCode pushingSectionPrio = SLIGHT_AVOID;
+            if (way.hasTag("highway", "steps"))
+                pushingSectionPrio = BAD;
+            else if (way.hasTag("bicycle", "yes") || way.hasTag("bicycle", "permissive"))
+                pushingSectionPrio = PREFER;
+            else if (bikeDesignated)
+                pushingSectionPrio = VERY_NICE;
+
+            if (way.hasTag("foot", "yes") && !way.hasTag("segregated", "yes"))
+                pushingSectionPrio = pushingSectionPrio.worse();
+
+            weightToPrioMap.put(100d, pushingSectionPrio);
+        }
+
+        if (way.hasTag("railway", "tram"))
+            weightToPrioMap.put(50d, AVOID_MORE);
+
+        String classBicycleValue = way.getTag("class:bicycle:roadcycling");
+        if (classBicycleValue == null) classBicycleValue = way.getTag("class:bicycle");
+
+        // We assume that humans are better in classifying preferences compared to our algorithm above
+        if (classBicycleValue != null) {
+            PriorityCode prio = convertClassValueToPriority(classBicycleValue);
+            // do not overwrite if e.g. designated
+            weightToPrioMap.compute(100d, (key, existing) ->
+                    existing == null || existing.getValue() < prio.getValue() ? prio : existing
+            );
+        }
+
         if (way.hasTag("foot", INTENDED)) {
             weightToPrioMap.put(100d, AVOID);
         } else if ("service".equals(highway) || "residential".equals(highway) || "unclassified".equals(highway)) {

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikePriorityParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikePriorityParser.java
@@ -33,49 +33,43 @@ public class RacingBikePriorityParser extends BikeCommonPriorityParser {
         avoidHighwayTags.put("motorway_link", BAD);
         avoidHighwayTags.put("trunk", BAD);
         avoidHighwayTags.put("trunk_link", BAD);
-
-        setSpecificClassBicycle("roadcycling");
-
-        avoidSpeedLimit = Double.POSITIVE_INFINITY;
+        avoidHighwayTags.put("service", SLIGHT_AVOID);
+        avoidHighwayTags.put("residential", SLIGHT_AVOID);
+        avoidHighwayTags.put("unclassified", SLIGHT_AVOID);
     }
 
     @Override
     void collect(ReaderWay way, boolean bikeDesignated, TreeMap<Double, PriorityCode> weightToPrioMap) {
         String highway = way.getTag("highway");
+        double maxSpeed = Math.max(OSMMaxSpeedParser.parseMaxSpeed(way, false), OSMMaxSpeedParser.parseMaxSpeed(way, true));
+
         if (bikeDesignated) {
-            boolean isGoodSurface = way.getTag("tracktype", "").equals("grade1") || goodSurface.contains(way.getTag("surface", ""));
-            if ("path".equals(highway) || "track".equals(highway) && isGoodSurface)
-                weightToPrioMap.put(100d, VERY_NICE);
-            else
-                weightToPrioMap.put(100d, PREFER);
+            boolean isGoodSurface = "grade1".equals(way.getTag("tracktype")) || goodSurface.contains(way.getTag("surface", ""));
+            weightToPrioMap.put(100d, "path".equals(highway) || "track".equals(highway) && isGoodSurface ? VERY_NICE : PREFER);
         }
 
-        double maxSpeed = Math.max(OSMMaxSpeedParser.parseMaxSpeed(way, false), OSMMaxSpeedParser.parseMaxSpeed(way, true));
-        if ("cycleway".equals(highway) && preferHighwayTags.contains(highway)) {
-            if (way.hasTag("foot", INTENDED) && !way.hasTag("segregated", "yes"))
-                weightToPrioMap.put(100d, PREFER);
-            else
-                weightToPrioMap.put(100d, VERY_NICE);
+        if ("track".equals(highway)) {
+            String trackType = way.getTag("tracktype");
+            if ("grade1".equals(trackType) || goodSurface.contains(way.getTag("surface", "")))
+                weightToPrioMap.put(110d, UNCHANGED);
+            else if (trackType == null || trackType.startsWith("grade"))
+                weightToPrioMap.put(110d, AVOID_MORE);
         } else if (preferHighwayTags.contains(highway) || maxSpeed <= 30) {
-            if (maxSpeed == MaxSpeed.MAXSPEED_MISSING || maxSpeed < avoidSpeedLimit) {
-                weightToPrioMap.put(40d, SLIGHT_PREFER);
-                if (way.hasTag("tunnel", INTENDED))
-                    weightToPrioMap.put(40d, UNCHANGED);
-            }
-        } else if (avoidHighwayTags.containsKey(highway)
-                || (maxSpeed != MaxSpeed.MAXSPEED_MISSING && maxSpeed >= avoidSpeedLimit && !"track".equals(highway))) {
-            PriorityCode priorityCode = avoidHighwayTags.get(highway);
-            weightToPrioMap.put(50d, priorityCode == null ? AVOID : priorityCode);
-            if (way.hasTag("tunnel", INTENDED)) {
-                PriorityCode worse = priorityCode == null ? BAD : priorityCode.worse().worse();
+            weightToPrioMap.put(40d, SLIGHT_PREFER);
+            if (way.hasTag("tunnel", INTENDED))
+                weightToPrioMap.put(40d, UNCHANGED);
+        } else if (avoidHighwayTags.containsKey(highway) || way.hasTag("foot", INTENDED)) {
+            PriorityCode priorityCode = avoidHighwayTags.getOrDefault(highway, AVOID);
+            weightToPrioMap.put(50d, priorityCode);
+            // tunnels are only dangerous on the high-speed roads we strongly avoid
+            if (way.hasTag("tunnel", INTENDED) && priorityCode == BAD) {
+                PriorityCode worse = priorityCode.worse().worse();
                 weightToPrioMap.put(50d, worse == EXCLUDE ? REACH_DESTINATION : worse);
             }
         }
 
         if (way.hasTag("bicycle", "use_sidepath")) {
             weightToPrioMap.put(100d, REACH_DESTINATION);
-        } else if (way.hasTag("bicycle", "optional_sidepath")) {
-            weightToPrioMap.put(100d, AVOID);
         }
 
         Set<String> cyclewayValues = Stream.of("cycleway", "cycleway:left", "cycleway:both", "cycleway:right").map(key -> way.getTag(key, "")).collect(Collectors.toSet());
@@ -89,22 +83,16 @@ public class RacingBikePriorityParser extends BikeCommonPriorityParser {
             PriorityCode pushingSectionPrio = SLIGHT_AVOID;
             if (way.hasTag("highway", "steps"))
                 pushingSectionPrio = BAD;
-            else if (way.hasTag("bicycle", "yes") || way.hasTag("bicycle", "permissive"))
-                pushingSectionPrio = PREFER;
-            else if (bikeDesignated)
-                pushingSectionPrio = VERY_NICE;
-
-            if (way.hasTag("foot", "yes") && !way.hasTag("segregated", "yes"))
+            else if (way.hasTag("foot", "yes"))
                 pushingSectionPrio = pushingSectionPrio.worse();
 
             weightToPrioMap.put(100d, pushingSectionPrio);
         }
 
-        if (way.hasTag("railway", "tram"))
-            weightToPrioMap.put(50d, AVOID_MORE);
+        if (way.hasTag("railway", "tram") && !bikeDesignated)
+            weightToPrioMap.put(100d, AVOID_MORE);
 
         String classBicycleValue = way.getTag("class:bicycle:roadcycling");
-        if (classBicycleValue == null) classBicycleValue = way.getTag("class:bicycle");
 
         // We assume that humans are better in classifying preferences compared to our algorithm above
         if (classBicycleValue != null) {
@@ -113,18 +101,6 @@ public class RacingBikePriorityParser extends BikeCommonPriorityParser {
             weightToPrioMap.compute(100d, (key, existing) ->
                     existing == null || existing.getValue() < prio.getValue() ? prio : existing
             );
-        }
-
-        if (way.hasTag("foot", INTENDED)) {
-            weightToPrioMap.put(100d, AVOID);
-        } else if ("service".equals(highway) || "residential".equals(highway) || "unclassified".equals(highway)) {
-            weightToPrioMap.put(40d, SLIGHT_AVOID);
-        } else if ("track".equals(highway)) {
-            String trackType = way.getTag("tracktype");
-            if ("grade1".equals(trackType) || goodSurface.contains(way.getTag("surface", "")))
-                weightToPrioMap.put(110d, UNCHANGED);
-            else if (trackType == null || trackType.startsWith("grade"))
-                weightToPrioMap.put(110d, AVOID_MORE);
         }
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikePriorityParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikePriorityParser.java
@@ -43,10 +43,8 @@ public class RacingBikePriorityParser extends BikeCommonPriorityParser {
         String highway = way.getTag("highway");
         double maxSpeed = Math.max(OSMMaxSpeedParser.parseMaxSpeed(way, false), OSMMaxSpeedParser.parseMaxSpeed(way, true));
 
-        if (bikeDesignated) {
-            boolean isGoodSurface = "grade1".equals(way.getTag("tracktype")) || goodSurface.contains(way.getTag("surface", ""));
-            weightToPrioMap.put(100d, "path".equals(highway) || "track".equals(highway) && isGoodSurface ? VERY_NICE : PREFER);
-        }
+        if (bikeDesignated)
+            weightToPrioMap.put(100d, PREFER);
 
         if ("track".equals(highway)) {
             String trackType = way.getTag("tracktype");

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikePriorityParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikePriorityParser.java
@@ -57,7 +57,7 @@ public class RacingBikePriorityParser extends BikeCommonPriorityParser {
             if (way.hasTag("tunnel", INTENDED))
                 weightToPrioMap.put(40d, UNCHANGED);
         } else if (avoidHighwayTags.containsKey(highway) || way.hasTag("foot", INTENDED)) {
-            PriorityCode priorityCode = avoidHighwayTags.getOrDefault(highway, AVOID);
+            PriorityCode priorityCode = avoidHighwayTags.getOrDefault(highway, SLIGHT_AVOID);
             weightToPrioMap.put(50d, priorityCode);
             // tunnels are only dangerous on the high-speed roads we strongly avoid
             if (way.hasTag("tunnel", INTENDED) && priorityCode == BAD) {

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/RacingBikeTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/RacingBikeTagParserTest.java
@@ -69,6 +69,26 @@ public class RacingBikeTagParserTest extends AbstractBikeTagParserTester {
     @Override
     @Test
     public void testCycleway() {
+        ReaderWay osmWay = new ReaderWay(1);
+        osmWay.setTag("highway", "cycleway");
+        assertPriorityAndSpeed(UNCHANGED, 24, osmWay);
+
+        osmWay = new ReaderWay(1);
+        osmWay.setTag("highway", "cycleway");
+        osmWay.setTag("foot", "yes");
+        assertPriorityAndSpeed(AVOID, 24, osmWay);
+
+        osmWay = new ReaderWay(1);
+        osmWay.setTag("highway", "unclassified");
+        osmWay.setTag("cycleway", "track");
+        assertPriorityAndSpeed(VERY_NICE, 24, osmWay);
+
+        // foot=yes is related to the highway, i.e. can be ignored for the cycleway
+        osmWay = new ReaderWay(1);
+        osmWay.setTag("highway", "unclassified");
+        osmWay.setTag("cycleway", "track");
+        osmWay.setTag("foot", "yes");
+        assertPriorityAndSpeed(VERY_NICE, 24, osmWay);
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/RacingBikeTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/RacingBikeTagParserTest.java
@@ -76,7 +76,13 @@ public class RacingBikeTagParserTest extends AbstractBikeTagParserTester {
         osmWay = new ReaderWay(1);
         osmWay.setTag("highway", "cycleway");
         osmWay.setTag("foot", "yes");
-        assertPriorityAndSpeed(AVOID, 24, osmWay);
+        assertPriorityAndSpeed(SLIGHT_AVOID, 24, osmWay);
+
+        // same or worse as highway=cycleway + foot=yes
+        osmWay = new ReaderWay(1);
+        osmWay.setTag("highway", "footway");
+        osmWay.setTag("bicycle", "designated");
+        assertPriorityAndSpeed(SLIGHT_AVOID, 24, osmWay);
 
         osmWay = new ReaderWay(1);
         osmWay.setTag("highway", "unclassified");
@@ -84,11 +90,19 @@ public class RacingBikeTagParserTest extends AbstractBikeTagParserTester {
         assertPriorityAndSpeed(VERY_NICE, 24, osmWay);
 
         // foot=yes is related to the highway, i.e. can be ignored for the cycleway
-        osmWay = new ReaderWay(1);
-        osmWay.setTag("highway", "unclassified");
-        osmWay.setTag("cycleway", "track");
         osmWay.setTag("foot", "yes");
         assertPriorityAndSpeed(VERY_NICE, 24, osmWay);
+    }
+
+    @Test
+    public void testAvoidHighway() {
+        ReaderWay osmWay = new ReaderWay(1);
+        osmWay.setTag("highway", "residential");
+        assertPriorityAndSpeed(SLIGHT_AVOID, 24, osmWay);
+        osmWay.setTag("bicycle", "designated");
+        assertPriorityAndSpeed(PREFER, 24, osmWay);
+        osmWay.setTag("foot", "yes"); // residential is allowed for foot anyway
+        assertPriorityAndSpeed(PREFER, 24, osmWay);
     }
 
     @Test


### PR DESCRIPTION
This change avoids the use of the BikeCommonPriorityParser.collect method as it is too different in too many places and not easy to adapt this. /cc @ratrun 

See [this commit](https://github.com/graphhopper/graphhopper/commit/d011c418a5012c6216390c1ff8dee250fd64530f) which shows the changes best (after copying everything from the super collect method).

This PR includes the following changes

 * The pushing section code for racingbike should not `PREFER` if `bicycle=yes` as it is inconsistent with the case `way.hasTag("foot", INTENDED)`. See e.g. [this route](https://graphhopper.com/maps/?point=51.17958%2C14.390842&point=51.179635%2C14.394708&profile=racingbike).
 * The case `preferHighwayTags.contains(highway)` should ignore `segregated` as we do for `way.hasTag("foot", INTENDED)`
 * no avoidSpeedLimit for racingbike
 * `class:bicycle:roadcycling` should not fallback to `class:bicycle`
 * put `highway=service`, `residential` and `unclassified` all into avoidHighwayTags instead of fixing the priority afterwards
 * removed case `if (way.hasTag("bicycle", "optional_sidepath"))`
 * `highway=path` and `track` should be handled in one place only
 * make highway=footway+bicycle=designated consistent with highway=cycleway+foot=yes
