### PR TITLE
Further deprioritize bicycle infrastructure for racebikes.

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikePriorityParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikePriorityParser.java
@@ -38,15 +38,15 @@ public class RacingBikePriorityParser extends BikeCommonPriorityParser {
         highwayToPrio.put("unclassified", UNCHANGED);
         highwayToPrio.put("primary", UNCHANGED);
         highwayToPrio.put("primary_link", UNCHANGED);
-        highwayToPrio.put("cycleway", UNCHANGED);
+        highwayToPrio.put("cycleway", AVOID);
 
-        highwayToPrio.put("road", SLIGHT_AVOID);
-        highwayToPrio.put("service", SLIGHT_AVOID);
+        highwayToPrio.put("road", AVOID);
+        highwayToPrio.put("service", AVOID);
         highwayToPrio.put("residential", SLIGHT_AVOID);
-        highwayToPrio.put("path", SLIGHT_AVOID);
-        highwayToPrio.put("footway", SLIGHT_AVOID);
-        highwayToPrio.put("pedestrian", SLIGHT_AVOID);
-        highwayToPrio.put("platform", SLIGHT_AVOID);
+        highwayToPrio.put("path", AVOID);
+        highwayToPrio.put("footway", AVOID);
+        highwayToPrio.put("pedestrian", AVOID);
+        highwayToPrio.put("platform", AVOID);
         highwayToPrio.put("living_street", AVOID);
         highwayToPrio.put("bridleway", AVOID);
         highwayToPrio.put("track", AVOID_MORE);
@@ -76,7 +76,7 @@ public class RacingBikePriorityParser extends BikeCommonPriorityParser {
             prio = prio.better();
         } else if ("cycleway".equals(highway) && way.hasTag("foot", INTENDED)) {
             // too narrow when shared with pedestrians; wide roads keep their priority
-            prio = SLIGHT_AVOID;
+            prio = AVOID;
         } else if (way.hasTag("tunnel", INTENDED)) {
             // tunnels are only dangerous on the high-speed roads that we strongly avoid anyway
             if (prio == BAD) prio = REACH_DESTINATION;

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikePriorityParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikePriorityParser.java
@@ -38,7 +38,7 @@ public class RacingBikePriorityParser extends BikeCommonPriorityParser {
         highwayToPrio.put("unclassified", UNCHANGED);
         highwayToPrio.put("primary", UNCHANGED);
         highwayToPrio.put("primary_link", UNCHANGED);
-        highwayToPrio.put("cycleway", AVOID);
+        highwayToPrio.put("cycleway", SLIGHT_AVOID);
 
         highwayToPrio.put("road", AVOID);
         highwayToPrio.put("service", AVOID);

--- a/core/src/main/resources/com/graphhopper/custom_models/racingbike.json
+++ b/core/src/main/resources/com/graphhopper/custom_models/racingbike.json
@@ -8,8 +8,8 @@
 {
   "priority": [
     { "if": "true",  "multiply_by": "racingbike_priority" },
-    { "if": "bike_network == INTERNATIONAL || bike_network == NATIONAL",  "multiply_by": "1.4" },
-    { "else_if": "bike_network == REGIONAL || bike_network == LOCAL",  "multiply_by": "1.2" },
+    { "if": "bike_network == INTERNATIONAL || bike_network == NATIONAL",  "multiply_by": "1.2" },
+    { "else_if": "bike_network == REGIONAL || bike_network == LOCAL",  "multiply_by": "1.1" },
     { "if": "road_environment == FERRY", "multiply_by": "0.5" },
     { "if": "mtb_rating > 2",  "multiply_by": "0" },
     { "else_if": "mtb_rating == 2",  "multiply_by": "0.5" },

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/BikeCustomModelTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/BikeCustomModelTest.java
@@ -200,16 +200,16 @@ public class BikeCustomModelTest {
         way.setTag("highway", "path");
         EdgeIteratorState edge = createEdge(way);
         CustomWeighting.Parameters p = CustomModelParser.createWeightingParameters(cm, em);
-        assertEquals(0.9, p.getEdgeToPriorityMapping().get(edge, false), 0.01);
+        assertEquals(0.8, p.getEdgeToPriorityMapping().get(edge, false), 0.01);
         assertEquals(6.0, p.getEdgeToSpeedMapping().get(edge, false), 0.01);
 
         way.setTag("mtb:scale", "0");
         edge = createEdge(way);
-        assertEquals(0.9, p.getEdgeToPriorityMapping().get(edge, false), 0.01);
+        assertEquals(0.8, p.getEdgeToPriorityMapping().get(edge, false), 0.01);
 
         way.setTag("mtb:scale", "1");
         edge = createEdge(way);
-        assertEquals(0.45, p.getEdgeToPriorityMapping().get(edge, false), 0.01);
+        assertEquals(0.4, p.getEdgeToPriorityMapping().get(edge, false), 0.01);
 
         way.setTag("mtb:scale", "2");
         edge = createEdge(way);
@@ -218,7 +218,7 @@ public class BikeCustomModelTest {
         way.removeTag("mtb:scale");
         way.setTag("sac_scale", "hiking");
         edge = createEdge(way);
-        assertEquals(0.9, p.getEdgeToPriorityMapping().get(edge, false), 0.01);
+        assertEquals(0.8, p.getEdgeToPriorityMapping().get(edge, false), 0.01);
         way.setTag("sac_scale", "mountain_hiking");
         edge = createEdge(way);
         assertEquals(0.0, p.getEdgeToPriorityMapping().get(edge, false), 0.01);

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/RacingBikeTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/RacingBikeTagParserTest.java
@@ -71,7 +71,7 @@ public class RacingBikeTagParserTest extends AbstractBikeTagParserTester {
     public void testCycleway() {
         ReaderWay osmWay = new ReaderWay(1);
         osmWay.setTag("highway", "cycleway");
-        assertPriorityAndSpeed(AVOID, 24, osmWay);
+        assertPriorityAndSpeed(SLIGHT_AVOID, 24, osmWay);
 
         osmWay = new ReaderWay(1);
         osmWay.setTag("highway", "cycleway");
@@ -93,7 +93,7 @@ public class RacingBikeTagParserTest extends AbstractBikeTagParserTester {
         osmWay = new ReaderWay(1);
         osmWay.setTag("highway", "cycleway");
         osmWay.setTag("segregated", "yes");
-        assertPriorityAndSpeed(AVOID, 24, osmWay);
+        assertPriorityAndSpeed(SLIGHT_AVOID, 24, osmWay);
 
         // same or worse as highway=cycleway + foot=yes
         osmWay = new ReaderWay(1);

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/RacingBikeTagParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/RacingBikeTagParserTest.java
@@ -71,12 +71,12 @@ public class RacingBikeTagParserTest extends AbstractBikeTagParserTester {
     public void testCycleway() {
         ReaderWay osmWay = new ReaderWay(1);
         osmWay.setTag("highway", "cycleway");
-        assertPriorityAndSpeed(UNCHANGED, 24, osmWay);
+        assertPriorityAndSpeed(AVOID, 24, osmWay);
 
         osmWay = new ReaderWay(1);
         osmWay.setTag("highway", "cycleway");
         osmWay.setTag("foot", "yes");
-        assertPriorityAndSpeed(SLIGHT_AVOID, 24, osmWay);
+        assertPriorityAndSpeed(AVOID, 24, osmWay);
 
         // bicycle=designated does not help if shared with pedestrians, even if segregated
         osmWay = new ReaderWay(1);
@@ -84,29 +84,29 @@ public class RacingBikeTagParserTest extends AbstractBikeTagParserTester {
         osmWay.setTag("bicycle", "designated");
         osmWay.setTag("foot", "designated");
         osmWay.setTag("segregated", "no");
-        assertPriorityAndSpeed(SLIGHT_AVOID, 24, osmWay);
+        assertPriorityAndSpeed(AVOID, 24, osmWay);
 
         osmWay.setTag("segregated", "yes");
-        assertPriorityAndSpeed(SLIGHT_AVOID, 24, osmWay);
+        assertPriorityAndSpeed(AVOID, 24, osmWay);
 
         // segregated=yes alone does not boost either
         osmWay = new ReaderWay(1);
         osmWay.setTag("highway", "cycleway");
         osmWay.setTag("segregated", "yes");
-        assertPriorityAndSpeed(UNCHANGED, 24, osmWay);
+        assertPriorityAndSpeed(AVOID, 24, osmWay);
 
         // same or worse as highway=cycleway + foot=yes
         osmWay = new ReaderWay(1);
         osmWay.setTag("highway", "footway");
         osmWay.setTag("bicycle", "designated");
-        assertPriorityAndSpeed(SLIGHT_AVOID, 24, osmWay);
+        assertPriorityAndSpeed(AVOID, 24, osmWay);
 
         // like the shared cycleway case above
         osmWay = new ReaderWay(1);
         osmWay.setTag("highway", "path");
         osmWay.setTag("bicycle", "designated");
         osmWay.setTag("foot", "designated");
-        assertPriority(SLIGHT_AVOID, osmWay);
+        assertPriority(AVOID, osmWay);
 
         osmWay = new ReaderWay(1);
         osmWay.setTag("highway", "unclassified");
@@ -161,7 +161,7 @@ public class RacingBikeTagParserTest extends AbstractBikeTagParserTester {
         // unknown classification, so unknown quality
         osmWay = new ReaderWay(1);
         osmWay.setTag("highway", "road");
-        assertPriority(SLIGHT_AVOID, osmWay);
+        assertPriority(AVOID, osmWay);
 
         osmWay = new ReaderWay(1);
         osmWay.setTag("highway", "bridleway");
@@ -202,12 +202,12 @@ public class RacingBikeTagParserTest extends AbstractBikeTagParserTester {
     public void testService() {
         ReaderWay way = new ReaderWay(1);
         way.setTag("highway", "service");
-        assertPriorityAndSpeed(SLIGHT_AVOID, 18, way);
+        assertPriorityAndSpeed(AVOID, 18, way);
 
         way.setTag("service", "parking_aisle");
-        assertPriorityAndSpeed(SLIGHT_AVOID, 8, way);
+        assertPriorityAndSpeed(AVOID, 8, way);
         way.setTag("bicycle", "designated");
-        assertPriority(SLIGHT_AVOID, way);
+        assertPriority(AVOID, way);
     }
 
     @Test


### PR DESCRIPTION
Improves remaining issues from https://github.com/gpxstudio/gpx.studio/issues/325#issuecomment-5096658894 

These are the mentioned cases:

http://localhost:8989/maps/?point=47.437422%2C15.282319&point=47.410845%2C15.273828&profile=racingbike&layer=OpenStreetMap Fixed
http://localhost:8989/maps/?point=47.466121%2C15.336426&point=47.474325%2C15.370978&profile=racingbike&layer=OpenStreetMap Already OK on master
http://localhost:8989/maps/?point=47.630049%2C15.658982&point=47.674609%2C15.489342&profile=racingbike&layer=OpenStreetMap Fixed
http://localhost:8989/maps/?point=47.40398%2C15.224011&point=47.381216%2C15.10702&profile=racingbike&layer=OpenStreetMap   Fixed
http://localhost:8989/maps/?point=47.289413%2C15.310959&point=47.280978%2C15.31001&profile=racingbike&layer=OpenStreetMap  Already OK on master
http://localhost:8989/maps/?point=47.052146%2C16.082349&point=47.065988%2C16.034605&profile=racingbike&layer=OpenStreetMap Fixed - identical to brouter now

Here is the brouter result for comparison:
https://brouter.de/brouter-web/#map=15/47.052146/16.082349/standard&lonlats=16.082349,47.052146;16.034605,47.065988&profile=fastbike

http://localhost:8989/maps/?point=47.073346%2C15.418422&point=47.019181%2C15.43863&profile=racingbike&layer=OpenStreetMap  Already identical to brouter with latest master, correct avoidance of bicycle=no

Here is the brouter result for comparison:
https://brouter.de/brouter-web/#map=15/47.073346/15.418422/standard&lonlats=15.418422,47.073346;15.43863,47.019181&profile=fastbike