### PR TITLE
Add surface=clay and surface=laterite speed caps for bike profiles

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/ev/Surface.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/Surface.java
@@ -50,6 +50,9 @@ public enum Surface {
         SURFACE_MAP.put("earth", DIRT);
         SURFACE_MAP.put("pebblestone", GRAVEL);
         SURFACE_MAP.put("grass_paver", GRASS);
+        SURFACE_MAP.put("mud", DIRT);
+        SURFACE_MAP.put("laterite", DIRT);
+        SURFACE_MAP.put("clay", DIRT);
     }
 
     public static EnumEncodedValue<Surface> create() {

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonAverageSpeedParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonAverageSpeedParser.java
@@ -57,7 +57,9 @@ public abstract class BikeCommonAverageSpeedParser extends AbstractAverageSpeedP
         setSurfaceSpeed("gravel", 12);
         setSurfaceSpeed("ice", MIN_SPEED);
         setSurfaceSpeed("metal", 10);
-        setSurfaceSpeed("mud", 10);
+        setSurfaceSpeed("mud", PUSHING_SECTION_SPEED);
+        setSurfaceSpeed("clay", 8); // dry and passable much of the year, but rougher than dirt
+        setSurfaceSpeed("laterite", 6); // as clay, but with a slippery near-frictionless phase when wet
         setSurfaceSpeed("pebblestone", 14);
         setSurfaceSpeed("salt", PUSHING_SECTION_SPEED);
         setSurfaceSpeed("sand", PUSHING_SECTION_SPEED);

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikeAverageSpeedParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikeAverageSpeedParser.java
@@ -38,6 +38,8 @@ public class RacingBikeAverageSpeedParser extends BikeCommonAverageSpeedParser {
         setSurfaceSpeed("ice", MIN_SPEED);
         setSurfaceSpeed("metal", MIN_SPEED);
         setSurfaceSpeed("mud", MIN_SPEED);
+        setSurfaceSpeed("clay", MIN_SPEED);
+        setSurfaceSpeed("laterite", MIN_SPEED);
         setSurfaceSpeed("pebblestone", PUSHING_SECTION_SPEED);
         setSurfaceSpeed("salt", MIN_SPEED);
         setSurfaceSpeed("sand", MIN_SPEED);

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/BikeTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/BikeTagParserTest.java
@@ -340,6 +340,15 @@ public class BikeTagParserTest extends AbstractBikeTagParserTester {
         way.setTag("surface", "unknown_surface");
         assertPriorityAndSpeed(UNCHANGED, PUSHING_SECTION_SPEED, way);
 
+        way.setTag("surface", "mud");
+        assertPriorityAndSpeed(UNCHANGED, PUSHING_SECTION_SPEED, way);
+
+        way.setTag("surface", "clay");
+        assertPriorityAndSpeed(UNCHANGED, 8, way);
+
+        way.setTag("surface", "laterite");
+        assertPriorityAndSpeed(UNCHANGED, 6, way);
+
         way.clearTags();
         way.setTag("highway", "track");
         way.setTag("surface", "gravel");

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMSurfaceParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMSurfaceParserTest.java
@@ -70,6 +70,18 @@ public class OSMSurfaceParserTest {
         readerWay.setTag("surface", "grass_paver");
         parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
         assertEquals(Surface.GRASS, surfaceEnc.getEnum(false, edgeId, edgeIntAccess));
+
+        readerWay.setTag("surface", "mud");
+        parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
+        assertEquals(Surface.DIRT, surfaceEnc.getEnum(false, edgeId, edgeIntAccess));
+
+        readerWay.setTag("surface", "laterite");
+        parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
+        assertEquals(Surface.DIRT, surfaceEnc.getEnum(false, edgeId, edgeIntAccess));
+
+        readerWay.setTag("surface", "clay");
+        parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
+        assertEquals(Surface.DIRT, surfaceEnc.getEnum(false, edgeId, edgeIntAccess));
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/RacingBikeTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/RacingBikeTagParserTest.java
@@ -151,6 +151,16 @@ public class RacingBikeTagParserTest extends AbstractBikeTagParserTester {
         way.setTag("highway", "primary");
         way.setTag("surface", "unknownpavement");
         assertEquals(PUSHING_SECTION_SPEED, getSpeedFromFlags(way), 1e-1);
+
+        way.clearTags();
+        way.setTag("highway", "primary");
+        way.setTag("surface", "clay");
+        assertEquals(MIN_SPEED, getSpeedFromFlags(way), 1e-1);
+
+        way.clearTags();
+        way.setTag("highway", "primary");
+        way.setTag("surface", "laterite");
+        assertEquals(MIN_SPEED, getSpeedFromFlags(way), 1e-1);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Adds dedicated speed caps for `surface=clay` and `surface=laterite` to `BikeCommonAverageSpeedParser` and `RacingBikeAverageSpeedParser`, both were previously uncapped and fell through unassigned.
- Fixes `mud` being capped the same as `dirt` (both 10) in `BikeCommonAverageSpeedParser`, it now uses `PUSHING_SECTION_SPEED` like `sand`/`salt`/`wood`, which is where it belongs given how it behaves.

Values chosen:
- `BikeCommonAverageSpeedParser`: `mud` 10 → `PUSHING_SECTION_SPEED` (4), `clay` = 8, `laterite` = 6. Both sit between the corrected mud value and dirt (10): clay closer to dirt since it lacks laterite's slippery near-frictionless phase when wet, laterite closer to mud because of that added risk.
- `RacingBikeAverageSpeedParser`: `clay` and `laterite` both use `MIN_SPEED`, same as dirt/mud already do there, no further differentiation needed given how coarse that profile's surface handling already is.

Discussed with @karussell in #3376. `surface=laterite` is documented via OSM's [Proposal:Surface=laterite](https://wiki.openstreetmap.org/wiki/Proposal:Surface%3Dlaterite) (29-0-0). Not touching the `Surface` enum / `SURFACE_MAP` in this PR, `laterite` falls through to `OTHER` there already (same as `mud`, which also has no enum mapping), which is consistent with where these values land.

Fixes #3376

## Test plan
- [x] Added assertions to `BikeTagParserTest.testTrack` for `mud`, `clay`, `laterite`
- [x] Added assertions to `RacingBikeTagParserTest.testGetSpeed` for `clay`, `laterite`
- [ ] Could not run the full test suite locally (this environment doesn't have the JDK 25 toolchain this project now requires), relying on CI here