### PR TITLE
Use continue on when the street name stays

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -9,6 +9,7 @@ Here is an overview:
  * andreaswolf, flag encoder versioning and more
  * andreylh, polygon for blocked area #1306
  * Anvoker, fixes like #1614 and helped with JUnit 5 migration #1632 
+ * AzazelSensei, continue on vs onto wording #1287
  * b3nn0, Android improvements
  * baumboi, path detail and landmark improvements
  * baybatu, improved error for EncodingManager

--- a/core/src/main/java/com/graphhopper/routing/InstructionsFromEdges.java
+++ b/core/src/main/java/com/graphhopper/routing/InstructionsFromEdges.java
@@ -379,6 +379,7 @@ public class InstructionsFromEdges implements Path.EdgeVisitor {
                     boolean needsDeferredFallback = isBlank(name) && isLinkRoad(edge);
 
                     prevInstruction = new Instruction(sign, name, new PointList(10, nodeAccess.is3D()));
+                    prevInstruction.setStreetNameChanged(!InstructionsHelper.isSameName(prevName, name));
                     // Remember the orientation and name of the road, before doing this maneuver
                     prevInstructionPrevOrientation = prevOrientation;
                     prevInstructionName = prevName;

--- a/core/src/main/resources/com/graphhopper/util/ar.txt
+++ b/core/src/main/resources/com/graphhopper/util/ar.txt
@@ -1,10 +1,12 @@
 # do not edit manually, instead use spreadsheet from translations.md and script ./core/files/update-translations.sh
 continue=استمر
 continue_onto=
+continue_on=
 finish=النهاية
 keep_left=احفظ الشمال
 keep_right=احفظ اليمين
 turn_onto=%1$s خلال %2$s
+turn_on=%1$s خلال %2$s
 turn_left=اتجه يساراً
 turn_right=اتجه يميناً
 turn_slight_left=إستدر لليسار قليلا

--- a/core/src/main/resources/com/graphhopper/util/ast.txt
+++ b/core/src/main/resources/com/graphhopper/util/ast.txt
@@ -1,10 +1,12 @@
 # do not edit manually, instead use spreadsheet from translations.md and script ./core/files/update-translations.sh
 continue=sigue
 continue_onto=sigue per %1$s
+continue_on=sigue per %1$s
 finish=¡Aportasti!
 keep_left=sigui pela izquierda
 keep_right=sigui pela derecha
 turn_onto=%1$s per %2$s
+turn_on=%1$s per %2$s
 turn_left=xira a la izquierda
 turn_right=xira a la drecha
 turn_slight_left=xira llixeramente a la izquierda

--- a/core/src/main/resources/com/graphhopper/util/az.txt
+++ b/core/src/main/resources/com/graphhopper/util/az.txt
@@ -1,10 +1,12 @@
 # do not edit manually, instead use spreadsheet from translations.md and script ./core/files/update-translations.sh
 continue=Davam edin
 continue_onto=Davam edin - %1$s
+continue_on=Davam edin - %1$s
 finish=Məntəqəyə çatdınız
 keep_left=Sol tərəfi tutaraq hərəkət edin
 keep_right=Sağ tərəfi tutaraq hərəkət edin
 turn_onto=%1$s - %2$s
+turn_on=%1$s - %2$s
 turn_left=Sola dönün
 turn_right=Sağa dönün
 turn_slight_left=Yavaşca sola dönün

--- a/core/src/main/resources/com/graphhopper/util/bg.txt
+++ b/core/src/main/resources/com/graphhopper/util/bg.txt
@@ -1,10 +1,12 @@
 # do not edit manually, instead use spreadsheet from translations.md and script ./core/files/update-translations.sh
 continue=продължете
 continue_onto=продължете по %1$s
+continue_on=продължете по %1$s
 finish=Пристигнахте в крайната точка
 keep_left=дръжте ляво
 keep_right=дръжте дясно
 turn_onto=%1$s по %2$s
+turn_on=%1$s по %2$s
 turn_left=завийте наляво
 turn_right=завийте надясно
 turn_slight_left=завийте леко наляво

--- a/core/src/main/resources/com/graphhopper/util/bn_BN.txt
+++ b/core/src/main/resources/com/graphhopper/util/bn_BN.txt
@@ -1,10 +1,12 @@
 # do not edit manually, instead use spreadsheet from translations.md and script ./core/files/update-translations.sh
 continue=সোজা যেতে থাকুন
 continue_onto=%1$s সড়কে সোজা যেতে থাকুন
+continue_on=%1$s সড়কে সোজা যেতে থাকুন
 finish=
 keep_left=বামে থাকুন
 keep_right=ডানে থাকুন
 turn_onto=%1$s  %2$s এর দিকে
+turn_on=%1$s  %2$s এর দিকে
 turn_left=বামে যান
 turn_right=ডানে যান
 turn_slight_left=একটু বামে যান

--- a/core/src/main/resources/com/graphhopper/util/ca.txt
+++ b/core/src/main/resources/com/graphhopper/util/ca.txt
@@ -1,10 +1,12 @@
 # do not edit manually, instead use spreadsheet from translations.md and script ./core/files/update-translations.sh
 continue=continua
 continue_onto=continua per %1$s
+continue_on=continua per %1$s
 finish=Has arribat!
 keep_left=estigues a l'esquerra
 keep_right=estigues a la dreta
 turn_onto=%1$s per %2$s
+turn_on=%1$s per %2$s
 turn_left=gira a l'esquerra
 turn_right=gira a la dreta
 turn_slight_left=gira lleugerament a l'esquerra

--- a/core/src/main/resources/com/graphhopper/util/cs_CZ.txt
+++ b/core/src/main/resources/com/graphhopper/util/cs_CZ.txt
@@ -1,10 +1,12 @@
 # do not edit manually, instead use spreadsheet from translations.md and script ./core/files/update-translations.sh
 continue=pokračujte
 continue_onto=pokračujte směr %1$s
+continue_on=pokračujte směr %1$s
 finish=příjezd do cíle
 keep_left=držte se vlevo
 keep_right=držte se vpravo
 turn_onto=%1$s na %2$s
+turn_on=%1$s na %2$s
 turn_left=odbočte vlevo
 turn_right=odbočte vpravo
 turn_slight_left=odbočte mírně vlevo

--- a/core/src/main/resources/com/graphhopper/util/da_DK.txt
+++ b/core/src/main/resources/com/graphhopper/util/da_DK.txt
@@ -1,10 +1,12 @@
 # do not edit manually, instead use spreadsheet from translations.md and script ./core/files/update-translations.sh
 continue=fortsæt
 continue_onto=fortsæt ind på %1$s
+continue_on=fortsæt ind på %1$s
 finish=Fremme!
 keep_left=hold til venstre
 keep_right=hold til højre
 turn_onto=%1$s ind på %2$s
+turn_on=%1$s ind på %2$s
 turn_left=drej til venstre
 turn_right=drej til højre
 turn_slight_left=drej lidt til venstre

--- a/core/src/main/resources/com/graphhopper/util/de_DE.txt
+++ b/core/src/main/resources/com/graphhopper/util/de_DE.txt
@@ -1,10 +1,12 @@
 # do not edit manually, instead use spreadsheet from translations.md and script ./core/files/update-translations.sh
 continue=dem Straßenverlauf folgen
 continue_onto=dem Straßenverlauf von %1$s folgen
+continue_on=dem Straßenverlauf von %1$s folgen
 finish=Ziel erreicht
 keep_left=links halten
 keep_right=rechts halten
 turn_onto=%1$s auf %2$s
+turn_on=%1$s auf %2$s
 turn_left=links abbiegen
 turn_right=rechts abbiegen
 turn_slight_left=leicht links abbiegen

--- a/core/src/main/resources/com/graphhopper/util/el.txt
+++ b/core/src/main/resources/com/graphhopper/util/el.txt
@@ -1,10 +1,12 @@
 # do not edit manually, instead use spreadsheet from translations.md and script ./core/files/update-translations.sh
 continue=συνεχίστε
 continue_onto=συνεχίστε στην %1$s
+continue_on=συνεχίστε στην %1$s
 finish=άφιξη στον προορισμό
 keep_left=μείνετε αριστερά
 keep_right=μείνετε δεξιά
 turn_onto=%1$s στην %2$s
+turn_on=%1$s στην %2$s
 turn_left=στρίψτε αριστερά
 turn_right=στρίψτε δεξιά
 turn_slight_left=στρίψτε λοξά αριστερά

--- a/core/src/main/resources/com/graphhopper/util/en_AU.txt
+++ b/core/src/main/resources/com/graphhopper/util/en_AU.txt
@@ -1,10 +1,12 @@
 # do not edit manually, instead use spreadsheet from translations.md and script ./core/files/update-translations.sh
 continue=
 continue_onto=
+continue_on=
 finish=
 keep_left=
 keep_right=
 turn_onto=
+turn_on=
 turn_left=
 turn_right=
 turn_slight_left=

--- a/core/src/main/resources/com/graphhopper/util/en_US.txt
+++ b/core/src/main/resources/com/graphhopper/util/en_US.txt
@@ -1,10 +1,12 @@
 # do not edit manually, instead use spreadsheet from translations.md and script ./core/files/update-translations.sh
 continue=continue
 continue_onto=continue onto %1$s
+continue_on=continue on %1$s
 finish=arrive at destination
 keep_left=keep left
 keep_right=keep right
 turn_onto=%1$s onto %2$s
+turn_on=%1$s on %2$s
 turn_left=turn left
 turn_right=turn right
 turn_slight_left=turn slight left

--- a/core/src/main/resources/com/graphhopper/util/eo.txt
+++ b/core/src/main/resources/com/graphhopper/util/eo.txt
@@ -1,10 +1,12 @@
 # do not edit manually, instead use spreadsheet from translations.md and script ./core/files/update-translations.sh
 continue=pluu
 continue_onto=pluu laŭlonge de %1$s
+continue_on=pluu laŭlonge de %1$s
 finish=Celo!
 keep_left=veturu ĉe maldekstra flanko
 keep_right=veturu ĉe dekstra fllanko
 turn_onto=%1$s al %2$s
+turn_on=%1$s al %2$s
 turn_left=turniĝu maldekstren
 turn_right=turniĝu dekstren
 turn_slight_left=turniĝetu maldekstren

--- a/core/src/main/resources/com/graphhopper/util/es.txt
+++ b/core/src/main/resources/com/graphhopper/util/es.txt
@@ -1,10 +1,12 @@
 # do not edit manually, instead use spreadsheet from translations.md and script ./core/files/update-translations.sh
 continue=continúa
 continue_onto=continúa por %1$s
+continue_on=continúa por %1$s
 finish=¡Fin del recorrido!
 keep_left=mantente a la izquierda
 keep_right=mantente a la derecha
 turn_onto=%1$s por %2$s
+turn_on=%1$s por %2$s
 turn_left=gira a la izquierda
 turn_right=gira a la derecha
 turn_slight_left=gira leve a la izquierda

--- a/core/src/main/resources/com/graphhopper/util/fa.txt
+++ b/core/src/main/resources/com/graphhopper/util/fa.txt
@@ -1,10 +1,12 @@
 # do not edit manually, instead use spreadsheet from translations.md and script ./core/files/update-translations.sh
 continue=ادامه دهید
 continue_onto=در %1$s ادامه دهید
+continue_on=در %1$s ادامه دهید
 finish=به مقصد رسیدید
 keep_left=به چپ برانید
 keep_right=به راست برانید
 turn_onto=%1$s و به %2$s وارد شوید
+turn_on=%1$s و به %2$s وارد شوید
 turn_left=به چپ بپیچید
 turn_right=به راست بپیچید
 turn_slight_left=کمی به چپ بپیچید

--- a/core/src/main/resources/com/graphhopper/util/fi.txt
+++ b/core/src/main/resources/com/graphhopper/util/fi.txt
@@ -1,10 +1,12 @@
 # do not edit manually, instead use spreadsheet from translations.md and script ./core/files/update-translations.sh
 continue=jatka
 continue_onto=jatka tielle %1$S
+continue_on=jatka tielle %1$S
 finish=Olet perillä!
 keep_left=pysy vasemmalla
 keep_right=pysy oikealla
 turn_onto=%1$S tielle %2$S
+turn_on=%1$S tielle %2$S
 turn_left=käänny vasemmalle
 turn_right=käänny oikealle
 turn_slight_left=käänny loivasti vasemmalle

--- a/core/src/main/resources/com/graphhopper/util/fil.txt
+++ b/core/src/main/resources/com/graphhopper/util/fil.txt
@@ -1,10 +1,12 @@
 # do not edit manually, instead use spreadsheet from translations.md and script ./core/files/update-translations.sh
 continue=tuwirín ang daán
 continue_onto=magpatuloy papunta sa %1$s
+continue_on=magpatuloy papunta sa %1$s
 finish=Tapusin!
 keep_left=
 keep_right=
 turn_onto=%1$s papunta sa %2$s
+turn_on=%1$s papunta sa %2$s
 turn_left=pagliko kaliwa
 turn_right=pagliko karapatan
 turn_slight_left=pagliko bahagyang kaliwa

--- a/core/src/main/resources/com/graphhopper/util/fr_CH.txt
+++ b/core/src/main/resources/com/graphhopper/util/fr_CH.txt
@@ -1,10 +1,12 @@
 # do not edit manually, instead use spreadsheet from translations.md and script ./core/files/update-translations.sh
 continue=continuez
 continue_onto=continuez sur %1$s
+continue_on=continuez sur %1$s
 finish=Arrivée
 keep_left=restez sur la gauche
 keep_right=restez sur la droite
 turn_onto=%1$s sur %2$s
+turn_on=%1$s sur %2$s
 turn_left=tournez à gauche
 turn_right=tournez à droite
 turn_slight_left=tournez légèrement à gauche

--- a/core/src/main/resources/com/graphhopper/util/fr_FR.txt
+++ b/core/src/main/resources/com/graphhopper/util/fr_FR.txt
@@ -1,10 +1,12 @@
 # do not edit manually, instead use spreadsheet from translations.md and script ./core/files/update-translations.sh
 continue=continuez
 continue_onto=continuez sur %1$s
+continue_on=continuez sur %1$s
 finish=Arrivée
 keep_left=restez sur la gauche
 keep_right=restez sur la droite
 turn_onto=%1$s sur %2$s
+turn_on=%1$s sur %2$s
 turn_left=tournez à gauche
 turn_right=tournez à droite
 turn_slight_left=tournez légèrement à gauche

--- a/core/src/main/resources/com/graphhopper/util/gl.txt
+++ b/core/src/main/resources/com/graphhopper/util/gl.txt
@@ -1,10 +1,12 @@
 # do not edit manually, instead use spreadsheet from translations.md and script ./core/files/update-translations.sh
 continue=continúe
 continue_onto=continúe por %1$s
+continue_on=continúe por %1$s
 finish=Obxectivo acadado
 keep_left=
 keep_right=
 turn_onto=%1$s por %2$s
+turn_on=%1$s por %2$s
 turn_left=vire por esquerda
 turn_right=vire por dereita
 turn_slight_left=vire á esquerda

--- a/core/src/main/resources/com/graphhopper/util/he.txt
+++ b/core/src/main/resources/com/graphhopper/util/he.txt
@@ -1,10 +1,12 @@
 # do not edit manually, instead use spreadsheet from translations.md and script ./core/files/update-translations.sh
 continue=להמשיך
 continue_onto=להמשיך אל %1$s
+continue_on=להמשיך אל %1$s
 finish=הגעת ליעד
 keep_left=להיצמד לשמאל
 keep_right=להיצמד לימין
 turn_onto=יש לפנות %1$s אל %2$s
+turn_on=יש לפנות %1$s אל %2$s
 turn_left=שמאלה
 turn_right=ימינה
 turn_slight_left=מעט שמאלה

--- a/core/src/main/resources/com/graphhopper/util/hr_HR.txt
+++ b/core/src/main/resources/com/graphhopper/util/hr_HR.txt
@@ -1,10 +1,12 @@
 # do not edit manually, instead use spreadsheet from translations.md and script ./core/files/update-translations.sh
 continue=nastavite
 continue_onto=nastavite na %1$s
+continue_on=nastavite na %1$s
 finish=Cilj!
 keep_left=
 keep_right=
 turn_onto=%1$s na %2$s
+turn_on=%1$s na %2$s
 turn_left=skrenite lijevo
 turn_right=skrenite desno
 turn_slight_left=skrenite blago lijevo

--- a/core/src/main/resources/com/graphhopper/util/hsb.txt
+++ b/core/src/main/resources/com/graphhopper/util/hsb.txt
@@ -1,10 +1,12 @@
 # do not edit manually, instead use spreadsheet from translations.md and script ./core/files/update-translations.sh
 continue=runjewon
 continue_onto=runjewon na %1$s
+continue_on=runjewon na %1$s
 finish=dojěł
 keep_left=
 keep_right=
 turn_onto=%1$s na %2$s
+turn_on=%1$s na %2$s
 turn_left=nalěwo wotbočić
 turn_right=naprawo wotbočić
 turn_slight_left=zlochka nalěwo wotbočić

--- a/core/src/main/resources/com/graphhopper/util/hu_HU.txt
+++ b/core/src/main/resources/com/graphhopper/util/hu_HU.txt
@@ -1,10 +1,12 @@
 # do not edit manually, instead use spreadsheet from translations.md and script ./core/files/update-translations.sh
 continue=haladjon tovább
 continue_onto=haladjon tovább erre: %1$s
+continue_on=haladjon tovább erre: %1$s
 finish=érkezés a célponthoz
 keep_left=tartson balra
 keep_right=tartson jobbra
 turn_onto=%1$s erre: %2$s
+turn_on=%1$s erre: %2$s
 turn_left=forduljon balra
 turn_right=forduljon jobbra
 turn_slight_left=forduljon enyhén balra

--- a/core/src/main/resources/com/graphhopper/util/in_ID.txt
+++ b/core/src/main/resources/com/graphhopper/util/in_ID.txt
@@ -1,10 +1,12 @@
 # do not edit manually, instead use spreadsheet from translations.md and script ./core/files/update-translations.sh
 continue=lanjut
 continue_onto=menuju pada %1$s
+continue_on=menuju pada %1$s
 finish=Sampai pada tujuan akhir
 keep_left=tetap berada jalur kiri
 keep_right=tetap berada jalur kiri
 turn_onto=%1$s belok menuju %2$s
+turn_on=%1$s belok menuju %2$s
 turn_left=belok kiri
 turn_right=belok kanan
 turn_slight_left=belok kiri sedikit

--- a/core/src/main/resources/com/graphhopper/util/it.txt
+++ b/core/src/main/resources/com/graphhopper/util/it.txt
@@ -1,10 +1,12 @@
 # do not edit manually, instead use spreadsheet from translations.md and script ./core/files/update-translations.sh
 continue=continua
 continue_onto=continua su %1$s
+continue_on=continua su %1$s
 finish=arrivato a destinazione
 keep_left=tieni la sinistra
 keep_right=tieni la destra
 turn_onto=%1$s su %2$s
+turn_on=%1$s su %2$s
 turn_left=gira a sinistra
 turn_right=gira a destra
 turn_slight_left=gira leggermente a sinistra

--- a/core/src/main/resources/com/graphhopper/util/ja.txt
+++ b/core/src/main/resources/com/graphhopper/util/ja.txt
@@ -1,10 +1,12 @@
 # do not edit manually, instead use spreadsheet from translations.md and script ./core/files/update-translations.sh
 continue=進む
 continue_onto=%1$sまで進む
+continue_on=%1$sまで進む
 finish=目標達成
 keep_left=
 keep_right=
 turn_onto=%1$sに曲がって%2$sに入る
+turn_on=%1$sに曲がって%2$sに入る
 turn_left=左に曲がる
 turn_right=右に曲がる
 turn_slight_left=左に曲がる

--- a/core/src/main/resources/com/graphhopper/util/kab_DZ.txt
+++ b/core/src/main/resources/com/graphhopper/util/kab_DZ.txt
@@ -1,10 +1,12 @@
 # do not edit manually, instead use spreadsheet from translations.md and script ./core/files/update-translations.sh
 continue=Kemmel
 continue_onto=Kemmel ɣef %1$s
+continue_on=Kemmel ɣef %1$s
 finish=ad tawḍeḍ anda i tettedduḍ
 keep_left=ṭṭef tama taẓelmaḍt
 keep_right=ṭṭef tama tayeffust
 turn_onto=%1$s ɣef %2$s
+turn_on=%1$s ɣef %2$s
 turn_left=bren ɣer tama taẓelmaḍt
 turn_right=bren ɣer tama tayeffust
 turn_slight_left=bren am wacemma ɣer tama taẓelmaḍt

--- a/core/src/main/resources/com/graphhopper/util/ko.txt
+++ b/core/src/main/resources/com/graphhopper/util/ko.txt
@@ -1,10 +1,12 @@
 # do not edit manually, instead use spreadsheet from translations.md and script ./core/files/update-translations.sh
 continue=계속
 continue_onto=%1$s(으)로 계속 이동
+continue_on=%1$s(으)로 계속 이동
 finish=도착
 keep_left=좌측 유지
 keep_right=우측 유지
 turn_onto=%2$s로 %1$s
+turn_on=%2$s로 %1$s
 turn_left=좌회전
 turn_right=우회전
 turn_slight_left=왼쪽 방향

--- a/core/src/main/resources/com/graphhopper/util/kz.txt
+++ b/core/src/main/resources/com/graphhopper/util/kz.txt
@@ -1,10 +1,12 @@
 # do not edit manually, instead use spreadsheet from translations.md and script ./core/files/update-translations.sh
 continue=Жалғастырыңыз
 continue_onto=%1$s бойынша жалғастырыңыз
+continue_on=%1$s бойынша жалғастырыңыз
 finish=мәреге жеттіңіз
 keep_left=сол жаққа шығыңыз
 keep_right=оң жаққа шығыңыз
 turn_onto=
+turn_on=
 turn_left=солға бұрылыңыз
 turn_right=оңға бұрылыңыз
 turn_slight_left=аздап солға бұрылыңыз

--- a/core/src/main/resources/com/graphhopper/util/lt_LT.txt
+++ b/core/src/main/resources/com/graphhopper/util/lt_LT.txt
@@ -1,10 +1,12 @@
 # do not edit manually, instead use spreadsheet from translations.md and script ./core/files/update-translations.sh
 continue=tęskite
 continue_onto=tęskite toliau %1$s
+continue_on=tęskite toliau %1$s
 finish=Tikslas pasiektas!
 keep_left=laikykitės kairiau
 keep_right=laikykitės dešiniau
 turn_onto=%1$s į %2$s
+turn_on=%1$s į %2$s
 turn_left=sukite kairėn
 turn_right=sukite dešinėn
 turn_slight_left=laikykite kairiau

--- a/core/src/main/resources/com/graphhopper/util/mn.txt
+++ b/core/src/main/resources/com/graphhopper/util/mn.txt
@@ -1,10 +1,12 @@
 # do not edit manually, instead use spreadsheet from translations.md and script ./core/files/update-translations.sh
 continue=үргэлжлүүл
 continue_onto=%1$s дээр үргэлжлүүлнэ үү
+continue_on=%1$s дээр үргэлжлүүлнэ үү
 finish=зорьсон газраа хүрэх
 keep_left=зүүн байлгах
 keep_right=зөв байлгах
 turn_onto=%1$s дээр %2$s
+turn_on=%1$s дээр %2$s
 turn_left=зүүн эргэ
 turn_right=баруун эргэ
 turn_slight_left=бага зэрэг зүүн эргэ

--- a/core/src/main/resources/com/graphhopper/util/nb_NO.txt
+++ b/core/src/main/resources/com/graphhopper/util/nb_NO.txt
@@ -1,10 +1,12 @@
 # do not edit manually, instead use spreadsheet from translations.md and script ./core/files/update-translations.sh
 continue=fortsett
 continue_onto=fortsett på %1$s
+continue_on=fortsett på %1$s
 finish=fremme
 keep_left=hold til venstre
 keep_right=hold til høyre
 turn_onto=%1$s på %2$s
+turn_on=%1$s på %2$s
 turn_left=sving til venstre
 turn_right=sving til høyre
 turn_slight_left=svak venstre

--- a/core/src/main/resources/com/graphhopper/util/ne.txt
+++ b/core/src/main/resources/com/graphhopper/util/ne.txt
@@ -1,10 +1,12 @@
 # do not edit manually, instead use spreadsheet from translations.md and script ./core/files/update-translations.sh
 continue=गहिरख्नुहोस
 continue_onto=%1$s गहिरख्नुहोस
+continue_on=%1$s गहिरख्नुहोस
 finish=सकियो
 keep_left=
 keep_right=
 turn_onto=%2$s मा %1$s मोड्नुहोस
+turn_on=%2$s मा %1$s मोड्नुहोस
 turn_left=बाया मोड्नुहोस
 turn_right=दाया मोड्नुहोस
 turn_slight_left=थोरै बाया मोड्नुहोस

--- a/core/src/main/resources/com/graphhopper/util/nl.txt
+++ b/core/src/main/resources/com/graphhopper/util/nl.txt
@@ -1,10 +1,12 @@
 # do not edit manually, instead use spreadsheet from translations.md and script ./core/files/update-translations.sh
 continue=Ga rechtdoor
 continue_onto=blijf op %1$s
+continue_on=blijf op %1$s
 finish=Bestemming bereikt
 keep_left=houd links aan
 keep_right=houd rechts aan
 turn_onto=%1$s naar %2$s
+turn_on=%1$s naar %2$s
 turn_left=linksaf
 turn_right=rechtsaf
 turn_slight_left=houd links aan

--- a/core/src/main/resources/com/graphhopper/util/pl.txt
+++ b/core/src/main/resources/com/graphhopper/util/pl.txt
@@ -1,10 +1,12 @@
 # do not edit manually, instead use spreadsheet from translations.md and script ./core/files/update-translations.sh
 continue=kontynuuj
 continue_onto=kontynuuj na %1$s
+continue_on=kontynuuj na %1$s
 finish=Jesteś u celu!
 keep_left=trzymaj się lewej strony
 keep_right=trzymaj się prawej strony
 turn_onto=%1$s na %2$s
+turn_on=%1$s na %2$s
 turn_left=skręć w lewo
 turn_right=skręć w prawo
 turn_slight_left=skręć delikatnie w lewo

--- a/core/src/main/resources/com/graphhopper/util/pt_BR.txt
+++ b/core/src/main/resources/com/graphhopper/util/pt_BR.txt
@@ -1,10 +1,12 @@
 # do not edit manually, instead use spreadsheet from translations.md and script ./core/files/update-translations.sh
 continue=continuar
 continue_onto=continue na %1$s
+continue_on=continue na %1$s
 finish=Destino alcançado!
 keep_left=mantenha-se à esquerda
 keep_right=mantenha-se à direita
 turn_onto=%1$s na %2$s
+turn_on=%1$s na %2$s
 turn_left=vire à esquerda
 turn_right=vire à direita
 turn_slight_left=curva suave à esquerda

--- a/core/src/main/resources/com/graphhopper/util/pt_PT.txt
+++ b/core/src/main/resources/com/graphhopper/util/pt_PT.txt
@@ -1,10 +1,12 @@
 # do not edit manually, instead use spreadsheet from translations.md and script ./core/files/update-translations.sh
 continue=continuar
 continue_onto=continue na %1$s
+continue_on=continue na %1$s
 finish=Chegou ao seu destino!
 keep_left=mantenha-se à esquerda
 keep_right=mantenha-se à direita
 turn_onto=%1$s para %2$s
+turn_on=%1$s para %2$s
 turn_left=vire à esquerda
 turn_right=vire à direita
 turn_slight_left=vire à curva ligeira à esquerda

--- a/core/src/main/resources/com/graphhopper/util/ro.txt
+++ b/core/src/main/resources/com/graphhopper/util/ro.txt
@@ -1,10 +1,12 @@
 # do not edit manually, instead use spreadsheet from translations.md and script ./core/files/update-translations.sh
 continue=continuă
 continue_onto=continuă pe %1$s
+continue_on=continuă pe %1$s
 finish=obiectiv atins
 keep_left=Rămâneți pe banda stângă
 keep_right=Rămâneți pe banda dreaptă
 turn_onto=%1$s pe %2$s
+turn_on=%1$s pe %2$s
 turn_left=schimbați direcția la stânga
 turn_right=schimbați direcția la dreapta
 turn_slight_left=schimbați direcția la ușor la stânga

--- a/core/src/main/resources/com/graphhopper/util/ru.txt
+++ b/core/src/main/resources/com/graphhopper/util/ru.txt
@@ -1,10 +1,12 @@
 # do not edit manually, instead use spreadsheet from translations.md and script ./core/files/update-translations.sh
 continue=Продолжите движение
 continue_onto=Продолжите движение по %1$s
+continue_on=Продолжите движение по %1$s
 finish=Цель достигнута!
 keep_left=Держитесь левее
 keep_right=Держитесь правее
 turn_onto=%1$s на %2$s
+turn_on=%1$s на %2$s
 turn_left=Поверните налево
 turn_right=Поверните направо
 turn_slight_left=Плавно поверните налево

--- a/core/src/main/resources/com/graphhopper/util/sk.txt
+++ b/core/src/main/resources/com/graphhopper/util/sk.txt
@@ -1,10 +1,12 @@
 # do not edit manually, instead use spreadsheet from translations.md and script ./core/files/update-translations.sh
 continue=pokračujte
 continue_onto=pokračujte na %1$s
+continue_on=pokračujte na %1$s
 finish=Cieľ!
 keep_left=držte sa vľavo
 keep_right=držte sa vpravo
 turn_onto=%1$s na %2$s
+turn_on=%1$s na %2$s
 turn_left=odbočte doľava
 turn_right=odbočte doprava
 turn_slight_left=odbočte mierne doľava

--- a/core/src/main/resources/com/graphhopper/util/sl_SI.txt
+++ b/core/src/main/resources/com/graphhopper/util/sl_SI.txt
@@ -1,10 +1,12 @@
 # do not edit manually, instead use spreadsheet from translations.md and script ./core/files/update-translations.sh
 continue=nadaljujte
 continue_onto=nadaljujte po %1$s
+continue_on=nadaljujte po %1$s
 finish=Konec!
 keep_left=držite se levo
 keep_right=držite se desno
 turn_onto=%1$s na %2$s
+turn_on=%1$s na %2$s
 turn_left=zavijte levo
 turn_right=zavijte desno
 turn_slight_left=zavijte rahlo levo

--- a/core/src/main/resources/com/graphhopper/util/sr_RS.txt
+++ b/core/src/main/resources/com/graphhopper/util/sr_RS.txt
@@ -1,10 +1,12 @@
 # do not edit manually, instead use spreadsheet from translations.md and script ./core/files/update-translations.sh
 continue=nastavite
 continue_onto=nastavite na %1$s
+continue_on=nastavite na %1$s
 finish=Cilj!
 keep_left=
 keep_right=
 turn_onto=%1$s na %2$s
+turn_on=%1$s na %2$s
 turn_left=skrenite levo
 turn_right=skrenite desno
 turn_slight_left=skrenite blago levo

--- a/core/src/main/resources/com/graphhopper/util/sv_SE.txt
+++ b/core/src/main/resources/com/graphhopper/util/sv_SE.txt
@@ -1,10 +1,12 @@
 # do not edit manually, instead use spreadsheet from translations.md and script ./core/files/update-translations.sh
 continue=fortsätt
 continue_onto=fortsätt in på %1$s
+continue_on=fortsätt in på %1$s
 finish=Framme!
 keep_left=håll till vänster
 keep_right=håll till höger
 turn_onto=%1$s in på %2$s
+turn_on=%1$s in på %2$s
 turn_left=sväng vänster
 turn_right=sväng höger
 turn_slight_left=sväng svagt vänster

--- a/core/src/main/resources/com/graphhopper/util/tr.txt
+++ b/core/src/main/resources/com/graphhopper/util/tr.txt
@@ -1,10 +1,12 @@
 # do not edit manually, instead use spreadsheet from translations.md and script ./core/files/update-translations.sh
 continue=devam
 continue_onto=%1$s üstünde devam edin
+continue_on=%1$s üstünde devam edin
 finish=hedefe ulaştınız
 keep_left=soldan ilerleyin
 keep_right=sağdan ilerleyin
 turn_onto=%2$s üstünde %1$s
+turn_on=%2$s üstünde %1$s
 turn_left=sola dönün
 turn_right=sağa dönün
 turn_slight_left=hafif sola dönün

--- a/core/src/main/resources/com/graphhopper/util/uk.txt
+++ b/core/src/main/resources/com/graphhopper/util/uk.txt
@@ -1,10 +1,12 @@
 # do not edit manually, instead use spreadsheet from translations.md and script ./core/files/update-translations.sh
 continue=продовжуйте
 continue_onto=продовжуйте по %1$s
+continue_on=продовжуйте по %1$s
 finish=Ви прибули до пункту призначення!
 keep_left=Тримайтеся ліворуч
 keep_right=Тримайтеся праворуч
 turn_onto=%1$s на %2$s
+turn_on=%1$s на %2$s
 turn_left=Поверніть ліворуч
 turn_right=Поверніть праворуч
 turn_slight_left=Поверніть трохи лівіше

--- a/core/src/main/resources/com/graphhopper/util/uz.txt
+++ b/core/src/main/resources/com/graphhopper/util/uz.txt
@@ -1,10 +1,12 @@
 # do not edit manually, instead use spreadsheet from translations.md and script ./core/files/update-translations.sh
 continue=Harakatni davom ettiring
 continue_onto=%1$s bo'ylab harakatni davom ettiring
+continue_on=%1$s bo'ylab harakatni davom ettiring
 finish=Yetib keldingiz
 keep_left=Chaproq tuting
 keep_right=O'ngroq tuting
 turn_onto=%1$s dan %2$s ga
+turn_on=%1$s dan %2$s ga
 turn_left=Chapga buriling
 turn_right=O'ngga buriling
 turn_slight_left=Yengil chapga buriling

--- a/core/src/main/resources/com/graphhopper/util/vi_VN.txt
+++ b/core/src/main/resources/com/graphhopper/util/vi_VN.txt
@@ -1,10 +1,12 @@
 # do not edit manually, instead use spreadsheet from translations.md and script ./core/files/update-translations.sh
 continue=tiếp tục
 continue_onto=tiếp tục đến %1$s
+continue_on=tiếp tục đến %1$s
 finish=Kết thúc!
 keep_left=ở bên trái
 keep_right=ở bên phải
 turn_onto=%1$s vào %2$s
+turn_on=%1$s vào %2$s
 turn_left=rẽ trái
 turn_right=rẽ phải
 turn_slight_left=rẽ nhẹ sang trái

--- a/core/src/main/resources/com/graphhopper/util/zh_CN.txt
+++ b/core/src/main/resources/com/graphhopper/util/zh_CN.txt
@@ -1,10 +1,12 @@
 # do not edit manually, instead use spreadsheet from translations.md and script ./core/files/update-translations.sh
 continue=继续
 continue_onto=继续行驶到 %1$s
+continue_on=继续行驶到 %1$s
 finish=到达终点
 keep_left=保持左行
 keep_right=保持右行
 turn_onto=%1$s到 %2$s
+turn_on=%1$s到 %2$s
 turn_left=左转
 turn_right=右转
 turn_slight_left=偏左转

--- a/core/src/main/resources/com/graphhopper/util/zh_HK.txt
+++ b/core/src/main/resources/com/graphhopper/util/zh_HK.txt
@@ -1,10 +1,12 @@
 # do not edit manually, instead use spreadsheet from translations.md and script ./core/files/update-translations.sh
 continue=繼續
 continue_onto=繼續行駛到 %1$s
+continue_on=繼續行駛到 %1$s
 finish=到達目的地
 keep_left=保持左行
 keep_right=保持右行
 turn_onto=%1$s 到 %2$s
+turn_on=%1$s 到 %2$s
 turn_left=左轉
 turn_right=右轉
 turn_slight_left=左轉

--- a/core/src/main/resources/com/graphhopper/util/zh_TW.txt
+++ b/core/src/main/resources/com/graphhopper/util/zh_TW.txt
@@ -1,10 +1,12 @@
 # do not edit manually, instead use spreadsheet from translations.md and script ./core/files/update-translations.sh
 continue=繼續
 continue_onto=繼續行駛到 %1$s
+continue_on=繼續行駛到 %1$s
 finish=抵達目的地
 keep_left=保持左側
 keep_right=保持右側
 turn_onto=%1$s 進入%2$s
+turn_on=%1$s 進入%2$s
 turn_left=左轉
 turn_right=右轉
 turn_slight_left=微靠左轉

--- a/core/src/test/java/com/graphhopper/util/InstructionListTest.java
+++ b/core/src/test/java/com/graphhopper/util/InstructionListTest.java
@@ -417,7 +417,7 @@ public class InstructionListTest {
         assertEquals(IntArrayList.from(4, 2, 3), p.calcNodes());
         InstructionList wayList = InstructionsFromEdges.calcInstructions(p, g, weighting, tmpEM, usTR);
         List<String> tmpList = getTurnDescriptions(wayList);
-        assertEquals(Arrays.asList("continue onto myroad", "keep right onto myroad", "arrive at destination"), tmpList);
+        assertEquals(Arrays.asList("continue onto myroad", "keep right on myroad", "arrive at destination"), tmpList);
         assertEquals(3, wayList.size());
         assertEquals(20, wayList.get(1).getDistance());
 
@@ -425,9 +425,22 @@ public class InstructionListTest {
         assertEquals(IntArrayList.from(4, 2, 1), p.calcNodes());
         wayList = InstructionsFromEdges.calcInstructions(p, g, weighting, tmpEM, usTR);
         tmpList = getTurnDescriptions(wayList);
-        assertEquals(Arrays.asList("continue onto myroad", "keep left onto myroad", "arrive at destination"), tmpList);
+        assertEquals(Arrays.asList("continue onto myroad", "keep left on myroad", "arrive at destination"), tmpList);
         assertEquals(3, wayList.size());
         assertEquals(20, wayList.get(1).getDistance());
+    }
+
+    @Test
+    public void testContinueOnWhenStreetNameUnchanged() {
+        Instruction cont = new Instruction(Instruction.CONTINUE_ON_STREET, "E42", new PointList());
+        assertEquals("continue onto E42", cont.getTurnDescription(usTR));
+        cont.setStreetNameChanged(false);
+        assertEquals("continue on E42", cont.getTurnDescription(usTR));
+
+        Instruction keep = new Instruction(Instruction.KEEP_LEFT, "E42", new PointList());
+        assertEquals("keep left onto E42", keep.getTurnDescription(usTR));
+        keep.setStreetNameChanged(false);
+        assertEquals("keep left on E42", keep.getTurnDescription(usTR));
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/util/TranslationMapTest.java
+++ b/core/src/test/java/com/graphhopper/util/TranslationMapTest.java
@@ -41,6 +41,9 @@ public class TranslationMapTest {
 
         Translation trMap = SINGLETON.getWithFallBack(Locale.GERMANY);
         assertEquals("Zu Fuß", trMap.tr("web.FOOT"));
+        // other locales keep the onto wording until translators update continue_on / turn_on
+        assertEquals("dem Straßenverlauf von E42 folgen", trMap.tr("continue_on", "E42"));
+        assertEquals("links halten auf E42", trMap.tr("turn_on", "links halten", "E42"));
 
         Translation ruMap = SINGLETON.getWithFallBack(new Locale("ru"));
         assertEquals("Пешком", ruMap.tr("web.FOOT"));

--- a/core/src/test/java/com/graphhopper/util/TranslationMapTest.java
+++ b/core/src/test/java/com/graphhopper/util/TranslationMapTest.java
@@ -36,6 +36,8 @@ public class TranslationMapTest {
     public void testToString() {
         Translation enMap = SINGLETON.getWithFallBack(Locale.UK);
         assertEquals("continue onto blp street", enMap.tr("continue_onto", "blp street"));
+        assertEquals("continue on blp street", enMap.tr("continue_on", "blp street"));
+        assertEquals("keep left on E42", enMap.tr("turn_on", "keep left", "E42"));
 
         Translation trMap = SINGLETON.getWithFallBack(Locale.GERMANY);
         assertEquals("Zu Fuß", trMap.tr("web.FOOT"));

--- a/web-api/src/main/java/com/graphhopper/util/Instruction.java
+++ b/web-api/src/main/java/com/graphhopper/util/Instruction.java
@@ -53,6 +53,8 @@ public class Instruction {
     protected double distance;
     protected long time;
     protected Map<String, Object> extraInfo = new HashMap<>(3);
+    // true: "onto" (name changed or first instruction). false: "on" (still on the same street).
+    private boolean streetNameChanged = true;
 
     /**
      * The points, distances and times have exactly the same count. The last point of this
@@ -89,6 +91,11 @@ public class Instruction {
 
     public void setName(String name) {
         if (name != null) this.name = name;
+    }
+
+    public Instruction setStreetNameChanged(boolean streetNameChanged) {
+        this.streetNameChanged = streetNameChanged;
+        return this;
     }
 
     String _getName() {
@@ -175,7 +182,13 @@ public class Instruction {
 
         int sign = getSign();
         if (sign == Instruction.CONTINUE_ON_STREET) {
-            str = Helper.isEmpty(streetName) ? tr.tr("continue") : tr.tr("continue_onto", streetName);
+            if (Helper.isEmpty(streetName)) {
+                str = tr.tr("continue");
+            } else if (streetNameChanged) {
+                str = tr.tr("continue_onto", streetName);
+            } else {
+                str = tr.tr("continue_on", streetName);
+            }
         } else if (sign == Instruction.FERRY) {
             if (ferryStr == null)
                 throw new RuntimeException("no ferry information provided but sign is FERRY");
@@ -225,8 +238,12 @@ public class Instruction {
             }
             if (dir == null)
                 str = tr.tr("unknown", sign);
+            else if (streetName.isEmpty())
+                str = dir;
+            else if (!streetNameChanged && (sign == Instruction.KEEP_LEFT || sign == Instruction.KEEP_RIGHT))
+                str = tr.tr("turn_on", dir, streetName);
             else
-                str = streetName.isEmpty() ? dir : tr.tr("turn_onto", dir, streetName);
+                str = tr.tr("turn_onto", dir, streetName);
         }
 
         if ("leave_ferry".equals(ferryStr))


### PR DESCRIPTION
Continue and keep used onto even when the road name did not change.

I used on when the name stays the same, and onto when it changes. Turns are still onto.

Added continue_on and turn_on to en_US (other locales fall back to English).

#1287