### PR TITLE
Support `maxweight:hgv`

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMMaxWeightParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMMaxWeightParser.java
@@ -31,7 +31,7 @@ import java.util.stream.Collectors;
 public class OSMMaxWeightParser implements TagParser {
 
     // do not include OSM tag "height" here as it has completely different meaning (height of peak)
-    private static final List<String> MAX_WEIGHT_TAGS = Arrays.asList("maxweight", "maxweightrating", "maxweightrating:hgv", "maxgcweight"/*abandoned*/);
+    private static final List<String> MAX_WEIGHT_TAGS = Arrays.asList("maxweight", "maxweight:hgv", "maxweightrating", "maxweightrating:hgv", "maxgcweight"/*abandoned*/);
     private static final List<String> HGV_RESTRICTIONS = OSMRoadAccessParser.toOSMRestrictions(TransportationMode.HGV).stream()
             .map(e -> e + ":conditional").collect(Collectors.toList());
     private final DecimalEncodedValue weightEncoder;

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMMaxWeightParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMMaxWeightParserTest.java
@@ -32,6 +32,11 @@ public class OSMMaxWeightParserTest {
         // if value is beyond the maximum then do not use infinity instead fallback to more restrictive maximum
         readerWay.setTag("maxweight", "54");
         assertEquals(51, getMaxWeight(readerWay), .01);
+
+        readerWay = new ReaderWay(1);
+        readerWay.setTag("highway", "primary");
+        readerWay.setTag("maxweight:hgv", "3.5");
+        assertEquals(3.5, getMaxWeight(readerWay), .01);
     }
 
     @Test


### PR DESCRIPTION
Similar to `maxweightrating:hgv` there's also a HGV variant of `maxweight`. See [Taginfo](https://taginfo.openstreetmap.org/keys/maxweight%3Ahgv)