### PR TITLE
Ignore unknown tag values in OSM parsing

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/parsers/AbstractAccessParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/AbstractAccessParser.java
@@ -48,7 +48,6 @@ public abstract class AbstractAccessParser implements TagParser {
         restrictedValues.add("restricted");
         restrictedValues.add("military");
         restrictedValues.add("emergency");
-        restrictedValues.add("unknown");
 
         restrictedValues.add("private");
         restrictedValues.add("service");

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/AbstractAccessParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/AbstractAccessParser.java
@@ -95,7 +95,8 @@ public abstract class AbstractAccessParser implements TagParser {
             if (value.isEmpty())
                 continue;
             boolean allowed = false, restricted = false;
-            for (String v : value.split(";")) {
+            for (String raw : value.split(";")) {
+                String v = raw.trim();
                 if (allowedValues.contains(v)) allowed = true;
                 else if (restrictedValues.contains(v)) restricted = true;
             }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/AbstractAccessParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/AbstractAccessParser.java
@@ -21,6 +21,7 @@ import com.graphhopper.reader.ReaderNode;
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.BooleanEncodedValue;
 import com.graphhopper.routing.ev.EdgeIntAccess;
+import com.graphhopper.routing.util.WayAccess;
 import com.graphhopper.storage.IntsRef;
 
 import java.util.*;
@@ -81,6 +82,31 @@ public abstract class AbstractAccessParser implements TagParser {
     }
 
     public abstract void handleWayTags(int edgeId, EdgeIntAccess edgeIntAccess, ReaderWay way);
+
+    /**
+     * Walks the restriction keys most-specific-first and returns the access decided by the first key
+     * with a recognized value (WAY if allowed, CAN_SKIP if restricted). Returns null if no key
+     * decides: all present values are unrecognized (so an unknown value defers to the more generic
+     * key instead of shadowing it) or a restricted value is lifted by a permissive temporal restriction.
+     */
+    protected WayAccess getAccessFromRestrictions(ReaderWay way) {
+        for (int i = 0; i < restrictionKeys.size(); i++) {
+            String value = way.getTag(restrictionKeys.get(i), "");
+            if (value.isEmpty())
+                continue;
+            boolean allowed = false, restricted = false;
+            for (String v : value.split(";")) {
+                if (allowedValues.contains(v)) allowed = true;
+                else if (restrictedValues.contains(v)) restricted = true;
+            }
+            if (allowed)
+                return WayAccess.WAY;
+            if (restricted)
+                return OSMTemporalAccessParser.hasPermissiveTemporalRestriction(way, i, restrictionKeys, allowedValues)
+                        ? null : WayAccess.CAN_SKIP;
+        }
+        return null;
+    }
 
     /**
      * @return true if the given OSM node blocks access for the specified restrictions, false otherwise

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonAccessParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonAccessParser.java
@@ -74,19 +74,28 @@ public abstract class BikeCommonAccessParser extends AbstractAccessParser implem
                 || "cycleway".equals(highwayValue) && !way.hasTag("bicycle", "no")) // cycleway gets bicycle=yes by default
             return WayAccess.WAY;
 
-        int firstIndex = way.getFirstIndex(restrictionKeys);
-        if (firstIndex >= 0) {
-            String firstValue = way.getTag(restrictionKeys.get(firstIndex), "");
+        // Walk the restriction keys in priority order (most specific first: bicycle, then access).
+        // A key only decides access if its value is recognized (allowed or restricted). An unknown
+        // value carries no information, so we defer to the next.
+        for (int i = 0; i < restrictionKeys.size(); i++) {
+            String firstValue = way.getTag(restrictionKeys.get(i), "");
+            if (firstValue.isEmpty())
+                continue;
             String[] restrict = firstValue.split(";");
-            // if any of the values allows access then return early (regardless of the order)
+            boolean allowed = false, restricted = false;
+            // an allowed value anywhere wins regardless of order
             for (String value : restrict) {
-                if (allowedValues.contains(value))
-                    return WayAccess.WAY;
+                if (allowedValues.contains(value)) allowed = true;
+                else if (restrictedValues.contains(value)) restricted = true;
             }
-            for (String value : restrict) {
-                if (restrictedValues.contains(value) && !hasPermissiveTemporalRestriction(way, firstIndex, restrictionKeys, allowedValues))
+            if (allowed)
+                return WayAccess.WAY;
+            if (restricted) {
+                if (!hasPermissiveTemporalRestriction(way, i, restrictionKeys, allowedValues))
                     return WayAccess.CAN_SKIP;
+                break; // restricted, but a permissive conditional applies -> fall through to default
             }
+            // value present but unrecognized -> defer to the next, more generic key
         }
 
         // accept only if explicitly tagged for bike usage

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonAccessParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonAccessParser.java
@@ -8,8 +8,6 @@ import com.graphhopper.routing.util.WayAccess;
 
 import java.util.*;
 
-import static com.graphhopper.routing.util.parsers.OSMTemporalAccessParser.hasPermissiveTemporalRestriction;
-
 public abstract class BikeCommonAccessParser extends AbstractAccessParser implements TagParser {
 
     private static final Set<String> OPP_LANES = new HashSet<>(Arrays.asList("opposite", "opposite_lane", "opposite_track"));
@@ -74,29 +72,9 @@ public abstract class BikeCommonAccessParser extends AbstractAccessParser implem
                 || "cycleway".equals(highwayValue) && !way.hasTag("bicycle", "no")) // cycleway gets bicycle=yes by default
             return WayAccess.WAY;
 
-        // Walk the restriction keys in priority order (most specific first: bicycle, then access).
-        // A key only decides access if its value is recognized (allowed or restricted). An unknown
-        // value carries no information, so we defer to the next.
-        for (int i = 0; i < restrictionKeys.size(); i++) {
-            String firstValue = way.getTag(restrictionKeys.get(i), "");
-            if (firstValue.isEmpty())
-                continue;
-            String[] restrict = firstValue.split(";");
-            boolean allowed = false, restricted = false;
-            // an allowed value anywhere wins regardless of order
-            for (String value : restrict) {
-                if (allowedValues.contains(value)) allowed = true;
-                else if (restrictedValues.contains(value)) restricted = true;
-            }
-            if (allowed)
-                return WayAccess.WAY;
-            if (restricted) {
-                if (!hasPermissiveTemporalRestriction(way, i, restrictionKeys, allowedValues))
-                    return WayAccess.CAN_SKIP;
-                break; // restricted, but a permissive conditional applies -> fall through to default
-            }
-            // value present but unrecognized -> defer to the next, more generic key
-        }
+        WayAccess access = getAccessFromRestrictions(way);
+        if (access != null)
+            return access;
 
         // accept only if explicitly tagged for bike usage
         if ("motorway".equals(highwayValue) || "motorway_link".equals(highwayValue))

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/CarAccessParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/CarAccessParser.java
@@ -112,33 +112,8 @@ public class CarAccessParser extends AbstractAccessParser implements TagParser {
         if (way.hasTag("impassable", "yes") || way.hasTag("status", "impassable"))
             return WayAccess.CAN_SKIP;
 
-        // Walk the restriction keys in priority order (most specific first: motorcar ->
-        // motor_vehicle -> vehicle -> access). A key only decides access if its value is recognized
-        // (allowed or restricted). An unrecognized value carries no information, so we defer to the
-        // next, more generic key instead of silently allowing the way - e.g. an unrecognized
-        // motor_vehicle=* must not shadow access=no. Multiple ';'-separated values are all checked.
-        for (int i = 0; i < restrictionKeys.size(); i++) {
-            String value = way.getTag(restrictionKeys.get(i), "");
-            if (value.isEmpty())
-                continue;
-            String[] restrict = value.split(";");
-            boolean allowed = false, restricted = false;
-            // an allowed value anywhere wins regardless of order
-            for (String v : restrict) {
-                if (allowedValues.contains(v)) allowed = true;
-                else if (restrictedValues.contains(v)) restricted = true;
-            }
-            if (allowed)
-                return WayAccess.WAY;
-            if (restricted) {
-                if (!hasPermissiveTemporalRestriction(way, i, restrictionKeys, allowedValues))
-                    return WayAccess.CAN_SKIP;
-                break; // restricted, but a permissive conditional applies -> fall through to default
-            }
-            // value present but unrecognized -> defer to the next, more generic key
-        }
-
-        return WayAccess.WAY;
+        WayAccess access = getAccessFromRestrictions(way);
+        return access != null ? access : WayAccess.WAY;
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/CarAccessParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/CarAccessParser.java
@@ -112,18 +112,30 @@ public class CarAccessParser extends AbstractAccessParser implements TagParser {
         if (way.hasTag("impassable", "yes") || way.hasTag("status", "impassable"))
             return WayAccess.CAN_SKIP;
 
-        // multiple restrictions needs special handling
-        if (firstIndex >= 0) {
-            String[] restrict = firstValue.split(";");
-            // if any of the values allows access then return early (regardless of the order)
-            for (String value : restrict) {
-                if (allowedValues.contains(value))
-                    return WayAccess.WAY;
+        // Walk the restriction keys in priority order (most specific first: motorcar ->
+        // motor_vehicle -> vehicle -> access). A key only decides access if its value is recognized
+        // (allowed or restricted). An unrecognized value carries no information, so we defer to the
+        // next, more generic key instead of silently allowing the way - e.g. an unrecognized
+        // motor_vehicle=* must not shadow access=no. Multiple ';'-separated values are all checked.
+        for (int i = 0; i < restrictionKeys.size(); i++) {
+            String value = way.getTag(restrictionKeys.get(i), "");
+            if (value.isEmpty())
+                continue;
+            String[] restrict = value.split(";");
+            boolean allowed = false, restricted = false;
+            // an allowed value anywhere wins regardless of order
+            for (String v : restrict) {
+                if (allowedValues.contains(v)) allowed = true;
+                else if (restrictedValues.contains(v)) restricted = true;
             }
-            for (String value : restrict) {
-                if (restrictedValues.contains(value) && !hasPermissiveTemporalRestriction(way, firstIndex, restrictionKeys, allowedValues))
+            if (allowed)
+                return WayAccess.WAY;
+            if (restricted) {
+                if (!hasPermissiveTemporalRestriction(way, i, restrictionKeys, allowedValues))
                     return WayAccess.CAN_SKIP;
+                break; // restricted, but a permissive conditional applies -> fall through to default
             }
+            // value present but unrecognized -> defer to the next, more generic key
         }
 
         return WayAccess.WAY;

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/FootAccessParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/FootAccessParser.java
@@ -113,19 +113,29 @@ public class FootAccessParser extends AbstractAccessParser implements TagParser 
         if ("via_ferrata".equals(highwayValue))
             return WayAccess.CAN_SKIP;
 
-        int firstIndex = way.getFirstIndex(restrictionKeys);
-        if (firstIndex >= 0) {
-            String firstValue = way.getTag(restrictionKeys.get(firstIndex), "");
+        // Walk the restriction keys in priority order (most specific first: foot, then access).
+        // A key only decides access if its value is recognized (allowed or restricted). An unknown
+        // value carries no information, so we defer to the next, more generic key instead of silently
+        // allowing the way - e.g. an unrecognized foot=* must not shadow access=no.
+        for (int i = 0; i < restrictionKeys.size(); i++) {
+            String firstValue = way.getTag(restrictionKeys.get(i), "");
+            if (firstValue.isEmpty())
+                continue;
             String[] restrict = firstValue.split(";");
-            // if any of the values allows access then return early (regardless of the order)
+            boolean allowed = false, restricted = false;
+            // an allowed value anywhere wins regardless of order
             for (String value : restrict) {
-                if (allowedValues.contains(value))
-                    return WayAccess.WAY;
+                if (allowedValues.contains(value)) allowed = true;
+                else if (restrictedValues.contains(value)) restricted = true;
             }
-            for (String value : restrict) {
-                if (restrictedValues.contains(value) && !hasPermissiveTemporalRestriction(way, firstIndex, restrictionKeys, allowedValues))
+            if (allowed)
+                return WayAccess.WAY;
+            if (restricted) {
+                if (!hasPermissiveTemporalRestriction(way, i, restrictionKeys, allowedValues))
                     return WayAccess.CAN_SKIP;
+                break; // restricted, but a permissive conditional applies -> fall through to default
             }
+            // value present but unrecognized -> defer to the next, more generic key
         }
 
         if (way.hasTag("sidewalk", sidewalkValues))

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/FootAccessParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/FootAccessParser.java
@@ -28,7 +28,6 @@ import java.util.*;
 
 import static com.graphhopper.routing.ev.RouteNetwork.*;
 import static com.graphhopper.routing.util.PriorityCode.UNCHANGED;
-import static com.graphhopper.routing.util.parsers.OSMTemporalAccessParser.hasPermissiveTemporalRestriction;
 
 public class FootAccessParser extends AbstractAccessParser implements TagParser {
 
@@ -113,30 +112,9 @@ public class FootAccessParser extends AbstractAccessParser implements TagParser 
         if ("via_ferrata".equals(highwayValue))
             return WayAccess.CAN_SKIP;
 
-        // Walk the restriction keys in priority order (most specific first: foot, then access).
-        // A key only decides access if its value is recognized (allowed or restricted). An unknown
-        // value carries no information, so we defer to the next, more generic key instead of silently
-        // allowing the way - e.g. an unrecognized foot=* must not shadow access=no.
-        for (int i = 0; i < restrictionKeys.size(); i++) {
-            String firstValue = way.getTag(restrictionKeys.get(i), "");
-            if (firstValue.isEmpty())
-                continue;
-            String[] restrict = firstValue.split(";");
-            boolean allowed = false, restricted = false;
-            // an allowed value anywhere wins regardless of order
-            for (String value : restrict) {
-                if (allowedValues.contains(value)) allowed = true;
-                else if (restrictedValues.contains(value)) restricted = true;
-            }
-            if (allowed)
-                return WayAccess.WAY;
-            if (restricted) {
-                if (!hasPermissiveTemporalRestriction(way, i, restrictionKeys, allowedValues))
-                    return WayAccess.CAN_SKIP;
-                break; // restricted, but a permissive conditional applies -> fall through to default
-            }
-            // value present but unrecognized -> defer to the next, more generic key
-        }
+        WayAccess access = getAccessFromRestrictions(way);
+        if (access != null)
+            return access;
 
         if (way.hasTag("sidewalk", sidewalkValues))
             return WayAccess.WAY;

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/BikeTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/BikeTagParserTest.java
@@ -520,6 +520,27 @@ public class BikeTagParserTest extends AbstractBikeTagParserTester {
     }
 
     @Test
+    public void testUnknownBicycleValueDoesNotShadowAccess() {
+        // An unrecognized bicycle value carries no information and must not shadow a more
+        // general access restriction: access=no still blocks (see #xyAccessParser hierarchy).
+        ReaderWay way = new ReaderWay(1);
+        way.setTag("highway", "service");
+        way.setTag("access", "no");
+        way.setTag("bicycle", "unknownvalue");
+        assertTrue(accessParser.getAccess(way).canSkip());
+
+        // a recognized bicycle value still overrides access=no as before
+        way.setTag("bicycle", "yes");
+        assertTrue(accessParser.getAccess(way).isWay());
+
+        // without an access restriction an unrecognized bicycle value stays allowed (unchanged)
+        way.clearTags();
+        way.setTag("highway", "service");
+        way.setTag("bicycle", "unknownvalue");
+        assertTrue(accessParser.getAccess(way).isWay());
+    }
+
+    @Test
     public void testPreferenceForSlowSpeed() {
         ReaderWay osmWay = new ReaderWay(1);
         osmWay.setTag("highway", "tertiary");

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/BikeTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/BikeTagParserTest.java
@@ -521,22 +521,15 @@ public class BikeTagParserTest extends AbstractBikeTagParserTester {
 
     @Test
     public void testUnknownBicycleValueDoesNotShadowAccess() {
-        // An unrecognized bicycle value carries no information and must not shadow a more
-        // general access restriction: access=no still blocks (see #xyAccessParser hierarchy).
+        // an unrecognized bicycle value must defer to access, not shadow it
         ReaderWay way = new ReaderWay(1);
         way.setTag("highway", "service");
         way.setTag("access", "no");
         way.setTag("bicycle", "unknownvalue");
         assertTrue(accessParser.getAccess(way).canSkip());
 
-        // a recognized bicycle value still overrides access=no as before
-        way.setTag("bicycle", "yes");
-        assertTrue(accessParser.getAccess(way).isWay());
-
-        // without an access restriction an unrecognized bicycle value stays allowed (unchanged)
-        way.clearTags();
-        way.setTag("highway", "service");
-        way.setTag("bicycle", "unknownvalue");
+        // but without any restriction it stays allowed
+        way.removeTag("access");
         assertTrue(accessParser.getAccess(way).isWay());
     }
 

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/CarTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/CarTagParserTest.java
@@ -155,34 +155,15 @@ public class CarTagParserTest {
 
     @Test
     public void testUnknownValueDoesNotShadowAccess() {
-        // An unrecognized value on a more specific key must not shadow a more general access
-        // restriction: it carries no information, so we defer to the next key in the hierarchy
-        // (motorcar -> motor_vehicle -> vehicle -> access).
+        // an unrecognized value on a more specific key must defer to access, not shadow it
         ReaderWay way = new ReaderWay(1);
         way.setTag("highway", "service");
         way.setTag("access", "no");
-        way.setTag("motor_vehicle", "somethingunexpected");
+        way.setTag("motor_vehicle", "unknownvalue");
         assertTrue(parser.getAccess(way).canSkip());
 
-        // an unrecognized value on the more specific key does not shadow a restriction on a less
-        // specific one either
-        way.clearTags();
-        way.setTag("highway", "service");
-        way.setTag("vehicle", "no");
-        way.setTag("motorcar", "somethingunexpected");
-        assertTrue(parser.getAccess(way).canSkip());
-
-        // a recognized value still overrides the more general key as before
-        way.clearTags();
-        way.setTag("highway", "service");
-        way.setTag("access", "no");
-        way.setTag("motor_vehicle", "yes");
-        assertTrue(parser.getAccess(way).isWay());
-
-        // without a restriction an unrecognized value stays allowed (unchanged behavior)
-        way.clearTags();
-        way.setTag("highway", "service");
-        way.setTag("motor_vehicle", "somethingunexpected");
+        // but without any restriction it stays allowed
+        way.removeTag("access");
         assertTrue(parser.getAccess(way).isWay());
     }
 

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/CarTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/CarTagParserTest.java
@@ -154,6 +154,39 @@ public class CarTagParserTest {
     }
 
     @Test
+    public void testUnknownValueDoesNotShadowAccess() {
+        // An unrecognized value on a more specific key must not shadow a more general access
+        // restriction: it carries no information, so we defer to the next key in the hierarchy
+        // (motorcar -> motor_vehicle -> vehicle -> access).
+        ReaderWay way = new ReaderWay(1);
+        way.setTag("highway", "service");
+        way.setTag("access", "no");
+        way.setTag("motor_vehicle", "somethingunexpected");
+        assertTrue(parser.getAccess(way).canSkip());
+
+        // an unrecognized value on the more specific key does not shadow a restriction on a less
+        // specific one either
+        way.clearTags();
+        way.setTag("highway", "service");
+        way.setTag("vehicle", "no");
+        way.setTag("motorcar", "somethingunexpected");
+        assertTrue(parser.getAccess(way).canSkip());
+
+        // a recognized value still overrides the more general key as before
+        way.clearTags();
+        way.setTag("highway", "service");
+        way.setTag("access", "no");
+        way.setTag("motor_vehicle", "yes");
+        assertTrue(parser.getAccess(way).isWay());
+
+        // without a restriction an unrecognized value stays allowed (unchanged behavior)
+        way.clearTags();
+        way.setTag("highway", "service");
+        way.setTag("motor_vehicle", "somethingunexpected");
+        assertTrue(parser.getAccess(way).isWay());
+    }
+
+    @Test
     public void testMilitaryAccess() {
         ReaderWay way = new ReaderWay(1);
         way.setTag("highway", "track");

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/FootTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/FootTagParserTest.java
@@ -201,6 +201,27 @@ public class FootTagParserTest {
     }
 
     @Test
+    public void testUnknownFootValueDoesNotShadowAccess() {
+        // An unrecognized foot value carries no information and must not shadow a more general
+        // access restriction: access=no still blocks (hierarchy foot -> access).
+        ReaderWay way = new ReaderWay(1);
+        way.setTag("highway", "service");
+        way.setTag("access", "no");
+        way.setTag("foot", "somethingunexpected");
+        assertTrue(accessParser.getAccess(way).canSkip());
+
+        // a recognized foot value still overrides access=no as before
+        way.setTag("foot", "yes");
+        assertTrue(accessParser.getAccess(way).isWay());
+
+        // without an access restriction an unrecognized foot value stays allowed (unchanged)
+        way.clearTags();
+        way.setTag("highway", "service");
+        way.setTag("foot", "somethingunexpected");
+        assertTrue(accessParser.getAccess(way).isWay());
+    }
+
+    @Test
     public void testFerry() {
         ReaderWay way = new ReaderWay(1);
         way.clearTags();

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/FootTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/FootTagParserTest.java
@@ -202,22 +202,15 @@ public class FootTagParserTest {
 
     @Test
     public void testUnknownFootValueDoesNotShadowAccess() {
-        // An unrecognized foot value carries no information and must not shadow a more general
-        // access restriction: access=no still blocks (hierarchy foot -> access).
+        // an unrecognized foot value must defer to access, not shadow it
         ReaderWay way = new ReaderWay(1);
         way.setTag("highway", "service");
         way.setTag("access", "no");
-        way.setTag("foot", "somethingunexpected");
+        way.setTag("foot", "unknownvalue");
         assertTrue(accessParser.getAccess(way).canSkip());
 
-        // a recognized foot value still overrides access=no as before
-        way.setTag("foot", "yes");
-        assertTrue(accessParser.getAccess(way).isWay());
-
-        // without an access restriction an unrecognized foot value stays allowed (unchanged)
-        way.clearTags();
-        way.setTag("highway", "service");
-        way.setTag("foot", "somethingunexpected");
+        // but without any restriction it stays allowed
+        way.removeTag("access");
         assertTrue(accessParser.getAccess(way).isWay());
     }
 

--- a/web/src/test/java/com/graphhopper/application/resources/RouteResourceLeipzigTest.java
+++ b/web/src/test/java/com/graphhopper/application/resources/RouteResourceLeipzigTest.java
@@ -80,12 +80,12 @@ public class RouteResourceLeipzigTest {
 
     @ParameterizedTest
     @CsvSource(value = {
-            "88,-1,algorithm=" + DIJKSTRA_BI,
-            "106,-1,algorithm=" + ASTAR_BI,
-            "30756,1,ch.disable=true&algorithm=" + DIJKSTRA,
-            "21147,1,ch.disable=true&algorithm=" + ASTAR,
-            "14860,1,ch.disable=true&algorithm=" + DIJKSTRA_BI,
-            "10536,1,ch.disable=true&algorithm=" + ASTAR_BI
+            "71,-1,algorithm=" + DIJKSTRA_BI,
+            "67,-1,algorithm=" + ASTAR_BI,
+            "30888,1,ch.disable=true&algorithm=" + DIJKSTRA,
+            "21203,1,ch.disable=true&algorithm=" + ASTAR,
+            "14862,1,ch.disable=true&algorithm=" + DIJKSTRA_BI,
+            "10538,1,ch.disable=true&algorithm=" + ASTAR_BI
     })
     void testTimeout(int expectedVisitedNodes, int timeout, String args) {
         {


### PR DESCRIPTION
Currently unknown or incorrect values for restrictions confuse the tag parsers. E.g. for

```
way.setTag("highway", "service");
way.setTag("access", "no");
way.setTag("bicycle", "xyz");
```

The parser would not just ignore the bicycle tag `xyz` but would even ignore the `access=no`. This is rare, but still worth a fix and the fix is rather simple via a loop like we already do in ModeAccessParser.

We also should not have `unknown` in the restrictedValues (added [here](https://github.com/graphhopper/graphhopper/commit/5626d066dbe856653cb8c3aea00fab657e4e2998) because of the problem explained above). As a result a few ways [like this](https://www.openstreetmap.org/way/28841096) and barriers like [this](https://www.openstreetmap.org/node/2922058392) are no longer restricted.