### PR TITLE
fix: throw on elevation download IO failures instead of elev=0

### DIFF
--- a/core/src/main/java/com/graphhopper/reader/dem/AbstractTiffElevationProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/AbstractTiffElevationProvider.java
@@ -23,6 +23,7 @@ import com.graphhopper.util.Downloader;
 import javax.net.ssl.SSLException;
 import java.awt.image.Raster;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.SocketTimeoutException;
 import java.util.HashMap;
@@ -129,18 +130,26 @@ public abstract class AbstractTiffElevationProvider extends TileBasedElevationPr
 
             if (!loadExisting) {
                 File zipFile = new File(cacheDir, new File(getFileNameOfLocalFile(lat, lon)).getName());
-                if (!zipFile.exists())
+                if (!zipFile.exists()) {
                     try {
                         String zippedURL = getDownloadURL(lat, lon);
                         downloadToFile(zipFile, zippedURL);
                     } catch (SSLException ex) {
+                        cacheData.remove(name);
                         throw new IllegalStateException("SSL problem with elevation provider " + getClass().getSimpleName(), ex);
-                    } catch (IOException ex) {
+                    } catch (FileNotFoundException ex) {
+                        // Missing tile (e.g. ocean): treat as sea level. Do not swallow other IO failures.
                         demProvider.setSeaLevel(true);
                         // use small size on disc and in-memory
                         heights.create(10).flush();
                         return 0;
+                    } catch (IOException ex) {
+                        // Timeout, connection errors, partial responses, etc. must not be cached as elev=0
+                        cacheData.remove(name);
+                        throw new IllegalStateException("Unable to download elevation data for " + name
+                                + " using " + getClass().getSimpleName(), ex);
                     }
+                }
 
                 // short == 2 bytes
                 heights.create(2L * WIDTH * HEIGHT);
@@ -171,7 +180,7 @@ public abstract class AbstractTiffElevationProvider extends TileBasedElevationPr
                     return;
                 } catch (SocketTimeoutException ex) {
                     if (trial >= max - 1)
-                        throw new RuntimeException(ex);
+                        throw ex;
                     try {
                         Thread.sleep(sleep);
                     } catch (InterruptedException ignored) {

--- a/core/src/test/java/com/graphhopper/reader/dem/CGIARProviderTest.java
+++ b/core/src/test/java/com/graphhopper/reader/dem/CGIARProviderTest.java
@@ -112,12 +112,26 @@ public class CGIARProviderTest {
             }
         });
 
-        try {
-            instance.setSleep(30);
-            instance.getEle(16, -20);
-            fail();
-        } catch (Exception ex) {
-        }
+        instance.setSleep(30);
+        IllegalStateException timeoutEx = assertThrows(IllegalStateException.class,
+                () -> instance.getEle(16, -20));
+        assertInstanceOf(SocketTimeoutException.class, timeoutEx.getCause());
+        assertTrue(timeoutEx.getMessage().contains("Unable to download elevation data"));
+
+        // Generic download failures must not be treated as sea level (elev=0)
+        instance.setDownloader(new Downloader() {
+            @Override
+            public void downloadFile(String url, String toFile) throws IOException {
+                throw new IOException("connection reset");
+            }
+        });
+        IllegalStateException ioEx = assertThrows(IllegalStateException.class,
+                () -> instance.getEle(26, -20));
+        assertInstanceOf(IOException.class, ioEx.getCause());
+        assertEquals("connection reset", ioEx.getCause().getMessage());
+        assertTrue(ioEx.getMessage().contains("Unable to download elevation data"));
+        // Failed download must not leave a sea-level cache entry
+        assertFalse(new File(instance.getCacheDir(), instance.getFileName(26, -20) + ".gh").exists());
 
         file.delete();
         zipFile.delete();

--- a/core/src/test/java/com/graphhopper/reader/dem/GMTEDProviderTest.java
+++ b/core/src/test/java/com/graphhopper/reader/dem/GMTEDProviderTest.java
@@ -112,12 +112,27 @@ public class GMTEDProviderTest {
             }
         });
 
-        try {
-            instance.setSleep(30);
-            instance.getEle(16, -20);
-            fail();
-        } catch (Exception ex) {
-        }
+        instance.setSleep(30);
+        // Use a different tile than the FileNotFound case above (GMTED tiles are 20°×30°)
+        IllegalStateException timeoutEx = assertThrows(IllegalStateException.class,
+                () -> instance.getEle(16, -20));
+        assertInstanceOf(SocketTimeoutException.class, timeoutEx.getCause());
+        assertTrue(timeoutEx.getMessage().contains("Unable to download elevation data"));
+
+        // Generic download failures must not be treated as sea level (elev=0).
+        // 50°N is a different tile than 16°N for GMTED (20° lat bands).
+        instance.setDownloader(new Downloader() {
+            @Override
+            public void downloadFile(String url, String toFile) throws IOException {
+                throw new IOException("connection reset");
+            }
+        });
+        IllegalStateException ioEx = assertThrows(IllegalStateException.class,
+                () -> instance.getEle(50, 0));
+        assertInstanceOf(IOException.class, ioEx.getCause());
+        assertEquals("connection reset", ioEx.getCause().getMessage());
+        assertTrue(ioEx.getMessage().contains("Unable to download elevation data"));
+        assertFalse(new File(instance.getCacheDir(), instance.getFileName(50, 0) + ".gh").exists());
 
         file.delete();
         zipFile.delete();


### PR DESCRIPTION
## Summary

Fixes #2867

When TIFF-based elevation providers (CGIAR, GMTED) failed to download a tile, `AbstractTiffElevationProvider` treated **any** `IOException` as “sea level” and returned `0.0`. That made timeouts / connection errors look like successful ocean tiles and could leave a useless in-memory cache entry.

This matches the intent called out by @otbutz on the issue (the catch around the download path) and aligns more closely with `AbstractSRTMElevationProvider`, which only treats missing tiles specially and fails loudly on other problems.

### Changes
- **`FileNotFoundException`** (HTTP 404 / missing tile, e.g. ocean): still sea level → `0` (unchanged behavior, covered by existing tests)
- **Other `IOException`s** (timeout after retries, connection reset, etc.): throw `IllegalStateException` with a clear message and cause
- Remove the failed tile from the in-memory cache so a later `getEle` can retry
- Re-throw `SocketTimeoutException` after retries as `IOException` instead of wrapping in `RuntimeException`

## Test plan

- [x] `CGIARProviderTest` / `GMTEDProviderTest` (Temurin 25): FileNotFound → 0; SocketTimeout and generic IOException → `IllegalStateException` with correct cause; no sea-level `.gh` left after failed download
- [x] `mvn -am -pl core -Dtest=CGIARProviderTest,GMTEDProviderTest -Dsurefire.failIfNoSpecifiedTests=false test` → BUILD SUCCESS