### PR TITLE
Allowing via routing to snap to levels.

### DIFF
--- a/client-hc/src/main/java/com/graphhopper/api/GraphHopperWeb.java
+++ b/client-hc/src/main/java/com/graphhopper/api/GraphHopperWeb.java
@@ -357,7 +357,7 @@ public class GraphHopperWeb {
             for (Double heading : ghRequest.getHeadings())
                 url += "&heading=" + heading;
         
-        if (ghRequest.getLevels().stream().anyMatch(h -> !Double.isNan(h)))
+        if (ghRequest.getLevels().stream().anyMatch(h -> !Double.isNaN(h)))
             for (Double level : ghRequest.getLevels())
                 url += "&level=" + level;
 

--- a/client-hc/src/main/java/com/graphhopper/api/GraphHopperWeb.java
+++ b/client-hc/src/main/java/com/graphhopper/api/GraphHopperWeb.java
@@ -261,6 +261,8 @@ public class GraphHopperWeb {
             requestJson.putArray("point_hints").addAll(createStringList(ghRequest.getPointHints()));
         if (!ghRequest.getHeadings().isEmpty())
             requestJson.putArray("headings").addAll(createDoubleList(ghRequest.getHeadings()));
+        if (!ghRequest.getLevels().isEmpty())
+            requestJson.putArray("levels").addAll(createDoubleList(ghRequest.getLevels()));
         if (!ghRequest.getCurbsides().isEmpty())
             requestJson.putArray("curbsides").addAll(createStringList(ghRequest.getCurbsides()));
         if (ghRequest.hasSnapPreventions())
@@ -354,6 +356,10 @@ public class GraphHopperWeb {
         if (ghRequest.getHeadings().stream().anyMatch(h -> !Double.isNaN(h)))
             for (Double heading : ghRequest.getHeadings())
                 url += "&heading=" + heading;
+        
+        if (ghRequest.getLevels().stream().anyMatch(h -> !Double.isNan(h)))
+            for (Double level : ghRequest.getLevels())
+                url += "&level=" + level;
 
         if (ghRequest.hasSnapPreventions()) {
             if (ghRequest.getSnapPreventions().isEmpty())

--- a/core/src/main/java/com/graphhopper/routing/Router.java
+++ b/core/src/main/java/com/graphhopper/routing/Router.java
@@ -235,7 +235,7 @@ public class Router {
         StopWatch sw = new StopWatch().start();
         DirectedEdgeFilter directedEdgeFilter = solver.createDirectedEdgeFilter();
         List<Snap> snaps = ViaRouting.lookup(encodingManager, request.getPoints(), solver.createSnapFilter(), locationIndex,
-                request.getSnapPreventions(), request.getPointHints(), directedEdgeFilter, request.getHeadings());
+                request.getSnapPreventions(), request.getPointHints(), directedEdgeFilter, request.getHeadings(), request.getLevels());
         ghRsp.addDebugInfo("idLookup:" + sw.stop().getSeconds() + "s");
         QueryGraph queryGraph = QueryGraph.create(graph, snaps);
         PathCalculator pathCalculator = solver.createPathCalculator(queryGraph);
@@ -268,7 +268,7 @@ public class Router {
         StopWatch sw = new StopWatch().start();
         DirectedEdgeFilter directedEdgeFilter = solver.createDirectedEdgeFilter();
         List<Snap> snaps = ViaRouting.lookup(encodingManager, request.getPoints(), solver.createSnapFilter(), locationIndex,
-                request.getSnapPreventions(), request.getPointHints(), directedEdgeFilter, request.getHeadings());
+                request.getSnapPreventions(), request.getPointHints(), directedEdgeFilter, request.getHeadings(), request.getLevels());
         ghRsp.addDebugInfo("idLookup:" + sw.stop().getSeconds() + "s");
         // (base) query graph used to resolve headings, curbsides etc. this is not necessarily the same thing as
         // the (possibly implementation specific) query graph used by PathCalculator

--- a/core/src/main/java/com/graphhopper/routing/ViaRouting.java
+++ b/core/src/main/java/com/graphhopper/routing/ViaRouting.java
@@ -56,12 +56,13 @@ public class ViaRouting {
      */
     public static List<Snap> lookup(EncodedValueLookup lookup, List<GHPoint> points, EdgeFilter snapFilter,
                                     LocationIndex locationIndex, List<String> snapPreventions, List<String> pointHints,
-                                    DirectedEdgeFilter directedSnapFilter, List<Double> headings) {
+                                    DirectedEdgeFilter directedSnapFilter, List<Double> headings, List<Double> levels) {
         if (points.size() < 2)
             throw new IllegalArgumentException("At least 2 points have to be specified, but was:" + points.size());
 
         final EnumEncodedValue<RoadClass> roadClassEnc = lookup.getEnumEncodedValue(RoadClass.KEY, RoadClass.class);
         final EnumEncodedValue<RoadEnvironment> roadEnvEnc = lookup.getEnumEncodedValue(RoadEnvironment.KEY, RoadEnvironment.class);
+        final DecimalEncodedValue levelEnc = lookup.getDecimalEncodedValue(Level.KEY)
         EdgeFilter strictEdgeFilter = snapPreventions.isEmpty()
                 ? snapFilter
                 : new SnapPreventionEdgeFilter(snapFilter, roadClassEnc, roadEnvEnc, snapPreventions);
@@ -75,6 +76,8 @@ public class ViaRouting {
                     throw new IllegalArgumentException("Cannot specify heading and point_hint at the same time. " +
                             "Make sure you specify either an empty point_hint (String) or a NaN heading (double) for point " + placeIndex);
                 snap = locationIndex.findClosest(point.lat, point.lon, new HeadingEdgeFilter(directedSnapFilter, headings.get(placeIndex), point));
+            } else if (placeIndex < levels.size() && !Double.isNan(levels.get(placeIndex))) {
+                snap = locationIndex.findClosest(point.lat, point.lon, new LevelEdgeFilter(strictEdgeFilter, levelEnc, levels.get(placeIndex)))
             } else if (!pointHints.isEmpty()) {
                 snap = locationIndex.findClosest(point.lat, point.lon, new NameSimilarityEdgeFilter(strictEdgeFilter,
                         pointHints.get(placeIndex), point, 170));

--- a/core/src/main/java/com/graphhopper/routing/ViaRouting.java
+++ b/core/src/main/java/com/graphhopper/routing/ViaRouting.java
@@ -20,8 +20,10 @@ package com.graphhopper.routing;
 import com.carrotsearch.hppc.IntArrayList;
 import com.graphhopper.routing.ev.EncodedValueLookup;
 import com.graphhopper.routing.ev.EnumEncodedValue;
+import com.graphhopper.routing.ev.DecimalEncodedValue;
 import com.graphhopper.routing.ev.RoadClass;
 import com.graphhopper.routing.ev.RoadEnvironment;
+import com.graphhopper.routing.ev.Level;
 import com.graphhopper.routing.querygraph.QueryGraph;
 import com.graphhopper.routing.querygraph.VirtualEdgeIteratorState;
 import com.graphhopper.routing.util.*;
@@ -62,7 +64,7 @@ public class ViaRouting {
 
         final EnumEncodedValue<RoadClass> roadClassEnc = lookup.getEnumEncodedValue(RoadClass.KEY, RoadClass.class);
         final EnumEncodedValue<RoadEnvironment> roadEnvEnc = lookup.getEnumEncodedValue(RoadEnvironment.KEY, RoadEnvironment.class);
-        final DecimalEncodedValue levelEnc = lookup.getDecimalEncodedValue(Level.KEY)
+        final DecimalEncodedValue levelEnc = lookup.getDecimalEncodedValue(Level.KEY);
         EdgeFilter strictEdgeFilter = snapPreventions.isEmpty()
                 ? snapFilter
                 : new SnapPreventionEdgeFilter(snapFilter, roadClassEnc, roadEnvEnc, snapPreventions);
@@ -76,8 +78,8 @@ public class ViaRouting {
                     throw new IllegalArgumentException("Cannot specify heading and point_hint at the same time. " +
                             "Make sure you specify either an empty point_hint (String) or a NaN heading (double) for point " + placeIndex);
                 snap = locationIndex.findClosest(point.lat, point.lon, new HeadingEdgeFilter(directedSnapFilter, headings.get(placeIndex), point));
-            } else if (placeIndex < levels.size() && !Double.isNan(levels.get(placeIndex))) {
-                snap = locationIndex.findClosest(point.lat, point.lon, new LevelEdgeFilter(strictEdgeFilter, levelEnc, levels.get(placeIndex)))
+            } else if (placeIndex < levels.size() && !Double.isNaN(levels.get(placeIndex))) {
+                snap = locationIndex.findClosest(point.lat, point.lon, new LevelEdgeFilter(strictEdgeFilter, levelEnc, levels.get(placeIndex)));
             } else if (!pointHints.isEmpty()) {
                 snap = locationIndex.findClosest(point.lat, point.lon, new NameSimilarityEdgeFilter(strictEdgeFilter,
                         pointHints.get(placeIndex), point, 170));

--- a/core/src/main/java/com/graphhopper/routing/ev/DefaultImportRegistry.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/DefaultImportRegistry.java
@@ -172,6 +172,11 @@ public class DefaultImportRegistry implements ImportRegistry {
                     (lookup, props) -> new OSMCyclewayParser(
                             lookup.getEnumEncodedValue(Cycleway.KEY, Cycleway.class))
             );
+        else if (Level.KEY.equals(name))
+            return ImportUnit.create(name, props -> Level.create(),
+                    (lookup, props) -> new OSMLevelParser(lookup
+                            .getEnumEncodedValue(Level.KEY, Level.class))
+            );
         else if (OSMWayID.KEY.equals(name))
             return ImportUnit.create(name, props -> OSMWayID.create(),
                     (lookup, props) -> new OSMWayIDParser(

--- a/core/src/main/java/com/graphhopper/routing/ev/DefaultImportRegistry.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/DefaultImportRegistry.java
@@ -18,67 +18,8 @@
 
 package com.graphhopper.routing.ev;
 
-<<<<<<< HEAD
 import com.graphhopper.routing.util.*;
 import com.graphhopper.routing.util.parsers.*;
-=======
-import com.graphhopper.routing.util.CurvatureCalculator;
-import com.graphhopper.routing.util.FerrySpeedCalculator;
-import com.graphhopper.routing.util.PriorityCode;
-import com.graphhopper.routing.util.SlopeCalculator;
-import com.graphhopper.routing.util.TransportationMode;
-import com.graphhopper.routing.util.parsers.BikeAccessParser;
-import com.graphhopper.routing.util.parsers.BikeAverageSpeedParser;
-import com.graphhopper.routing.util.parsers.BikePriorityParser;
-import com.graphhopper.routing.util.parsers.CarAccessParser;
-import com.graphhopper.routing.util.parsers.CarAverageSpeedParser;
-import com.graphhopper.routing.util.parsers.CountryParser;
-import com.graphhopper.routing.util.parsers.FootAccessParser;
-import com.graphhopper.routing.util.parsers.FootAverageSpeedParser;
-import com.graphhopper.routing.util.parsers.FootPriorityParser;
-import com.graphhopper.routing.util.parsers.MaxWeightExceptParser;
-import com.graphhopper.routing.util.parsers.ModeAccessParser;
-import com.graphhopper.routing.util.parsers.MountainBikeAccessParser;
-import com.graphhopper.routing.util.parsers.MountainBikeAverageSpeedParser;
-import com.graphhopper.routing.util.parsers.MountainBikePriorityParser;
-import com.graphhopper.routing.util.parsers.OSMCrossingParser;
-import com.graphhopper.routing.util.parsers.OSMFootwayParser;
-import com.graphhopper.routing.util.parsers.OSMGetOffBikeParser;
-import com.graphhopper.routing.util.parsers.OSMHazmatParser;
-import com.graphhopper.routing.util.parsers.OSMHazmatTunnelParser;
-import com.graphhopper.routing.util.parsers.OSMHazmatWaterParser;
-import com.graphhopper.routing.util.parsers.OSMHgvParser;
-import com.graphhopper.routing.util.parsers.OSMHikeRatingParser;
-import com.graphhopper.routing.util.parsers.OSMHorseRatingParser;
-import com.graphhopper.routing.util.parsers.OSMKerbParser;
-import com.graphhopper.routing.util.parsers.OSMLanesParser;
-import com.graphhopper.routing.util.parsers.OSMLevelParser;
-import com.graphhopper.routing.util.parsers.OSMMaxAxleLoadParser;
-import com.graphhopper.routing.util.parsers.OSMMaxHeightParser;
-import com.graphhopper.routing.util.parsers.OSMMaxLengthParser;
-import com.graphhopper.routing.util.parsers.OSMMaxSpeedParser;
-import com.graphhopper.routing.util.parsers.OSMMaxWeightParser;
-import com.graphhopper.routing.util.parsers.OSMMaxWidthParser;
-import com.graphhopper.routing.util.parsers.OSMMtbRatingParser;
-import com.graphhopper.routing.util.parsers.OSMRoadAccessParser;
-import com.graphhopper.routing.util.parsers.OSMRoadClassLinkParser;
-import com.graphhopper.routing.util.parsers.OSMRoadClassParser;
-import com.graphhopper.routing.util.parsers.OSMRoadEnvironmentParser;
-import com.graphhopper.routing.util.parsers.OSMRoundaboutParser;
-import com.graphhopper.routing.util.parsers.OSMSmoothnessParser;
-import com.graphhopper.routing.util.parsers.OSMSurfaceParser;
-import com.graphhopper.routing.util.parsers.OSMTactilePavingParser;
-import com.graphhopper.routing.util.parsers.OSMTemporalAccessParser;
-import com.graphhopper.routing.util.parsers.OSMTollParser;
-import com.graphhopper.routing.util.parsers.OSMTrackTypeParser;
-import com.graphhopper.routing.util.parsers.OSMTrafficSignalsSoundParser;
-import com.graphhopper.routing.util.parsers.OSMWayIDParser;
-import com.graphhopper.routing.util.parsers.OrientationCalculator;
-import com.graphhopper.routing.util.parsers.RacingBikeAccessParser;
-import com.graphhopper.routing.util.parsers.RacingBikeAverageSpeedParser;
-import com.graphhopper.routing.util.parsers.RacingBikePriorityParser;
-import com.graphhopper.routing.util.parsers.StateParser;
->>>>>>> 0e9dd7a73 (Fixed silly mistakes and added simple unit test.)
 import com.graphhopper.util.PMap;
 
 public class DefaultImportRegistry implements ImportRegistry {

--- a/core/src/main/java/com/graphhopper/routing/ev/DefaultImportRegistry.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/DefaultImportRegistry.java
@@ -18,8 +18,67 @@
 
 package com.graphhopper.routing.ev;
 
+<<<<<<< HEAD
 import com.graphhopper.routing.util.*;
 import com.graphhopper.routing.util.parsers.*;
+=======
+import com.graphhopper.routing.util.CurvatureCalculator;
+import com.graphhopper.routing.util.FerrySpeedCalculator;
+import com.graphhopper.routing.util.PriorityCode;
+import com.graphhopper.routing.util.SlopeCalculator;
+import com.graphhopper.routing.util.TransportationMode;
+import com.graphhopper.routing.util.parsers.BikeAccessParser;
+import com.graphhopper.routing.util.parsers.BikeAverageSpeedParser;
+import com.graphhopper.routing.util.parsers.BikePriorityParser;
+import com.graphhopper.routing.util.parsers.CarAccessParser;
+import com.graphhopper.routing.util.parsers.CarAverageSpeedParser;
+import com.graphhopper.routing.util.parsers.CountryParser;
+import com.graphhopper.routing.util.parsers.FootAccessParser;
+import com.graphhopper.routing.util.parsers.FootAverageSpeedParser;
+import com.graphhopper.routing.util.parsers.FootPriorityParser;
+import com.graphhopper.routing.util.parsers.MaxWeightExceptParser;
+import com.graphhopper.routing.util.parsers.ModeAccessParser;
+import com.graphhopper.routing.util.parsers.MountainBikeAccessParser;
+import com.graphhopper.routing.util.parsers.MountainBikeAverageSpeedParser;
+import com.graphhopper.routing.util.parsers.MountainBikePriorityParser;
+import com.graphhopper.routing.util.parsers.OSMCrossingParser;
+import com.graphhopper.routing.util.parsers.OSMFootwayParser;
+import com.graphhopper.routing.util.parsers.OSMGetOffBikeParser;
+import com.graphhopper.routing.util.parsers.OSMHazmatParser;
+import com.graphhopper.routing.util.parsers.OSMHazmatTunnelParser;
+import com.graphhopper.routing.util.parsers.OSMHazmatWaterParser;
+import com.graphhopper.routing.util.parsers.OSMHgvParser;
+import com.graphhopper.routing.util.parsers.OSMHikeRatingParser;
+import com.graphhopper.routing.util.parsers.OSMHorseRatingParser;
+import com.graphhopper.routing.util.parsers.OSMKerbParser;
+import com.graphhopper.routing.util.parsers.OSMLanesParser;
+import com.graphhopper.routing.util.parsers.OSMLevelParser;
+import com.graphhopper.routing.util.parsers.OSMMaxAxleLoadParser;
+import com.graphhopper.routing.util.parsers.OSMMaxHeightParser;
+import com.graphhopper.routing.util.parsers.OSMMaxLengthParser;
+import com.graphhopper.routing.util.parsers.OSMMaxSpeedParser;
+import com.graphhopper.routing.util.parsers.OSMMaxWeightParser;
+import com.graphhopper.routing.util.parsers.OSMMaxWidthParser;
+import com.graphhopper.routing.util.parsers.OSMMtbRatingParser;
+import com.graphhopper.routing.util.parsers.OSMRoadAccessParser;
+import com.graphhopper.routing.util.parsers.OSMRoadClassLinkParser;
+import com.graphhopper.routing.util.parsers.OSMRoadClassParser;
+import com.graphhopper.routing.util.parsers.OSMRoadEnvironmentParser;
+import com.graphhopper.routing.util.parsers.OSMRoundaboutParser;
+import com.graphhopper.routing.util.parsers.OSMSmoothnessParser;
+import com.graphhopper.routing.util.parsers.OSMSurfaceParser;
+import com.graphhopper.routing.util.parsers.OSMTactilePavingParser;
+import com.graphhopper.routing.util.parsers.OSMTemporalAccessParser;
+import com.graphhopper.routing.util.parsers.OSMTollParser;
+import com.graphhopper.routing.util.parsers.OSMTrackTypeParser;
+import com.graphhopper.routing.util.parsers.OSMTrafficSignalsSoundParser;
+import com.graphhopper.routing.util.parsers.OSMWayIDParser;
+import com.graphhopper.routing.util.parsers.OrientationCalculator;
+import com.graphhopper.routing.util.parsers.RacingBikeAccessParser;
+import com.graphhopper.routing.util.parsers.RacingBikeAverageSpeedParser;
+import com.graphhopper.routing.util.parsers.RacingBikePriorityParser;
+import com.graphhopper.routing.util.parsers.StateParser;
+>>>>>>> 0e9dd7a73 (Fixed silly mistakes and added simple unit test.)
 import com.graphhopper.util.PMap;
 
 public class DefaultImportRegistry implements ImportRegistry {
@@ -153,9 +212,15 @@ public class DefaultImportRegistry implements ImportRegistry {
                             lookup.getEnumEncodedValue(HazmatWater.KEY, HazmatWater.class))
             );
         else if (Lanes.KEY.equals(name))
+        else if (Lanes.KEY.equals(name))
             return ImportUnit.create(name, props -> Lanes.create(),
                     (lookup, props) -> new OSMLanesParser(
                             lookup.getIntEncodedValue(Lanes.KEY))
+            );
+        else if (Level.KEY.equals(name))
+            return ImportUnit.create(name, props -> Level.create(),
+                    (lookup, props) -> new OSMLevelParser(
+                            lookup.getIntEncodedValue(Level.KEY))
             );
         else if (Footway.KEY.equals(name))
             return ImportUnit.create(name, props -> Footway.create(),
@@ -171,11 +236,6 @@ public class DefaultImportRegistry implements ImportRegistry {
             return ImportUnit.create(name, props -> Cycleway.create(),
                     (lookup, props) -> new OSMCyclewayParser(
                             lookup.getEnumEncodedValue(Cycleway.KEY, Cycleway.class))
-            );
-        else if (Level.KEY.equals(name))
-            return ImportUnit.create(name, props -> Level.create(),
-                    (lookup, props) -> new OSMLevelParser(lookup
-                            .getEnumEncodedValue(Level.KEY, Level.class))
             );
         else if (OSMWayID.KEY.equals(name))
             return ImportUnit.create(name, props -> OSMWayID.create(),

--- a/core/src/main/java/com/graphhopper/routing/ev/DefaultImportRegistry.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/DefaultImportRegistry.java
@@ -212,7 +212,6 @@ public class DefaultImportRegistry implements ImportRegistry {
                             lookup.getEnumEncodedValue(HazmatWater.KEY, HazmatWater.class))
             );
         else if (Lanes.KEY.equals(name))
-        else if (Lanes.KEY.equals(name))
             return ImportUnit.create(name, props -> Lanes.create(),
                     (lookup, props) -> new OSMLanesParser(
                             lookup.getIntEncodedValue(Lanes.KEY))
@@ -220,7 +219,7 @@ public class DefaultImportRegistry implements ImportRegistry {
         else if (Level.KEY.equals(name))
             return ImportUnit.create(name, props -> Level.create(),
                     (lookup, props) -> new OSMLevelParser(
-                            lookup.getIntEncodedValue(Level.KEY))
+                            lookup.getDecimalEncodedValue(Level.KEY))
             );
         else if (Footway.KEY.equals(name))
             return ImportUnit.create(name, props -> Footway.create(),

--- a/core/src/main/java/com/graphhopper/routing/ev/Level.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/Level.java
@@ -21,15 +21,13 @@ package com.graphhopper.routing.ev;
 public class Level {
     public static final String KEY = "level";
 
-    public static IntEncodedValue create() {
-        // 8 bits stores 256 values. Burj Khalifa containes 163 stories.
-        // -50 allows for plenty of space in negative values.
+    public static DecimalEncodedValue create() {
+        // factor: 0.1 in order to get half levels for stairs.
+        // bits: 11 bits stores 2048 values, so 204.7 total levels.
+        // minStorableValue: -400 * 0.1 = -40 (minLevel) and 204.7 - 40 = 164.7 (maxLevel)
+        // For reference Burj Khalifa has 163 floors
         // negateReverseDirection is false, levels keep their sign
-        // storeTwoDirections contains the level of the starting point of the way.
-        // Examples :
-        // 1. a way going from level 0 to level 1, will contain 0 in the 
-        // forward direction and 1 in the backward direction
-        // 2. a way that stays on the same level 0, contains 0 in both directions.
-        return new IntEncodedValueImpl(KEY, 8, -50, false, true);
+        // storeTwoDirections: false, only one level per way.
+        return new DecimalEncodedValueImpl(KEY, 11, -40, 0.1, false, false, false);
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/ev/Level.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/Level.java
@@ -1,0 +1,35 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.graphhopper.routing.ev;
+
+public class Level {
+    public static final String KEY = "level";
+
+    public static IntEncodedValue create() {
+        // 8 bits stores 256 values. Burj Khalifa containes 163 stories.
+        // -50 allows for plenty of space in negative values.
+        // negateReverseDirection is false, levels keep their sign
+        // storeTwoDirections contains the level of the starting point of the way.
+        // Examples :
+        // 1. a way going from level 0 to level 1, will contain 0 in the 
+        // forward direction and 1 in the backward direction
+        // 2. a way that stays on the same level 0, contains 0 in both directions.
+        return new IntEncodedValueImpl(KEY, 8, -50, false, true);
+    }
+}

--- a/core/src/main/java/com/graphhopper/routing/util/LevelEdgeFilter.java
+++ b/core/src/main/java/com/graphhopper/routing/util/LevelEdgeFilter.java
@@ -1,0 +1,23 @@
+public class LevelEdgeFilter implements EdgeFilter {
+    private final EdgeFilter edgeFilter;
+    private final DecimalEncodedValue levelEnc;
+    private final double level;
+
+    public LevelEdgeFilter(EdgeFilter edgeFilter, DecimalEncodedValue levelEnc, double level) {
+        this.edgeFilter = edgeFilter;
+        this.levelEnc = levelEnc;
+        this.level = level;
+    }
+
+    @Override
+    public boolean accept(EdgeIteratorState edgeState) {
+        if (!edgeFilter.accept(edgeState))
+            return false;
+        if (Double.isNaN(level))
+            return true;
+        
+        double edgeLevel = edgeState.get(levelEnc);
+        // Level EV factor is 0.1, check within precision tolerance
+        return Math.abs(edgeLevel - level) < 0.1;
+    }
+}

--- a/core/src/main/java/com/graphhopper/routing/util/LevelEdgeFilter.java
+++ b/core/src/main/java/com/graphhopper/routing/util/LevelEdgeFilter.java
@@ -1,3 +1,8 @@
+import com.graphhopper.routing.util;
+import com.graphhopper.util.*;
+import com.graphhopper.routing.ev.DecimalEncodedValue;
+
+
 public class LevelEdgeFilter implements EdgeFilter {
     private final EdgeFilter edgeFilter;
     private final DecimalEncodedValue levelEnc;
@@ -18,6 +23,6 @@ public class LevelEdgeFilter implements EdgeFilter {
         
         double edgeLevel = edgeState.get(levelEnc);
         // Level EV factor is 0.1, check within precision tolerance
-        return Math.abs(edgeLevel - level) < 0.1;
+        return Math.abs(edgeLevel - level) < 0.05;
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/util/LevelEdgeFilter.java
+++ b/core/src/main/java/com/graphhopper/routing/util/LevelEdgeFilter.java
@@ -1,4 +1,5 @@
-import com.graphhopper.routing.util;
+package com.graphhopper.routing.util;
+
 import com.graphhopper.util.*;
 import com.graphhopper.routing.ev.DecimalEncodedValue;
 

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMLevelParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMLevelParser.java
@@ -1,0 +1,80 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.graphhopper.routing.util.parsers;
+
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.EdgeIntAccess;
+import com.graphhopper.routing.ev.IntEncodedValue;
+import com.graphhopper.storage.IntsRef;
+
+/**
+ * https://wiki.openstreetmap.org/wiki/Key:level
+ */
+public class OSMLevelParser implements TagParser {
+    private final IntEncodedValue levelEnc;
+
+    public OSMLanesParser(IntEncodedValue levelEnc) {
+        this.levelEnc = levelEnc;
+    }
+
+    private int clampLevel (int level) {
+        int minLevel = -50
+        int maxLevel = 256 + minLevel - 1
+
+        if (level < minLevel)
+            return minLevel
+        else if (levelInt > maxLevel)
+            return maxLevel
+        else/
+            return level
+    }
+
+    @Override
+    public void handleWayTags(int edgeId, EdgeIntAccess edgeIntAccess, ReaderWay way, IntsRef relationFlags) {
+        int forward = 0;
+        int backward = 0;
+
+        if (way.hasTag("level")) {
+            String levels = way.getTag("level");
+            String[] levelsTok = levels.split(";");
+
+            // TODO
+            if (levelsTok.length == 1) {
+                try {
+                    int levelInt = this.clampLevel(Integer.parseInt(levelsTok[0]));
+                    forward = levelInt;
+                    backward = levelInt;
+                } catch (NumberFormatException ex) {
+                    // ignore if no number
+                }
+            } else if levelsTok.length == 2 {
+                try {
+                    int first = this.clampLevel(Integer.parseInt(levelsTok[0]));
+                    int second = this.clampLevel(Integer.parseInt(levelsTok[1]));
+                    forward = first;
+                    backward = second;
+                } catch (NumberFormatException ex) {
+                    // ignore if no number
+                }
+            }
+        }
+        lanesEnc.setInt(false, edgeId, edgeIntAccess, forward);
+        lanesEnc.setInt(true, edgeId, edgeIntAccess, backward);
+    }
+}

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMLevelParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMLevelParser.java
@@ -35,29 +35,30 @@ public class OSMLevelParser implements TagParser {
 
     @Override
     public void handleWayTags(int edgeId, EdgeIntAccess edgeIntAccess, ReaderWay way, IntsRef relationFlags) {
-        float level = 0;
+        double level = 0;
 
         if (way.hasTag("level")) {
             String levels = way.getTag("level");
-            String[] levelsTok = levels.split(";|-");
+            
+            String[] levelsTok = levels.split(";|(?<=\\d)\\s*-\\s*(?=-?\\d)");
 
-            // TODO
             if (levelsTok.length == 1) {
                 try {
-                    level = Float.parseFloat(levelsTok[0]);
+                    level = Double.parseDouble(levelsTok[0]);
                 } catch (NumberFormatException ex) {
                     // ignore if no number
                 }
             } else if (levelsTok.length == 2) {
                 try {
-                    float first = Float.parseFloat(levelsTok[0]);
-                    float second = Float.parseFloat(levelsTok[1]);
+                    double first = Double.parseDouble(levelsTok[0]);
+                    double second = Double.parseDouble(levelsTok[1]);
                     level = (first + second)/2;
                 } catch (NumberFormatException ex) {
                     // ignore if no number
                 }
             }
         }
+        level = Math.max(levelEnc.getMinStorableDecimal(), Math.min(levelEnc.getMaxStorableDecimal(), level));
         levelEnc.setDecimal(false, edgeId, edgeIntAccess, level);
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMLevelParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMLevelParser.java
@@ -29,20 +29,20 @@ import com.graphhopper.storage.IntsRef;
 public class OSMLevelParser implements TagParser {
     private final IntEncodedValue levelEnc;
 
-    public OSMLanesParser(IntEncodedValue levelEnc) {
+    public OSMLevelParser(IntEncodedValue levelEnc) {
         this.levelEnc = levelEnc;
     }
 
     private int clampLevel (int level) {
-        int minLevel = -50
-        int maxLevel = 256 + minLevel - 1
+        int minLevel = -50;
+        int maxLevel = 256 + minLevel - 1;
 
         if (level < minLevel)
-            return minLevel
-        else if (levelInt > maxLevel)
-            return maxLevel
-        else/
-            return level
+            return minLevel;
+        else if (level > maxLevel)
+            return maxLevel;
+        else
+            return level;
     }
 
     @Override
@@ -63,7 +63,7 @@ public class OSMLevelParser implements TagParser {
                 } catch (NumberFormatException ex) {
                     // ignore if no number
                 }
-            } else if levelsTok.length == 2 {
+            } else if (levelsTok.length == 2) {
                 try {
                     int first = this.clampLevel(Integer.parseInt(levelsTok[0]));
                     int second = this.clampLevel(Integer.parseInt(levelsTok[1]));
@@ -74,7 +74,7 @@ public class OSMLevelParser implements TagParser {
                 }
             }
         }
-        lanesEnc.setInt(false, edgeId, edgeIntAccess, forward);
-        lanesEnc.setInt(true, edgeId, edgeIntAccess, backward);
+        levelEnc.setInt(false, edgeId, edgeIntAccess, forward);
+        levelEnc.setInt(true, edgeId, edgeIntAccess, backward);
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMLevelParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMLevelParser.java
@@ -20,68 +20,44 @@ package com.graphhopper.routing.util.parsers;
 
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.EdgeIntAccess;
-import com.graphhopper.routing.ev.IntEncodedValue;
+import com.graphhopper.routing.ev.DecimalEncodedValue;
 import com.graphhopper.storage.IntsRef;
 
 /**
  * https://wiki.openstreetmap.org/wiki/Key:level
  */
 public class OSMLevelParser implements TagParser {
-    private final IntEncodedValue levelEnc;
+    private final DecimalEncodedValue levelEnc;
 
-    public OSMLevelParser(IntEncodedValue levelEnc) {
+    public OSMLevelParser(DecimalEncodedValue levelEnc) {
         this.levelEnc = levelEnc;
-    }
-
-    private int cleanAndClampLevel(String levelStr) {
-        int level;
-        try {
-            level = Integer.parseInt(levelStr);
-        } catch (NumberFormatException ex) {
-            level = (int) Math.floor(Float.parseFloat(levelStr));
-        }
-
-        int minLevel = -50;
-        int maxLevel = 256 + minLevel - 1;
-
-        if (level < minLevel)
-            return minLevel;
-        else if (level > maxLevel)
-            return maxLevel;
-        else
-            return level;
     }
 
     @Override
     public void handleWayTags(int edgeId, EdgeIntAccess edgeIntAccess, ReaderWay way, IntsRef relationFlags) {
-        int forward = 0;
-        int backward = 0;
+        float level = 0;
 
         if (way.hasTag("level")) {
             String levels = way.getTag("level");
-            String[] levelsTok = levels.split(";");
+            String[] levelsTok = levels.split(";|-");
 
             // TODO
             if (levelsTok.length == 1) {
                 try {
-                    int levelInt = cleanAndClampLevel(levelsTok[0]);
-                    forward = levelInt;
-                    backward = levelInt;
+                    level = Float.parseFloat(levelsTok[0]);
                 } catch (NumberFormatException ex) {
                     // ignore if no number
                 }
             } else if (levelsTok.length == 2) {
                 try {
-                    int first = cleanAndClampLevel(levelsTok[0]);
-                    int second = cleanAndClampLevel(levelsTok[1]);
-                    forward = first;
-                    backward = second;
+                    float first = Float.parseFloat(levelsTok[0]);
+                    float second = Float.parseFloat(levelsTok[1]);
+                    level = (first + second)/2;
                 } catch (NumberFormatException ex) {
                     // ignore if no number
                 }
             }
         }
-        levelEnc.setInt(false, edgeId, edgeIntAccess, forward);
-        levelEnc.setInt(true, edgeId, edgeIntAccess, backward);
+        levelEnc.setDecimal(false, edgeId, edgeIntAccess, level);
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMLevelParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMLevelParser.java
@@ -33,7 +33,14 @@ public class OSMLevelParser implements TagParser {
         this.levelEnc = levelEnc;
     }
 
-    private int clampLevel (int level) {
+    private int cleanAndClampLevel(String levelStr) {
+        int level;
+        try {
+            level = Integer.parseInt(levelStr);
+        } catch (NumberFormatException ex) {
+            level = (int) Math.floor(Float.parseFloat(levelStr));
+        }
+
         int minLevel = -50;
         int maxLevel = 256 + minLevel - 1;
 
@@ -57,7 +64,7 @@ public class OSMLevelParser implements TagParser {
             // TODO
             if (levelsTok.length == 1) {
                 try {
-                    int levelInt = this.clampLevel(Integer.parseInt(levelsTok[0]));
+                    int levelInt = cleanAndClampLevel(levelsTok[0]);
                     forward = levelInt;
                     backward = levelInt;
                 } catch (NumberFormatException ex) {
@@ -65,8 +72,8 @@ public class OSMLevelParser implements TagParser {
                 }
             } else if (levelsTok.length == 2) {
                 try {
-                    int first = this.clampLevel(Integer.parseInt(levelsTok[0]));
-                    int second = this.clampLevel(Integer.parseInt(levelsTok[1]));
+                    int first = cleanAndClampLevel(levelsTok[0]);
+                    int second = cleanAndClampLevel(levelsTok[1]);
                     forward = first;
                     backward = second;
                 } catch (NumberFormatException ex) {

--- a/core/src/main/java/com/graphhopper/routing/weighting/custom/ValueExpressionVisitor.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/custom/ValueExpressionVisitor.java
@@ -36,7 +36,8 @@ public class ValueExpressionVisitor implements Visitor.AtomVisitor<Boolean, Exce
 
     private static final String INFINITY = Double.toString(Double.POSITIVE_INFINITY);
     private static final Set<String> allowedMethodParents = Set.of("Math");
-    private static final Set<String> allowedMethods = Set.of("sqrt");
+    // functions must be monotone in every argument (see findMinMax)
+    private static final Set<String> allowedMethods = Set.of("sqrt", "min", "max");
     private final ParseResult result;
     private final NameValidator variableValidator;
     private String invalidMessage;
@@ -91,6 +92,9 @@ public class ValueExpressionVisitor implements Visitor.AtomVisitor<Boolean, Exce
                             } else if (mi.arguments.length == 1) {
                                 // return "x" but verify before
                                 return mi.arguments[0].accept(this);
+                            } else if (mi.arguments.length == 2) {
+                                // Math.min(x, 10) or Math.max(0.5, x)
+                                return mi.arguments[0].accept(this) && mi.arguments[1].accept(this);
                             }
                         }
                         // TODO unlike in ConditionalExpressionVisitor we don't support a call like road_class.ordinal()

--- a/core/src/test/java/com/graphhopper/routing/util/LevelEdgeFilterTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/LevelEdgeFilterTest.java
@@ -1,0 +1,32 @@
+package com.graphhopper.routing.util;
+
+import com.graphhopper.routing.ev.DecimalEncodedValue;
+import com.graphhopper.routing.ev.Level;
+import com.graphhopper.storage.BaseGraph;
+import com.graphhopper.util.EdgeIteratorState;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LevelEdgeFilterTest {
+
+    @Test
+    void testAccept() {
+        DecimalEncodedValue levelEnc = Level.create();
+        EncodingManager em = new EncodingManager.Builder().add(levelEnc).build();
+        BaseGraph graph = new BaseGraph.Builder(em).create();
+        EdgeIteratorState edge = graph.edge(0, 1).setDistance(100);
+
+        edge.set(levelEnc, 1.0);
+
+        LevelEdgeFilter filterLevel1 = new LevelEdgeFilter(EdgeFilter.ALL_EDGES, levelEnc, 1.0);
+        assertTrue(filterLevel1.accept(edge));
+
+        LevelEdgeFilter filterLevel0 = new LevelEdgeFilter(EdgeFilter.ALL_EDGES, levelEnc, 0.0);
+        assertFalse(filterLevel0.accept(edge));
+
+        LevelEdgeFilter filterNaN = new LevelEdgeFilter(EdgeFilter.ALL_EDGES, levelEnc, Double.NaN);
+        assertTrue(filterNaN.accept(edge));
+    }
+}

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMLevelParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMLevelParserTest.java
@@ -71,16 +71,28 @@ class OSMLevelParserTest {
     }
 
     @Test
-    void halfLevelsNotSupported() {
-        // Half levels aren't documented, but should be rounded down, 
-        // instead of default value of 0.
+    void floatAndClamping() {
         ReaderWay readerWay = new ReaderWay(1);
         EdgeIntAccess edgeIntAccess = new ArrayEdgeIntAccess(1);
         int edgeId = 0;
+        
         readerWay.setTag("level", "1.5");
         parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
         Assertions.assertEquals(1, levelEnc.getInt(false, edgeId, edgeIntAccess));
         Assertions.assertEquals(1, levelEnc.getInt(true, edgeId, edgeIntAccess));
+        
+        readerWay.setTag("level", "-1.5");
+        parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
+        Assertions.assertEquals(-2, levelEnc.getInt(false, edgeId, edgeIntAccess));
+        Assertions.assertEquals(-2, levelEnc.getInt(true, edgeId, edgeIntAccess));
+
+        readerWay.setTag("level", "-100");
+        parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
+        Assertions.assertEquals(-50, levelEnc.getInt(false, edgeId, edgeIntAccess));
+
+        readerWay.setTag("level", "300");
+        parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
+        Assertions.assertEquals(205, levelEnc.getInt(false, edgeId, edgeIntAccess));
     }
 
     

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMLevelParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMLevelParserTest.java
@@ -48,6 +48,43 @@ class OSMLevelParserTest {
         Assertions.assertEquals(2, levelEnc.getInt(true, edgeId, edgeIntAccess));
     }
 
+    @Test
+    void staircaseUp() {
+        ReaderWay readerWay = new ReaderWay(1);
+        EdgeIntAccess edgeIntAccess = new ArrayEdgeIntAccess(1);
+        int edgeId = 0;
+        readerWay.setTag("level", "0;1");
+        parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
+        Assertions.assertEquals(0, levelEnc.getInt(false, edgeId, edgeIntAccess));
+        Assertions.assertEquals(1, levelEnc.getInt(true, edgeId, edgeIntAccess));
+    }
+
+    @Test
+    void staircaseDown() {
+        ReaderWay readerWay = new ReaderWay(1);
+        EdgeIntAccess edgeIntAccess = new ArrayEdgeIntAccess(1);
+        int edgeId = 0;
+        readerWay.setTag("level", "3;2");
+        parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
+        Assertions.assertEquals(3, levelEnc.getInt(false, edgeId, edgeIntAccess));
+        Assertions.assertEquals(2, levelEnc.getInt(true, edgeId, edgeIntAccess));
+    }
+
+    @Test
+    void halfLevelsNotSupported() {
+        // Half levels aren't documented, but should be rounded down, 
+        // instead of default value of 0.
+        ReaderWay readerWay = new ReaderWay(1);
+        EdgeIntAccess edgeIntAccess = new ArrayEdgeIntAccess(1);
+        int edgeId = 0;
+        readerWay.setTag("level", "1.5");
+        parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
+        Assertions.assertEquals(1, levelEnc.getInt(false, edgeId, edgeIntAccess));
+        Assertions.assertEquals(1, levelEnc.getInt(true, edgeId, edgeIntAccess));
+    }
+
+    
+
     // @Test
     // void notTagged() {
     //     ReaderWay readerWay = new ReaderWay(1);

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMLevelParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMLevelParserTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class OSMLevelParserTest {
-    private final IntEncodedValue levelEnc = Level.create();
+    private final DecimalEncodedValue levelEnc = Level.create();
     private OSMLevelParser parser;
     private IntsRef relFlags;
 
@@ -44,8 +44,7 @@ class OSMLevelParserTest {
         int edgeId = 0;
         readerWay.setTag("level", "2");
         parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
-        Assertions.assertEquals(2, levelEnc.getInt(false, edgeId, edgeIntAccess));
-        Assertions.assertEquals(2, levelEnc.getInt(true, edgeId, edgeIntAccess));
+        Assertions.assertEquals(2.0, levelEnc.getDecimal(false, edgeId, edgeIntAccess));
     }
 
     @Test
@@ -55,8 +54,7 @@ class OSMLevelParserTest {
         int edgeId = 0;
         readerWay.setTag("level", "0;1");
         parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
-        Assertions.assertEquals(0, levelEnc.getInt(false, edgeId, edgeIntAccess));
-        Assertions.assertEquals(1, levelEnc.getInt(true, edgeId, edgeIntAccess));
+        Assertions.assertEquals(0.5, levelEnc.getDecimal(false, edgeId, edgeIntAccess));
     }
 
     @Test
@@ -66,8 +64,7 @@ class OSMLevelParserTest {
         int edgeId = 0;
         readerWay.setTag("level", "3;2");
         parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
-        Assertions.assertEquals(3, levelEnc.getInt(false, edgeId, edgeIntAccess));
-        Assertions.assertEquals(2, levelEnc.getInt(true, edgeId, edgeIntAccess));
+        Assertions.assertEquals(2.5, levelEnc.getDecimal(false, edgeId, edgeIntAccess));
     }
 
     @Test
@@ -78,32 +75,18 @@ class OSMLevelParserTest {
         
         readerWay.setTag("level", "1.5");
         parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
-        Assertions.assertEquals(1, levelEnc.getInt(false, edgeId, edgeIntAccess));
-        Assertions.assertEquals(1, levelEnc.getInt(true, edgeId, edgeIntAccess));
+        Assertions.assertEquals(1.5, levelEnc.getDecimal(false, edgeId, edgeIntAccess));
         
         readerWay.setTag("level", "-1.5");
         parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
-        Assertions.assertEquals(-2, levelEnc.getInt(false, edgeId, edgeIntAccess));
-        Assertions.assertEquals(-2, levelEnc.getInt(true, edgeId, edgeIntAccess));
+        Assertions.assertEquals(-1.5, levelEnc.getDecimal(false, edgeId, edgeIntAccess));
 
         readerWay.setTag("level", "-100");
         parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
-        Assertions.assertEquals(-50, levelEnc.getInt(false, edgeId, edgeIntAccess));
+        Assertions.assertEquals(-40.0, levelEnc.getDecimal(false, edgeId, edgeIntAccess));
 
         readerWay.setTag("level", "300");
         parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
-        Assertions.assertEquals(205, levelEnc.getInt(false, edgeId, edgeIntAccess));
+        Assertions.assertEquals(164.7, levelEnc.getDecimal(false, edgeId, edgeIntAccess));
     }
-
-    
-
-    // @Test
-    // void notTagged() {
-    //     ReaderWay readerWay = new ReaderWay(1);
-    //     EdgeIntAccess edgeIntAccess = new ArrayEdgeIntAccess(1);
-    //     int edgeId = 0;
-    //     parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
-    //     Assertions.assertEquals(1, lanesEnc.getInt(false, edgeId, edgeIntAccess));
-    // }
-
 }

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMLevelParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMLevelParserTest.java
@@ -68,7 +68,7 @@ class OSMLevelParserTest {
     }
 
     @Test
-    void floatAndClamping() {
+    void floatLevel() {
         ReaderWay readerWay = new ReaderWay(1);
         EdgeIntAccess edgeIntAccess = new ArrayEdgeIntAccess(1);
         int edgeId = 0;
@@ -76,17 +76,37 @@ class OSMLevelParserTest {
         readerWay.setTag("level", "1.5");
         parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
         Assertions.assertEquals(1.5, levelEnc.getDecimal(false, edgeId, edgeIntAccess));
-        
+    }
+
+    @Test
+    void negativeFloatLevel() {
+        ReaderWay readerWay = new ReaderWay(1);
+        EdgeIntAccess edgeIntAccess = new ArrayEdgeIntAccess(1);
+        int edgeId = 0;
+                
         readerWay.setTag("level", "-1.5");
         parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
         Assertions.assertEquals(-1.5, levelEnc.getDecimal(false, edgeId, edgeIntAccess));
+    }
+
+    @Test
+    void belowMinLevel() {
+        ReaderWay readerWay = new ReaderWay(1);
+        EdgeIntAccess edgeIntAccess = new ArrayEdgeIntAccess(1);
+        int edgeId = 0;
 
         readerWay.setTag("level", "-100");
         parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
         Assertions.assertEquals(-40.0, levelEnc.getDecimal(false, edgeId, edgeIntAccess));
+    }
 
+    @Test
+    void aboveMaxLevel() {
+        ReaderWay readerWay = new ReaderWay(1);
+        EdgeIntAccess edgeIntAccess = new ArrayEdgeIntAccess(1);
+        int edgeId = 0;
+        
         readerWay.setTag("level", "300");
         parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
         Assertions.assertEquals(164.7, levelEnc.getDecimal(false, edgeId, edgeIntAccess));
     }
-}

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMLevelParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMLevelParserTest.java
@@ -1,0 +1,60 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.graphhopper.routing.util.parsers;
+
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.*;
+import com.graphhopper.storage.IntsRef;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class OSMLevelParserTest {
+    private final IntEncodedValue levelEnc = Level.create();
+    private OSMLevelParser parser;
+    private IntsRef relFlags;
+
+    @BeforeEach
+    void setup() {
+        levelEnc.init(new EncodedValue.InitializerConfig());
+        parser = new OSMLevelParser(levelEnc);
+        relFlags = new IntsRef(2);
+    }
+
+    @Test
+    void basic() {
+        ReaderWay readerWay = new ReaderWay(1);
+        EdgeIntAccess edgeIntAccess = new ArrayEdgeIntAccess(1);
+        int edgeId = 0;
+        readerWay.setTag("level", "2");
+        parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
+        Assertions.assertEquals(2, levelEnc.getInt(false, edgeId, edgeIntAccess));
+        Assertions.assertEquals(2, levelEnc.getInt(true, edgeId, edgeIntAccess));
+    }
+
+    // @Test
+    // void notTagged() {
+    //     ReaderWay readerWay = new ReaderWay(1);
+    //     EdgeIntAccess edgeIntAccess = new ArrayEdgeIntAccess(1);
+    //     int edgeId = 0;
+    //     parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
+    //     Assertions.assertEquals(1, lanesEnc.getInt(false, edgeId, edgeIntAccess));
+    // }
+
+}

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMLevelParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMLevelParserTest.java
@@ -108,5 +108,6 @@ class OSMLevelParserTest {
         
         readerWay.setTag("level", "300");
         parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
-        Assertions.assertEquals(164.7, levelEnc.getDecimal(false, edgeId, edgeIntAccess));
+        Assertions.assertEquals(164.7, levelEnc.getDecimal(false, edgeId, edgeIntAccess), 1e-10);
     }
+}

--- a/core/src/test/java/com/graphhopper/routing/weighting/custom/CustomWeightingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/custom/CustomWeightingTest.java
@@ -69,6 +69,19 @@ class CustomWeightingTest {
     }
 
     @Test
+    public void testMinMaxInValueExpression() {
+        DecimalEncodedValue myPriorityEnc = encodingManager.getDecimalEncodedValue("my_priority");
+        EdgeIteratorState edge = graph.edge(0, 1).setDistance(1000).set(avSpeedEnc, 50, 50).set(myPriorityEnc, 0.7);
+        Weighting weighting = createWeighting(createSpeedCustomModel(avSpeedEnc).setDistanceInfluence(0d).
+                addToPriority(If("true", MULTIPLY, "Math.min(my_priority, 0.5)")));
+        // the priority is limited to 0.5 -> the weight doubles compared to 72s
+        assertEquals(10 * 72 / 0.5, weighting.calcEdgeWeight(edge, false), 0.1);
+        weighting = createWeighting(createSpeedCustomModel(avSpeedEnc).setDistanceInfluence(0d).
+                addToPriority(If("true", MULTIPLY, "Math.max(0.8, 1 - my_priority)")));
+        assertEquals(10 * 72 / 0.8, weighting.calcEdgeWeight(edge, false), 0.1);
+    }
+
+    @Test
     public void speedOnly() {
         // 50km/h -> 72s per km, 100km/h -> 36s per km
         EdgeIteratorState edge = graph.edge(0, 1).setDistance(1000).set(avSpeedEnc, 50, 100);

--- a/core/src/test/java/com/graphhopper/routing/weighting/custom/ValueExpressionVisitorTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/custom/ValueExpressionVisitorTest.java
@@ -44,6 +44,13 @@ class ValueExpressionVisitorTest {
         assertTrue(result.ok, result.invalidMessage);
         assertEquals("[my_speed]", result.guessedVariables.toString());
 
+        result = parse("Math.min(my_speed, 10)", (arg) -> arg.equals("my_speed"));
+        assertTrue(result.ok, result.invalidMessage);
+        assertEquals("[my_speed]", result.guessedVariables.toString());
+        result = parse("1 - 0.1 * Math.max(0.5, my_speed)", (arg) -> arg.equals("my_speed"));
+        assertTrue(result.ok, result.invalidMessage);
+        assertFalse(parse("Math.pow(my_speed, 2)", (arg) -> arg.equals("my_speed")).ok);
+
         result = parse("edge.getDistance()", (arg) -> false);
         assertFalse(result.ok);
 
@@ -119,6 +126,10 @@ class ValueExpressionVisitorTest {
         assertInterval(2, 2, "2", lookup);
 
         assertInterval(0, 62, "2*my_priority", lookup);
+        // Math.min and Math.max are monotone, so the bounds from the range endpoints are exact
+        assertInterval(0, 10, "Math.min(my_priority, 10)", lookup);
+        assertInterval(10, 31, "Math.max(10, my_priority)", lookup);
+        assertInterval(0.7, 1, "1 - 0.03 * Math.min(my_priority, 10)", lookup);
 
         assertInterval(-52, 10, "-2*my_priority2", lookup);
     }

--- a/docs/core/custom-models.md
+++ b/docs/core/custom-models.md
@@ -687,7 +687,7 @@ Similarly, you can discourage border crossings by penalizing transitions between
 
 The value of `limit_to` or `multiply_by` is usually only a number but can be more complex expression like `max_speed`
 or even something like `max_speed + 0.5`. In general one encoded value is accepted in combination with one or more 
-operations with a number and the operator `+`, `*` and `-`.
+operations with a number and the operator `+`, `*` and `-`, and the methods `Math.sqrt`, `Math.min` and `Math.max`.
 
 This can be useful to reduce the speed of the base profile to a dynamic value. See e.g. the following example:
 

--- a/web-api/src/main/java/com/graphhopper/GHRequest.java
+++ b/web-api/src/main/java/com/graphhopper/GHRequest.java
@@ -233,8 +233,20 @@ public class GHRequest {
         return this.pathDetails;
     }
 
+    /**
+     * Sets the levels, i.e. the level the route should leave the starting point and the levels the route
+     * should arrive from at the via-points and the end point. Levels are given as a decimal number,
+     * or NaN or null if no level shall be specified.
+     * <p>
+     * The number of levels must be zero (default), one (for the start point) or equal to the number of points
+     * when sending the request.
+     */
     public GHRequest setLevels(List<Double> levels) {
-        this.levels = levels;
+        this.levels = levels == null 
+            ? new ArrayList<>() 
+            : levels.stream()
+                .map(d -> d == null ? Double.NaN : d)
+                .collect(Collectors.toList());
         return this;
     }
 

--- a/web-api/src/main/java/com/graphhopper/GHRequest.java
+++ b/web-api/src/main/java/com/graphhopper/GHRequest.java
@@ -45,6 +45,7 @@ public class GHRequest {
     private List<String> curbsides = new ArrayList<>();
     private List<String> snapPreventions;
     private List<String> pathDetails = new ArrayList<>();
+    private List<String> levels = new ArrayList<>();
     private String algo = "";
     private Locale locale = Locale.US;
     private CustomModel customModel;
@@ -230,6 +231,15 @@ public class GHRequest {
 
     public List<String> getPathDetails() {
         return this.pathDetails;
+    }
+
+    public GHRequest setLevels(List<Double> levels) {
+        this.levels = levels;
+        return this;
+    }
+
+    public List<String> getLevels() {
+        return this.levels;
     }
 
     @Override

--- a/web-api/src/main/java/com/graphhopper/GHRequest.java
+++ b/web-api/src/main/java/com/graphhopper/GHRequest.java
@@ -45,7 +45,7 @@ public class GHRequest {
     private List<String> curbsides = new ArrayList<>();
     private List<String> snapPreventions;
     private List<String> pathDetails = new ArrayList<>();
-    private List<String> levels = new ArrayList<>();
+    private List<Double> levels = new ArrayList<>();
     private String algo = "";
     private Locale locale = Locale.US;
     private CustomModel customModel;
@@ -238,7 +238,7 @@ public class GHRequest {
         return this;
     }
 
-    public List<String> getLevels() {
+    public List<Double> getLevels() {
         return this.levels;
     }
 

--- a/web-api/src/main/java/com/graphhopper/util/Parameters.java
+++ b/web-api/src/main/java/com/graphhopper/util/Parameters.java
@@ -134,6 +134,7 @@ public class Parameters {
          */
         public static final double DEFAULT_HEADING_PENALTY = 300;
         public static final String HEADING_PENALTY = "heading_penalty";
+        public static final String LEVEL = "level";
     }
 
     /**

--- a/web-bundle/src/main/java/com/graphhopper/resources/RouteResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/RouteResource.java
@@ -101,6 +101,7 @@ public class RouteResource {
             @QueryParam(SNAP_PREVENTION) List<String> snapPreventions,
             @QueryParam(PATH_DETAILS) List<String> pathDetails,
             @QueryParam("heading") @NotNull List<Double> headings,
+            @QueryParam("level") @NotNull List<Double> levels,
             @QueryParam("gpx.route") @DefaultValue("true") boolean withRoute /* default to false for the route part in next API version, see #437 */,
             @QueryParam("gpx.track") @DefaultValue("true") boolean withTrack,
             @QueryParam("gpx.waypoints") @DefaultValue("false") boolean withWayPoints,
@@ -124,6 +125,7 @@ public class RouteResource {
                 setAlgorithm(algoStr).
                 setLocale(localeStr).
                 setHeadings(headings).
+                setLevels(levels).
                 setPointHints(pointHints).
                 setCurbsides(curbsides).
                 setPathDetails(pathDetails).


### PR DESCRIPTION
This is a follow-up PR related to #3398, and a big step towards solving #215.

This PR basically adds a new LevelEdgeFilter which uses the previously added `level` encoded value to snap any routing point (start, end, waypoint) to a given level.

GHRequest, ViaRouting and other files were updated to enable this behavior, mimicking what is done for the `heading` routing parameter, which is very close to the usage I was working toward.

Docs were updated as well, with an example.

I will leave this PR in draft until the previous #3398 PR is merged in order to see fewer "Files changed".

This will also give me the opportunity to add corrections, as this code has just been deployed to one of our GH instances for an indoor routing project, and we might see some obvious bugs.