### PR TITLE
isochrone: fix performance/OOM regression of tolerance handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - OSMReader no longer sets the artificial speed_from_duration tag but instead uses duration_in_seconds, when the duration tag is present (#3266)
 - country rules were moved into parsers and are now enabled by default
 - speeds generated from highway class now respects country-specific default speed limits, but the max_speed encoded value is now required; see #3249
+- isochrones: the tolerance parameter thins the triangulation again like <= 10.x (coarser output for a given tolerance) and the convex hull is computed from the sites instead of all triangulation edges, fixing a performance/OOM regression introduced in 11.0 by #3128
 
 ### 11.0 [14 Oct 2025]
 

--- a/core/src/main/java/com/graphhopper/isochrone/algorithm/JTSTriangulator.java
+++ b/core/src/main/java/com/graphhopper/isochrone/algorithm/JTSTriangulator.java
@@ -25,6 +25,7 @@ import com.graphhopper.storage.index.Snap;
 import com.graphhopper.util.EdgeIteratorState;
 import com.graphhopper.util.FetchMode;
 import com.graphhopper.util.PointList;
+import org.locationtech.jts.algorithm.ConvexHull;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
@@ -35,6 +36,8 @@ import org.locationtech.jts.triangulate.quadedge.Vertex;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.function.ToDoubleFunction;
 
 public class JTSTriangulator implements Triangulator {
@@ -83,10 +86,32 @@ public class JTSTriangulator implements Triangulator {
         // But that's okay, the triangulator de-dupes by itself, and it keeps the first z-value it sees, which is
         // what we want.
 
+        // Pre-thin the sites to the requested tolerance before triangulating. Before 11.0 the
+        // ConformingDelaunayTriangulator snapped vertices within 'tolerance' at insertion time,
+        // so the effective triangulation size was bounded by the output resolution.
+        // DelaunayTriangulationBuilder's setTolerance also snaps at insertion, but through a much
+        // slower code path, and only after the full site set was deep-copied. Keeping the first
+        // site per tolerance-sized grid cell (the SPT emits labels in ascending time, so first ==
+        // minimum time) restores the pre-11.0 cost model.
+        Collection<Coordinate> thinnedSites = sites;
+        if (tolerance > 0) {
+            Map<Long, Coordinate> cells = new LinkedHashMap<>();
+            for (Coordinate site : sites) {
+                long cx = Math.round(site.x / tolerance);
+                long cy = Math.round(site.y / tolerance);
+                cells.putIfAbsent((cx << 32) ^ (cy & 0xffffffffL), site);
+            }
+            thinnedSites = cells.values();
+        }
+
         DelaunayTriangulationBuilder triangulationBuilder = new DelaunayTriangulationBuilder();
-        triangulationBuilder.setSites(sites);
+        triangulationBuilder.setSites(thinnedSites);
         triangulationBuilder.setTolerance(tolerance);
-        Geometry convexHull = triangulationBuilder.getEdges(new GeometryFactory()).convexHull();
+        // The convex hull of a Delaunay triangulation equals the convex hull of its sites.
+        // Computing it from the sites avoids materializing every triangulation edge as JTS
+        // geometry via getEdges() (gigabytes of transient objects on metro-scale point sets).
+        Geometry convexHull = new ConvexHull(thinnedSites.toArray(new Coordinate[0]),
+                new GeometryFactory()).getConvexHull();
 
         // If there's only one site (and presumably also if the convex hull is otherwise degenerated),
         // the triangulation only contains the frame, and not the site within the frame. Not sure if I agree with that.

--- a/web/src/test/java/com/graphhopper/application/resources/IsochroneResourceTest.java
+++ b/web/src/test/java/com/graphhopper/application/resources/IsochroneResourceTest.java
@@ -97,6 +97,33 @@ public class IsochroneResourceTest {
     }
 
     @Test
+    public void requestWithTolerance() {
+        JsonFeatureCollection rawCollection = clientTarget(app, "/isochrone")
+                .queryParam("profile", "fast_car")
+                .queryParam("point", "42.531073,1.573792")
+                .queryParam("time_limit", 5 * 60)
+                .queryParam("type", "geojson")
+                .request().get(JsonFeatureCollection.class);
+        Geometry raw = rawCollection.getFeatures().get(0).getGeometry();
+
+        JsonFeatureCollection thinnedCollection = clientTarget(app, "/isochrone")
+                .queryParam("profile", "fast_car")
+                .queryParam("point", "42.531073,1.573792")
+                .queryParam("time_limit", 5 * 60)
+                .queryParam("type", "geojson")
+                .queryParam("tolerance", 200)
+                .request().get(JsonFeatureCollection.class);
+        Geometry thinned = thinnedCollection.getFeatures().get(0).getGeometry();
+
+        assertTrue(thinned.getNumPoints() * 2 < raw.getNumPoints(),
+                "tolerance should thin the polygon, got " + thinned.getNumPoints() + " of "
+                        + raw.getNumPoints() + " points");
+        assertTrue(thinned.contains(geometryFactory.createPoint(new Coordinate(1.587224, 42.5386))));
+        assertFalse(thinned.contains(geometryFactory.createPoint(new Coordinate(1.635246, 42.53841))));
+        assertEquals(raw.getArea(), thinned.getArea(), 0.15 * raw.getArea());
+    }
+
+    @Test
     public void requestByTimeLimitNoTurnRestrictions() {
         JsonFeatureCollection featureCollection = clientTarget(app, "/isochrone")
                 .queryParam("profile", "fast_car_no_turn_restrictions")


### PR DESCRIPTION
Hi all, 
I'd like to preface the PR with a disclosure that I'm an infra engineer and don't understand what I'm doing 🙂 

I was working on upgrading Graphhopper from v7 to v11 in our self-hosted setup. One of the pipelines/use-cases handled the upgrade w/o any unpleasant side-effects, but another use-case had a regression where the same call would either take too much time or will be cut by a reverse proxy in front of the graphhopper service, because the graphhopper will take too much time to respond.

I used an LLM to run a/b tests with k6 for that use-case and analyse the issue, and it spit out this patch.

Two things besides I've checked: 1) this patch restores the performance; 2) the results seem to make sense (it's a bit harder to test for me, because the datasets for v7 and v11 are different)

---

Below is LLM-generated/human-edited description of the issue and the patch:

#3128 (first shipped in 11.0) rewrote `JTSTriangulator` from JTS `ConformingDelaunayTriangulator`
to `DelaunayTriangulationBuilder`. The new triangulator itself is a clear improvement — with
`tolerance=0` we measured 11.0 *faster* than 7.0 on the same query (6.9 s vs 27.8 s, table below).
But it changed two things that make large `/isochrone` requests with `tolerance > 0` dramatically
slower, and in heap-constrained setups OOM:

1. **`tolerance` no longer thins the triangulation — it only triggers a slow path.** Before 11.0,
   `ConformingDelaunayTriangulator` snapped vertices within `tolerance` at insertion time, so the
   effective triangulation size was bounded by the output resolution regardless of SPT size.
   `DelaunayTriangulationBuilder.setTolerance` also snaps at insertion, but through a much slower
   code path (see also locationtech/jts#1121), and only after `setSites` deep-copied the full site
   set — and it barely reduces the result.
2. **The convex hull materializes every triangulation edge.** `getEdges(new GeometryFactory())`
   builds a `LineString` per edge (plus a large intermediate `HashSet` of quad-edges) only to feed
   a degeneracy check. On metro-scale shortest-path trees this allocates gigabytes of transient
   objects.

Both effects were captured in production-like OOM stacks (`-Xmx18g`, `time_limit=3600`,
`tolerance=1000`), landing exactly on those two lines:

```
java.lang.OutOfMemoryError: Java heap space
    at org.locationtech.jts.geom.Coordinate.copy(Coordinate.java:416)
    at org.locationtech.jts.geom.CoordinateArrays.copyDeep(CoordinateArrays.java:341)
    at org.locationtech.jts.triangulate.DelaunayTriangulationBuilder.unique(DelaunayTriangulationBuilder.java:59)
    at org.locationtech.jts.triangulate.DelaunayTriangulationBuilder.setSites(DelaunayTriangulationBuilder.java:129)
    at com.graphhopper.isochrone.algorithm.JTSTriangulator.triangulate(JTSTriangulator.java:87)
    at com.graphhopper.resources.IsochroneResource.doGet(IsochroneResource.java:128)

java.lang.OutOfMemoryError: Java heap space
    at java.base/java.util.HashMap.resize / HashSet.add
    at org.locationtech.jts.triangulate.quadedge.QuadEdgeSubdivision.getPrimaryEdges(QuadEdgeSubdivision.java:613)
    at org.locationtech.jts.triangulate.quadedge.QuadEdgeSubdivision.getEdges(QuadEdgeSubdivision.java:858)
    at org.locationtech.jts.triangulate.DelaunayTriangulationBuilder.getEdges(DelaunayTriangulationBuilder.java:175)
    at com.graphhopper.isochrone.algorithm.JTSTriangulator.triangulate(JTSTriangulator.java:89)
```

## Measurements

### tolerance A/B — the discriminating experiment

Same point (Mall of America, Minneapolis metro), `time_limit=1200`, car profile. 7.0 instance on a
2024 OSM extract with `-Xmx18g`; 11.0 instance on a 2026 extract with `-Xmx22g` (to keep it from
OOMing), so absolute numbers are not directly comparable — the per-engine trend is the signal:

| tolerance | 7.0 latency | 7.0 coords | 11.0 latency | 11.0 coords |
|---|---|---|---|---|
| 0 | 27.8 s | 8930 | **6.9 s** | 11003 |
| 200 | 2.3 s | 2589 | 18.3 s | 9480 |
| 1000 | 1.1 s | 456 | 17.3 s | 7290 |
| 5000 | 0.8 s | 59 | 2.4 s | 1783 |

On 7.0, tolerance collapses both cost and output size — that snapping is why large isochrones were
ever fast. On 11.0, `tolerance>0` is *slower* than `tolerance=0` and barely thins the output.

### Large-isochrone sweep, before/after this patch

k6, 1 VU, car profile, `tolerance` in the 200–1000 m range; ">120 s" = aborted at a 120 s gateway
timeout:

| point | time_limit | 7.0 | 11.0 stock (-Xmx22g) | 11.0 + this patch |
|---|---|---|---|---|
| Mall of America | 1800 | 1.9 s | 68.5 s | **1.6 s** |
| Mall of America | 4800 | 4.5 s | >120 s | **3.0 s** |
| Rancho Cucamonga | 3600 | 5.0 s | >120 s | **6.6 s** |
| Rancho Cucamonga | 4800 | 8.0 s | >120 s | **8.3 s** |
| rural control point | 4800 | 2.8 s | 68.2 s | **2.1 s** |

Full 18-case sweep: 37.3 s total with the patch vs 38.0 s on 7.0.

## The fix

Two changes in `JTSTriangulator`, both addressing the same #3128 regression:

1. **Pre-thin the sites to a `tolerance`-sized grid before triangulating**, keeping the first site
   per cell (the SPT emits labels in ascending order, so first == minimum time). This restores the
   pre-11.0 cost model: triangulation size bounded by output resolution, and `setSites`' deep copy
   now operates on the thinned set.
2. **Compute the convex hull from the sites instead of `getEdges(...)`.** The hull is only used for
   the degeneracy check, and the convex hull of a Delaunay triangulation equals the convex hull of
   its sites (`getEdges` excludes frame edges), so behavior is identical — including the
   degenerate cases (1 site → `Point`, collinear → `LineString`, both still throw). This removes
   the second allocation site entirely, for any tolerance.

### Intentional output change

At a given `tolerance`, output has roughly 4× fewer vertices than stock 11.x (see the coords
columns in the A/B table) — this *restores* the ≤10.x semantics, where `tolerance` was an output
resolution knob; density vs 7.0 is comparable, e.g. 4066 vs 3019 coords at the 80-min case above. Polygon quality vs 7.0 was validated over all 18 sweep cases: area ratio within
0.94–1.04, shape IoU 0.82–0.97 (worst = smallest polygon, where the ±tolerance boundary band
dominates), all polygons valid with zero holes, monotonic containment across `time_limit`s matching
7.0's own jitter.

Measurements were taken on the `11.0` tag; the patch applies to `master` unchanged. A regression
test (`IsochroneResourceTest.requestWithTolerance`) asserts that `tolerance` actually thins the
output while returning the same polygon.

---

The tests seem to be passing:
```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for GraphHopper Parent Project 12.0-SNAPSHOT:
[INFO]
[INFO] GraphHopper Parent Project ......................... SUCCESS [  0.191 s]
[INFO] GraphHopper Web API ................................ SUCCESS [  1.849 s]
[INFO] GraphHopper Core ................................... SUCCESS [ 40.083 s]
[INFO] GraphHopper Reader for Gtfs Data ................... SUCCESS [ 15.694 s]
[INFO] GraphHopper Tools .................................. SUCCESS [  1.728 s]
[INFO] GraphHopper Map Matching ........................... SUCCESS [  0.229 s]
[INFO] GraphHopper Directions API hand-crafted Java Client. SUCCESS [  0.816 s]
[INFO] GraphHopper Dropwizard Bundle ...................... SUCCESS [ 14.680 s]
[INFO] GraphHopper Navigation ............................. SUCCESS [  1.616 s]
[INFO] GraphHopper Web .................................... SUCCESS [01:08 min]
[INFO] GraphHopper Example ................................ SUCCESS [  1.897 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:27 min
[INFO] Finished at: 2026-08-18T12:24:26+03:00
[INFO] ------------------------------------------------------------------------
```