### PR TITLE
Racingbike: simplify 'collect'

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonPriorityParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonPriorityParser.java
@@ -22,7 +22,7 @@ public abstract class BikeCommonPriorityParser implements TagParser {
     private static final List<String> CYCLEWAY_BICYCLE_KEYS = List.of("cycleway:bicycle", "cycleway:both:bicycle", "cycleway:left:bicycle", "cycleway:right:bicycle");
 
     // pushing section highways are parts where you need to get off your bike and push it
-    protected final HashSet<String> pushingSectionsHighways = new HashSet<>();
+    protected final Set<String> pushingSectionsHighways = new HashSet<>();
     protected final Set<String> preferHighwayTags = new HashSet<>();
     protected final Map<String, PriorityCode> avoidHighwayTags = new HashMap<>();
     protected final DecimalEncodedValue priorityEnc;

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikePriorityParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikePriorityParser.java
@@ -70,7 +70,9 @@ public class RacingBikePriorityParser extends BikeCommonPriorityParser {
             // tunnels are only dangerous on the high-speed roads that we strongly avoid anyway
             if (prio == BAD) prio = REACH_DESTINATION;
             else if (prio == SLIGHT_PREFER) prio = UNCHANGED;
-        } else if (maxSpeed <= 30 && !NARROW_WAYS.contains(highway) && prio.getValue() < SLIGHT_PREFER.getValue()) {
+        } else if (maxSpeed <= 30 && prio == UNCHANGED && !"cycleway".equals(highway)) {
+            // a slow but otherwise neutral road is pleasant, but this must not lift
+            // e.g. residential in a 30 zone above the parallel main road
             prio = SLIGHT_PREFER;
         }
 

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikePriorityParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikePriorityParser.java
@@ -5,7 +5,6 @@ import com.graphhopper.routing.ev.*;
 import com.graphhopper.routing.util.PriorityCode;
 
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -17,7 +16,7 @@ import static com.graphhopper.routing.util.parsers.AbstractAccessParser.INTENDED
 public class RacingBikePriorityParser extends BikeCommonPriorityParser {
 
     // usually too narrow for racing bikes, so e.g. bicycle=designated must not boost them
-    private static final Set<String> NARROW_WAYS = new HashSet<>(List.of("cycleway", "path", "footway", "pedestrian", "platform"));
+    private static final Set<String> NARROW_WAYS = Set.of("cycleway", "path", "footway", "pedestrian", "platform");
 
     private static final List<String> CYCLEWAY_KEYS = List.of("cycleway", "cycleway:left", "cycleway:both", "cycleway:right");
     private static final Set<String> CYCLEWAY_LANES = Set.of("lane", "shoulder");
@@ -54,7 +53,7 @@ public class RacingBikePriorityParser extends BikeCommonPriorityParser {
 
     @Override
     void collect(ReaderWay way, boolean bikeDesignated, TreeMap<Double, PriorityCode> weightToPrioMap) {
-        String highway = way.getTag("highway");
+        String highway = way.getTag("highway", "");
         double maxSpeed = Math.max(OSMMaxSpeedParser.parseMaxSpeed(way, false), OSMMaxSpeedParser.parseMaxSpeed(way, true));
         PriorityCode prio = highwayToPrio.getOrDefault(highway, UNCHANGED);
 
@@ -77,9 +76,8 @@ public class RacingBikePriorityParser extends BikeCommonPriorityParser {
             // tunnels are only dangerous on the high-speed roads that we strongly avoid anyway
             if (prio == BAD) prio = REACH_DESTINATION;
             else if (prio == SLIGHT_PREFER) prio = UNCHANGED;
-        } else if (maxSpeed <= 30 && prio == UNCHANGED && !"cycleway".equals(highway)) {
-            // a slow but otherwise neutral road is pleasant, but this must not lift
-            // e.g. residential in a 30 zone above the parallel main road
+        } else if (maxSpeed <= 30 && highway.startsWith("primary")) {
+            // a slow primary is as pleasant as a secondary
             prio = SLIGHT_PREFER;
         }
 

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikePriorityParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikePriorityParser.java
@@ -73,20 +73,19 @@ public class RacingBikePriorityParser extends BikeCommonPriorityParser {
         } else if (maxSpeed <= 30 && !NARROW_WAYS.contains(highway) && prio.getValue() < SLIGHT_PREFER.getValue()) {
             prio = SLIGHT_PREFER;
         }
-        weightToPrioMap.put(100d, prio);
 
         if (way.hasTag("railway", "tram") && !bikeDesignated)
-            weightToPrioMap.put(100d, AVOID_MORE);
+            prio = AVOID_MORE;
 
         String classBicycleValue = way.getTag("class:bicycle:roadcycling");
-
-        // We assume that humans are better in classifying preferences compared to our algorithm above
         if (classBicycleValue != null) {
-            PriorityCode prioFromClass = convertClassValueToPriority(classBicycleValue);
-            // do not overwrite if e.g. designated
-            weightToPrioMap.compute(100d, (key, existing) ->
-                    existing == null || existing.getValue() < prioFromClass.getValue() ? prioFromClass : existing
-            );
+            // We assume that humans are better in classifying preferences compared to our algorithm above,
+            // but do not degrade e.g. designated
+            PriorityCode classPrio = convertClassValueToPriority(classBicycleValue);
+            if (classPrio.getValue() > prio.getValue())
+                prio = classPrio;
         }
+
+        weightToPrioMap.put(100d, prio);
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikePriorityParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikePriorityParser.java
@@ -19,6 +19,9 @@ public class RacingBikePriorityParser extends BikeCommonPriorityParser {
     // usually too narrow for racing bikes, so e.g. bicycle=designated must not boost them
     private static final Set<String> NARROW_WAYS = new HashSet<>(List.of("cycleway", "path", "footway", "pedestrian", "platform"));
 
+    private static final List<String> CYCLEWAY_KEYS = List.of("cycleway", "cycleway:left", "cycleway:both", "cycleway:right");
+    private static final Set<String> CYCLEWAY_LANES = Set.of("lane", "shoulder");
+
     private final Map<String, PriorityCode> highwayToPrio = new HashMap<>();
 
     public RacingBikePriorityParser(EncodedValueLookup lookup) {
@@ -63,6 +66,9 @@ public class RacingBikePriorityParser extends BikeCommonPriorityParser {
             prio = REACH_DESTINATION;
         } else if (bikeDesignated && !NARROW_WAYS.contains(highway) && !"parking_aisle".equals(way.getTag("service"))) {
             prio = PREFER;
+        } else if (prio.getValue() < SLIGHT_PREFER.getValue() && way.hasTag(CYCLEWAY_KEYS, CYCLEWAY_LANES)) {
+            // a painted lane boosts one step, but always stays below cycleway=track (PREFER via designated)
+            prio = prio.better();
         } else if ("cycleway".equals(highway) && way.hasTag("foot", INTENDED)) {
             // too narrow when shared with pedestrians; wide roads keep their priority
             prio = SLIGHT_AVOID;

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikePriorityParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikePriorityParser.java
@@ -4,15 +4,22 @@ import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.*;
 import com.graphhopper.routing.util.PriorityCode;
 
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static com.graphhopper.routing.util.PriorityCode.*;
 import static com.graphhopper.routing.util.parsers.AbstractAccessParser.INTENDED;
 
 public class RacingBikePriorityParser extends BikeCommonPriorityParser {
+
+    // usually too narrow for racing bikes, so e.g. bicycle=designated must not boost them
+    private static final Set<String> NARROW_WAYS = new HashSet<>(List.of("cycleway", "path", "footway", "pedestrian", "platform"));
+
+    private final Map<String, PriorityCode> highwayToPrio = new HashMap<>();
 
     public RacingBikePriorityParser(EncodedValueLookup lookup) {
         this(lookup.getDecimalEncodedValue(VehiclePriority.key("racingbike")));
@@ -21,72 +28,52 @@ public class RacingBikePriorityParser extends BikeCommonPriorityParser {
     protected RacingBikePriorityParser(DecimalEncodedValue priorityEnc) {
         super(priorityEnc);
 
-        addPushingSection("path");
-
-        preferHighwayTags.add("road");
-        preferHighwayTags.add("secondary");
-        preferHighwayTags.add("secondary_link");
-        preferHighwayTags.add("tertiary");
-        preferHighwayTags.add("tertiary_link");
-
-        avoidHighwayTags.put("motorway", BAD);
-        avoidHighwayTags.put("motorway_link", BAD);
-        avoidHighwayTags.put("trunk", BAD);
-        avoidHighwayTags.put("trunk_link", BAD);
-        avoidHighwayTags.put("service", SLIGHT_AVOID);
-        avoidHighwayTags.put("residential", SLIGHT_AVOID);
-        avoidHighwayTags.put("unclassified", SLIGHT_AVOID);
+        highwayToPrio.put("road", SLIGHT_PREFER);
+        highwayToPrio.put("secondary", SLIGHT_PREFER);
+        highwayToPrio.put("secondary_link", SLIGHT_PREFER);
+        highwayToPrio.put("tertiary", SLIGHT_PREFER);
+        highwayToPrio.put("tertiary_link", SLIGHT_PREFER);
+        highwayToPrio.put("service", SLIGHT_AVOID);
+        highwayToPrio.put("residential", SLIGHT_AVOID);
+        highwayToPrio.put("unclassified", SLIGHT_AVOID);
+        highwayToPrio.put("path", SLIGHT_AVOID);
+        highwayToPrio.put("footway", SLIGHT_AVOID);
+        highwayToPrio.put("pedestrian", SLIGHT_AVOID);
+        highwayToPrio.put("platform", SLIGHT_AVOID);
+        highwayToPrio.put("track", AVOID_MORE);
+        highwayToPrio.put("bridleway", AVOID);
+        highwayToPrio.put("motorway", BAD);
+        highwayToPrio.put("motorway_link", BAD);
+        highwayToPrio.put("trunk", BAD);
+        highwayToPrio.put("trunk_link", BAD);
     }
 
     @Override
     void collect(ReaderWay way, boolean bikeDesignated, TreeMap<Double, PriorityCode> weightToPrioMap) {
         String highway = way.getTag("highway");
         double maxSpeed = Math.max(OSMMaxSpeedParser.parseMaxSpeed(way, false), OSMMaxSpeedParser.parseMaxSpeed(way, true));
+        PriorityCode prio = highwayToPrio.getOrDefault(highway, UNCHANGED);
 
-        if ("track".equals(highway)) {
-            String trackType = way.getTag("tracktype");
-            if ("grade1".equals(trackType) || goodSurface.contains(way.getTag("surface", "")))
-                weightToPrioMap.put(110d, UNCHANGED);
-            else if (trackType == null || trackType.startsWith("grade"))
-                weightToPrioMap.put(110d, AVOID_MORE);
-        } else if (bikeDesignated && !"cycleway".equals(highway)) {
-            // no boost for cycleway: usually too narrow for racing bikes, and if shared
-            // with pedestrians it is even avoided via the foot handling below
-            weightToPrioMap.put(100d, PREFER);
-        } else if (preferHighwayTags.contains(highway) || maxSpeed <= 30) {
-            weightToPrioMap.put(40d, SLIGHT_PREFER);
-            if (way.hasTag("tunnel", INTENDED))
-                weightToPrioMap.put(40d, UNCHANGED);
-        } else if (avoidHighwayTags.containsKey(highway) || way.hasTag("foot", INTENDED)) {
-            PriorityCode priorityCode = avoidHighwayTags.getOrDefault(highway, SLIGHT_AVOID);
-            weightToPrioMap.put(50d, priorityCode);
-            // tunnels are only dangerous on the high-speed roads we strongly avoid
-            if (way.hasTag("tunnel", INTENDED) && priorityCode == BAD) {
-                PriorityCode worse = priorityCode.worse().worse();
-                weightToPrioMap.put(50d, worse == EXCLUDE ? REACH_DESTINATION : worse);
-            }
+        if ("steps".equals(highway)) {
+            prio = BAD;
+        } else if ("track".equals(highway)) {
+            if ("grade1".equals(way.getTag("tracktype")) || goodSurface.contains(way.getTag("surface", "")))
+                prio = UNCHANGED;
+        } else if (way.hasTag("bicycle", "use_sidepath")) {
+            prio = REACH_DESTINATION;
+        } else if (bikeDesignated && !NARROW_WAYS.contains(highway)) {
+            prio = PREFER;
+        } else if ("cycleway".equals(highway) && way.hasTag("foot", INTENDED)) {
+            // too narrow when shared with pedestrians; wide roads keep their priority
+            prio = SLIGHT_AVOID;
+        } else if (way.hasTag("tunnel", INTENDED)) {
+            // tunnels are only dangerous on the high-speed roads that we strongly avoid anyway
+            if (prio == BAD) prio = REACH_DESTINATION;
+            else if (prio == SLIGHT_PREFER) prio = UNCHANGED;
+        } else if (maxSpeed <= 30 && !NARROW_WAYS.contains(highway) && prio.getValue() < SLIGHT_PREFER.getValue()) {
+            prio = SLIGHT_PREFER;
         }
-
-        if (way.hasTag("bicycle", "use_sidepath")) {
-            weightToPrioMap.put(100d, REACH_DESTINATION);
-        }
-
-        Set<String> cyclewayValues = Stream.of("cycleway", "cycleway:left", "cycleway:both", "cycleway:right").map(key -> way.getTag(key, "")).collect(Collectors.toSet());
-        if (cyclewayValues.contains("track")) {
-            weightToPrioMap.put(100d, VERY_NICE);
-        } else if (Stream.of("lane", "opposite_track", "shared_lane", "share_busway", "shoulder").anyMatch(cyclewayValues::contains)) {
-            PriorityCode current = weightToPrioMap.lastEntry().getValue();
-            if (current.getValue() < PREFER.getValue())
-                weightToPrioMap.put(100d, current.better());
-        } else if (pushingSectionsHighways.contains(highway) || "parking_aisle".equals(way.getTag("service"))) {
-            PriorityCode pushingSectionPrio = SLIGHT_AVOID;
-            if (way.hasTag("highway", "steps"))
-                pushingSectionPrio = BAD;
-            else if (way.hasTag("foot", "yes"))
-                pushingSectionPrio = pushingSectionPrio.worse();
-
-            weightToPrioMap.put(100d, pushingSectionPrio);
-        }
+        weightToPrioMap.put(100d, prio);
 
         if (way.hasTag("railway", "tram") && !bikeDesignated)
             weightToPrioMap.put(100d, AVOID_MORE);
@@ -95,10 +82,10 @@ public class RacingBikePriorityParser extends BikeCommonPriorityParser {
 
         // We assume that humans are better in classifying preferences compared to our algorithm above
         if (classBicycleValue != null) {
-            PriorityCode prio = convertClassValueToPriority(classBicycleValue);
+            PriorityCode prioFromClass = convertClassValueToPriority(classBicycleValue);
             // do not overwrite if e.g. designated
             weightToPrioMap.compute(100d, (key, existing) ->
-                    existing == null || existing.getValue() < prio.getValue() ? prio : existing
+                    existing == null || existing.getValue() < prioFromClass.getValue() ? prioFromClass : existing
             );
         }
     }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikePriorityParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikePriorityParser.java
@@ -44,6 +44,7 @@ public class RacingBikePriorityParser extends BikeCommonPriorityParser {
         highwayToPrio.put("pedestrian", SLIGHT_AVOID);
         highwayToPrio.put("platform", SLIGHT_AVOID);
         highwayToPrio.put("track", AVOID_MORE);
+        highwayToPrio.put("living_street", AVOID);
         highwayToPrio.put("bridleway", AVOID);
         highwayToPrio.put("motorway", BAD);
         highwayToPrio.put("motorway_link", BAD);

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikePriorityParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikePriorityParser.java
@@ -61,7 +61,7 @@ public class RacingBikePriorityParser extends BikeCommonPriorityParser {
                 prio = UNCHANGED;
         } else if (way.hasTag("bicycle", "use_sidepath")) {
             prio = REACH_DESTINATION;
-        } else if (bikeDesignated && !NARROW_WAYS.contains(highway)) {
+        } else if (bikeDesignated && !NARROW_WAYS.contains(highway) && !"parking_aisle".equals(way.getTag("service"))) {
             prio = PREFER;
         } else if ("cycleway".equals(highway) && way.hasTag("foot", INTENDED)) {
             // too narrow when shared with pedestrians; wide roads keep their priority

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikePriorityParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikePriorityParser.java
@@ -30,21 +30,26 @@ public class RacingBikePriorityParser extends BikeCommonPriorityParser {
     protected RacingBikePriorityParser(DecimalEncodedValue priorityEnc) {
         super(priorityEnc);
 
-        highwayToPrio.put("road", SLIGHT_PREFER);
         highwayToPrio.put("secondary", SLIGHT_PREFER);
         highwayToPrio.put("secondary_link", SLIGHT_PREFER);
         highwayToPrio.put("tertiary", SLIGHT_PREFER);
         highwayToPrio.put("tertiary_link", SLIGHT_PREFER);
+
+        highwayToPrio.put("unclassified", UNCHANGED);
+        highwayToPrio.put("primary", UNCHANGED);
+        highwayToPrio.put("primary_link", UNCHANGED);
+        highwayToPrio.put("cycleway", UNCHANGED);
+
+        highwayToPrio.put("road", SLIGHT_AVOID);
         highwayToPrio.put("service", SLIGHT_AVOID);
         highwayToPrio.put("residential", SLIGHT_AVOID);
-        highwayToPrio.put("unclassified", SLIGHT_AVOID);
         highwayToPrio.put("path", SLIGHT_AVOID);
         highwayToPrio.put("footway", SLIGHT_AVOID);
         highwayToPrio.put("pedestrian", SLIGHT_AVOID);
         highwayToPrio.put("platform", SLIGHT_AVOID);
-        highwayToPrio.put("track", AVOID_MORE);
         highwayToPrio.put("living_street", AVOID);
         highwayToPrio.put("bridleway", AVOID);
+        highwayToPrio.put("track", AVOID_MORE);
         highwayToPrio.put("motorway", BAD);
         highwayToPrio.put("motorway_link", BAD);
         highwayToPrio.put("trunk", BAD);
@@ -86,11 +91,8 @@ public class RacingBikePriorityParser extends BikeCommonPriorityParser {
 
         String classBicycleValue = way.getTag("class:bicycle:roadcycling");
         if (classBicycleValue != null) {
-            // We assume that humans are better in classifying preferences compared to our algorithm above,
-            // but do not degrade e.g. designated
-            PriorityCode classPrio = convertClassValueToPriority(classBicycleValue);
-            if (classPrio.getValue() > prio.getValue())
-                prio = classPrio;
+            // We assume that humans are better in classifying preferences compared to our algorithm above
+            prio = convertClassValueToPriority(classBicycleValue);
         }
 
         weightToPrioMap.put(100d, prio);

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikePriorityParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikePriorityParser.java
@@ -43,15 +43,16 @@ public class RacingBikePriorityParser extends BikeCommonPriorityParser {
         String highway = way.getTag("highway");
         double maxSpeed = Math.max(OSMMaxSpeedParser.parseMaxSpeed(way, false), OSMMaxSpeedParser.parseMaxSpeed(way, true));
 
-        if (bikeDesignated)
-            weightToPrioMap.put(100d, PREFER);
-
         if ("track".equals(highway)) {
             String trackType = way.getTag("tracktype");
             if ("grade1".equals(trackType) || goodSurface.contains(way.getTag("surface", "")))
                 weightToPrioMap.put(110d, UNCHANGED);
             else if (trackType == null || trackType.startsWith("grade"))
                 weightToPrioMap.put(110d, AVOID_MORE);
+        } else if (bikeDesignated && !"cycleway".equals(highway)) {
+            // no boost for cycleway: usually too narrow for racing bikes, and if shared
+            // with pedestrians it is even avoided via the foot handling below
+            weightToPrioMap.put(100d, PREFER);
         } else if (preferHighwayTags.contains(highway) || maxSpeed <= 30) {
             weightToPrioMap.put(40d, SLIGHT_PREFER);
             if (way.hasTag("tunnel", INTENDED))

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/RacingBikeTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/RacingBikeTagParserTest.java
@@ -116,6 +116,22 @@ public class RacingBikeTagParserTest extends AbstractBikeTagParserTester {
         // foot=yes is related to the highway, i.e. can be ignored for the cycleway
         osmWay.setTag("foot", "yes");
         assertPriorityAndSpeed(PREFER, 24, osmWay);
+
+        // a painted lane boosts one step but stays below cycleway=track
+        osmWay = new ReaderWay(1);
+        osmWay.setTag("highway", "residential");
+        osmWay.setTag("cycleway", "lane");
+        assertPriorityAndSpeed(UNCHANGED, 24, osmWay);
+
+        osmWay = new ReaderWay(1);
+        osmWay.setTag("highway", "primary");
+        osmWay.setTag("cycleway:right", "shoulder");
+        assertPriorityAndSpeed(SLIGHT_PREFER, 24, osmWay);
+
+        osmWay = new ReaderWay(1);
+        osmWay.setTag("highway", "secondary");
+        osmWay.setTag("cycleway", "lane");
+        assertPriorityAndSpeed(SLIGHT_PREFER, 24, osmWay);
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/RacingBikeTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/RacingBikeTagParserTest.java
@@ -78,6 +78,17 @@ public class RacingBikeTagParserTest extends AbstractBikeTagParserTester {
         osmWay.setTag("foot", "yes");
         assertPriorityAndSpeed(SLIGHT_AVOID, 24, osmWay);
 
+        // bicycle=designated does not help if shared with pedestrians, even if segregated
+        osmWay = new ReaderWay(1);
+        osmWay.setTag("highway", "cycleway");
+        osmWay.setTag("bicycle", "designated");
+        osmWay.setTag("foot", "designated");
+        osmWay.setTag("segregated", "no");
+        assertPriorityAndSpeed(SLIGHT_AVOID, 24, osmWay);
+
+        osmWay.setTag("segregated", "yes");
+        assertPriorityAndSpeed(SLIGHT_AVOID, 24, osmWay);
+
         // same or worse as highway=cycleway + foot=yes
         osmWay = new ReaderWay(1);
         osmWay.setTag("highway", "footway");

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/RacingBikeTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/RacingBikeTagParserTest.java
@@ -89,11 +89,24 @@ public class RacingBikeTagParserTest extends AbstractBikeTagParserTester {
         osmWay.setTag("segregated", "yes");
         assertPriorityAndSpeed(SLIGHT_AVOID, 24, osmWay);
 
+        // segregated=yes alone does not boost either
+        osmWay = new ReaderWay(1);
+        osmWay.setTag("highway", "cycleway");
+        osmWay.setTag("segregated", "yes");
+        assertPriorityAndSpeed(UNCHANGED, 24, osmWay);
+
         // same or worse as highway=cycleway + foot=yes
         osmWay = new ReaderWay(1);
         osmWay.setTag("highway", "footway");
         osmWay.setTag("bicycle", "designated");
         assertPriorityAndSpeed(SLIGHT_AVOID, 24, osmWay);
+
+        // like the shared cycleway case above
+        osmWay = new ReaderWay(1);
+        osmWay.setTag("highway", "path");
+        osmWay.setTag("bicycle", "designated");
+        osmWay.setTag("foot", "designated");
+        assertPriority(SLIGHT_AVOID, osmWay);
 
         osmWay = new ReaderWay(1);
         osmWay.setTag("highway", "unclassified");
@@ -120,6 +133,10 @@ public class RacingBikeTagParserTest extends AbstractBikeTagParserTester {
         osmWay.setTag("highway", "primary");
         osmWay.setTag("foot", "yes");
         assertPriorityAndSpeed(UNCHANGED, 24, osmWay);
+
+        osmWay = new ReaderWay(1);
+        osmWay.setTag("highway", "bridleway");
+        assertPriority(AVOID, osmWay);
     }
 
     @Test
@@ -137,6 +154,11 @@ public class RacingBikeTagParserTest extends AbstractBikeTagParserTester {
 
         osmWay.setTag("bicycle", "designated");
         assertPriorityAndSpeed(PREFER, 24, osmWay);
+
+        osmWay = new ReaderWay(1);
+        osmWay.setTag("highway", "trunk");
+        osmWay.setTag("tunnel", "yes");
+        assertPriority(REACH_DESTINATION, osmWay);
     }
 
     @Test
@@ -148,6 +170,8 @@ public class RacingBikeTagParserTest extends AbstractBikeTagParserTester {
 
         way.setTag("service", "parking_aisle");
         assertPriorityAndSpeed(SLIGHT_AVOID, 8, way);
+        way.setTag("bicycle", "designated");
+        assertPriority(SLIGHT_AVOID, way);
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/RacingBikeTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/RacingBikeTagParserTest.java
@@ -153,6 +153,13 @@ public class RacingBikeTagParserTest extends AbstractBikeTagParserTester {
         osmWay = new ReaderWay(1);
         osmWay.setTag("highway", "bridleway");
         assertPriority(AVOID, osmWay);
+
+        // walking pace, so also no 30 zone boost
+        osmWay = new ReaderWay(1);
+        osmWay.setTag("highway", "living_street");
+        assertPriority(AVOID, osmWay);
+        osmWay.setTag("maxspeed", "30");
+        assertPriority(AVOID, osmWay);
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/RacingBikeTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/RacingBikeTagParserTest.java
@@ -151,6 +151,19 @@ public class RacingBikeTagParserTest extends AbstractBikeTagParserTester {
         assertPriorityAndSpeed(UNCHANGED, 24, osmWay);
 
         osmWay = new ReaderWay(1);
+        osmWay.setTag("highway", "unclassified");
+        assertPriority(UNCHANGED, osmWay);
+
+        // a 30 zone must not make it a detour worth taking (#3375)
+        osmWay.setTag("maxspeed", "30");
+        assertPriority(UNCHANGED, osmWay);
+
+        // unknown classification, so unknown quality
+        osmWay = new ReaderWay(1);
+        osmWay.setTag("highway", "road");
+        assertPriority(SLIGHT_AVOID, osmWay);
+
+        osmWay = new ReaderWay(1);
         osmWay.setTag("highway", "bridleway");
         assertPriority(AVOID, osmWay);
 
@@ -419,6 +432,16 @@ public class RacingBikeTagParserTest extends AbstractBikeTagParserTester {
 
         way.setTag("class:bicycle", "-2");
         assertPriority(BEST, way);
+
+        // a bad classification degrades the highway priority
+        way = new ReaderWay(1);
+        way.setTag("highway", "tertiary");
+        way.setTag("class:bicycle:roadcycling", "-3");
+        assertPriority(REACH_DESTINATION, way);
+
+        // even for designated infrastructure
+        way.setTag("bicycle", "designated");
+        assertPriority(REACH_DESTINATION, way);
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/RacingBikeTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/RacingBikeTagParserTest.java
@@ -98,11 +98,11 @@ public class RacingBikeTagParserTest extends AbstractBikeTagParserTester {
         osmWay = new ReaderWay(1);
         osmWay.setTag("highway", "unclassified");
         osmWay.setTag("cycleway", "track");
-        assertPriorityAndSpeed(VERY_NICE, 24, osmWay);
+        assertPriorityAndSpeed(PREFER, 24, osmWay);
 
         // foot=yes is related to the highway, i.e. can be ignored for the cycleway
         osmWay.setTag("foot", "yes");
-        assertPriorityAndSpeed(VERY_NICE, 24, osmWay);
+        assertPriorityAndSpeed(PREFER, 24, osmWay);
     }
 
     @Test
@@ -114,6 +114,12 @@ public class RacingBikeTagParserTest extends AbstractBikeTagParserTester {
         assertPriorityAndSpeed(PREFER, 24, osmWay);
         osmWay.setTag("foot", "yes"); // residential is allowed for foot anyway
         assertPriorityAndSpeed(PREFER, 24, osmWay);
+
+        // wide roads keep their priority even with foot=yes
+        osmWay = new ReaderWay(1);
+        osmWay.setTag("highway", "primary");
+        osmWay.setTag("foot", "yes");
+        assertPriorityAndSpeed(UNCHANGED, 24, osmWay);
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/RacingBikeTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/RacingBikeTagParserTest.java
@@ -379,5 +379,16 @@ public class RacingBikeTagParserTest extends AbstractBikeTagParserTester {
         ReaderWay osmWay = new ReaderWay(1);
         osmWay.setTag("highway", "tertiary");
         assertPriority(SLIGHT_PREFER, osmWay);
+
+        osmWay = new ReaderWay(1);
+        osmWay.setTag("highway", "primary");
+        osmWay.setTag("maxspeed", "30");
+        assertPriority(SLIGHT_PREFER, osmWay);
+
+        // a 30 zone must not lift smaller roads above the parallel main road
+        osmWay = new ReaderWay(1);
+        osmWay.setTag("highway", "residential");
+        osmWay.setTag("maxspeed", "30");
+        assertPriority(SLIGHT_AVOID, osmWay);
     }
 }


### PR DESCRIPTION
After the collect method from racingbike is now decoupled I tried to simplify the code further and I like it.

wdyt @ratrun ?

Finally mainly three cases:

1. priority via simple highwayToPrio HashMap
2. "track", "cycleway" and "steps" exceptions
3. boost wider roads with bikeDesignated
4. (tunnel handling -> not so sure if really needed for racingbike)
5. (minor boost for primary if "maxSpeed <= 30". e.g. secondary is already at "slight prefer")

Minor behaviour change: removed shared_lane (no advantage for racingbike IMO) and also share_busway+opposite_track are not that good (not sure why we have this for normal bike?)

This change also fixes some wrong shortcuts/detours:

 * https://graphhopper.com/maps/?point=47.395673%2C15.160168&point=47.396893%2C15.164878&profile=racingbike
 * https://graphhopper.com/maps/?point=47.40608%2C15.262696&point=47.404806%2C15.25618&profile=racingbike
 * https://graphhopper.com/maps/?point=47.741086%2C15.310372&point=47.741103%2C15.307773&profile=racingbike
 * https://graphhopper.com/maps/?point=47.40979%2C15.274089&point=47.406505%2C15.269758&profile=racingbike

One remaining obstacle we can (later) improve: lower bike_network boost so that [certain detours](https://graphhopper.com/maps/?point=47.421552%2C15.273507&point=47.425199%2C15.271171&profile=racingbike) disappear. E.g. local+regional to 1.1 and (inter)national to 1.3