### PR TITLE
Add `level` encoded value.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -65,6 +65,7 @@ Here is an overview:
  * michaz, one of the core developers
  * mprins, improvements for travis CI and regarding JDK9 #806
  * msbarry, fixes like #1733
+ * n8dx, contributions for accessible pedestrian routing
  * nakaner, documentation
  * naser13, fixes like #1923
  * njanakiev, fixes like #1560

--- a/core/src/main/java/com/graphhopper/routing/ev/DefaultImportRegistry.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/DefaultImportRegistry.java
@@ -172,6 +172,11 @@ public class DefaultImportRegistry implements ImportRegistry {
                     (lookup, props) -> new OSMCyclewayParser(
                             lookup.getEnumEncodedValue(Cycleway.KEY, Cycleway.class))
             );
+        else if (Level.KEY.equals(name))
+            return ImportUnit.create(name, props -> Level.create(),
+                    (lookup, props) -> new OSMLevelParser(lookup
+                            .getEnumEncodedValue(Level.KEY, Level.class))
+            );
         else if (OSMWayID.KEY.equals(name))
             return ImportUnit.create(name, props -> OSMWayID.create(),
                     (lookup, props) -> new OSMWayIDParser(

--- a/core/src/main/java/com/graphhopper/routing/ev/DefaultImportRegistry.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/DefaultImportRegistry.java
@@ -18,67 +18,8 @@
 
 package com.graphhopper.routing.ev;
 
-<<<<<<< HEAD
 import com.graphhopper.routing.util.*;
 import com.graphhopper.routing.util.parsers.*;
-=======
-import com.graphhopper.routing.util.CurvatureCalculator;
-import com.graphhopper.routing.util.FerrySpeedCalculator;
-import com.graphhopper.routing.util.PriorityCode;
-import com.graphhopper.routing.util.SlopeCalculator;
-import com.graphhopper.routing.util.TransportationMode;
-import com.graphhopper.routing.util.parsers.BikeAccessParser;
-import com.graphhopper.routing.util.parsers.BikeAverageSpeedParser;
-import com.graphhopper.routing.util.parsers.BikePriorityParser;
-import com.graphhopper.routing.util.parsers.CarAccessParser;
-import com.graphhopper.routing.util.parsers.CarAverageSpeedParser;
-import com.graphhopper.routing.util.parsers.CountryParser;
-import com.graphhopper.routing.util.parsers.FootAccessParser;
-import com.graphhopper.routing.util.parsers.FootAverageSpeedParser;
-import com.graphhopper.routing.util.parsers.FootPriorityParser;
-import com.graphhopper.routing.util.parsers.MaxWeightExceptParser;
-import com.graphhopper.routing.util.parsers.ModeAccessParser;
-import com.graphhopper.routing.util.parsers.MountainBikeAccessParser;
-import com.graphhopper.routing.util.parsers.MountainBikeAverageSpeedParser;
-import com.graphhopper.routing.util.parsers.MountainBikePriorityParser;
-import com.graphhopper.routing.util.parsers.OSMCrossingParser;
-import com.graphhopper.routing.util.parsers.OSMFootwayParser;
-import com.graphhopper.routing.util.parsers.OSMGetOffBikeParser;
-import com.graphhopper.routing.util.parsers.OSMHazmatParser;
-import com.graphhopper.routing.util.parsers.OSMHazmatTunnelParser;
-import com.graphhopper.routing.util.parsers.OSMHazmatWaterParser;
-import com.graphhopper.routing.util.parsers.OSMHgvParser;
-import com.graphhopper.routing.util.parsers.OSMHikeRatingParser;
-import com.graphhopper.routing.util.parsers.OSMHorseRatingParser;
-import com.graphhopper.routing.util.parsers.OSMKerbParser;
-import com.graphhopper.routing.util.parsers.OSMLanesParser;
-import com.graphhopper.routing.util.parsers.OSMLevelParser;
-import com.graphhopper.routing.util.parsers.OSMMaxAxleLoadParser;
-import com.graphhopper.routing.util.parsers.OSMMaxHeightParser;
-import com.graphhopper.routing.util.parsers.OSMMaxLengthParser;
-import com.graphhopper.routing.util.parsers.OSMMaxSpeedParser;
-import com.graphhopper.routing.util.parsers.OSMMaxWeightParser;
-import com.graphhopper.routing.util.parsers.OSMMaxWidthParser;
-import com.graphhopper.routing.util.parsers.OSMMtbRatingParser;
-import com.graphhopper.routing.util.parsers.OSMRoadAccessParser;
-import com.graphhopper.routing.util.parsers.OSMRoadClassLinkParser;
-import com.graphhopper.routing.util.parsers.OSMRoadClassParser;
-import com.graphhopper.routing.util.parsers.OSMRoadEnvironmentParser;
-import com.graphhopper.routing.util.parsers.OSMRoundaboutParser;
-import com.graphhopper.routing.util.parsers.OSMSmoothnessParser;
-import com.graphhopper.routing.util.parsers.OSMSurfaceParser;
-import com.graphhopper.routing.util.parsers.OSMTactilePavingParser;
-import com.graphhopper.routing.util.parsers.OSMTemporalAccessParser;
-import com.graphhopper.routing.util.parsers.OSMTollParser;
-import com.graphhopper.routing.util.parsers.OSMTrackTypeParser;
-import com.graphhopper.routing.util.parsers.OSMTrafficSignalsSoundParser;
-import com.graphhopper.routing.util.parsers.OSMWayIDParser;
-import com.graphhopper.routing.util.parsers.OrientationCalculator;
-import com.graphhopper.routing.util.parsers.RacingBikeAccessParser;
-import com.graphhopper.routing.util.parsers.RacingBikeAverageSpeedParser;
-import com.graphhopper.routing.util.parsers.RacingBikePriorityParser;
-import com.graphhopper.routing.util.parsers.StateParser;
->>>>>>> 0e9dd7a73 (Fixed silly mistakes and added simple unit test.)
 import com.graphhopper.util.PMap;
 
 public class DefaultImportRegistry implements ImportRegistry {

--- a/core/src/main/java/com/graphhopper/routing/ev/DefaultImportRegistry.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/DefaultImportRegistry.java
@@ -18,8 +18,67 @@
 
 package com.graphhopper.routing.ev;
 
+<<<<<<< HEAD
 import com.graphhopper.routing.util.*;
 import com.graphhopper.routing.util.parsers.*;
+=======
+import com.graphhopper.routing.util.CurvatureCalculator;
+import com.graphhopper.routing.util.FerrySpeedCalculator;
+import com.graphhopper.routing.util.PriorityCode;
+import com.graphhopper.routing.util.SlopeCalculator;
+import com.graphhopper.routing.util.TransportationMode;
+import com.graphhopper.routing.util.parsers.BikeAccessParser;
+import com.graphhopper.routing.util.parsers.BikeAverageSpeedParser;
+import com.graphhopper.routing.util.parsers.BikePriorityParser;
+import com.graphhopper.routing.util.parsers.CarAccessParser;
+import com.graphhopper.routing.util.parsers.CarAverageSpeedParser;
+import com.graphhopper.routing.util.parsers.CountryParser;
+import com.graphhopper.routing.util.parsers.FootAccessParser;
+import com.graphhopper.routing.util.parsers.FootAverageSpeedParser;
+import com.graphhopper.routing.util.parsers.FootPriorityParser;
+import com.graphhopper.routing.util.parsers.MaxWeightExceptParser;
+import com.graphhopper.routing.util.parsers.ModeAccessParser;
+import com.graphhopper.routing.util.parsers.MountainBikeAccessParser;
+import com.graphhopper.routing.util.parsers.MountainBikeAverageSpeedParser;
+import com.graphhopper.routing.util.parsers.MountainBikePriorityParser;
+import com.graphhopper.routing.util.parsers.OSMCrossingParser;
+import com.graphhopper.routing.util.parsers.OSMFootwayParser;
+import com.graphhopper.routing.util.parsers.OSMGetOffBikeParser;
+import com.graphhopper.routing.util.parsers.OSMHazmatParser;
+import com.graphhopper.routing.util.parsers.OSMHazmatTunnelParser;
+import com.graphhopper.routing.util.parsers.OSMHazmatWaterParser;
+import com.graphhopper.routing.util.parsers.OSMHgvParser;
+import com.graphhopper.routing.util.parsers.OSMHikeRatingParser;
+import com.graphhopper.routing.util.parsers.OSMHorseRatingParser;
+import com.graphhopper.routing.util.parsers.OSMKerbParser;
+import com.graphhopper.routing.util.parsers.OSMLanesParser;
+import com.graphhopper.routing.util.parsers.OSMLevelParser;
+import com.graphhopper.routing.util.parsers.OSMMaxAxleLoadParser;
+import com.graphhopper.routing.util.parsers.OSMMaxHeightParser;
+import com.graphhopper.routing.util.parsers.OSMMaxLengthParser;
+import com.graphhopper.routing.util.parsers.OSMMaxSpeedParser;
+import com.graphhopper.routing.util.parsers.OSMMaxWeightParser;
+import com.graphhopper.routing.util.parsers.OSMMaxWidthParser;
+import com.graphhopper.routing.util.parsers.OSMMtbRatingParser;
+import com.graphhopper.routing.util.parsers.OSMRoadAccessParser;
+import com.graphhopper.routing.util.parsers.OSMRoadClassLinkParser;
+import com.graphhopper.routing.util.parsers.OSMRoadClassParser;
+import com.graphhopper.routing.util.parsers.OSMRoadEnvironmentParser;
+import com.graphhopper.routing.util.parsers.OSMRoundaboutParser;
+import com.graphhopper.routing.util.parsers.OSMSmoothnessParser;
+import com.graphhopper.routing.util.parsers.OSMSurfaceParser;
+import com.graphhopper.routing.util.parsers.OSMTactilePavingParser;
+import com.graphhopper.routing.util.parsers.OSMTemporalAccessParser;
+import com.graphhopper.routing.util.parsers.OSMTollParser;
+import com.graphhopper.routing.util.parsers.OSMTrackTypeParser;
+import com.graphhopper.routing.util.parsers.OSMTrafficSignalsSoundParser;
+import com.graphhopper.routing.util.parsers.OSMWayIDParser;
+import com.graphhopper.routing.util.parsers.OrientationCalculator;
+import com.graphhopper.routing.util.parsers.RacingBikeAccessParser;
+import com.graphhopper.routing.util.parsers.RacingBikeAverageSpeedParser;
+import com.graphhopper.routing.util.parsers.RacingBikePriorityParser;
+import com.graphhopper.routing.util.parsers.StateParser;
+>>>>>>> 0e9dd7a73 (Fixed silly mistakes and added simple unit test.)
 import com.graphhopper.util.PMap;
 
 public class DefaultImportRegistry implements ImportRegistry {
@@ -153,9 +212,15 @@ public class DefaultImportRegistry implements ImportRegistry {
                             lookup.getEnumEncodedValue(HazmatWater.KEY, HazmatWater.class))
             );
         else if (Lanes.KEY.equals(name))
+        else if (Lanes.KEY.equals(name))
             return ImportUnit.create(name, props -> Lanes.create(),
                     (lookup, props) -> new OSMLanesParser(
                             lookup.getIntEncodedValue(Lanes.KEY))
+            );
+        else if (Level.KEY.equals(name))
+            return ImportUnit.create(name, props -> Level.create(),
+                    (lookup, props) -> new OSMLevelParser(
+                            lookup.getIntEncodedValue(Level.KEY))
             );
         else if (Footway.KEY.equals(name))
             return ImportUnit.create(name, props -> Footway.create(),
@@ -171,11 +236,6 @@ public class DefaultImportRegistry implements ImportRegistry {
             return ImportUnit.create(name, props -> Cycleway.create(),
                     (lookup, props) -> new OSMCyclewayParser(
                             lookup.getEnumEncodedValue(Cycleway.KEY, Cycleway.class))
-            );
-        else if (Level.KEY.equals(name))
-            return ImportUnit.create(name, props -> Level.create(),
-                    (lookup, props) -> new OSMLevelParser(lookup
-                            .getEnumEncodedValue(Level.KEY, Level.class))
             );
         else if (OSMWayID.KEY.equals(name))
             return ImportUnit.create(name, props -> OSMWayID.create(),

--- a/core/src/main/java/com/graphhopper/routing/ev/DefaultImportRegistry.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/DefaultImportRegistry.java
@@ -212,7 +212,6 @@ public class DefaultImportRegistry implements ImportRegistry {
                             lookup.getEnumEncodedValue(HazmatWater.KEY, HazmatWater.class))
             );
         else if (Lanes.KEY.equals(name))
-        else if (Lanes.KEY.equals(name))
             return ImportUnit.create(name, props -> Lanes.create(),
                     (lookup, props) -> new OSMLanesParser(
                             lookup.getIntEncodedValue(Lanes.KEY))
@@ -220,7 +219,7 @@ public class DefaultImportRegistry implements ImportRegistry {
         else if (Level.KEY.equals(name))
             return ImportUnit.create(name, props -> Level.create(),
                     (lookup, props) -> new OSMLevelParser(
-                            lookup.getIntEncodedValue(Level.KEY))
+                            lookup.getDecimalEncodedValue(Level.KEY))
             );
         else if (Footway.KEY.equals(name))
             return ImportUnit.create(name, props -> Footway.create(),

--- a/core/src/main/java/com/graphhopper/routing/ev/Level.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/Level.java
@@ -21,15 +21,13 @@ package com.graphhopper.routing.ev;
 public class Level {
     public static final String KEY = "level";
 
-    public static IntEncodedValue create() {
-        // 8 bits stores 256 values. Burj Khalifa containes 163 stories.
-        // -50 allows for plenty of space in negative values.
+    public static DecimalEncodedValue create() {
+        // factor: 0.1 in order to get half levels for stairs.
+        // bits: 11 bits stores 2048 values, so 204.7 total levels.
+        // minStorableValue: -400 * 0.1 = -40 (minLevel) and 204.7 - 40 = 164.7 (maxLevel)
+        // For reference Burj Khalifa has 163 floors
         // negateReverseDirection is false, levels keep their sign
-        // storeTwoDirections contains the level of the starting point of the way.
-        // Examples :
-        // 1. a way going from level 0 to level 1, will contain 0 in the 
-        // forward direction and 1 in the backward direction
-        // 2. a way that stays on the same level 0, contains 0 in both directions.
-        return new IntEncodedValueImpl(KEY, 8, -50, false, true);
+        // storeTwoDirections: false, only one level per way.
+        return new DecimalEncodedValueImpl(KEY, 11, -40, 0.1, false, false, false);
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/ev/Level.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/Level.java
@@ -1,0 +1,35 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.graphhopper.routing.ev;
+
+public class Level {
+    public static final String KEY = "level";
+
+    public static IntEncodedValue create() {
+        // 8 bits stores 256 values. Burj Khalifa containes 163 stories.
+        // -50 allows for plenty of space in negative values.
+        // negateReverseDirection is false, levels keep their sign
+        // storeTwoDirections contains the level of the starting point of the way.
+        // Examples :
+        // 1. a way going from level 0 to level 1, will contain 0 in the 
+        // forward direction and 1 in the backward direction
+        // 2. a way that stays on the same level 0, contains 0 in both directions.
+        return new IntEncodedValueImpl(KEY, 8, -50, false, true);
+    }
+}

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMLevelParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMLevelParser.java
@@ -1,0 +1,80 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.graphhopper.routing.util.parsers;
+
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.EdgeIntAccess;
+import com.graphhopper.routing.ev.IntEncodedValue;
+import com.graphhopper.storage.IntsRef;
+
+/**
+ * https://wiki.openstreetmap.org/wiki/Key:level
+ */
+public class OSMLevelParser implements TagParser {
+    private final IntEncodedValue levelEnc;
+
+    public OSMLanesParser(IntEncodedValue levelEnc) {
+        this.levelEnc = levelEnc;
+    }
+
+    private int clampLevel (int level) {
+        int minLevel = -50
+        int maxLevel = 256 + minLevel - 1
+
+        if (level < minLevel)
+            return minLevel
+        else if (levelInt > maxLevel)
+            return maxLevel
+        else/
+            return level
+    }
+
+    @Override
+    public void handleWayTags(int edgeId, EdgeIntAccess edgeIntAccess, ReaderWay way, IntsRef relationFlags) {
+        int forward = 0;
+        int backward = 0;
+
+        if (way.hasTag("level")) {
+            String levels = way.getTag("level");
+            String[] levelsTok = levels.split(";");
+
+            // TODO
+            if (levelsTok.length == 1) {
+                try {
+                    int levelInt = this.clampLevel(Integer.parseInt(levelsTok[0]));
+                    forward = levelInt;
+                    backward = levelInt;
+                } catch (NumberFormatException ex) {
+                    // ignore if no number
+                }
+            } else if levelsTok.length == 2 {
+                try {
+                    int first = this.clampLevel(Integer.parseInt(levelsTok[0]));
+                    int second = this.clampLevel(Integer.parseInt(levelsTok[1]));
+                    forward = first;
+                    backward = second;
+                } catch (NumberFormatException ex) {
+                    // ignore if no number
+                }
+            }
+        }
+        lanesEnc.setInt(false, edgeId, edgeIntAccess, forward);
+        lanesEnc.setInt(true, edgeId, edgeIntAccess, backward);
+    }
+}

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMLevelParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMLevelParser.java
@@ -35,29 +35,30 @@ public class OSMLevelParser implements TagParser {
 
     @Override
     public void handleWayTags(int edgeId, EdgeIntAccess edgeIntAccess, ReaderWay way, IntsRef relationFlags) {
-        float level = 0;
+        double level = 0;
 
         if (way.hasTag("level")) {
             String levels = way.getTag("level");
-            String[] levelsTok = levels.split(";|-");
+            
+            String[] levelsTok = levels.split(";|(?<=\\d)\\s*-\\s*(?=-?\\d)");
 
-            // TODO
             if (levelsTok.length == 1) {
                 try {
-                    level = Float.parseFloat(levelsTok[0]);
+                    level = Double.parseDouble(levelsTok[0]);
                 } catch (NumberFormatException ex) {
                     // ignore if no number
                 }
             } else if (levelsTok.length == 2) {
                 try {
-                    float first = Float.parseFloat(levelsTok[0]);
-                    float second = Float.parseFloat(levelsTok[1]);
+                    double first = Double.parseDouble(levelsTok[0]);
+                    double second = Double.parseDouble(levelsTok[1]);
                     level = (first + second)/2;
                 } catch (NumberFormatException ex) {
                     // ignore if no number
                 }
             }
         }
+        level = Math.max(levelEnc.getMinStorableDecimal(), Math.min(levelEnc.getMaxStorableDecimal(), level));
         levelEnc.setDecimal(false, edgeId, edgeIntAccess, level);
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMLevelParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMLevelParser.java
@@ -29,20 +29,20 @@ import com.graphhopper.storage.IntsRef;
 public class OSMLevelParser implements TagParser {
     private final IntEncodedValue levelEnc;
 
-    public OSMLanesParser(IntEncodedValue levelEnc) {
+    public OSMLevelParser(IntEncodedValue levelEnc) {
         this.levelEnc = levelEnc;
     }
 
     private int clampLevel (int level) {
-        int minLevel = -50
-        int maxLevel = 256 + minLevel - 1
+        int minLevel = -50;
+        int maxLevel = 256 + minLevel - 1;
 
         if (level < minLevel)
-            return minLevel
-        else if (levelInt > maxLevel)
-            return maxLevel
-        else/
-            return level
+            return minLevel;
+        else if (level > maxLevel)
+            return maxLevel;
+        else
+            return level;
     }
 
     @Override
@@ -63,7 +63,7 @@ public class OSMLevelParser implements TagParser {
                 } catch (NumberFormatException ex) {
                     // ignore if no number
                 }
-            } else if levelsTok.length == 2 {
+            } else if (levelsTok.length == 2) {
                 try {
                     int first = this.clampLevel(Integer.parseInt(levelsTok[0]));
                     int second = this.clampLevel(Integer.parseInt(levelsTok[1]));
@@ -74,7 +74,7 @@ public class OSMLevelParser implements TagParser {
                 }
             }
         }
-        lanesEnc.setInt(false, edgeId, edgeIntAccess, forward);
-        lanesEnc.setInt(true, edgeId, edgeIntAccess, backward);
+        levelEnc.setInt(false, edgeId, edgeIntAccess, forward);
+        levelEnc.setInt(true, edgeId, edgeIntAccess, backward);
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMLevelParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMLevelParser.java
@@ -20,68 +20,44 @@ package com.graphhopper.routing.util.parsers;
 
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.EdgeIntAccess;
-import com.graphhopper.routing.ev.IntEncodedValue;
+import com.graphhopper.routing.ev.DecimalEncodedValue;
 import com.graphhopper.storage.IntsRef;
 
 /**
  * https://wiki.openstreetmap.org/wiki/Key:level
  */
 public class OSMLevelParser implements TagParser {
-    private final IntEncodedValue levelEnc;
+    private final DecimalEncodedValue levelEnc;
 
-    public OSMLevelParser(IntEncodedValue levelEnc) {
+    public OSMLevelParser(DecimalEncodedValue levelEnc) {
         this.levelEnc = levelEnc;
-    }
-
-    private int cleanAndClampLevel(String levelStr) {
-        int level;
-        try {
-            level = Integer.parseInt(levelStr);
-        } catch (NumberFormatException ex) {
-            level = (int) Math.floor(Float.parseFloat(levelStr));
-        }
-
-        int minLevel = -50;
-        int maxLevel = 256 + minLevel - 1;
-
-        if (level < minLevel)
-            return minLevel;
-        else if (level > maxLevel)
-            return maxLevel;
-        else
-            return level;
     }
 
     @Override
     public void handleWayTags(int edgeId, EdgeIntAccess edgeIntAccess, ReaderWay way, IntsRef relationFlags) {
-        int forward = 0;
-        int backward = 0;
+        float level = 0;
 
         if (way.hasTag("level")) {
             String levels = way.getTag("level");
-            String[] levelsTok = levels.split(";");
+            String[] levelsTok = levels.split(";|-");
 
             // TODO
             if (levelsTok.length == 1) {
                 try {
-                    int levelInt = cleanAndClampLevel(levelsTok[0]);
-                    forward = levelInt;
-                    backward = levelInt;
+                    level = Float.parseFloat(levelsTok[0]);
                 } catch (NumberFormatException ex) {
                     // ignore if no number
                 }
             } else if (levelsTok.length == 2) {
                 try {
-                    int first = cleanAndClampLevel(levelsTok[0]);
-                    int second = cleanAndClampLevel(levelsTok[1]);
-                    forward = first;
-                    backward = second;
+                    float first = Float.parseFloat(levelsTok[0]);
+                    float second = Float.parseFloat(levelsTok[1]);
+                    level = (first + second)/2;
                 } catch (NumberFormatException ex) {
                     // ignore if no number
                 }
             }
         }
-        levelEnc.setInt(false, edgeId, edgeIntAccess, forward);
-        levelEnc.setInt(true, edgeId, edgeIntAccess, backward);
+        levelEnc.setDecimal(false, edgeId, edgeIntAccess, level);
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMLevelParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMLevelParser.java
@@ -33,7 +33,14 @@ public class OSMLevelParser implements TagParser {
         this.levelEnc = levelEnc;
     }
 
-    private int clampLevel (int level) {
+    private int cleanAndClampLevel(String levelStr) {
+        int level;
+        try {
+            level = Integer.parseInt(levelStr);
+        } catch (NumberFormatException ex) {
+            level = (int) Math.floor(Float.parseFloat(levelStr));
+        }
+
         int minLevel = -50;
         int maxLevel = 256 + minLevel - 1;
 
@@ -57,7 +64,7 @@ public class OSMLevelParser implements TagParser {
             // TODO
             if (levelsTok.length == 1) {
                 try {
-                    int levelInt = this.clampLevel(Integer.parseInt(levelsTok[0]));
+                    int levelInt = cleanAndClampLevel(levelsTok[0]);
                     forward = levelInt;
                     backward = levelInt;
                 } catch (NumberFormatException ex) {
@@ -65,8 +72,8 @@ public class OSMLevelParser implements TagParser {
                 }
             } else if (levelsTok.length == 2) {
                 try {
-                    int first = this.clampLevel(Integer.parseInt(levelsTok[0]));
-                    int second = this.clampLevel(Integer.parseInt(levelsTok[1]));
+                    int first = cleanAndClampLevel(levelsTok[0]);
+                    int second = cleanAndClampLevel(levelsTok[1]);
                     forward = first;
                     backward = second;
                 } catch (NumberFormatException ex) {

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMLevelParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMLevelParserTest.java
@@ -71,16 +71,28 @@ class OSMLevelParserTest {
     }
 
     @Test
-    void halfLevelsNotSupported() {
-        // Half levels aren't documented, but should be rounded down, 
-        // instead of default value of 0.
+    void floatAndClamping() {
         ReaderWay readerWay = new ReaderWay(1);
         EdgeIntAccess edgeIntAccess = new ArrayEdgeIntAccess(1);
         int edgeId = 0;
+        
         readerWay.setTag("level", "1.5");
         parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
         Assertions.assertEquals(1, levelEnc.getInt(false, edgeId, edgeIntAccess));
         Assertions.assertEquals(1, levelEnc.getInt(true, edgeId, edgeIntAccess));
+        
+        readerWay.setTag("level", "-1.5");
+        parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
+        Assertions.assertEquals(-2, levelEnc.getInt(false, edgeId, edgeIntAccess));
+        Assertions.assertEquals(-2, levelEnc.getInt(true, edgeId, edgeIntAccess));
+
+        readerWay.setTag("level", "-100");
+        parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
+        Assertions.assertEquals(-50, levelEnc.getInt(false, edgeId, edgeIntAccess));
+
+        readerWay.setTag("level", "300");
+        parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
+        Assertions.assertEquals(205, levelEnc.getInt(false, edgeId, edgeIntAccess));
     }
 
     

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMLevelParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMLevelParserTest.java
@@ -48,6 +48,43 @@ class OSMLevelParserTest {
         Assertions.assertEquals(2, levelEnc.getInt(true, edgeId, edgeIntAccess));
     }
 
+    @Test
+    void staircaseUp() {
+        ReaderWay readerWay = new ReaderWay(1);
+        EdgeIntAccess edgeIntAccess = new ArrayEdgeIntAccess(1);
+        int edgeId = 0;
+        readerWay.setTag("level", "0;1");
+        parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
+        Assertions.assertEquals(0, levelEnc.getInt(false, edgeId, edgeIntAccess));
+        Assertions.assertEquals(1, levelEnc.getInt(true, edgeId, edgeIntAccess));
+    }
+
+    @Test
+    void staircaseDown() {
+        ReaderWay readerWay = new ReaderWay(1);
+        EdgeIntAccess edgeIntAccess = new ArrayEdgeIntAccess(1);
+        int edgeId = 0;
+        readerWay.setTag("level", "3;2");
+        parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
+        Assertions.assertEquals(3, levelEnc.getInt(false, edgeId, edgeIntAccess));
+        Assertions.assertEquals(2, levelEnc.getInt(true, edgeId, edgeIntAccess));
+    }
+
+    @Test
+    void halfLevelsNotSupported() {
+        // Half levels aren't documented, but should be rounded down, 
+        // instead of default value of 0.
+        ReaderWay readerWay = new ReaderWay(1);
+        EdgeIntAccess edgeIntAccess = new ArrayEdgeIntAccess(1);
+        int edgeId = 0;
+        readerWay.setTag("level", "1.5");
+        parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
+        Assertions.assertEquals(1, levelEnc.getInt(false, edgeId, edgeIntAccess));
+        Assertions.assertEquals(1, levelEnc.getInt(true, edgeId, edgeIntAccess));
+    }
+
+    
+
     // @Test
     // void notTagged() {
     //     ReaderWay readerWay = new ReaderWay(1);

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMLevelParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMLevelParserTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class OSMLevelParserTest {
-    private final IntEncodedValue levelEnc = Level.create();
+    private final DecimalEncodedValue levelEnc = Level.create();
     private OSMLevelParser parser;
     private IntsRef relFlags;
 
@@ -44,8 +44,7 @@ class OSMLevelParserTest {
         int edgeId = 0;
         readerWay.setTag("level", "2");
         parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
-        Assertions.assertEquals(2, levelEnc.getInt(false, edgeId, edgeIntAccess));
-        Assertions.assertEquals(2, levelEnc.getInt(true, edgeId, edgeIntAccess));
+        Assertions.assertEquals(2.0, levelEnc.getDecimal(false, edgeId, edgeIntAccess));
     }
 
     @Test
@@ -55,8 +54,7 @@ class OSMLevelParserTest {
         int edgeId = 0;
         readerWay.setTag("level", "0;1");
         parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
-        Assertions.assertEquals(0, levelEnc.getInt(false, edgeId, edgeIntAccess));
-        Assertions.assertEquals(1, levelEnc.getInt(true, edgeId, edgeIntAccess));
+        Assertions.assertEquals(0.5, levelEnc.getDecimal(false, edgeId, edgeIntAccess));
     }
 
     @Test
@@ -66,8 +64,7 @@ class OSMLevelParserTest {
         int edgeId = 0;
         readerWay.setTag("level", "3;2");
         parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
-        Assertions.assertEquals(3, levelEnc.getInt(false, edgeId, edgeIntAccess));
-        Assertions.assertEquals(2, levelEnc.getInt(true, edgeId, edgeIntAccess));
+        Assertions.assertEquals(2.5, levelEnc.getDecimal(false, edgeId, edgeIntAccess));
     }
 
     @Test
@@ -78,32 +75,18 @@ class OSMLevelParserTest {
         
         readerWay.setTag("level", "1.5");
         parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
-        Assertions.assertEquals(1, levelEnc.getInt(false, edgeId, edgeIntAccess));
-        Assertions.assertEquals(1, levelEnc.getInt(true, edgeId, edgeIntAccess));
+        Assertions.assertEquals(1.5, levelEnc.getDecimal(false, edgeId, edgeIntAccess));
         
         readerWay.setTag("level", "-1.5");
         parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
-        Assertions.assertEquals(-2, levelEnc.getInt(false, edgeId, edgeIntAccess));
-        Assertions.assertEquals(-2, levelEnc.getInt(true, edgeId, edgeIntAccess));
+        Assertions.assertEquals(-1.5, levelEnc.getDecimal(false, edgeId, edgeIntAccess));
 
         readerWay.setTag("level", "-100");
         parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
-        Assertions.assertEquals(-50, levelEnc.getInt(false, edgeId, edgeIntAccess));
+        Assertions.assertEquals(-40.0, levelEnc.getDecimal(false, edgeId, edgeIntAccess));
 
         readerWay.setTag("level", "300");
         parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
-        Assertions.assertEquals(205, levelEnc.getInt(false, edgeId, edgeIntAccess));
+        Assertions.assertEquals(164.7, levelEnc.getDecimal(false, edgeId, edgeIntAccess));
     }
-
-    
-
-    // @Test
-    // void notTagged() {
-    //     ReaderWay readerWay = new ReaderWay(1);
-    //     EdgeIntAccess edgeIntAccess = new ArrayEdgeIntAccess(1);
-    //     int edgeId = 0;
-    //     parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
-    //     Assertions.assertEquals(1, lanesEnc.getInt(false, edgeId, edgeIntAccess));
-    // }
-
 }

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMLevelParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMLevelParserTest.java
@@ -68,7 +68,7 @@ class OSMLevelParserTest {
     }
 
     @Test
-    void floatAndClamping() {
+    void floatLevel() {
         ReaderWay readerWay = new ReaderWay(1);
         EdgeIntAccess edgeIntAccess = new ArrayEdgeIntAccess(1);
         int edgeId = 0;
@@ -76,17 +76,37 @@ class OSMLevelParserTest {
         readerWay.setTag("level", "1.5");
         parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
         Assertions.assertEquals(1.5, levelEnc.getDecimal(false, edgeId, edgeIntAccess));
-        
+    }
+
+    @Test
+    void negativeFloatLevel() {
+        ReaderWay readerWay = new ReaderWay(1);
+        EdgeIntAccess edgeIntAccess = new ArrayEdgeIntAccess(1);
+        int edgeId = 0;
+                
         readerWay.setTag("level", "-1.5");
         parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
         Assertions.assertEquals(-1.5, levelEnc.getDecimal(false, edgeId, edgeIntAccess));
+    }
+
+    @Test
+    void belowMinLevel() {
+        ReaderWay readerWay = new ReaderWay(1);
+        EdgeIntAccess edgeIntAccess = new ArrayEdgeIntAccess(1);
+        int edgeId = 0;
 
         readerWay.setTag("level", "-100");
         parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
         Assertions.assertEquals(-40.0, levelEnc.getDecimal(false, edgeId, edgeIntAccess));
+    }
 
+    @Test
+    void aboveMaxLevel() {
+        ReaderWay readerWay = new ReaderWay(1);
+        EdgeIntAccess edgeIntAccess = new ArrayEdgeIntAccess(1);
+        int edgeId = 0;
+        
         readerWay.setTag("level", "300");
         parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
         Assertions.assertEquals(164.7, levelEnc.getDecimal(false, edgeId, edgeIntAccess));
     }
-}

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMLevelParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMLevelParserTest.java
@@ -1,0 +1,60 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.graphhopper.routing.util.parsers;
+
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.*;
+import com.graphhopper.storage.IntsRef;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class OSMLevelParserTest {
+    private final IntEncodedValue levelEnc = Level.create();
+    private OSMLevelParser parser;
+    private IntsRef relFlags;
+
+    @BeforeEach
+    void setup() {
+        levelEnc.init(new EncodedValue.InitializerConfig());
+        parser = new OSMLevelParser(levelEnc);
+        relFlags = new IntsRef(2);
+    }
+
+    @Test
+    void basic() {
+        ReaderWay readerWay = new ReaderWay(1);
+        EdgeIntAccess edgeIntAccess = new ArrayEdgeIntAccess(1);
+        int edgeId = 0;
+        readerWay.setTag("level", "2");
+        parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
+        Assertions.assertEquals(2, levelEnc.getInt(false, edgeId, edgeIntAccess));
+        Assertions.assertEquals(2, levelEnc.getInt(true, edgeId, edgeIntAccess));
+    }
+
+    // @Test
+    // void notTagged() {
+    //     ReaderWay readerWay = new ReaderWay(1);
+    //     EdgeIntAccess edgeIntAccess = new ArrayEdgeIntAccess(1);
+    //     int edgeId = 0;
+    //     parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
+    //     Assertions.assertEquals(1, lanesEnc.getInt(false, edgeId, edgeIntAccess));
+    // }
+
+}

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMLevelParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMLevelParserTest.java
@@ -108,5 +108,6 @@ class OSMLevelParserTest {
         
         readerWay.setTag("level", "300");
         parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
-        Assertions.assertEquals(164.7, levelEnc.getDecimal(false, edgeId, edgeIntAccess));
+        Assertions.assertEquals(164.7, levelEnc.getDecimal(false, edgeId, edgeIntAccess), 1e-10);
     }
+}


### PR DESCRIPTION
The goal is to improve indoor routing #215, seen through the prism of accessible pedestrian routing for the blind and low vision.

As preliminary step, I have added `level` as an encoded value.

## Discussion

There are many things to do in order to get better indoor routing.

1. We want to know what level we are on.
2. We want our waypoints to stick to the correct floor.
3. We want to know if we are going up or down stairs.
4. Some people might want to route across areas.

This PR focuses exclusively on 1.

## Choices

### IntEncodedValue: Bad
I started out trying to do 1 and 3 together.
Using an IntEncodedValue seemed logical as levels are usually Integers (`level=1`).
However in the case of stairs or escalators, we get two values (`level=0;1`). If a staircase serves several floors, we can even get a range (`level=2-6`).
I briefly tried to fit both numbers into a single encoded value, by storing one for each direction, but it just doesn't make any sense.

Furthermore, with an Integer, it doesn't seem desirable to store only the first or second number, a default number or a NaN. 
E.g : setting `level=0` on a staircase going from 0 to 4th floor seems like information loss.

### DecimalEncodedValue : Good

Switching to a decimal encoded value takes a few more bits, but allows us to store regular integer values, and have a "good enough" value for things like stairs :

`decimalLevel = (startLevel + endLevel) / 2`

This method :  
- works great for routing details (for post-processing client side).
- works for Custom Models priorities
- would work in a future waypoint snapping LevelEdgeFilter, by setting the level to a given value, even though there might be rare ambiguous values (`level=0;2`and `level=0;4` parallel right next to each other ??) 

### No incline, will need another encoded value.

Unfortunately this encoded value does not encode the **incline** of such steps. My opinion is that trying to guess incline through levels would be an antipattern anyway, since many steps in the wild don't have levels associated to them, they just have the [`incline=up|down |...`](https://wiki.openstreetmap.org/wiki/Key:incline) tag.

## Next steps

This is my first contribution, so I keep it simple.
Next step is allowing waypoints to snap to a given level thanks to these encoded values, which already works on my fork.
