### PR TITLE
use Arrays.binarySearch in GHLongLongBTree

### DIFF
--- a/core/src/main/java/com/graphhopper/coll/GHLongLongBTree.java
+++ b/core/src/main/java/com/graphhopper/coll/GHLongLongBTree.java
@@ -72,6 +72,25 @@ public class GHLongLongBTree implements LongLongMap {
         clear();
     }
 
+    // Like Arrays.binarySearch but without range check
+    private static int binarySearch(long[] a, int fromIndex, int toIndex, long key) {
+        int low = fromIndex;
+        int high = toIndex - 1;
+
+        while (low <= high) {
+            int mid = (low + high) >>> 1;
+            long midVal = a[mid];
+
+            if (midVal < key)
+                low = mid + 1;
+            else if (midVal > key)
+                high = mid - 1;
+            else
+                return mid; // key found
+        }
+        return -(low + 1);  // key not found.
+    }
+
     @Override
     public long put(long key, long value) {
         if (value > maxValue)
@@ -257,7 +276,7 @@ public class GHLongLongBTree implements LongLongMap {
          * @return the old value which was associated with the specified key or null if no update.
          */
         ReturnValue put(long key, long newValue) {
-            int index = Arrays.binarySearch(keys, 0, entrySize, key);
+            int index = binarySearch(keys, 0, entrySize, key);
             if (index >= 0) {
                 // update
                 byte[] oldValue = new byte[bytesPerValue];
@@ -308,7 +327,7 @@ public class GHLongLongBTree implements LongLongMap {
          * This avoids a separate get+put traversal.
          */
         ReturnValue putOrCompute(long key, long valueIfAbsent, LongUnaryOperator computeIfPresent) {
-            int index = Arrays.binarySearch(keys, 0, entrySize, key);
+            int index = binarySearch(keys, 0, entrySize, key);
             if (index >= 0) {
                 // key exists: compute new value from old value
                 byte[] oldValue = new byte[bytesPerValue];
@@ -428,7 +447,7 @@ public class GHLongLongBTree implements LongLongMap {
         }
 
         long get(long key) {
-            int index = Arrays.binarySearch(keys, 0, entrySize, key);
+            int index = binarySearch(keys, 0, entrySize, key);
             if (index >= 0) {
                 return toLong(values, index * bytesPerValue);
             }

--- a/core/src/main/java/com/graphhopper/coll/GHLongLongBTree.java
+++ b/core/src/main/java/com/graphhopper/coll/GHLongLongBTree.java
@@ -72,31 +72,6 @@ public class GHLongLongBTree implements LongLongMap {
         clear();
     }
 
-    static int binarySearch(long[] keys, int start, int len, long key) {
-        int high = start + len, low = start - 1, guess;
-        while (high - low > 1) {
-            // use >>> for average or we could get an integer overflow.
-            guess = (high + low) >>> 1;
-            long guessedKey = keys[guess];
-            if (guessedKey < key) {
-                low = guess;
-            } else {
-                high = guess;
-            }
-        }
-
-        if (high == start + len) {
-            return ~(start + len);
-        }
-
-        long highKey = keys[high];
-        if (highKey == key) {
-            return high;
-        } else {
-            return ~high;
-        }
-    }
-
     @Override
     public long put(long key, long value) {
         if (value > maxValue)
@@ -283,7 +258,7 @@ public class GHLongLongBTree implements LongLongMap {
          * returns noNumberValue
          */
         ReturnValue put(long key, long newValue) {
-            int index = binarySearch(keys, 0, entrySize, key);
+            int index = Arrays.binarySearch(keys, 0, entrySize, key);
             if (index >= 0) {
                 // update
                 byte[] oldValue = new byte[bytesPerValue];
@@ -334,7 +309,7 @@ public class GHLongLongBTree implements LongLongMap {
          * This avoids a separate get+put traversal.
          */
         ReturnValue putOrCompute(long key, long valueIfAbsent, LongUnaryOperator computeIfPresent) {
-            int index = binarySearch(keys, 0, entrySize, key);
+            int index = Arrays.binarySearch(keys, 0, entrySize, key);
             if (index >= 0) {
                 // key exists: compute new value from old value
                 byte[] oldValue = new byte[bytesPerValue];
@@ -454,7 +429,7 @@ public class GHLongLongBTree implements LongLongMap {
         }
 
         long get(long key) {
-            int index = binarySearch(keys, 0, entrySize, key);
+            int index = Arrays.binarySearch(keys, 0, entrySize, key);
             if (index >= 0) {
                 return toLong(values, index * bytesPerValue);
             }

--- a/core/src/main/java/com/graphhopper/coll/GHLongLongBTree.java
+++ b/core/src/main/java/com/graphhopper/coll/GHLongLongBTree.java
@@ -72,31 +72,6 @@ public class GHLongLongBTree implements LongLongMap {
         clear();
     }
 
-    static int binarySearch(long[] keys, int len, long key) {
-        int high = len, low = - 1, guess;
-        while (high - low > 1) {
-            // use >>> for average or we could get an integer overflow.
-            guess = (high + low) >>> 1;
-            long guessedKey = keys[guess];
-            if (guessedKey < key) {
-                low = guess;
-                continue;
-            }
-            high = guess;
-        }
-
-        if (high == len) {
-            return ~(len);
-        }
-
-        long highKey = keys[high];
-        if (highKey == key) {
-            return high;
-        } else {
-            return ~high;
-        }
-    }
-
     @Override
     public long put(long key, long value) {
         if (value > maxValue)
@@ -282,7 +257,7 @@ public class GHLongLongBTree implements LongLongMap {
          * @return the old value which was associated with the specified key or null if no update.
          */
         ReturnValue put(long key, long newValue) {
-            int index = binarySearch(keys, entrySize, key);
+            int index = Arrays.binarySearch(keys, 0, entrySize, key);
             if (index >= 0) {
                 // update
                 byte[] oldValue = new byte[bytesPerValue];
@@ -333,7 +308,7 @@ public class GHLongLongBTree implements LongLongMap {
          * This avoids a separate get+put traversal.
          */
         ReturnValue putOrCompute(long key, long valueIfAbsent, LongUnaryOperator computeIfPresent) {
-            int index = binarySearch(keys, entrySize, key);
+            int index = Arrays.binarySearch(keys, 0, entrySize, key);
             if (index >= 0) {
                 // key exists: compute new value from old value
                 byte[] oldValue = new byte[bytesPerValue];
@@ -453,7 +428,7 @@ public class GHLongLongBTree implements LongLongMap {
         }
 
         long get(long key) {
-            int index = binarySearch(keys, entrySize, key);
+            int index = Arrays.binarySearch(keys, 0, entrySize, key);
             if (index >= 0) {
                 return toLong(values, index * bytesPerValue);
             }

--- a/core/src/main/java/com/graphhopper/coll/GHLongLongBTree.java
+++ b/core/src/main/java/com/graphhopper/coll/GHLongLongBTree.java
@@ -254,8 +254,7 @@ public class GHLongLongBTree implements LongLongMap {
         }
 
         /**
-         * @return the old value which was associated with the specified key or if no update it
-         * returns noNumberValue
+         * @return the old value which was associated with the specified key or null if no update.
          */
         ReturnValue put(long key, long newValue) {
             int index = Arrays.binarySearch(keys, 0, entrySize, key);

--- a/core/src/main/java/com/graphhopper/coll/GHLongLongBTree.java
+++ b/core/src/main/java/com/graphhopper/coll/GHLongLongBTree.java
@@ -72,23 +72,29 @@ public class GHLongLongBTree implements LongLongMap {
         clear();
     }
 
-    // Like Arrays.binarySearch but without range check
-    private static int binarySearch(long[] a, int fromIndex, int toIndex, long key) {
-        int low = fromIndex;
-        int high = toIndex - 1;
-
-        while (low <= high) {
-            int mid = (low + high) >>> 1;
-            long midVal = a[mid];
-
-            if (midVal < key)
-                low = mid + 1;
-            else if (midVal > key)
-                high = mid - 1;
-            else
-                return mid; // key found
+    static int binarySearch(long[] keys, int len, long key) {
+        int high = len, low = - 1, guess;
+        while (high - low > 1) {
+            // use >>> for average or we could get an integer overflow.
+            guess = (high + low) >>> 1;
+            long guessedKey = keys[guess];
+            if (guessedKey < key) {
+                low = guess;
+                continue;
+            }
+            high = guess;
         }
-        return -(low + 1);  // key not found.
+
+        if (high == len) {
+            return ~(len);
+        }
+
+        long highKey = keys[high];
+        if (highKey == key) {
+            return high;
+        } else {
+            return ~high;
+        }
     }
 
     @Override
@@ -276,7 +282,7 @@ public class GHLongLongBTree implements LongLongMap {
          * @return the old value which was associated with the specified key or null if no update.
          */
         ReturnValue put(long key, long newValue) {
-            int index = binarySearch(keys, 0, entrySize, key);
+            int index = binarySearch(keys, entrySize, key);
             if (index >= 0) {
                 // update
                 byte[] oldValue = new byte[bytesPerValue];
@@ -327,7 +333,7 @@ public class GHLongLongBTree implements LongLongMap {
          * This avoids a separate get+put traversal.
          */
         ReturnValue putOrCompute(long key, long valueIfAbsent, LongUnaryOperator computeIfPresent) {
-            int index = binarySearch(keys, 0, entrySize, key);
+            int index = binarySearch(keys, entrySize, key);
             if (index >= 0) {
                 // key exists: compute new value from old value
                 byte[] oldValue = new byte[bytesPerValue];
@@ -447,7 +453,7 @@ public class GHLongLongBTree implements LongLongMap {
         }
 
         long get(long key) {
-            int index = binarySearch(keys, 0, entrySize, key);
+            int index = binarySearch(keys, entrySize, key);
             if (index >= 0) {
                 return toLong(values, index * bytesPerValue);
             }


### PR DESCRIPTION
This change makes the OSM import 8% faster (the get method itself is around 30% faster).

It looks simple but was rather tricky to find. Due to special circumstances I found via AI that the import got faster when I replaced the following code in binarySearch:

```java
if (guessedKey < key) {
    low = guess;
} else {
    high = guess;
}
```

with
```java
if (guessedKey < key) {
   low = guess;
   continue;
}
high = guess;
```

Because then, the AI stated, the C2 compiler of the JVM no longer uses CMOV and instead is able to load multiple values in parallel (ie several iterations' loads are in flight at once). Making this method significantly faster for our case.

And it turns out the inbuilt Arrays.binarySearch is already optimized like this and so it can be used instead. It has an explicit range check which is not measurable (TODO wait for confirmation from benchmark).