### PR TITLE
Improve instructions for customized profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 12.0 [not yet released]
 
+- the profile parameter instructions_base_mode (car, bike or foot) replaces navigation_mode and is derived from the profile name if not specified, with car as fallback (#TODO)
 - several changes regarding DAType (#3382) including constructor parameters of DataAccess
 - the roundabout instruction can now be split into two instructions: the first one has turn_angle and the second has exited==true. Enable via the request parameter roundabout_exits=true (default is false)
 - weightings are now expected to return whole numbers, the built-in weightings (most importantly CustomWeighting) now return x10 their previous value (#3297) 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### 12.0 [not yet released]
 
-- the profile parameter instructions_base_mode (car, bike or foot) replaces navigation_mode and is derived from the profile name if not specified, with car as fallback (#TODO)
+- the profile parameter instructions_base_mode (car, bike or foot) replaces navigation_mode and is derived from the profile name if not specified, with car as fallback (#3394)
 - several changes regarding DAType (#3382) including constructor parameters of DataAccess
 - the roundabout instruction can now be split into two instructions: the first one has turn_angle and the second has exited==true. Enable via the request parameter roundabout_exits=true (default is false)
 - weightings are now expected to return whole numbers, the built-in weightings (most importantly CustomWeighting) now return x10 their previous value (#3297) 

--- a/config-example.yml
+++ b/config-example.yml
@@ -53,7 +53,7 @@ graphhopper:
 #      custom_model_files: [mtb.json, bike_elevation.json]
 #
 #    - name: custom_profile
-#      navigation_mode: bike
+#      instructions_base_mode: bike
 #      turn_costs:
 #        vehicle_types: [bicycle]
 #        u_turn_costs: 10

--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -294,9 +294,9 @@ public class GraphHopper {
         return profilesByName.get(profileName);
     }
 
-    public TransportationMode getNavigationMode(String profileName) {
+    public TransportationMode getInstructionsBaseMode(String profileName) {
         Profile profile = profilesByName.get(profileName);
-        return profile == null ? TransportationMode.CAR : profile.getNavigationMode();
+        return profile == null ? TransportationMode.CAR : profile.getInstructionsBaseMode();
     }
 
     /**

--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -296,12 +296,7 @@ public class GraphHopper {
 
     public TransportationMode getNavigationMode(String profileName) {
         Profile profile = profilesByName.get(profileName);
-        if (profile == null) return TransportationMode.CAR;
-        try {
-            return TransportationMode.valueOf(profile.getHints().getString("navigation_mode", profileName).toUpperCase(Locale.ROOT));
-        } catch (IllegalArgumentException e) {
-            return TransportationMode.CAR;
-        }
+        return profile == null ? TransportationMode.CAR : profile.getNavigationMode();
     }
 
     /**

--- a/core/src/main/java/com/graphhopper/config/Profile.java
+++ b/core/src/main/java/com/graphhopper/config/Profile.java
@@ -21,12 +21,14 @@ package com.graphhopper.config;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.graphhopper.routing.util.TransportationMode;
 import com.graphhopper.util.CustomModel;
 import com.graphhopper.util.Helper;
 import com.graphhopper.util.PMap;
 import com.graphhopper.util.TurnCostsConfig;
 
 import java.util.List;
+import java.util.Locale;
 
 import static java.util.Collections.emptyList;
 
@@ -108,6 +110,19 @@ public class Profile {
 
     public boolean hasTurnCosts() {
         return turnCostsConfig != null;
+    }
+
+    /**
+     * The mode of transportation the user of this profile navigates with, e.g. used for the turn instructions.
+     * It is specified via the profile entry "navigation_mode" and defaults to the profile name, or CAR.
+     */
+    @JsonIgnore
+    public TransportationMode getNavigationMode() {
+        try {
+            return TransportationMode.valueOf(getHints().getString("navigation_mode", getName()).toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            return TransportationMode.CAR;
+        }
     }
 
     @JsonIgnore

--- a/core/src/main/java/com/graphhopper/config/Profile.java
+++ b/core/src/main/java/com/graphhopper/config/Profile.java
@@ -114,9 +114,8 @@ public class Profile {
 
     /**
      * The base mode of transportation used when creating the instructions, i.e. which roads the driver
-     * perceives as usable (#3223) and which voice instruction distances fit. Restricted to CAR, BIKE or FOOT.
-     * It is specified via the profile entry "instructions_base_mode" and otherwise derived from the profile
-     * name, with CAR as fallback.
+     * perceives as usable (not necessarily routable) and which voice instruction distances fit.
+     * Restricted to BIKE, FOOT and CAR. CAR is the fallback if instructions_base_mode is empty or unknown.
      */
     @JsonIgnore
     public TransportationMode getInstructionsBaseMode() {

--- a/core/src/main/java/com/graphhopper/config/Profile.java
+++ b/core/src/main/java/com/graphhopper/config/Profile.java
@@ -126,6 +126,7 @@ public class Profile {
             case "mtb":
             case "racingbike":
             case "cargobike":
+            case "cargo_bike":
             case "cycling":
             case "biking":
                 return TransportationMode.BIKE;

--- a/core/src/main/java/com/graphhopper/config/Profile.java
+++ b/core/src/main/java/com/graphhopper/config/Profile.java
@@ -27,8 +27,8 @@ import com.graphhopper.util.Helper;
 import com.graphhopper.util.PMap;
 import com.graphhopper.util.TurnCostsConfig;
 
+import java.util.Arrays;
 import java.util.List;
-import java.util.Locale;
 
 import static java.util.Collections.emptyList;
 
@@ -113,15 +113,31 @@ public class Profile {
     }
 
     /**
-     * The mode of transportation the user of this profile navigates with, e.g. used for the turn instructions.
-     * It is specified via the profile entry "navigation_mode" and defaults to the profile name, or CAR.
+     * The base mode of transportation used when creating the instructions, i.e. which roads the driver
+     * perceives as usable (#3223) and which voice instruction distances fit. Restricted to CAR, BIKE or FOOT.
+     * It is specified via the profile entry "instructions_base_mode" and otherwise derived from the profile
+     * name, with CAR as fallback.
      */
     @JsonIgnore
-    public TransportationMode getNavigationMode() {
-        try {
-            return TransportationMode.valueOf(getHints().getString("navigation_mode", getName()).toUpperCase(Locale.ROOT));
-        } catch (IllegalArgumentException e) {
-            return TransportationMode.CAR;
+    public TransportationMode getInstructionsBaseMode() {
+        switch (Helper.toLowerCase(getHints().getString("instructions_base_mode", getName()))) {
+            case "bike":
+            case "bicycle":
+            case "mtb":
+            case "racingbike":
+            case "cargobike":
+            case "cycling":
+            case "biking":
+                return TransportationMode.BIKE;
+            case "foot":
+            case "hike":
+            case "hiking":
+            case "pedestrian":
+            case "walking":
+            case "walk":
+                return TransportationMode.FOOT;
+            default:
+                return TransportationMode.CAR;
         }
     }
 
@@ -136,6 +152,10 @@ public class Profile {
             throw new IllegalArgumentException("u_turn_costs no longer accepted in profile. Use the turn costs configuration instead, see docs/migration/config-migration-08-09.md");
         if (key.equals("vehicle"))
             throw new IllegalArgumentException("vehicle no longer accepted in profile, see docs/migration/config-migration-08-09.md");
+        if (key.equals("navigation_mode"))
+            throw new IllegalArgumentException("navigation_mode no longer accepted in profile, use instructions_base_mode instead");
+        if (key.equals("instructions_base_mode") && !Arrays.asList("car", "bike", "foot").contains(Helper.toLowerCase(value.toString())))
+            throw new IllegalArgumentException("instructions_base_mode must be car, bike or foot, but was: " + value);
         this.hints.putObject(key, value);
         return this;
     }

--- a/core/src/main/java/com/graphhopper/routing/InstructionsFromEdges.java
+++ b/core/src/main/java/com/graphhopper/routing/InstructionsFromEdges.java
@@ -295,7 +295,7 @@ public class InstructionsFromEdges implements Path.EdgeVisitor {
             RoundaboutInstruction rInstr = (RoundaboutInstruction) prevInstruction;
             rInstr.setRadian(deltaInOut).setDirOfRotation(deltaOut);
 
-            // we use an exit that is not considered as it is inaccessible by car (#3081)
+            // we use an exit that is not considered as it has no car or base access (#3081)
             if (rInstr.getExitNumber() == 0) rInstr.increaseExitNumber();
 
             if (includeRoundaboutExits) {

--- a/core/src/main/java/com/graphhopper/routing/InstructionsFromEdges.java
+++ b/core/src/main/java/com/graphhopper/routing/InstructionsFromEdges.java
@@ -37,6 +37,8 @@ import static com.graphhopper.util.Parameters.Details.*;
 public class InstructionsFromEdges implements Path.EdgeVisitor {
 
     private final Weighting weighting;
+    // without the query-time custom model, so roads it blocks stay visible for junction classification, see #3223
+    private final Weighting baseWeighting;
     private final NodeAccess nodeAccess;
 
     private final InstructionList ways;
@@ -93,9 +95,10 @@ public class InstructionsFromEdges implements Path.EdgeVisitor {
 
     private static final int MAX_U_TURN_DISTANCE = 35;
 
-    public InstructionsFromEdges(Graph graph, Weighting weighting, EncodedValueLookup evLookup,
+    public InstructionsFromEdges(Graph graph, Weighting weighting, Weighting baseWeighting, EncodedValueLookup evLookup,
                                  InstructionList ways, boolean includeRoundaboutExits) {
         this.weighting = weighting;
+        this.baseWeighting = baseWeighting;
         this.roundaboutEnc = evLookup.getBooleanEncodedValue(Roundabout.KEY);
         this.roadEnvEnc = evLookup.getEnumEncodedValue(RoadEnvironment.KEY, RoadEnvironment.class);
         this.roadClassEnc = evLookup.getEnumEncodedValue(RoadClass.KEY, RoadClass.class);
@@ -116,16 +119,22 @@ public class InstructionsFromEdges implements Path.EdgeVisitor {
         // if the current profile can use them.
         BooleanEncodedValue carAccessEnc = evLookup.getBooleanEncodedValue(VehicleAccess.key("car"));
         outEdgeExplorer = graph.createEdgeExplorer(edge -> edge.get(carAccessEnc)
-                || !edge.getReverse(carAccessEnc) && Double.isFinite(weighting.calcEdgeWeight(edge, false)));
+                || !edge.getReverse(carAccessEnc) && Double.isFinite(baseWeighting.calcEdgeWeight(edge, false)));
         allExplorer = graph.createEdgeExplorer();
     }
 
     public static InstructionList calcInstructions(Path path, Graph graph, Weighting weighting,
                                                    EncodedValueLookup evLookup, final Translation tr) {
-        return calcInstructions(path, graph, weighting, evLookup, tr, false);
+        return calcInstructions(path, graph, weighting, weighting, evLookup, tr, false);
     }
 
     public static InstructionList calcInstructions(Path path, Graph graph, Weighting weighting,
+                                                   EncodedValueLookup evLookup, final Translation tr,
+                                                   boolean includeRoundaboutExits) {
+        return calcInstructions(path, graph, weighting, weighting, evLookup, tr, includeRoundaboutExits);
+    }
+
+    public static InstructionList calcInstructions(Path path, Graph graph, Weighting weighting, Weighting baseWeighting,
                                                    EncodedValueLookup evLookup, final Translation tr,
                                                    boolean includeRoundaboutExits) {
         final InstructionList ways = new InstructionList(tr);
@@ -133,7 +142,7 @@ public class InstructionsFromEdges implements Path.EdgeVisitor {
             if (path.getEdgeCount() == 0) {
                 ways.add(new FinishInstruction(graph.getNodeAccess(), path.getEndNode()));
             } else {
-                path.forEveryEdge(new InstructionsFromEdges(graph, weighting, evLookup, ways, includeRoundaboutExits));
+                path.forEveryEdge(new InstructionsFromEdges(graph, weighting, baseWeighting, evLookup, ways, includeRoundaboutExits));
             }
         }
         return ways;
@@ -328,7 +337,7 @@ public class InstructionsFromEdges implements Path.EdgeVisitor {
                         && (sign < 0) == (prevInstruction.getSign() < 0)
                         && (Math.abs(sign) == Instruction.TURN_SLIGHT_RIGHT || Math.abs(sign) == Instruction.TURN_RIGHT || Math.abs(sign) == Instruction.TURN_SHARP_RIGHT)
                         && (Math.abs(prevInstruction.getSign()) == Instruction.TURN_SLIGHT_RIGHT || Math.abs(prevInstruction.getSign()) == Instruction.TURN_RIGHT || Math.abs(prevInstruction.getSign()) == Instruction.TURN_SHARP_RIGHT)
-                        && Double.isFinite(weighting.calcEdgeWeight(edge, false)) != Double.isFinite(weighting.calcEdgeWeight(edge, true))
+                        && Double.isFinite(baseWeighting.calcEdgeWeight(edge, false)) != Double.isFinite(baseWeighting.calcEdgeWeight(edge, true))
                         && InstructionsHelper.isSameName(prevInstructionName, name)) {
                     // Chances are good that this is a u-turn, we only need to check if the orientation matches
                     GHPoint point = InstructionsHelper.getPointForOrientationCalculation(edge, nodeAccess);
@@ -422,7 +431,7 @@ public class InstructionsFromEdges implements Path.EdgeVisitor {
         prevOrientation = AngleCalc.ANGLE_CALC.calcOrientation(doublePrevLat, doublePrevLon, prevLat, prevLon);
         int sign = InstructionsHelper.calculateSign(prevLat, prevLon, lat, lon, prevOrientation);
 
-        InstructionsOutgoingEdges outgoingEdges = new InstructionsOutgoingEdges(prevEdge, edge, weighting, maxSpeedEnc,
+        InstructionsOutgoingEdges outgoingEdges = new InstructionsOutgoingEdges(prevEdge, edge, baseWeighting, maxSpeedEnc,
                 roadClassEnc, roadClassLinkEnc, lanesEnc, allExplorer, nodeAccess, prevNode, baseNode, adjNode);
         int nrOfPossibleTurns = outgoingEdges.getAllowedTurns();
 

--- a/core/src/main/java/com/graphhopper/routing/InstructionsFromEdges.java
+++ b/core/src/main/java/com/graphhopper/routing/InstructionsFromEdges.java
@@ -19,6 +19,7 @@ package com.graphhopper.routing;
 
 import com.graphhopper.routing.ev.*;
 import com.graphhopper.routing.util.DirectedEdgeFilter;
+import com.graphhopper.routing.util.TransportationMode;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.Graph;
 import com.graphhopper.storage.NodeAccess;
@@ -98,6 +99,11 @@ public class InstructionsFromEdges implements Path.EdgeVisitor {
 
     public InstructionsFromEdges(Graph graph, Weighting weighting, EncodedValueLookup evLookup,
                                  InstructionList ways, boolean includeRoundaboutExits) {
+        this(graph, weighting, TransportationMode.CAR, evLookup, ways, includeRoundaboutExits);
+    }
+
+    public InstructionsFromEdges(Graph graph, Weighting weighting, TransportationMode navigationMode, EncodedValueLookup evLookup,
+                                 InstructionList ways, boolean includeRoundaboutExits) {
         this.weighting = weighting;
         this.roundaboutEnc = evLookup.getBooleanEncodedValue(Roundabout.KEY);
         this.roadEnvEnc = evLookup.getEnumEncodedValue(RoadEnvironment.KEY, RoadEnvironment.class);
@@ -114,14 +120,18 @@ public class InstructionsFromEdges implements Path.EdgeVisitor {
         prevRoadEnv = null;
         prevInstructionNeedsNameFallback = false;
 
-        // an edge is usable if cars can access it, even if it is blocked for the current request (#3223), or
-        // if it has no car access (cycleway, footway, ...) but the current request can use it
-        BooleanEncodedValue carAccessEnc = evLookup.getBooleanEncodedValue(VehicleAccess.key("car"));
+        // an edge is usable if the navigation_mode vehicle can access it, even if it is blocked for the
+        // current request (#3223), or if it has no such access but the current request can use it
+        String accessKey = VehicleAccess.key(Helper.toLowerCase(navigationMode.name()));
+        BooleanEncodedValue accessEnc = evLookup.hasEncodedValue(accessKey)
+                ? evLookup.getBooleanEncodedValue(accessKey)
+                : evLookup.getBooleanEncodedValue(VehicleAccess.key("car"));
         usableEdges = (edge, reverse) -> reverse
-                ? edge.getReverse(carAccessEnc) || Double.isFinite(weighting.calcEdgeWeight(edge, true))
-                : edge.get(carAccessEnc) || Double.isFinite(weighting.calcEdgeWeight(edge, false));
+                ? edge.getReverse(accessEnc) || Double.isFinite(weighting.calcEdgeWeight(edge, true))
+                : edge.get(accessEnc) || Double.isFinite(weighting.calcEdgeWeight(edge, false));
         // roundabout exits are counted like for a car: roads leading in for cars are not counted, even if the
         // current request could use them, see #3079
+        BooleanEncodedValue carAccessEnc = evLookup.getBooleanEncodedValue(VehicleAccess.key("car"));
         outEdgeExplorer = graph.createEdgeExplorer(edge -> edge.get(carAccessEnc)
                 || !edge.getReverse(carAccessEnc) && Double.isFinite(weighting.calcEdgeWeight(edge, false)));
         allExplorer = graph.createEdgeExplorer();
@@ -135,12 +145,18 @@ public class InstructionsFromEdges implements Path.EdgeVisitor {
     public static InstructionList calcInstructions(Path path, Graph graph, Weighting weighting,
                                                    EncodedValueLookup evLookup, final Translation tr,
                                                    boolean includeRoundaboutExits) {
+        return calcInstructions(path, graph, weighting, TransportationMode.CAR, evLookup, tr, includeRoundaboutExits);
+    }
+
+    public static InstructionList calcInstructions(Path path, Graph graph, Weighting weighting, TransportationMode navigationMode,
+                                                   EncodedValueLookup evLookup, final Translation tr,
+                                                   boolean includeRoundaboutExits) {
         final InstructionList ways = new InstructionList(tr);
         if (path.isFound()) {
             if (path.getEdgeCount() == 0) {
                 ways.add(new FinishInstruction(graph.getNodeAccess(), path.getEndNode()));
             } else {
-                path.forEveryEdge(new InstructionsFromEdges(graph, weighting, evLookup, ways, includeRoundaboutExits));
+                path.forEveryEdge(new InstructionsFromEdges(graph, weighting, navigationMode, evLookup, ways, includeRoundaboutExits));
             }
         }
         return ways;

--- a/core/src/main/java/com/graphhopper/routing/InstructionsFromEdges.java
+++ b/core/src/main/java/com/graphhopper/routing/InstructionsFromEdges.java
@@ -120,20 +120,21 @@ public class InstructionsFromEdges implements Path.EdgeVisitor {
         prevRoadEnv = null;
         prevInstructionNeedsNameFallback = false;
 
-        // an edge is usable if the instructions_base_mode vehicle can access it, even if it is blocked for
-        // the current request (#3223), or if it has no such access but the current request can use it
-        String accessKey = VehicleAccess.key(Helper.toLowerCase(instructionsBaseMode.name()));
-        BooleanEncodedValue accessEnc = evLookup.hasEncodedValue(accessKey)
-                ? evLookup.getBooleanEncodedValue(accessKey)
-                : evLookup.getBooleanEncodedValue(VehicleAccess.key("car"));
-        usableEdges = (edge, reverse) -> reverse
-                ? edge.getReverse(accessEnc) || Double.isFinite(weighting.calcEdgeWeight(edge, true))
-                : edge.get(accessEnc) || Double.isFinite(weighting.calcEdgeWeight(edge, false));
-        // roundabout exits are counted like for a car: roads leading in for cars are not counted, even if the
-        // current request could use them, see #3079
+        // the driver perceives an edge as accessible if it belongs to the general (car) road network or to the
+        // infrastructure of the instructions_base_mode vehicle, even if it is blocked for the current request (#3223)
         BooleanEncodedValue carAccessEnc = evLookup.getBooleanEncodedValue(VehicleAccess.key("car"));
-        outEdgeExplorer = graph.createEdgeExplorer(edge -> edge.get(carAccessEnc)
-                || !edge.getReverse(carAccessEnc) && Double.isFinite(weighting.calcEdgeWeight(edge, false)));
+        String accessKey = VehicleAccess.key(Helper.toLowerCase(instructionsBaseMode.name()));
+        BooleanEncodedValue baseAccessEnc = evLookup.hasEncodedValue(accessKey) ? evLookup.getBooleanEncodedValue(accessKey) : carAccessEnc;
+        DirectedEdgeFilter perceivedAccess = (edge, reverse) -> reverse
+                ? edge.getReverse(carAccessEnc) || edge.getReverse(baseAccessEnc)
+                : edge.get(carAccessEnc) || edge.get(baseAccessEnc);
+        // and an edge without such access (e.g. a path for the car mode) is usable if the current request can use it
+        usableEdges = (edge, reverse) -> perceivedAccess.accept(edge, reverse)
+                || Double.isFinite(weighting.calcEdgeWeight(edge, reverse));
+        // roundabout exits are counted the same way, but roads leading in are not counted, even if the
+        // current request could use them, see #3079
+        outEdgeExplorer = graph.createEdgeExplorer(edge -> perceivedAccess.accept(edge, false)
+                || !perceivedAccess.accept(edge, true) && Double.isFinite(weighting.calcEdgeWeight(edge, false)));
         allExplorer = graph.createEdgeExplorer();
     }
 

--- a/core/src/main/java/com/graphhopper/routing/InstructionsFromEdges.java
+++ b/core/src/main/java/com/graphhopper/routing/InstructionsFromEdges.java
@@ -102,7 +102,7 @@ public class InstructionsFromEdges implements Path.EdgeVisitor {
         this(graph, weighting, TransportationMode.CAR, evLookup, ways, includeRoundaboutExits);
     }
 
-    public InstructionsFromEdges(Graph graph, Weighting weighting, TransportationMode navigationMode, EncodedValueLookup evLookup,
+    public InstructionsFromEdges(Graph graph, Weighting weighting, TransportationMode instructionsBaseMode, EncodedValueLookup evLookup,
                                  InstructionList ways, boolean includeRoundaboutExits) {
         this.weighting = weighting;
         this.roundaboutEnc = evLookup.getBooleanEncodedValue(Roundabout.KEY);
@@ -120,9 +120,9 @@ public class InstructionsFromEdges implements Path.EdgeVisitor {
         prevRoadEnv = null;
         prevInstructionNeedsNameFallback = false;
 
-        // an edge is usable if the navigation_mode vehicle can access it, even if it is blocked for the
-        // current request (#3223), or if it has no such access but the current request can use it
-        String accessKey = VehicleAccess.key(Helper.toLowerCase(navigationMode.name()));
+        // an edge is usable if the instructions_base_mode vehicle can access it, even if it is blocked for
+        // the current request (#3223), or if it has no such access but the current request can use it
+        String accessKey = VehicleAccess.key(Helper.toLowerCase(instructionsBaseMode.name()));
         BooleanEncodedValue accessEnc = evLookup.hasEncodedValue(accessKey)
                 ? evLookup.getBooleanEncodedValue(accessKey)
                 : evLookup.getBooleanEncodedValue(VehicleAccess.key("car"));
@@ -148,7 +148,7 @@ public class InstructionsFromEdges implements Path.EdgeVisitor {
         return calcInstructions(path, graph, weighting, TransportationMode.CAR, evLookup, tr, includeRoundaboutExits);
     }
 
-    public static InstructionList calcInstructions(Path path, Graph graph, Weighting weighting, TransportationMode navigationMode,
+    public static InstructionList calcInstructions(Path path, Graph graph, Weighting weighting, TransportationMode instructionsBaseMode,
                                                    EncodedValueLookup evLookup, final Translation tr,
                                                    boolean includeRoundaboutExits) {
         final InstructionList ways = new InstructionList(tr);
@@ -156,7 +156,7 @@ public class InstructionsFromEdges implements Path.EdgeVisitor {
             if (path.getEdgeCount() == 0) {
                 ways.add(new FinishInstruction(graph.getNodeAccess(), path.getEndNode()));
             } else {
-                path.forEveryEdge(new InstructionsFromEdges(graph, weighting, navigationMode, evLookup, ways, includeRoundaboutExits));
+                path.forEveryEdge(new InstructionsFromEdges(graph, weighting, instructionsBaseMode, evLookup, ways, includeRoundaboutExits));
             }
         }
         return ways;

--- a/core/src/main/java/com/graphhopper/routing/InstructionsFromEdges.java
+++ b/core/src/main/java/com/graphhopper/routing/InstructionsFromEdges.java
@@ -125,16 +125,16 @@ public class InstructionsFromEdges implements Path.EdgeVisitor {
         BooleanEncodedValue carAccessEnc = evLookup.getBooleanEncodedValue(VehicleAccess.key("car"));
         String accessKey = VehicleAccess.key(Helper.toLowerCase(instructionsBaseMode.name()));
         BooleanEncodedValue baseAccessEnc = evLookup.hasEncodedValue(accessKey) ? evLookup.getBooleanEncodedValue(accessKey) : carAccessEnc;
-        DirectedEdgeFilter perceivedAccess = (edge, reverse) -> reverse
+        DirectedEdgeFilter carOrBaseAccess = (edge, reverse) -> reverse
                 ? edge.getReverse(carAccessEnc) || edge.getReverse(baseAccessEnc)
                 : edge.get(carAccessEnc) || edge.get(baseAccessEnc);
         // and an edge without such access (e.g. a path for the car mode) is usable if the current request can use it
-        usableEdges = (edge, reverse) -> perceivedAccess.accept(edge, reverse)
+        usableEdges = (edge, reverse) -> carOrBaseAccess.accept(edge, reverse)
                 || Double.isFinite(weighting.calcEdgeWeight(edge, reverse));
         // roundabout exits are counted the same way, but roads leading in are not counted, even if the
         // current request could use them, see #3079
-        outEdgeExplorer = graph.createEdgeExplorer(edge -> perceivedAccess.accept(edge, false)
-                || !perceivedAccess.accept(edge, true) && Double.isFinite(weighting.calcEdgeWeight(edge, false)));
+        outEdgeExplorer = graph.createEdgeExplorer(edge -> carOrBaseAccess.accept(edge, false)
+                || !carOrBaseAccess.accept(edge, true) && Double.isFinite(weighting.calcEdgeWeight(edge, false)));
         allExplorer = graph.createEdgeExplorer();
     }
 

--- a/core/src/main/java/com/graphhopper/routing/InstructionsFromEdges.java
+++ b/core/src/main/java/com/graphhopper/routing/InstructionsFromEdges.java
@@ -18,6 +18,7 @@
 package com.graphhopper.routing;
 
 import com.graphhopper.routing.ev.*;
+import com.graphhopper.routing.util.DirectedEdgeFilter;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.Graph;
 import com.graphhopper.storage.NodeAccess;
@@ -37,8 +38,8 @@ import static com.graphhopper.util.Parameters.Details.*;
 public class InstructionsFromEdges implements Path.EdgeVisitor {
 
     private final Weighting weighting;
-    // without the query-time custom model, so roads it blocks stay visible for junction classification, see #3223
-    private final Weighting baseWeighting;
+    // roads blocked for routing, e.g. via a custom model, are still visible to the driver, see #3223
+    private final DirectedEdgeFilter usableEdges;
     private final NodeAccess nodeAccess;
 
     private final InstructionList ways;
@@ -95,10 +96,9 @@ public class InstructionsFromEdges implements Path.EdgeVisitor {
 
     private static final int MAX_U_TURN_DISTANCE = 35;
 
-    public InstructionsFromEdges(Graph graph, Weighting weighting, Weighting baseWeighting, EncodedValueLookup evLookup,
+    public InstructionsFromEdges(Graph graph, Weighting weighting, EncodedValueLookup evLookup,
                                  InstructionList ways, boolean includeRoundaboutExits) {
         this.weighting = weighting;
-        this.baseWeighting = baseWeighting;
         this.roundaboutEnc = evLookup.getBooleanEncodedValue(Roundabout.KEY);
         this.roadEnvEnc = evLookup.getEnumEncodedValue(RoadEnvironment.KEY, RoadEnvironment.class);
         this.roadClassEnc = evLookup.getEnumEncodedValue(RoadClass.KEY, RoadClass.class);
@@ -114,27 +114,25 @@ public class InstructionsFromEdges implements Path.EdgeVisitor {
         prevRoadEnv = null;
         prevInstructionNeedsNameFallback = false;
 
-        // roundabout exits are counted like for a car (roads leading in for cars are not counted, even if the
-        // profile could use them, see #3079). Roads without any car access (cycleway, footway, ...) are counted
-        // if the current profile can use them.
+        // an edge is usable if cars can access it, even if it is blocked for the current request (#3223), or
+        // if it has no car access (cycleway, footway, ...) but the current request can use it
         BooleanEncodedValue carAccessEnc = evLookup.getBooleanEncodedValue(VehicleAccess.key("car"));
+        usableEdges = (edge, reverse) -> reverse
+                ? edge.getReverse(carAccessEnc) || Double.isFinite(weighting.calcEdgeWeight(edge, true))
+                : edge.get(carAccessEnc) || Double.isFinite(weighting.calcEdgeWeight(edge, false));
+        // roundabout exits are counted like for a car: roads leading in for cars are not counted, even if the
+        // current request could use them, see #3079
         outEdgeExplorer = graph.createEdgeExplorer(edge -> edge.get(carAccessEnc)
-                || !edge.getReverse(carAccessEnc) && Double.isFinite(baseWeighting.calcEdgeWeight(edge, false)));
+                || !edge.getReverse(carAccessEnc) && Double.isFinite(weighting.calcEdgeWeight(edge, false)));
         allExplorer = graph.createEdgeExplorer();
     }
 
     public static InstructionList calcInstructions(Path path, Graph graph, Weighting weighting,
                                                    EncodedValueLookup evLookup, final Translation tr) {
-        return calcInstructions(path, graph, weighting, weighting, evLookup, tr, false);
+        return calcInstructions(path, graph, weighting, evLookup, tr, false);
     }
 
     public static InstructionList calcInstructions(Path path, Graph graph, Weighting weighting,
-                                                   EncodedValueLookup evLookup, final Translation tr,
-                                                   boolean includeRoundaboutExits) {
-        return calcInstructions(path, graph, weighting, weighting, evLookup, tr, includeRoundaboutExits);
-    }
-
-    public static InstructionList calcInstructions(Path path, Graph graph, Weighting weighting, Weighting baseWeighting,
                                                    EncodedValueLookup evLookup, final Translation tr,
                                                    boolean includeRoundaboutExits) {
         final InstructionList ways = new InstructionList(tr);
@@ -142,7 +140,7 @@ public class InstructionsFromEdges implements Path.EdgeVisitor {
             if (path.getEdgeCount() == 0) {
                 ways.add(new FinishInstruction(graph.getNodeAccess(), path.getEndNode()));
             } else {
-                path.forEveryEdge(new InstructionsFromEdges(graph, weighting, baseWeighting, evLookup, ways, includeRoundaboutExits));
+                path.forEveryEdge(new InstructionsFromEdges(graph, weighting, evLookup, ways, includeRoundaboutExits));
             }
         }
         return ways;
@@ -337,7 +335,7 @@ public class InstructionsFromEdges implements Path.EdgeVisitor {
                         && (sign < 0) == (prevInstruction.getSign() < 0)
                         && (Math.abs(sign) == Instruction.TURN_SLIGHT_RIGHT || Math.abs(sign) == Instruction.TURN_RIGHT || Math.abs(sign) == Instruction.TURN_SHARP_RIGHT)
                         && (Math.abs(prevInstruction.getSign()) == Instruction.TURN_SLIGHT_RIGHT || Math.abs(prevInstruction.getSign()) == Instruction.TURN_RIGHT || Math.abs(prevInstruction.getSign()) == Instruction.TURN_SHARP_RIGHT)
-                        && Double.isFinite(baseWeighting.calcEdgeWeight(edge, false)) != Double.isFinite(baseWeighting.calcEdgeWeight(edge, true))
+                        && usableEdges.accept(edge, false) != usableEdges.accept(edge, true)
                         && InstructionsHelper.isSameName(prevInstructionName, name)) {
                     // Chances are good that this is a u-turn, we only need to check if the orientation matches
                     GHPoint point = InstructionsHelper.getPointForOrientationCalculation(edge, nodeAccess);
@@ -431,7 +429,7 @@ public class InstructionsFromEdges implements Path.EdgeVisitor {
         prevOrientation = AngleCalc.ANGLE_CALC.calcOrientation(doublePrevLat, doublePrevLon, prevLat, prevLon);
         int sign = InstructionsHelper.calculateSign(prevLat, prevLon, lat, lon, prevOrientation);
 
-        InstructionsOutgoingEdges outgoingEdges = new InstructionsOutgoingEdges(prevEdge, edge, baseWeighting, maxSpeedEnc,
+        InstructionsOutgoingEdges outgoingEdges = new InstructionsOutgoingEdges(prevEdge, edge, weighting, usableEdges, maxSpeedEnc,
                 roadClassEnc, roadClassLinkEnc, lanesEnc, allExplorer, nodeAccess, prevNode, baseNode, adjNode);
         int nrOfPossibleTurns = outgoingEdges.getAllowedTurns();
 

--- a/core/src/main/java/com/graphhopper/routing/InstructionsFromEdges.java
+++ b/core/src/main/java/com/graphhopper/routing/InstructionsFromEdges.java
@@ -39,7 +39,7 @@ import static com.graphhopper.util.Parameters.Details.*;
 public class InstructionsFromEdges implements Path.EdgeVisitor {
 
     private final Weighting weighting;
-    // roads blocked for routing, e.g. via a custom model, are still visible to the driver, see #3223
+    // This includes edges where car or base access is true, or where the weighting is finite, see #3223. (for 'base' see Profile.getInstructionsBaseMode)
     private final DirectedEdgeFilter candidateEdges;
     private final NodeAccess nodeAccess;
 

--- a/core/src/main/java/com/graphhopper/routing/InstructionsFromEdges.java
+++ b/core/src/main/java/com/graphhopper/routing/InstructionsFromEdges.java
@@ -40,7 +40,7 @@ public class InstructionsFromEdges implements Path.EdgeVisitor {
 
     private final Weighting weighting;
     // roads blocked for routing, e.g. via a custom model, are still visible to the driver, see #3223
-    private final DirectedEdgeFilter usableEdges;
+    private final DirectedEdgeFilter candidateEdges;
     private final NodeAccess nodeAccess;
 
     private final InstructionList ways;
@@ -128,8 +128,8 @@ public class InstructionsFromEdges implements Path.EdgeVisitor {
         DirectedEdgeFilter carOrBaseAccess = (edge, reverse) -> reverse
                 ? edge.getReverse(carAccessEnc) || edge.getReverse(baseAccessEnc)
                 : edge.get(carAccessEnc) || edge.get(baseAccessEnc);
-        // and an edge without such access (e.g. a path for the car mode) is usable if the current request can use it
-        usableEdges = (edge, reverse) -> carOrBaseAccess.accept(edge, reverse)
+        // and an edge without such access (e.g. a path for the car mode) is still a candidate if the current request can use it
+        candidateEdges = (edge, reverse) -> carOrBaseAccess.accept(edge, reverse)
                 || Double.isFinite(weighting.calcEdgeWeight(edge, reverse));
         // roundabout exits are counted the same way, but roads leading in are not counted, even if the
         // current request could use them, see #3079
@@ -352,7 +352,7 @@ public class InstructionsFromEdges implements Path.EdgeVisitor {
                         && (sign < 0) == (prevInstruction.getSign() < 0)
                         && (Math.abs(sign) == Instruction.TURN_SLIGHT_RIGHT || Math.abs(sign) == Instruction.TURN_RIGHT || Math.abs(sign) == Instruction.TURN_SHARP_RIGHT)
                         && (Math.abs(prevInstruction.getSign()) == Instruction.TURN_SLIGHT_RIGHT || Math.abs(prevInstruction.getSign()) == Instruction.TURN_RIGHT || Math.abs(prevInstruction.getSign()) == Instruction.TURN_SHARP_RIGHT)
-                        && usableEdges.accept(edge, false) != usableEdges.accept(edge, true)
+                        && candidateEdges.accept(edge, false) != candidateEdges.accept(edge, true)
                         && InstructionsHelper.isSameName(prevInstructionName, name)) {
                     // Chances are good that this is a u-turn, we only need to check if the orientation matches
                     GHPoint point = InstructionsHelper.getPointForOrientationCalculation(edge, nodeAccess);
@@ -446,7 +446,7 @@ public class InstructionsFromEdges implements Path.EdgeVisitor {
         prevOrientation = AngleCalc.ANGLE_CALC.calcOrientation(doublePrevLat, doublePrevLon, prevLat, prevLon);
         int sign = InstructionsHelper.calculateSign(prevLat, prevLon, lat, lon, prevOrientation);
 
-        InstructionsOutgoingEdges outgoingEdges = new InstructionsOutgoingEdges(prevEdge, edge, weighting, usableEdges, maxSpeedEnc,
+        InstructionsOutgoingEdges outgoingEdges = new InstructionsOutgoingEdges(prevEdge, edge, weighting, candidateEdges, maxSpeedEnc,
                 roadClassEnc, roadClassLinkEnc, lanesEnc, allExplorer, nodeAccess, prevNode, baseNode, adjNode);
         int nrOfPossibleTurns = outgoingEdges.getAllowedTurns();
 

--- a/core/src/main/java/com/graphhopper/routing/InstructionsOutgoingEdges.java
+++ b/core/src/main/java/com/graphhopper/routing/InstructionsOutgoingEdges.java
@@ -18,6 +18,7 @@
 package com.graphhopper.routing;
 
 import com.graphhopper.routing.ev.*;
+import com.graphhopper.routing.util.DirectedEdgeFilter;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.NodeAccess;
 import com.graphhopper.util.EdgeExplorer;
@@ -65,12 +66,14 @@ class InstructionsOutgoingEdges {
     private final IntEncodedValue lanesEnc;
     private final NodeAccess nodeAccess;
     private final Weighting weighting;
+    private final DirectedEdgeFilter usableEdges;
     private final int baseNode;
     private final EdgeExplorer allExplorer;
 
     public InstructionsOutgoingEdges(EdgeIteratorState prevEdge,
                                      EdgeIteratorState currentEdge,
                                      Weighting weighting,
+                                     DirectedEdgeFilter usableEdges,
                                      DecimalEncodedValue maxSpeedEnc,
                                      EnumEncodedValue<RoadClass> roadClassEnc,
                                      BooleanEncodedValue roadClassLinkEnc,
@@ -83,6 +86,7 @@ class InstructionsOutgoingEdges {
         this.prevEdge = prevEdge;
         this.currentEdge = currentEdge;
         this.weighting = weighting;
+        this.usableEdges = usableEdges;
         this.maxSpeedEnc = maxSpeedEnc;
         this.roadClassEnc = roadClassEnc;
         this.roadClassLinkEnc = roadClassLinkEnc;
@@ -96,11 +100,11 @@ class InstructionsOutgoingEdges {
         EdgeIterator edgeIter = allExplorer.setBaseNode(baseNode);
         while (edgeIter.next()) {
             if (edgeIter.getAdjNode() != prevNode && edgeIter.getAdjNode() != adjNode) {
-                if (Double.isFinite(weighting.calcEdgeWeight(edgeIter, false))) {
+                if (usableEdges.accept(edgeIter, false)) {
                     EdgeIteratorState tmpEdge = edgeIter.detach(false);
                     allowedAlternativeTurns.add(tmpEdge);
                     visibleAlternativeTurns.add(tmpEdge);
-                } else if (Double.isFinite(weighting.calcEdgeWeight(edgeIter, true))) {
+                } else if (usableEdges.accept(edgeIter, true)) {
                     visibleAlternativeTurns.add(edgeIter.detach(false));
                 }
             }
@@ -223,23 +227,22 @@ class InstructionsOutgoingEdges {
                     && prevEdge.getEdge() != edgeIter.getEdge()
                     && roadClass == edgeIter.get(roadClassEnc)
                     && InstructionsHelper.isSameName(name, edgeIter.getName())
-                    && (Double.isFinite(weighting.calcEdgeWeight(edgeIter, false))
-                    || Double.isFinite(weighting.calcEdgeWeight(edgeIter, true)))) {
+                    && (usableEdges.accept(edgeIter, false) || usableEdges.accept(edgeIter, true))) {
                 if (otherEdge != null) return false; // too many possible other edges
                 otherEdge = edgeIter.detach(false);
             }
         }
         if (otherEdge == null) return false;
 
-        if (Double.isFinite(weighting.calcEdgeWeight(currentEdge, true))) {
+        if (usableEdges.accept(currentEdge, true)) {
             // assume two ways are merged into one way
             // -> prev ->
             //              <- edge ->
             // -> other ->
-            if (Double.isFinite(weighting.calcEdgeWeight(prevEdge, true))) return false;
+            if (usableEdges.accept(prevEdge, true)) return false;
             // otherEdge has direction from junction outwards
-            if (!Double.isFinite(weighting.calcEdgeWeight(otherEdge, false))) return false;
-            if (Double.isFinite(weighting.calcEdgeWeight(otherEdge, true))) return false;
+            if (!usableEdges.accept(otherEdge, false)) return false;
+            if (usableEdges.accept(otherEdge, true)) return false;
 
             int delta = Math.abs(prevEdge.get(lanesEnc) + otherEdge.get(lanesEnc) - currentEdge.get(lanesEnc));
             return delta <= 1;
@@ -249,10 +252,10 @@ class InstructionsOutgoingEdges {
         //             -> edge ->
         // <- prev ->
         //             -> other ->
-        if (!Double.isFinite(weighting.calcEdgeWeight(prevEdge, true))) return false;
+        if (!usableEdges.accept(prevEdge, true)) return false;
         // otherEdge has direction from junction outwards
-        if (Double.isFinite(weighting.calcEdgeWeight(otherEdge, false))) return false;
-        if (!Double.isFinite(weighting.calcEdgeWeight(otherEdge, true))) return false;
+        if (usableEdges.accept(otherEdge, false)) return false;
+        if (!usableEdges.accept(otherEdge, true)) return false;
 
         int delta = prevEdge.get(lanesEnc) - (currentEdge.get(lanesEnc) + otherEdge.get(lanesEnc));
         return delta <= 1;

--- a/core/src/main/java/com/graphhopper/routing/InstructionsOutgoingEdges.java
+++ b/core/src/main/java/com/graphhopper/routing/InstructionsOutgoingEdges.java
@@ -66,14 +66,14 @@ class InstructionsOutgoingEdges {
     private final IntEncodedValue lanesEnc;
     private final NodeAccess nodeAccess;
     private final Weighting weighting;
-    private final DirectedEdgeFilter usableEdges;
+    private final DirectedEdgeFilter candidateEdges;
     private final int baseNode;
     private final EdgeExplorer allExplorer;
 
     public InstructionsOutgoingEdges(EdgeIteratorState prevEdge,
                                      EdgeIteratorState currentEdge,
                                      Weighting weighting,
-                                     DirectedEdgeFilter usableEdges,
+                                     DirectedEdgeFilter candidateEdges,
                                      DecimalEncodedValue maxSpeedEnc,
                                      EnumEncodedValue<RoadClass> roadClassEnc,
                                      BooleanEncodedValue roadClassLinkEnc,
@@ -86,7 +86,7 @@ class InstructionsOutgoingEdges {
         this.prevEdge = prevEdge;
         this.currentEdge = currentEdge;
         this.weighting = weighting;
-        this.usableEdges = usableEdges;
+        this.candidateEdges = candidateEdges;
         this.maxSpeedEnc = maxSpeedEnc;
         this.roadClassEnc = roadClassEnc;
         this.roadClassLinkEnc = roadClassLinkEnc;
@@ -100,11 +100,11 @@ class InstructionsOutgoingEdges {
         EdgeIterator edgeIter = allExplorer.setBaseNode(baseNode);
         while (edgeIter.next()) {
             if (edgeIter.getAdjNode() != prevNode && edgeIter.getAdjNode() != adjNode) {
-                if (usableEdges.accept(edgeIter, false)) {
+                if (candidateEdges.accept(edgeIter, false)) {
                     EdgeIteratorState tmpEdge = edgeIter.detach(false);
                     allowedAlternativeTurns.add(tmpEdge);
                     visibleAlternativeTurns.add(tmpEdge);
-                } else if (usableEdges.accept(edgeIter, true)) {
+                } else if (candidateEdges.accept(edgeIter, true)) {
                     visibleAlternativeTurns.add(edgeIter.detach(false));
                 }
             }
@@ -227,22 +227,22 @@ class InstructionsOutgoingEdges {
                     && prevEdge.getEdge() != edgeIter.getEdge()
                     && roadClass == edgeIter.get(roadClassEnc)
                     && InstructionsHelper.isSameName(name, edgeIter.getName())
-                    && (usableEdges.accept(edgeIter, false) || usableEdges.accept(edgeIter, true))) {
+                    && (candidateEdges.accept(edgeIter, false) || candidateEdges.accept(edgeIter, true))) {
                 if (otherEdge != null) return false; // too many possible other edges
                 otherEdge = edgeIter.detach(false);
             }
         }
         if (otherEdge == null) return false;
 
-        if (usableEdges.accept(currentEdge, true)) {
+        if (candidateEdges.accept(currentEdge, true)) {
             // assume two ways are merged into one way
             // -> prev ->
             //              <- edge ->
             // -> other ->
-            if (usableEdges.accept(prevEdge, true)) return false;
+            if (candidateEdges.accept(prevEdge, true)) return false;
             // otherEdge has direction from junction outwards
-            if (!usableEdges.accept(otherEdge, false)) return false;
-            if (usableEdges.accept(otherEdge, true)) return false;
+            if (!candidateEdges.accept(otherEdge, false)) return false;
+            if (candidateEdges.accept(otherEdge, true)) return false;
 
             int delta = Math.abs(prevEdge.get(lanesEnc) + otherEdge.get(lanesEnc) - currentEdge.get(lanesEnc));
             return delta <= 1;
@@ -252,10 +252,10 @@ class InstructionsOutgoingEdges {
         //             -> edge ->
         // <- prev ->
         //             -> other ->
-        if (!usableEdges.accept(prevEdge, true)) return false;
+        if (!candidateEdges.accept(prevEdge, true)) return false;
         // otherEdge has direction from junction outwards
-        if (usableEdges.accept(otherEdge, false)) return false;
-        if (!usableEdges.accept(otherEdge, true)) return false;
+        if (candidateEdges.accept(otherEdge, false)) return false;
+        if (!candidateEdges.accept(otherEdge, true)) return false;
 
         int delta = prevEdge.get(lanesEnc) - (currentEdge.get(lanesEnc) + otherEdge.get(lanesEnc));
         return delta <= 1;

--- a/core/src/main/java/com/graphhopper/routing/InstructionsOutgoingEdges.java
+++ b/core/src/main/java/com/graphhopper/routing/InstructionsOutgoingEdges.java
@@ -34,9 +34,10 @@ import java.util.List;
  * There are different sets of edges.
  * The previous edge is the edge we are coming from.
  * The current edge is the edge we turn on.
- * The allowedAlternativeTurns contains all edges that the current vehicle is allowed(*) to turn on to, excluding the prev edge and the current edge.
+ * The allowedAlternativeTurns contains all edges that the driver perceives(*) as turn options, excluding the prev edge and the current edge.
  * The visibleAlternativeTurns contains all edges surrounding this turn instruction, without the prev edge and the current edge.
- * (*): This might not consider turn restrictions, but only simple access values.
+ * (*): Since #3223 this can include edges blocked for the current request, e.g. via a custom model, as long as
+ * they have car or base access. Turn restrictions are not considered.
  * Here is an example:
  * <pre>
  * A --> B --> C

--- a/core/src/main/java/com/graphhopper/routing/Router.java
+++ b/core/src/main/java/com/graphhopper/routing/Router.java
@@ -221,7 +221,7 @@ public class Router {
         // we merge the different legs of the roundtrip into one response path
         // note that the waypoints are not just the snapped points of the snaps, as usual, because we do some kind of tweak
         // to avoid 'unnecessary tails' in the roundtrip algo
-        ResponsePath responsePath = concatenatePaths(request, solver.weighting, queryGraph, result.paths, result.wayPoints);
+        ResponsePath responsePath = concatenatePaths(request, solver, queryGraph, result.paths, result.wayPoints);
         ghRsp.add(responsePath);
         ghRsp.getHints().putObject("visited_nodes.sum", result.visitedNodes);
         ghRsp.getHints().putObject("visited_nodes.average", (float) result.visitedNodes / (snaps.size() - 1));
@@ -252,7 +252,7 @@ public class Router {
             throw new RuntimeException("Empty paths for alternative route calculation not expected");
 
         // each path represents a different alternative and we do the path merging for each of them
-        PathMerger pathMerger = createPathMerger(request, solver.weighting, queryGraph);
+        PathMerger pathMerger = createPathMerger(request, solver, queryGraph);
         for (Path path : result.paths) {
             PointList waypoints = getWaypoints(snaps);
             ResponsePath responsePath = pathMerger.doWork(waypoints, Collections.singletonList(path), encodingManager, translationMap.getWithFallBack(request.getLocale()));
@@ -283,7 +283,7 @@ public class Router {
             throw new RuntimeException("There should be exactly one more point than paths. points:" + request.getPoints().size() + ", paths:" + result.paths.size());
 
         // here each path represents one leg of the via-route and we merge them all together into one response path
-        ResponsePath responsePath = concatenatePaths(request, solver.weighting, queryGraph, result.paths, getWaypoints(snaps));
+        ResponsePath responsePath = concatenatePaths(request, solver, queryGraph, result.paths, getWaypoints(snaps));
         responsePath.addDebugInfo(result.debug);
         ghRsp.add(responsePath);
         ghRsp.getHints().putObject("visited_nodes.sum", result.visitedNodes);
@@ -291,7 +291,7 @@ public class Router {
         return ghRsp;
     }
 
-    private PathMerger createPathMerger(GHRequest request, Weighting weighting, Graph graph) {
+    private PathMerger createPathMerger(GHRequest request, Solver solver, Graph graph) {
         boolean enableInstructions = request.getHints().getBool(Parameters.Routing.INSTRUCTIONS, routerConfig.isInstructionsEnabled());
         boolean includeRoundaboutExitInstruction = request.getHints().getBool(Parameters.Routing.ROUNDABOUT_EXITS, false);
         boolean enableViaPointInstructions = request.getHints().getBool(Parameters.Routing.VIA_POINT_INSTRUCTIONS, routerConfig.isViaPointInstructionsEnabled());
@@ -302,7 +302,7 @@ public class Router {
         RamerDouglasPeucker peucker = new RamerDouglasPeucker().
                 setMaxDistance(wayPointMaxDistance).
                 setElevationMaxDistance(elevationWayPointMaxDistance);
-        PathMerger pathMerger = new PathMerger(graph, weighting).
+        PathMerger pathMerger = new PathMerger(graph, solver.weighting, solver.baseWeighting).
                 setCalcPoints(calcPoints).
                 setRamerDouglasPeucker(peucker).
                 setEnableInstructions(enableInstructions).
@@ -316,8 +316,8 @@ public class Router {
         return pathMerger;
     }
 
-    private ResponsePath concatenatePaths(GHRequest request, Weighting weighting, QueryGraph queryGraph, List<Path> paths, PointList waypoints) {
-        PathMerger pathMerger = createPathMerger(request, weighting, queryGraph);
+    private ResponsePath concatenatePaths(GHRequest request, Solver solver, QueryGraph queryGraph, List<Path> paths, PointList waypoints) {
+        PathMerger pathMerger = createPathMerger(request, solver, queryGraph);
         return pathMerger.doWork(waypoints, paths, encodingManager, translationMap.getWithFallBack(request.getLocale()));
     }
 
@@ -354,6 +354,7 @@ public class Router {
         private final RouterConfig routerConfig;
         protected Profile profile;
         protected Weighting weighting;
+        protected Weighting baseWeighting;
         protected final EncodedValueLookup lookup;
 
         public Solver(GHRequest request, Map<String, Profile> profilesByName, RouterConfig routerConfig, EncodedValueLookup lookup) {
@@ -382,6 +383,7 @@ public class Router {
             profile = getProfile();
             checkProfileCompatibility();
             weighting = createWeighting();
+            baseWeighting = createBaseWeighting();
         }
 
         protected Profile getProfile() {
@@ -406,6 +408,13 @@ public class Router {
         }
 
         protected abstract Weighting createWeighting();
+
+        /**
+         * The weighting without the query-time custom model, used for the turn instructions, see #3223.
+         */
+        protected Weighting createBaseWeighting() {
+            return weighting;
+        }
 
         protected EdgeFilter createSnapFilter() {
             return new DefaultSnapFilter(weighting, lookup.getBooleanEncodedValue(Subnetwork.key(profile.getName())));
@@ -519,6 +528,13 @@ public class Router {
             PMap requestHints = new PMap(request.getHints());
             requestHints.putObject(CustomModel.KEY, request.getCustomModel());
             return weightingFactory.createWeighting(profile, requestHints, false);
+        }
+
+        @Override
+        protected Weighting createBaseWeighting() {
+            if (request.getCustomModel() == null) return weighting;
+            // turn costs are irrelevant as only edge weights are checked
+            return weightingFactory.createWeighting(profile, new PMap(request.getHints()), true);
         }
 
         @Override

--- a/core/src/main/java/com/graphhopper/routing/Router.java
+++ b/core/src/main/java/com/graphhopper/routing/Router.java
@@ -303,6 +303,7 @@ public class Router {
                 setMaxDistance(wayPointMaxDistance).
                 setElevationMaxDistance(elevationWayPointMaxDistance);
         PathMerger pathMerger = new PathMerger(graph, weighting).
+                setNavigationMode(profilesByName.get(request.getProfile()).getNavigationMode()).
                 setCalcPoints(calcPoints).
                 setRamerDouglasPeucker(peucker).
                 setEnableInstructions(enableInstructions).

--- a/core/src/main/java/com/graphhopper/routing/Router.java
+++ b/core/src/main/java/com/graphhopper/routing/Router.java
@@ -303,7 +303,7 @@ public class Router {
                 setMaxDistance(wayPointMaxDistance).
                 setElevationMaxDistance(elevationWayPointMaxDistance);
         PathMerger pathMerger = new PathMerger(graph, weighting).
-                setNavigationMode(profilesByName.get(request.getProfile()).getNavigationMode()).
+                setInstructionsBaseMode(profilesByName.get(request.getProfile()).getInstructionsBaseMode()).
                 setCalcPoints(calcPoints).
                 setRamerDouglasPeucker(peucker).
                 setEnableInstructions(enableInstructions).

--- a/core/src/main/java/com/graphhopper/routing/Router.java
+++ b/core/src/main/java/com/graphhopper/routing/Router.java
@@ -221,7 +221,7 @@ public class Router {
         // we merge the different legs of the roundtrip into one response path
         // note that the waypoints are not just the snapped points of the snaps, as usual, because we do some kind of tweak
         // to avoid 'unnecessary tails' in the roundtrip algo
-        ResponsePath responsePath = concatenatePaths(request, solver, queryGraph, result.paths, result.wayPoints);
+        ResponsePath responsePath = concatenatePaths(request, solver.weighting, queryGraph, result.paths, result.wayPoints);
         ghRsp.add(responsePath);
         ghRsp.getHints().putObject("visited_nodes.sum", result.visitedNodes);
         ghRsp.getHints().putObject("visited_nodes.average", (float) result.visitedNodes / (snaps.size() - 1));
@@ -252,7 +252,7 @@ public class Router {
             throw new RuntimeException("Empty paths for alternative route calculation not expected");
 
         // each path represents a different alternative and we do the path merging for each of them
-        PathMerger pathMerger = createPathMerger(request, solver, queryGraph);
+        PathMerger pathMerger = createPathMerger(request, solver.weighting, queryGraph);
         for (Path path : result.paths) {
             PointList waypoints = getWaypoints(snaps);
             ResponsePath responsePath = pathMerger.doWork(waypoints, Collections.singletonList(path), encodingManager, translationMap.getWithFallBack(request.getLocale()));
@@ -283,7 +283,7 @@ public class Router {
             throw new RuntimeException("There should be exactly one more point than paths. points:" + request.getPoints().size() + ", paths:" + result.paths.size());
 
         // here each path represents one leg of the via-route and we merge them all together into one response path
-        ResponsePath responsePath = concatenatePaths(request, solver, queryGraph, result.paths, getWaypoints(snaps));
+        ResponsePath responsePath = concatenatePaths(request, solver.weighting, queryGraph, result.paths, getWaypoints(snaps));
         responsePath.addDebugInfo(result.debug);
         ghRsp.add(responsePath);
         ghRsp.getHints().putObject("visited_nodes.sum", result.visitedNodes);
@@ -291,7 +291,7 @@ public class Router {
         return ghRsp;
     }
 
-    private PathMerger createPathMerger(GHRequest request, Solver solver, Graph graph) {
+    private PathMerger createPathMerger(GHRequest request, Weighting weighting, Graph graph) {
         boolean enableInstructions = request.getHints().getBool(Parameters.Routing.INSTRUCTIONS, routerConfig.isInstructionsEnabled());
         boolean includeRoundaboutExitInstruction = request.getHints().getBool(Parameters.Routing.ROUNDABOUT_EXITS, false);
         boolean enableViaPointInstructions = request.getHints().getBool(Parameters.Routing.VIA_POINT_INSTRUCTIONS, routerConfig.isViaPointInstructionsEnabled());
@@ -302,7 +302,7 @@ public class Router {
         RamerDouglasPeucker peucker = new RamerDouglasPeucker().
                 setMaxDistance(wayPointMaxDistance).
                 setElevationMaxDistance(elevationWayPointMaxDistance);
-        PathMerger pathMerger = new PathMerger(graph, solver.weighting, solver.baseWeighting).
+        PathMerger pathMerger = new PathMerger(graph, weighting).
                 setCalcPoints(calcPoints).
                 setRamerDouglasPeucker(peucker).
                 setEnableInstructions(enableInstructions).
@@ -316,8 +316,8 @@ public class Router {
         return pathMerger;
     }
 
-    private ResponsePath concatenatePaths(GHRequest request, Solver solver, QueryGraph queryGraph, List<Path> paths, PointList waypoints) {
-        PathMerger pathMerger = createPathMerger(request, solver, queryGraph);
+    private ResponsePath concatenatePaths(GHRequest request, Weighting weighting, QueryGraph queryGraph, List<Path> paths, PointList waypoints) {
+        PathMerger pathMerger = createPathMerger(request, weighting, queryGraph);
         return pathMerger.doWork(waypoints, paths, encodingManager, translationMap.getWithFallBack(request.getLocale()));
     }
 
@@ -354,7 +354,6 @@ public class Router {
         private final RouterConfig routerConfig;
         protected Profile profile;
         protected Weighting weighting;
-        protected Weighting baseWeighting;
         protected final EncodedValueLookup lookup;
 
         public Solver(GHRequest request, Map<String, Profile> profilesByName, RouterConfig routerConfig, EncodedValueLookup lookup) {
@@ -383,7 +382,6 @@ public class Router {
             profile = getProfile();
             checkProfileCompatibility();
             weighting = createWeighting();
-            baseWeighting = createBaseWeighting();
         }
 
         protected Profile getProfile() {
@@ -408,13 +406,6 @@ public class Router {
         }
 
         protected abstract Weighting createWeighting();
-
-        /**
-         * The weighting without the query-time custom model, used for the turn instructions, see #3223.
-         */
-        protected Weighting createBaseWeighting() {
-            return weighting;
-        }
 
         protected EdgeFilter createSnapFilter() {
             return new DefaultSnapFilter(weighting, lookup.getBooleanEncodedValue(Subnetwork.key(profile.getName())));
@@ -528,13 +519,6 @@ public class Router {
             PMap requestHints = new PMap(request.getHints());
             requestHints.putObject(CustomModel.KEY, request.getCustomModel());
             return weightingFactory.createWeighting(profile, requestHints, false);
-        }
-
-        @Override
-        protected Weighting createBaseWeighting() {
-            if (request.getCustomModel() == null) return weighting;
-            // turn costs are irrelevant as only edge weights are checked
-            return weightingFactory.createWeighting(profile, new PMap(request.getHints()), true);
         }
 
         @Override

--- a/core/src/main/java/com/graphhopper/util/PathMerger.java
+++ b/core/src/main/java/com/graphhopper/util/PathMerger.java
@@ -48,6 +48,7 @@ public class PathMerger {
     private static final RamerDouglasPeucker RDP = new RamerDouglasPeucker();
     private final Graph graph;
     private final Weighting weighting;
+    private final Weighting baseWeighting;
 
     private boolean enableInstructions = true;
     private boolean includeRoundaboutExitInstruction = false;
@@ -60,8 +61,13 @@ public class PathMerger {
     private double favoredHeading = Double.NaN;
 
     public PathMerger(Graph graph, Weighting weighting) {
+        this(graph, weighting, weighting);
+    }
+
+    public PathMerger(Graph graph, Weighting weighting, Weighting baseWeighting) {
         this.graph = graph;
         this.weighting = graph.wrapWeighting(weighting);
+        this.baseWeighting = graph.wrapWeighting(baseWeighting);
     }
 
     public PathMerger setCalcPoints(boolean calcPoints) {
@@ -123,7 +129,7 @@ public class PathMerger {
             fullDistance_mm += path.getDistance_mm();
             fullWeight += path.getWeight();
             if (enableInstructions) {
-                InstructionList il = InstructionsFromEdges.calcInstructions(path, graph, weighting, evLookup, tr, includeRoundaboutExitInstruction);
+                InstructionList il = InstructionsFromEdges.calcInstructions(path, graph, weighting, baseWeighting, evLookup, tr, includeRoundaboutExitInstruction);
 
                 if (!il.isEmpty()) {
                     fullInstructions.addAll(il);

--- a/core/src/main/java/com/graphhopper/util/PathMerger.java
+++ b/core/src/main/java/com/graphhopper/util/PathMerger.java
@@ -56,7 +56,7 @@ public class PathMerger {
     private boolean simplifyResponse = true;
     private RamerDouglasPeucker ramerDouglasPeucker = RDP;
     private boolean calcPoints = true;
-    private TransportationMode navigationMode = TransportationMode.CAR;
+    private TransportationMode instructionsBaseMode = TransportationMode.CAR;
     private PathDetailsBuilderFactory pathBuilderFactory;
     private List<String> requestedPathDetails = Collections.emptyList();
     private double favoredHeading = Double.NaN;
@@ -66,8 +66,8 @@ public class PathMerger {
         this.weighting = graph.wrapWeighting(weighting);
     }
 
-    public PathMerger setNavigationMode(TransportationMode navigationMode) {
-        this.navigationMode = navigationMode;
+    public PathMerger setInstructionsBaseMode(TransportationMode instructionsBaseMode) {
+        this.instructionsBaseMode = instructionsBaseMode;
         return this;
     }
 
@@ -130,7 +130,7 @@ public class PathMerger {
             fullDistance_mm += path.getDistance_mm();
             fullWeight += path.getWeight();
             if (enableInstructions) {
-                InstructionList il = InstructionsFromEdges.calcInstructions(path, graph, weighting, navigationMode, evLookup, tr, includeRoundaboutExitInstruction);
+                InstructionList il = InstructionsFromEdges.calcInstructions(path, graph, weighting, instructionsBaseMode, evLookup, tr, includeRoundaboutExitInstruction);
 
                 if (!il.isEmpty()) {
                     fullInstructions.addAll(il);

--- a/core/src/main/java/com/graphhopper/util/PathMerger.java
+++ b/core/src/main/java/com/graphhopper/util/PathMerger.java
@@ -21,6 +21,7 @@ import com.graphhopper.ResponsePath;
 import com.graphhopper.routing.InstructionsFromEdges;
 import com.graphhopper.routing.Path;
 import com.graphhopper.routing.ev.EncodedValueLookup;
+import com.graphhopper.routing.util.TransportationMode;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.Graph;
 import com.graphhopper.util.details.PathDetailsBuilderFactory;
@@ -55,6 +56,7 @@ public class PathMerger {
     private boolean simplifyResponse = true;
     private RamerDouglasPeucker ramerDouglasPeucker = RDP;
     private boolean calcPoints = true;
+    private TransportationMode navigationMode = TransportationMode.CAR;
     private PathDetailsBuilderFactory pathBuilderFactory;
     private List<String> requestedPathDetails = Collections.emptyList();
     private double favoredHeading = Double.NaN;
@@ -62,6 +64,11 @@ public class PathMerger {
     public PathMerger(Graph graph, Weighting weighting) {
         this.graph = graph;
         this.weighting = graph.wrapWeighting(weighting);
+    }
+
+    public PathMerger setNavigationMode(TransportationMode navigationMode) {
+        this.navigationMode = navigationMode;
+        return this;
     }
 
     public PathMerger setCalcPoints(boolean calcPoints) {
@@ -123,7 +130,7 @@ public class PathMerger {
             fullDistance_mm += path.getDistance_mm();
             fullWeight += path.getWeight();
             if (enableInstructions) {
-                InstructionList il = InstructionsFromEdges.calcInstructions(path, graph, weighting, evLookup, tr, includeRoundaboutExitInstruction);
+                InstructionList il = InstructionsFromEdges.calcInstructions(path, graph, weighting, navigationMode, evLookup, tr, includeRoundaboutExitInstruction);
 
                 if (!il.isEmpty()) {
                     fullInstructions.addAll(il);

--- a/core/src/main/java/com/graphhopper/util/PathMerger.java
+++ b/core/src/main/java/com/graphhopper/util/PathMerger.java
@@ -48,7 +48,6 @@ public class PathMerger {
     private static final RamerDouglasPeucker RDP = new RamerDouglasPeucker();
     private final Graph graph;
     private final Weighting weighting;
-    private final Weighting baseWeighting;
 
     private boolean enableInstructions = true;
     private boolean includeRoundaboutExitInstruction = false;
@@ -61,13 +60,8 @@ public class PathMerger {
     private double favoredHeading = Double.NaN;
 
     public PathMerger(Graph graph, Weighting weighting) {
-        this(graph, weighting, weighting);
-    }
-
-    public PathMerger(Graph graph, Weighting weighting, Weighting baseWeighting) {
         this.graph = graph;
         this.weighting = graph.wrapWeighting(weighting);
-        this.baseWeighting = graph.wrapWeighting(baseWeighting);
     }
 
     public PathMerger setCalcPoints(boolean calcPoints) {
@@ -129,7 +123,7 @@ public class PathMerger {
             fullDistance_mm += path.getDistance_mm();
             fullWeight += path.getWeight();
             if (enableInstructions) {
-                InstructionList il = InstructionsFromEdges.calcInstructions(path, graph, weighting, baseWeighting, evLookup, tr, includeRoundaboutExitInstruction);
+                InstructionList il = InstructionsFromEdges.calcInstructions(path, graph, weighting, evLookup, tr, includeRoundaboutExitInstruction);
 
                 if (!il.isEmpty()) {
                     fullInstructions.addAll(il);

--- a/core/src/test/java/com/graphhopper/routing/HeadingAndCustomModelRoutingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/HeadingAndCustomModelRoutingTest.java
@@ -397,11 +397,70 @@ class HeadingAndCustomModelRoutingTest {
         assertEquals("Side", il.get(1).getName());
     }
 
+    @Test
+    public void testTurnInstructionAtBlockedAreaForBike() {
+        BooleanEncodedValue accessEnc = VehicleAccess.create("bike");
+        DecimalEncodedValue speedEnc = VehicleSpeed.create("bike", 4, 2, false);
+        EncodingManager encodingManager = new EncodingManager.Builder().add(accessEnc).add(speedEnc)
+                .add(VehicleAccess.create("car"))
+                .add(RoadClass.create())
+                .add(RoadClassLink.create())
+                .add(RoadEnvironment.create())
+                .add(Roundabout.create())
+                .add(MaxSpeed.create())
+                .add(Subnetwork.create("profile")).build();
+        BaseGraph graph = new BaseGraph.Builder(encodingManager).create();
+        // same scenario as in testTurnInstructionAtBlockedArea, but with bike-only ways (no car access)
+        // 0 --- 1 --- 2   Main
+        //       |
+        //       3         Side
+        NodeAccess na = graph.getNodeAccess();
+        na.setNode(0, 0.001, 0.000);
+        na.setNode(1, 0.001, 0.001);
+        na.setNode(2, 0.001, 0.002);
+        na.setNode(3, 0.000, 0.001);
+        GHUtility.setSpeed(18, true, true, accessEnc, speedEnc, graph.edge(0, 1).setDistance(110).setKeyValues(Map.of(STREET_NAME, new KValue("Main"))));
+        GHUtility.setSpeed(18, true, true, accessEnc, speedEnc, graph.edge(1, 2).setDistance(110).setKeyValues(Map.of(STREET_NAME, new KValue("Main"))));
+        GHUtility.setSpeed(18, true, true, accessEnc, speedEnc, graph.edge(1, 3).setDistance(110).setKeyValues(Map.of(STREET_NAME, new KValue("Side"))));
+
+        JsonFeature area = new JsonFeature();
+        area.setId("area1");
+        area.setGeometry(new GeometryFactory().createPolygon(new Coordinate[]{
+                new Coordinate(0.0015, 0.0005),
+                new Coordinate(0.0025, 0.0005),
+                new Coordinate(0.0025, 0.0015),
+                new Coordinate(0.0015, 0.0015),
+                new Coordinate(0.0015, 0.0005)}));
+        CustomModel customModel = new CustomModel();
+        customModel.addToPriority(If("in_area1", MULTIPLY, "0"));
+        customModel.getAreas().getFeatures().add(area);
+        GHRequest req = new GHRequest(new GHPoint(0.001, 0.000), new GHPoint(0.000, 0.001)).
+                setProfile("profile").setCustomModel(customModel);
+
+        // with navigation_mode: bike the blocked continuation of Main is visible and the turn is created
+        Profile profile = TestProfiles.accessAndSpeed("profile", "bike").putHint("navigation_mode", "bike");
+        GHResponse rsp = createRouter(graph, encodingManager, profile).route(req);
+        assertFalse(rsp.hasErrors(), rsp.getErrors().toString());
+        InstructionList il = rsp.getBest().getInstructions();
+        assertEquals(3, il.size());
+        assertEquals(Instruction.TURN_RIGHT, il.get(1).getSign());
+        assertEquals("Side", il.get(1).getName());
+
+        // without navigation_mode it falls back to car_access and the blocked bike-only way stays invisible
+        rsp = createRouter(graph, encodingManager, TestProfiles.accessAndSpeed("profile", "bike")).route(req);
+        assertFalse(rsp.hasErrors(), rsp.getErrors().toString());
+        assertEquals(2, rsp.getBest().getInstructions().size());
+    }
+
     private Router createRouter(BaseGraph graph, EncodingManager encodingManager) {
+        return createRouter(graph, encodingManager, TestProfiles.accessAndSpeed("profile", "car"));
+    }
+
+    private Router createRouter(BaseGraph graph, EncodingManager encodingManager, Profile profile) {
         LocationIndexTree locationIndex = new LocationIndexTree(graph, new GHDirectory("", DAType.RAM));
         locationIndex.prepareIndex();
         Map<String, Profile> profilesByName = new HashMap<>();
-        profilesByName.put("profile", TestProfiles.accessAndSpeed("profile", "car"));
+        profilesByName.put(profile.getName(), profile);
         return new Router(graph.getBaseGraph(), encodingManager, locationIndex, profilesByName, new PathDetailsBuilderFactory(), new TranslationMap().doImport(), new RouterConfig(),
                 new DefaultWeightingFactory(graph.getBaseGraph(), encodingManager), Collections.emptyMap(), Collections.emptyMap());
     }

--- a/core/src/test/java/com/graphhopper/routing/HeadingAndCustomModelRoutingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/HeadingAndCustomModelRoutingTest.java
@@ -437,8 +437,8 @@ class HeadingAndCustomModelRoutingTest {
         GHRequest req = new GHRequest(new GHPoint(0.001, 0.000), new GHPoint(0.000, 0.001)).
                 setProfile("profile").setCustomModel(customModel);
 
-        // with navigation_mode: bike the blocked continuation of Main is visible and the turn is created
-        Profile profile = TestProfiles.accessAndSpeed("profile", "bike").putHint("navigation_mode", "bike");
+        // with instructions_base_mode: bike the blocked continuation of Main is visible and the turn is created
+        Profile profile = TestProfiles.accessAndSpeed("profile", "bike").putHint("instructions_base_mode", "bike");
         GHResponse rsp = createRouter(graph, encodingManager, profile).route(req);
         assertFalse(rsp.hasErrors(), rsp.getErrors().toString());
         InstructionList il = rsp.getBest().getInstructions();
@@ -446,7 +446,7 @@ class HeadingAndCustomModelRoutingTest {
         assertEquals(Instruction.TURN_RIGHT, il.get(1).getSign());
         assertEquals("Side", il.get(1).getName());
 
-        // without navigation_mode it falls back to car_access and the blocked bike-only way stays invisible
+        // without instructions_base_mode it falls back to car_access and the blocked bike-only way stays invisible
         rsp = createRouter(graph, encodingManager, TestProfiles.accessAndSpeed("profile", "bike")).route(req);
         assertFalse(rsp.hasErrors(), rsp.getErrors().toString());
         assertEquals(2, rsp.getBest().getInstructions().size());

--- a/core/src/test/java/com/graphhopper/routing/HeadingAndCustomModelRoutingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/HeadingAndCustomModelRoutingTest.java
@@ -437,7 +437,7 @@ class HeadingAndCustomModelRoutingTest {
         GHRequest req = new GHRequest(new GHPoint(0.001, 0.000), new GHPoint(0.000, 0.001)).
                 setProfile("profile").setCustomModel(customModel);
 
-        // with instructions_base_mode: bike the blocked continuation of Main is visible and the turn is created
+        // with 'instructions_base_mode: bike' the blocked continuation of Main is visible and the turn is created
         Profile profile = TestProfiles.accessAndSpeed("profile", "bike").putHint("instructions_base_mode", "bike");
         GHResponse rsp = createRouter(graph, encodingManager, profile).route(req);
         assertFalse(rsp.hasErrors(), rsp.getErrors().toString());
@@ -446,7 +446,8 @@ class HeadingAndCustomModelRoutingTest {
         assertEquals(Instruction.TURN_RIGHT, il.get(1).getSign());
         assertEquals("Side", il.get(1).getName());
 
-        // without instructions_base_mode it falls back to car_access and the blocked bike-only way stays invisible
+        // without instructions_base_mode it falls back to car_access (because profile name is 'profile')
+        // and the blocked bike-only way stays invisible
         rsp = createRouter(graph, encodingManager, TestProfiles.accessAndSpeed("profile", "bike")).route(req);
         assertFalse(rsp.hasErrors(), rsp.getErrors().toString());
         assertEquals(2, rsp.getBest().getInstructions().size());

--- a/core/src/test/java/com/graphhopper/routing/HeadingAndCustomModelRoutingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/HeadingAndCustomModelRoutingTest.java
@@ -27,30 +27,32 @@ import com.graphhopper.routing.ev.*;
 import com.graphhopper.routing.util.EncodingManager;
 import com.graphhopper.storage.*;
 import com.graphhopper.storage.index.LocationIndexTree;
-import com.graphhopper.util.EdgeIteratorState;
-import com.graphhopper.util.GHUtility;
-import com.graphhopper.util.Parameters;
-import com.graphhopper.util.TranslationMap;
+import com.graphhopper.util.*;
 import com.graphhopper.util.details.PathDetail;
 import com.graphhopper.util.details.PathDetailsBuilderFactory;
 import com.graphhopper.util.shapes.GHPoint;
 import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
 
 import java.util.*;
 
+import static com.graphhopper.json.Statement.If;
+import static com.graphhopper.json.Statement.Op.MULTIPLY;
+import static com.graphhopper.search.KVStorage.KValue;
 import static com.graphhopper.util.Parameters.Algorithms.DIJKSTRA;
+import static com.graphhopper.util.Parameters.Details.STREET_NAME;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * These tests were taken from GraphHopperAPITest. Really, they are low-level routing algorithm tests, but currently
- * heading is still implemented in Router. When heading is removed from QueryGraph with #1765 these tests should
- * be pushed further 'down' into EdgeBasedRoutingAlgorithmTest. We already have some high-level heading tests in
- * GraphHopperTest.
+ * Router tests with a small in-memory graph for per-request features like heading, pass_through and the
+ * query-time custom model. When heading is removed from QueryGraph with #1765 the heading tests should be
+ * pushed further 'down' into EdgeBasedRoutingAlgorithmTest. There are also high-level heading tests in GraphHopperTest.
  */
-class HeadingRoutingTest {
+class HeadingAndCustomModelRoutingTest {
 
     @Test
-    public void headingTest1() {
+    public void testStartDirection() {
         // Test enforce start direction
         BooleanEncodedValue accessEnc = VehicleAccess.create("car");
         DecimalEncodedValue speedEnc = VehicleSpeed.create("car", 5, 5, false);
@@ -80,7 +82,7 @@ class HeadingRoutingTest {
     }
 
     @Test
-    public void headingTest2() {
+    public void testStartEndDirection() {
         // Test enforce south start direction and east end direction
         BooleanEncodedValue accessEnc = VehicleAccess.create("car");
         DecimalEncodedValue speedEnc = VehicleSpeed.create("car", 5, 5, false);
@@ -115,7 +117,7 @@ class HeadingRoutingTest {
     }
 
     @Test
-    public void headingTest3() {
+    public void testViaDirection() {
         BooleanEncodedValue accessEnc = VehicleAccess.create("car");
         DecimalEncodedValue speedEnc = VehicleSpeed.create("car", 5, 5, false);
         EncodingManager encodingManager = new EncodingManager.Builder().add(accessEnc).add(speedEnc)
@@ -146,7 +148,7 @@ class HeadingRoutingTest {
     }
 
     @Test
-    public void headingTest4() {
+    public void testPassThrough() {
         // Test straight via routing
         BooleanEncodedValue accessEnc = VehicleAccess.create("car");
         DecimalEncodedValue speedEnc = VehicleSpeed.create("car", 5, 5, false);
@@ -178,7 +180,7 @@ class HeadingRoutingTest {
     }
 
     @Test
-    public void headingTest5() {
+    public void testHeadingPerLeg() {
         // Test independence of previous enforcement for subsequent paths
         BooleanEncodedValue accessEnc = VehicleAccess.create("car");
         DecimalEncodedValue speedEnc = VehicleSpeed.create("car", 5, 5, false);
@@ -318,7 +320,7 @@ class HeadingRoutingTest {
     }
 
     @Test
-    public void headingTest6() {
+    public void testHeadingAtTowerNode() {
         // Test if snaps at tower nodes are ignored
         BooleanEncodedValue accessEnc = VehicleAccess.create("car");
         DecimalEncodedValue speedEnc = VehicleSpeed.create("car", 5, 5, false);
@@ -345,6 +347,54 @@ class HeadingRoutingTest {
         GHResponse response = router.route(req);
         assertFalse(response.hasErrors());
         assertEquals(IntArrayList.from(0, 1, 2, 3, 4), calcNodes(graph, response.getAll().get(0)));
+    }
+
+    @Test
+    public void testTurnInstructionAtBlockedArea() {
+        BooleanEncodedValue accessEnc = VehicleAccess.create("car");
+        DecimalEncodedValue speedEnc = VehicleSpeed.create("car", 5, 5, false);
+        EncodingManager encodingManager = new EncodingManager.Builder().add(accessEnc).add(speedEnc)
+                .add(RoadClass.create())
+                .add(RoadClassLink.create())
+                .add(RoadEnvironment.create())
+                .add(Roundabout.create())
+                .add(MaxSpeed.create())
+                .add(Subnetwork.create("profile")).build();
+        BaseGraph graph = new BaseGraph.Builder(encodingManager).create();
+        // 0 --- 1 --- 2   Main
+        //       |
+        //       3         Side
+        NodeAccess na = graph.getNodeAccess();
+        na.setNode(0, 0.001, 0.000);
+        na.setNode(1, 0.001, 0.001);
+        na.setNode(2, 0.001, 0.002);
+        na.setNode(3, 0.000, 0.001);
+        GHUtility.setSpeed(60, true, true, accessEnc, speedEnc, graph.edge(0, 1).setDistance(110).setKeyValues(Map.of(STREET_NAME, new KValue("Main"))));
+        GHUtility.setSpeed(60, true, true, accessEnc, speedEnc, graph.edge(1, 2).setDistance(110).setKeyValues(Map.of(STREET_NAME, new KValue("Main"))));
+        GHUtility.setSpeed(60, true, true, accessEnc, speedEnc, graph.edge(1, 3).setDistance(110).setKeyValues(Map.of(STREET_NAME, new KValue("Side"))));
+        Router router = createRouter(graph, encodingManager);
+
+        // the area blocks Main east of the junction, so the route onto Side has no alternative there, see #3223
+        JsonFeature area = new JsonFeature();
+        area.setId("area1");
+        area.setGeometry(new GeometryFactory().createPolygon(new Coordinate[]{
+                new Coordinate(0.0015, 0.0005),
+                new Coordinate(0.0025, 0.0005),
+                new Coordinate(0.0025, 0.0015),
+                new Coordinate(0.0015, 0.0015),
+                new Coordinate(0.0015, 0.0005)}));
+        CustomModel customModel = new CustomModel();
+        customModel.addToPriority(If("in_area1", MULTIPLY, "0"));
+        customModel.getAreas().getFeatures().add(area);
+
+        GHRequest req = new GHRequest(new GHPoint(0.001, 0.000), new GHPoint(0.000, 0.001)).
+                setProfile("profile").setCustomModel(customModel);
+        GHResponse rsp = router.route(req);
+        assertFalse(rsp.hasErrors(), rsp.getErrors().toString());
+        InstructionList il = rsp.getBest().getInstructions();
+        assertEquals(3, il.size());
+        assertEquals(Instruction.TURN_RIGHT, il.get(1).getSign());
+        assertEquals("Side", il.get(1).getName());
     }
 
     private Router createRouter(BaseGraph graph, EncodingManager encodingManager) {

--- a/core/src/test/java/com/graphhopper/routing/PathTest.java
+++ b/core/src/test/java/com/graphhopper/routing/PathTest.java
@@ -22,6 +22,7 @@ import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.*;
 import com.graphhopper.routing.util.AllEdgesIterator;
 import com.graphhopper.routing.util.EncodingManager;
+import com.graphhopper.routing.util.TransportationMode;
 import com.graphhopper.routing.util.TraversalMode;
 import com.graphhopper.routing.util.parsers.OrientationCalculator;
 import com.graphhopper.routing.weighting.SpeedWeighting;
@@ -887,6 +888,46 @@ public class PathTest {
 
         // Contain only start and finish instruction
         assertEquals(2, wayList.size());
+    }
+
+    @Test
+    public void testCalcInstructionsTurnIfOnlyAlternativeIsCarOnly() {
+        DecimalEncodedValue speedEnc = new DecimalEncodedValueImpl("speed", 5, 5, true);
+        BooleanEncodedValue bikeAccessEnc = VehicleAccess.create("bike");
+        EncodingManager em = EncodingManager.start().add(speedEnc).add(bikeAccessEnc).add(VehicleAccess.create("car")).
+                add(Roundabout.create()).add(RoadClass.create()).add(RoadEnvironment.create()).
+                add(RoadClassLink.create()).add(MaxSpeed.create()).build();
+        BooleanEncodedValue carAccessEnc = em.getBooleanEncodedValue(VehicleAccess.key("car"));
+        final BaseGraph graph = new BaseGraph.Builder(em).create();
+        final NodeAccess na = graph.getNodeAccess();
+
+        // 1 -- 2 -- 3
+        //      |
+        //      4
+        na.setNode(1, 52.514, 13.348);
+        na.setNode(2, 52.514, 13.349);
+        na.setNode(3, 52.514, 13.350);
+        na.setNode(4, 52.513, 13.349);
+
+        graph.edge(1, 2).set(speedEnc, 20, 20).set(bikeAccessEnc, true, true).setDistance(70).setKeyValues(Map.of(STREET_NAME, new KValue("Main")));
+        // the continuation of Main is for cars only
+        EdgeIteratorState carOnlyEdge = graph.edge(2, 3).set(speedEnc, 60, 60).set(carAccessEnc, true, true).setDistance(70).setKeyValues(Map.of(STREET_NAME, new KValue("Main")));
+        graph.edge(2, 4).set(speedEnc, 20, 20).set(bikeAccessEnc, true, true).setDistance(110).setKeyValues(Map.of(STREET_NAME, new KValue("Side")));
+
+        Weighting bikeWeighting = new SpeedWeighting(speedEnc) {
+            @Override
+            public double calcEdgeWeight(EdgeIteratorState edgeState, boolean reverse) {
+                return edgeState.getEdge() == carOnlyEdge.getEdge() ? Double.POSITIVE_INFINITY : super.calcEdgeWeight(edgeState, reverse);
+            }
+        };
+        Path p = new Dijkstra(graph, bikeWeighting, TraversalMode.NODE_BASED).calcPath(1, 4);
+        assertTrue(p.isFound());
+
+        // although the bike can neither access nor use the continuation of Main, the driver sees it and
+        // so the turn must be created
+        InstructionList wayList = InstructionsFromEdges.calcInstructions(p, graph, bikeWeighting, TransportationMode.BIKE, em, tr, false);
+        assertEquals(3, wayList.size());
+        assertEquals("turn right onto Side", wayList.get(1).getTurnDescription(tr));
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/routing/PathTest.java
+++ b/core/src/test/java/com/graphhopper/routing/PathTest.java
@@ -890,6 +890,44 @@ public class PathTest {
     }
 
     @Test
+    public void testCalcInstructionsTurnIfOnlyAlternativeIsBlocked() {
+        final BaseGraph graph = new BaseGraph.Builder(carManager).create();
+        final NodeAccess na = graph.getNodeAccess();
+
+        // 1 -- 2 -- 3
+        //      |
+        //      4
+        na.setNode(1, 52.514, 13.348);
+        na.setNode(2, 52.514, 13.349);
+        na.setNode(3, 52.514, 13.350);
+        na.setNode(4, 52.513, 13.349);
+
+        graph.edge(1, 2).set(carAvSpeedEnc, 60, 60).setDistance(70).setKeyValues(Map.of(STREET_NAME, new KValue("Main")));
+        EdgeIteratorState blockedEdge = graph.edge(2, 3).set(carAvSpeedEnc, 60, 60).setDistance(70).setKeyValues(Map.of(STREET_NAME, new KValue("Main")));
+        graph.edge(2, 4).set(carAvSpeedEnc, 60, 60).setDistance(110).setKeyValues(Map.of(STREET_NAME, new KValue("Side")));
+
+        Weighting weighting = new SpeedWeighting(carAvSpeedEnc);
+        // simulates a query-time custom model blocking the continuation of Main
+        Weighting blockedWeighting = new SpeedWeighting(carAvSpeedEnc) {
+            @Override
+            public double calcEdgeWeight(EdgeIteratorState edgeState, boolean reverse) {
+                return edgeState.getEdge() == blockedEdge.getEdge() ? Double.POSITIVE_INFINITY : super.calcEdgeWeight(edgeState, reverse);
+            }
+        };
+        Path p = new Dijkstra(graph, blockedWeighting, TraversalMode.NODE_BASED).calcPath(1, 4);
+        assertTrue(p.isFound());
+
+        // the blocked edge is invisible for the request weighting, so the turn is missing, see #3223
+        InstructionList wayList = InstructionsFromEdges.calcInstructions(p, graph, blockedWeighting, carManager, tr);
+        assertEquals(2, wayList.size());
+
+        // but visible for the base weighting, so the turn is created
+        wayList = InstructionsFromEdges.calcInstructions(p, graph, blockedWeighting, weighting, carManager, tr, false);
+        assertEquals(3, wayList.size());
+        assertEquals("turn right onto Side", wayList.get(1).getTurnDescription(tr));
+    }
+
+    @Test
     public void testCalcInstructionForForkWithSameName() {
         final BaseGraph graph = new BaseGraph.Builder(carManager).create();
         final NodeAccess na = graph.getNodeAccess();

--- a/core/src/test/java/com/graphhopper/routing/PathTest.java
+++ b/core/src/test/java/com/graphhopper/routing/PathTest.java
@@ -902,11 +902,11 @@ public class PathTest {
         na.setNode(3, 52.514, 13.350);
         na.setNode(4, 52.513, 13.349);
 
-        graph.edge(1, 2).set(carAvSpeedEnc, 60, 60).setDistance(70).setKeyValues(Map.of(STREET_NAME, new KValue("Main")));
-        EdgeIteratorState blockedEdge = graph.edge(2, 3).set(carAvSpeedEnc, 60, 60).setDistance(70).setKeyValues(Map.of(STREET_NAME, new KValue("Main")));
-        graph.edge(2, 4).set(carAvSpeedEnc, 60, 60).setDistance(110).setKeyValues(Map.of(STREET_NAME, new KValue("Side")));
+        BooleanEncodedValue carAccessEnc = carManager.getBooleanEncodedValue(VehicleAccess.key("car"));
+        graph.edge(1, 2).set(carAvSpeedEnc, 60, 60).set(carAccessEnc, true, true).setDistance(70).setKeyValues(Map.of(STREET_NAME, new KValue("Main")));
+        EdgeIteratorState blockedEdge = graph.edge(2, 3).set(carAvSpeedEnc, 60, 60).set(carAccessEnc, true, true).setDistance(70).setKeyValues(Map.of(STREET_NAME, new KValue("Main")));
+        graph.edge(2, 4).set(carAvSpeedEnc, 60, 60).set(carAccessEnc, true, true).setDistance(110).setKeyValues(Map.of(STREET_NAME, new KValue("Side")));
 
-        Weighting weighting = new SpeedWeighting(carAvSpeedEnc);
         // simulates a query-time custom model blocking the continuation of Main
         Weighting blockedWeighting = new SpeedWeighting(carAvSpeedEnc) {
             @Override
@@ -917,12 +917,9 @@ public class PathTest {
         Path p = new Dijkstra(graph, blockedWeighting, TraversalMode.NODE_BASED).calcPath(1, 4);
         assertTrue(p.isFound());
 
-        // the blocked edge is invisible for the request weighting, so the turn is missing, see #3223
+        // the blocked edge is invisible for the weighting but not for the driver (car access), so
+        // the turn must be created, see #3223
         InstructionList wayList = InstructionsFromEdges.calcInstructions(p, graph, blockedWeighting, carManager, tr);
-        assertEquals(2, wayList.size());
-
-        // but visible for the base weighting, so the turn is created
-        wayList = InstructionsFromEdges.calcInstructions(p, graph, blockedWeighting, weighting, carManager, tr, false);
         assertEquals(3, wayList.size());
         assertEquals("turn right onto Side", wayList.get(1).getTurnDescription(tr));
     }

--- a/navigation/src/main/java/com/graphhopper/navigation/NavigateResource.java
+++ b/navigation/src/main/java/com/graphhopper/navigation/NavigateResource.java
@@ -149,7 +149,7 @@ public class NavigateResource {
         } else {
             DistanceUtils.Unit unit = voiceUnits.equals("metric") ? DistanceUtils.Unit.METRIC : DistanceUtils.Unit.IMPERIAL;
             Locale locale = Helper.getLocale(localeStr);
-            DistanceConfig config = new DistanceConfig(unit, translationMap, locale, graphHopper.getNavigationMode(ghProfile));
+            DistanceConfig config = new DistanceConfig(unit, translationMap, locale, graphHopper.getInstructionsBaseMode(ghProfile));
             logger.info(logStr);
             return Response.ok(NavigateResponseConverter.convertFromGHResponse(ghResponse, translationMap, locale, config)).
                     header("X-GH-Took", "" + Math.round(took * 1000)).
@@ -220,7 +220,7 @@ public class NavigateResource {
                 unit = DistanceUtils.Unit.IMPERIAL;
             }
 
-            DistanceConfig config = new DistanceConfig(unit, translationMap, request.getLocale(), graphHopper.getNavigationMode(request.getProfile()));
+            DistanceConfig config = new DistanceConfig(unit, translationMap, request.getLocale(), graphHopper.getInstructionsBaseMode(request.getProfile()));
             logger.info(logStr);
             return Response.ok(NavigateResponseConverter.convertFromGHResponse(ghResponse, translationMap, request.getLocale(), config)).
                     header("X-GH-Took", "" + Math.round(took * 1000)).

--- a/navigation/src/test/java/com/graphhopper/navigation/DistanceConfigTest.java
+++ b/navigation/src/test/java/com/graphhopper/navigation/DistanceConfigTest.java
@@ -6,6 +6,7 @@ import com.graphhopper.routing.util.TransportationMode;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class DistanceConfigTest {
 
@@ -25,11 +26,15 @@ public class DistanceConfigTest {
         GraphHopper hopper = new GraphHopper().setProfiles(
                 new Profile("my_truck"),
                 new Profile("foot"),
-                new Profile("ebike").putHint("navigation_mode", "bike"));
-        assertEquals(TransportationMode.CAR, hopper.getNavigationMode("unknown"));
-        assertEquals(TransportationMode.CAR, hopper.getNavigationMode("my_truck"));
-        assertEquals(TransportationMode.FOOT, hopper.getNavigationMode("foot"));
-        assertEquals(TransportationMode.BIKE, hopper.getNavigationMode("ebike"));
+                new Profile("walking"),
+                new Profile("ebike").putHint("instructions_base_mode", "bike"));
+        assertEquals(TransportationMode.CAR, hopper.getInstructionsBaseMode("unknown"));
+        assertEquals(TransportationMode.CAR, hopper.getInstructionsBaseMode("my_truck"));
+        assertEquals(TransportationMode.FOOT, hopper.getInstructionsBaseMode("foot"));
+        assertEquals(TransportationMode.FOOT, hopper.getInstructionsBaseMode("walking"));
+        assertEquals(TransportationMode.BIKE, hopper.getInstructionsBaseMode("ebike"));
+        assertThrows(IllegalArgumentException.class, () -> new Profile("x").putHint("navigation_mode", "bike"));
+        assertThrows(IllegalArgumentException.class, () -> new Profile("x").putHint("instructions_base_mode", "hgv"));
 
         // from String
         DistanceConfig driving = new DistanceConfig(DistanceUtils.Unit.METRIC, null, null, "driving");

--- a/reader-gtfs/src/main/java/com/graphhopper/gtfs/TripFromLabel.java
+++ b/reader-gtfs/src/main/java/com/graphhopper/gtfs/TripFromLabel.java
@@ -398,7 +398,7 @@ class TripFromLabel {
         } else {
             InstructionList instructions = new InstructionList(tr);
             InstructionsFromEdges instructionsFromEdges = new InstructionsFromEdges(graph,
-                    weighting, weighting, encodedValueLookup, instructions, includeRoundaboutExit);
+                    weighting, encodedValueLookup, instructions, includeRoundaboutExit);
             int prevEdgeId = -1;
             for (int i = 1; i < path.size(); i++) {
                 if (path.get(i).edge.getType() != GtfsStorage.EdgeType.HIGHWAY) {

--- a/reader-gtfs/src/main/java/com/graphhopper/gtfs/TripFromLabel.java
+++ b/reader-gtfs/src/main/java/com/graphhopper/gtfs/TripFromLabel.java
@@ -32,6 +32,7 @@ import com.graphhopper.gtfs.fare.Fares;
 import com.graphhopper.routing.InstructionsFromEdges;
 import com.graphhopper.routing.Path;
 import com.graphhopper.routing.ev.EncodedValueLookup;
+import com.graphhopper.routing.util.TransportationMode;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.Graph;
 import com.graphhopper.util.*;
@@ -398,7 +399,7 @@ class TripFromLabel {
         } else {
             InstructionList instructions = new InstructionList(tr);
             InstructionsFromEdges instructionsFromEdges = new InstructionsFromEdges(graph,
-                    weighting, encodedValueLookup, instructions, includeRoundaboutExit);
+                    weighting, TransportationMode.FOOT, encodedValueLookup, instructions, includeRoundaboutExit);
             int prevEdgeId = -1;
             for (int i = 1; i < path.size(); i++) {
                 if (path.get(i).edge.getType() != GtfsStorage.EdgeType.HIGHWAY) {

--- a/reader-gtfs/src/main/java/com/graphhopper/gtfs/TripFromLabel.java
+++ b/reader-gtfs/src/main/java/com/graphhopper/gtfs/TripFromLabel.java
@@ -398,7 +398,7 @@ class TripFromLabel {
         } else {
             InstructionList instructions = new InstructionList(tr);
             InstructionsFromEdges instructionsFromEdges = new InstructionsFromEdges(graph,
-                    weighting, encodedValueLookup, instructions, includeRoundaboutExit);
+                    weighting, weighting, encodedValueLookup, instructions, includeRoundaboutExit);
             int prevEdgeId = -1;
             for (int i = 1; i < path.size(); i++) {
                 if (path.get(i).edge.getType() != GtfsStorage.EdgeType.HIGHWAY) {

--- a/web-bundle/src/main/java/com/graphhopper/resources/MapMatchingResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/MapMatchingResource.java
@@ -154,6 +154,7 @@ public class MapMatchingResource {
             Translation tr = trMap.getWithFallBack(Helper.getLocale(localeStr));
             RamerDouglasPeucker simplifyAlgo = new RamerDouglasPeucker().setMaxDistance(minPathPrecision);
             PathMerger pathMerger = new PathMerger(matchResult.getGraph(), matchResult.getWeighting()).
+                    setInstructionsBaseMode(graphHopper.getInstructionsBaseMode(profile)).
                     setEnableInstructions(instructions).
                     setPathDetailsBuilders(graphHopper.getPathDetailsBuilderFactory(), pathDetails).
                     setRamerDouglasPeucker(simplifyAlgo).

--- a/web/src/main/java/com/graphhopper/application/cli/MatchCommand.java
+++ b/web/src/main/java/com/graphhopper/application/cli/MatchCommand.java
@@ -130,6 +130,7 @@ public class MatchCommand extends ConfiguredCommand<GraphHopperServerConfigurati
                 System.out.println("\texport results to:" + outFile);
 
                 ResponsePath responsePath = new PathMerger(mr.getGraph(), mr.getWeighting()).
+                        setInstructionsBaseMode(hopper.getInstructionsBaseMode(args.getString("profile"))).
                         doWork(PointList.EMPTY, Collections.singletonList(mr.getMergedPath()), hopper.getEncodingManager(), tr);
                 if (responsePath.hasErrors()) {
                     System.err.println("Problem with file " + gpxFile + ", " + responsePath.getErrors());


### PR DESCRIPTION
Currently if a custom model blocks a road ("not routable") it also disappears for the code that creates the instruction (although it is "visible") 

This fixes #3223. We had a similar problem for [roundabout exits](https://github.com/graphhopper/graphhopper/commit/26828e32dd11c9a68385e8dda3674ec314335834) which now uses the same approach. Also map matching and gtfs use this approach now to create turn instructions.

This change now tries to solve this via combining three terms: 

 * the accessibility from the weighting itself OR
 * the "base access" (car|bike|foot) OR
 * car access (necessary for e.g. foot to still "see" roads that are motor-vehicle-access only)

The change consolidates the current `navigation_mode` and replaces it with `instructions_base_mode`. It can be only car|bike|foot and is automatically determined for a couple of profile names, if not explicitly specified.